### PR TITLE
hot fix: increase observation message size

### DIFF
--- a/x/zetacore/types/message_send_voter.go
+++ b/x/zetacore/types/message_send_voter.go
@@ -74,7 +74,8 @@ func (msg *MsgSendVoter) ValidateBasic() error {
 	}
 
 	// TODO: should parameterize the hardcoded max len
-	if len(msg.Message) > 1024 {
+	// FIXME: should allow this observation and handle errors in the state machine
+	if len(msg.Message) > 10240 {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "message is too long: %d", len(msg.Message))
 	}
 


### PR DESCRIPTION
1024 is too small for certain applications. 

e.g.
https://ropsten.etherscan.io/tx/0x937f18cd9767453e13f05042751ee72814c2c5cd08c3c21515012bdd0f6e74ed