### PR TITLE
fix: add panic handler for btcutil.DecodeAddress

### DIFF
--- a/zetaclient/bitcoin_client.go
+++ b/zetaclient/bitcoin_client.go
@@ -518,6 +518,11 @@ func (ob *BitcoinChainClient) WatchUTXOS() {
 }
 
 func (ob *BitcoinChainClient) fetchUTXOS() error {
+	defer func() {
+		if err := recover(); err != nil {
+			ob.logger.WatchUTXOS.Error().Msgf("BTC fetchUTXOS: caught panic error: %v", err)
+		}
+	}()
 	// get the current block height.
 	bh, err := ob.rpcClient.GetBlockCount()
 	if err != nil {

--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -177,6 +177,12 @@ func (signer *BTCSigner) Broadcast(signedTx *wire.MsgTx) error {
 }
 
 func (signer *BTCSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *OutTxProcessorManager, outTxID string, chainclient ChainClient, zetaBridge *ZetaCoreBridge) {
+	defer func() {
+		if err := recover(); err != nil {
+			signer.logger.Error().Msgf("BTC TryProcessOutTx: %s, caught panic error: %v", send.Index, err)
+		}
+	}()
+
 	logger := signer.logger.With().
 		Str("OutTxID", outTxID).
 		Str("SendHash", send.Index).
@@ -214,6 +220,7 @@ func (signer *BTCSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 		logger.Error().Msgf("cannot convert gas price  %s ", send.GetCurrentOutTxParam().OutboundTxGasPrice)
 		return
 	}
+
 	// FIXME: config chain params
 	addr, err := btcutil.DecodeAddress(string(toAddr), config.BitconNetParams)
 	if err != nil {


### PR DESCRIPTION
# Description

Addresses Zelic audit issue 10 by adding panic handler to handle panic of btcutil.DecodeAddress.

Potentially panic handling can be used for other external methods, which can cause panics. 

For go-ethereum package inspected their methods code that we use and none can potentially return panic, they will just return error. For Bitcoin potentially could be other places, but Zelic didn't identify more.

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
