### PR TITLE
Update CI to use make install-testnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,8 +282,9 @@ jobs:
     runs-on: ["zeta-runners"]
     timeout-minutes: 60
     needs:
-      - upload
-
+      - build-and-test
+      - build-alpine-and-test
+      
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
# Description

We have a new makefile rule to build for testnet

Updated upgrade-path testing to run sooner instead of waiting for the upload job to complete. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

GitHub Actions Pass 
