### PR TITLE
feat: enforce max number of UTXOs

### DIFF
--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -25,6 +25,11 @@ import (
 	clienttypes "github.com/zeta-chain/zetacore/zetaclient/types"
 )
 
+const (
+	dustSats           = 0.00001 // 1000 sats
+	maxNoOfInputsPerTx = 20
+)
+
 type BTCSigner struct {
 	tssSigner TSSSigner
 	rpcClient *rpcclient.Client
@@ -47,24 +52,20 @@ func NewBTCSigner(tssSigner TSSSigner, rpcClient *rpcclient.Client, logger zerol
 
 // SignWithdrawTx receives utxos sorted by value, amount in BTC, feeRate in BTC per Kb
 func (signer *BTCSigner) SignWithdrawTx(to *btcutil.AddressWitnessPubKeyHash, amount float64, gasPrice *big.Int, utxos []btcjson.ListUnspentResult, db *gorm.DB, height uint64) (*wire.MsgTx, error) {
-	var total float64
-	prevOuts := make([]btcjson.ListUnspentResult, 0, len(utxos))
-	// select N utxo sufficient to cover the amount
-	//estimateFee := size (100 inputs + 2 output) * feeRate
+	// enforce dust limit
+	if amount < dustSats {
+		return nil, fmt.Errorf("must send at least %v BTC, got %v", dustSats, amount)
+	}
+
+	// select N UTXOs to cover the amount
 	estimateFee := 0.0001 // 10,000 sats, should be good for testnet
 	minFee := 0.00005
-	for _, utxo := range utxos {
-		total = total + utxo.Amount
-		prevOuts = append(prevOuts, utxo)
-
-		if total >= amount+estimateFee {
-			break
-		}
-	}
-	if total < amount {
-		return nil, fmt.Errorf("not enough btc in reserve - available : %v , tx amount : %v", total, amount)
+	prevOuts, total, err := selectUTXOs(utxos, amount+estimateFee, maxNoOfInputsPerTx)
+	if err != nil {
+		return nil, err
 	}
 	remaining := total - amount
+
 	// build tx with selected unspents
 	tx := wire.NewMsgTx(wire.TxVersion)
 	for _, prevOut := range prevOuts {
@@ -284,6 +285,35 @@ func (signer *BTCSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 
 			break // successful broadcast; no need to retry
 		}
-
 	}
+}
+
+// Selects a sublist of utxos to be used as inputs.
+//
+// Parameters:
+//   - utxos: A list of ordered (by amount in ascending order) UTXO
+//   - amount: The desired minimum total value of the selected UTXOs.
+//   - utxoCap: The maximum number of UTXOs to be selected.
+//
+// Returns: a sublist of selected UTXOs or an error if the qulifying sublist cannot be found.
+func selectUTXOs(utxos []btcjson.ListUnspentResult, amount float64, utxoCap uint8) ([]btcjson.ListUnspentResult, float64, error) {
+	total := 0.0
+	left, right := 0, 0
+
+	for total < amount && right < len(utxos) {
+		if utxoCap > 0 { // expand sublist
+			total += utxos[right].Amount
+			right++
+			utxoCap--
+		} else { // pop the smallest utxo and append the current one
+			total -= utxos[left].Amount
+			total += utxos[right].Amount
+			left++
+			right++
+		}
+	}
+	if total < amount {
+		return nil, 0, fmt.Errorf("not enough btc in reserve - available : %v , tx amount : %v", total, amount)
+	}
+	return utxos[left:right], total, nil
 }

--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	dustSats           = 0.00001 // 1000 sats
 	maxNoOfInputsPerTx = 20
 )
 
@@ -52,11 +51,6 @@ func NewBTCSigner(tssSigner TSSSigner, rpcClient *rpcclient.Client, logger zerol
 
 // SignWithdrawTx receives utxos sorted by value, amount in BTC, feeRate in BTC per Kb
 func (signer *BTCSigner) SignWithdrawTx(to *btcutil.AddressWitnessPubKeyHash, amount float64, gasPrice *big.Int, utxos []btcjson.ListUnspentResult, db *gorm.DB, height uint64) (*wire.MsgTx, error) {
-	// enforce dust limit
-	if amount < dustSats {
-		return nil, fmt.Errorf("must send at least %v BTC, got %v", dustSats, amount)
-	}
-
 	// select N UTXOs to cover the amount
 	estimateFee := 0.0001 // 10,000 sats, should be good for testnet
 	minFee := 0.00005

--- a/zetaclient/btc_test.go
+++ b/zetaclient/btc_test.go
@@ -5,10 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 	"testing"
 
-	"github.com/btcsuite/btcd/btcjson"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -26,7 +24,6 @@ type BTCSignTestSuite struct {
 	suite.Suite
 	testSigner *TestSigner
 	db         *gorm.DB
-	utxos      []btcjson.ListUnspentResult
 }
 
 const (
@@ -55,21 +52,6 @@ func (suite *BTCSignTestSuite) SetupTest() {
 	suite.NoError(err)
 
 	suite.db = db
-
-	//Create UTXOs
-	for i := 0; i < utxoCount; i++ {
-		suite.utxos = append(suite.utxos, btcjson.ListUnspentResult{
-			TxID:          strconv.Itoa(i),
-			Vout:          uint32(i),
-			Address:       "",
-			Account:       "",
-			ScriptPubKey:  "",
-			RedeemScript:  "",
-			Amount:        0,
-			Confirmations: 0,
-			Spendable:     false,
-		})
-	}
 }
 
 func (suite *BTCSignTestSuite) TearDownSuite() {


### PR DESCRIPTION
# Description

Spending each UTXO requires one keysign, a bitcoin transaction might cause keysign timeouts if too many UTXOs are used as inputs. This PR enforces the maximum number of UTXOs check (<= 20 UTXOs) for BTC outbound transfers.

Closes: #773

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
