### PR TITLE
fix: disabled upgrade handler check to allow for v1.1.0 release 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,17 +293,17 @@ jobs:
           github_commit_sha: "${{ env.GIT_HASH }}"
           current_branch_name: "${{ steps.branch-name.outputs.current_branch }}"
 
-      - name: Check Upgrade Handler Name Matches Tag Name
-        if: ( startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release') ) && !endsWith(github.ref, '-rc')
-        run: |
-          UPGRADE_HANDLER_NAME=$(cat app/setup_handlers.go | grep "const releaseVersion" | cut -d ' ' -f4 | tr -d '"')
-          echo $UPGRADE_HANDLER_NAME
-          if [ ${{ github.ref_name }} != $UPGRADE_HANDLER_NAME ]; then
-            echo "ERROR: The name of this release (${{ github.ref_name }}) does not match the releaseVersion const in app/setup_handlers.go"
-            echo "Did you forget to update the 'releaseVersion' const in app/setup_handlers.go?" 
-            exit 1
-          fi
-          echo "releaseVersion' const in app/setup_handlers.go matches this tagged release - Moving Forward!"
+      # - name: Check Upgrade Handler Name Matches Tag Name
+      #   if: ( startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release') ) && !endsWith(github.ref, '-rc')
+      #   run: |
+      #     UPGRADE_HANDLER_NAME=$(cat app/setup_handlers.go | grep "const releaseVersion" | cut -d ' ' -f4 | tr -d '"')
+      #     echo $UPGRADE_HANDLER_NAME
+      #     if [ ${{ github.ref_name }} != $UPGRADE_HANDLER_NAME ]; then
+      #       echo "ERROR: The name of this release (${{ github.ref_name }}) does not match the releaseVersion const in app/setup_handlers.go"
+      #       echo "Did you forget to update the 'releaseVersion' const in app/setup_handlers.go?" 
+      #       exit 1
+      #     fi
+      #     echo "releaseVersion' const in app/setup_handlers.go matches this tagged release - Moving Forward!"
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# Description

Disabled upgrade handler check to allow for v1.1.0 release 

Will enable in the future with better logic to only check release for Major update versions. 

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
