### PR TITLE
Bugfix/tx not observed all nodes

### DIFF
--- a/zetaclient/zetacore_observer.go
+++ b/zetaclient/zetacore_observer.go
@@ -290,6 +290,7 @@ func (co *CoreObserver) startSendScheduler() {
 						go co.TryProcessOutTx(send, sinceBlock, outTxMan)
 					}
 					if idx > 50 { // only look at 50 sends per chain
+						logger.Info().Msgf("sends per chain > 50 : %v", idx)
 						break
 					}
 				}


### PR DESCRIPTION
### Missing event observation

[This goerli Tx](https://goerli.etherscan.io/tx/0x487517db6ca72fdd8f38e697a5a8cd2a8c2b502e27ad583fcaf1a8250da92fc1)
was only observed by a single node promptly:  [log](https://app.datadoghq.com/logs?query=service%3Azetaclientd-start.sh%20env%3Astaging%200x487517db6ca72fdd8f38e697a5a8cd2a8c2b502e27ad583fcaf1a8250da92fc1&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1661534998294&to_ts=1661707798294&live=true)
it was later observed by all nodes during a re-scan.

Added logging to catch possible sources