### PR TITLE
Added workflow to enable/disable zetaclientd

### DIFF
--- a/.github/workflows/chain-operations.yml
+++ b/.github/workflows/chain-operations.yml
@@ -1,0 +1,64 @@
+name: Chain Operations
+on:
+  workflow_dispatch:
+    inputs:
+      ENVIRONMENT:
+        description: 'Which environment to update?'
+        type: environment
+        required: true
+      ZETACORED_STATUS:
+        description: 'Do you want to start, stop, or restart the zetacored?'
+        type: choice
+        options:
+          - 'start'
+          - 'stop'
+          - 'restart'
+        required: true
+      ZETACLIENTD_STATUS:
+        description: 'Do you want to start, stop, or restart the zetaclientd?'
+        type: choice
+        options:
+          - 'start'
+          - 'stop'
+          - 'restart'
+        required: true
+
+env:
+  AWS_REGION: "us-east-1"
+
+jobs:
+  start-stop-processes:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.ENVIRONMENT }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup-git-credentials
+        uses: de-vri-es/setup-git-credentials@v2.0.8
+        with:
+          credentials: ${{ secrets.PAT_GITHUB_SERVICE_ACCT }} 
+          
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Chnage Zetacored Status
+        run: |
+          source .github/actions/deploy-binaries/functions
+          COMMAND_ID=$(run_ssm_cmds_validators "systemctl ${{ github.event.inputs.ZETACORED_STATUS }} cosmovisor")
+          check_cmd_status $COMMAND_ID
+          COMMAND_ID=$(run_ssm_cmds_api_nodes "systemctl ${{ github.event.inputs.ZETACORED_STATUS }} cosmovisor")
+          check_cmd_status $COMMAND_ID
+          COMMAND_ID=$(run_ssm_cmds_archive_nodes "systemctl ${{ github.event.inputs.ZETACORED_STATUS }} cosmovisor")
+          check_cmd_status $COMMAND_ID
+
+
+      - name: Change Zetaclientd Status
+        run: |
+          source .github/actions/deploy-binaries/functions
+          COMMAND_ID=$(run_ssm_cmds_validators "systemctl ${{ github.event.inputs.ZETACLIENTD_STATUS }} zetaclientd")
+          check_cmd_status $COMMAND_ID
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,23 +2,23 @@ name: Deploy ZetaChain Update
 on:
   workflow_dispatch:
     inputs:
-      VERSION:
-        description: 'Version number for the release (0.0.1)'
-        type: string
-        required: true
-      # UPGRADE_BLOCK_HEIGHT:
-      #   description: 'What block height to upgrade at - If Blank, will upgrade in 150 blocks'
-      #   type: string
-      #   required: false
       ENVIRONMENT:
         description: 'What Environment to deploy into (athens2, development)'
         type: environment
         required: true
-      REGENESIS:
-        description: 'Whether to regenesis the chain (Keeping existing keys)'
-        type: boolean
-        required: false
-        default: false
+      # VERSION:
+      #   description: 'Version number for the release (0.0.1)'
+      #   type: string
+      #   required: true
+      # UPGRADE_BLOCK_HEIGHT:
+      #   description: 'What block height to upgrade at - If Blank, will upgrade in 150 blocks'
+      #   type: string
+      #   required: false
+      # REGENESIS:
+      #   description: 'Perform Regenesis? (Keeping existing keys)'
+      #   type: boolean
+      #   required: false
+      #   default: false
 
 env:
   S3_BUCKET_NAME: "zetachain-deployment-files"


### PR DESCRIPTION
# Description

Adds a manual workflow that can be triggered through to start/stop zetacored or zetaclientd 
Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in development 

- [ ] Tested CCTX in localnet
- [ ] Go unit tests
- [ ] Go integration tests

# Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix feature works
- [ ] I included code comments (if needed)
- [ ] Upgrade Handler (if needed)
- [ ] I have made corresponding changes to the documentation (if needed)
