### PR TITLE
fix: remove SetCrossChainTx() at the first ballot creation time

### DIFF
--- a/x/crosschain/genesis.go
+++ b/x/crosschain/genesis.go
@@ -46,7 +46,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 
 	// Set all the send
 	for _, elem := range genState.CrossChainTxs {
-		k.SetCrossChainTx(ctx, *elem)
+		k.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, *elem)
 	}
 
 	// Set all the nodeAccount

--- a/x/crosschain/keeper/events.go
+++ b/x/crosschain/keeper/events.go
@@ -70,7 +70,7 @@ func EmitZetaWithdrawCreated(ctx sdk.Context, cctx types.CrossChainTx) {
 
 }
 
-func EmitOutboundSuccess(ctx sdk.Context, msg *types.MsgVoteOnObservedOutboundTx, oldStatus string, newStatus string, cctx *types.CrossChainTx) {
+func EmitOutboundSuccess(ctx sdk.Context, msg *types.MsgVoteOnObservedOutboundTx, oldStatus string, newStatus string, cctx types.CrossChainTx) {
 	err := ctx.EventManager().EmitTypedEvents(&types.EventOutboundSuccess{
 		MsgTypeUrl: sdk.MsgTypeURL(&types.MsgVoteOnObservedOutboundTx{}),
 		CctxIndex:  cctx.Index,
@@ -84,7 +84,7 @@ func EmitOutboundSuccess(ctx sdk.Context, msg *types.MsgVoteOnObservedOutboundTx
 
 }
 
-func EmitOutboundFailure(ctx sdk.Context, msg *types.MsgVoteOnObservedOutboundTx, oldStatus string, newStatus string, cctx *types.CrossChainTx) {
+func EmitOutboundFailure(ctx sdk.Context, msg *types.MsgVoteOnObservedOutboundTx, oldStatus string, newStatus string, cctx types.CrossChainTx) {
 	err := ctx.EventManager().EmitTypedEvents(&types.EventOutboundFailure{
 		MsgTypeUrl: sdk.MsgTypeURL(&types.MsgVoteOnObservedOutboundTx{}),
 		CctxIndex:  cctx.Index,

--- a/x/crosschain/keeper/evm_hooks.go
+++ b/x/crosschain/keeper/evm_hooks.go
@@ -152,7 +152,7 @@ func (k Keeper) ProcessCCTX(ctx sdk.Context, cctx zetacoretypes.CrossChainTx, re
 		return fmt.Errorf("ProcessWithdrawalEvent: update nonce failed: %s", err.Error())
 	}
 
-	k.SetCrossChainTx(ctx, cctx)
+	k.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, cctx)
 	ctx.Logger().Debug("ProcessCCTX successful \n")
 	return nil
 }

--- a/x/crosschain/keeper/keeper_cross_chain_tx.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// SetCrossChainTx set a specific send in the store from its index
-func (k Keeper) SetCrossChainTx(ctx sdk.Context, send types.CrossChainTx) {
+// SetCctxAndNonceToCctxAndInTxHashToCctx set a specific send in the store from its index
+func (k Keeper) SetCctxAndNonceToCctxAndInTxHashToCctx(ctx sdk.Context, send types.CrossChainTx) {
 
 	p := types.KeyPrefix(fmt.Sprintf("%s", types.SendKey))
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), p)

--- a/x/crosschain/keeper/keeper_cross_chain_tx_test.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_test.go
@@ -31,7 +31,7 @@ func createNCctxWithStatus(keeper *Keeper, ctx sdk.Context, n int, status types.
 		items[i].ZetaFees = math.OneUint()
 		items[i].InboundTxParams = &types.InboundTxParams{InboundTxObservedHash: fmt.Sprintf("%d", i), Amount: math.OneUint()}
 
-		keeper.SetCrossChainTx(ctx, items[i])
+		keeper.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, items[i])
 	}
 	return items
 }
@@ -71,7 +71,7 @@ func createNCctx(keeper *Keeper, ctx sdk.Context, n int) []types.CrossChainTx {
 
 		items[i].ZetaFees = math.OneUint()
 		items[i].Index = fmt.Sprintf("%d", i)
-		keeper.SetCrossChainTx(ctx, items[i])
+		keeper.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, items[i])
 	}
 	return items
 }

--- a/x/crosschain/keeper/keeper_cross_chain_tx_vote_inbound_tx.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_vote_inbound_tx.go
@@ -88,7 +88,7 @@ func (k msgServer) VoteOnObservedInboundTx(goCtx context.Context, msg *types.Msg
 	cctx := k.CreateNewCCTX(ctx, msg, index, types.CctxStatus_PendingInbound, observationChain, receiverChain)
 	defer func() {
 		EmitEventInboundFinalized(ctx, &cctx)
-		k.SetCrossChainTx(ctx, cctx)
+		k.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, cctx)
 	}()
 	// FinalizeInbound updates CCTX Prices and Nonce
 	// Aborts is any of the updates fail
@@ -132,7 +132,18 @@ func (k msgServer) VoteOnObservedInboundTx(goCtx context.Context, msg *types.Msg
 			return &types.MsgVoteOnObservedInboundTxResponse{}, nil
 		}
 	} else { // Cross Chain SWAP
-		err = k.FinalizeInbound(ctx, &cctx, *receiverChain, len(ballot.VoterList))
+		err = func() error {
+			cctx.InboundTxParams.InboundTxFinalizedZetaHeight = uint64(ctx.BlockHeader().Height)
+			err := k.UpdatePrices(ctx, receiverChain.ChainId, &cctx)
+			if err != nil {
+				return err
+			}
+			err = k.UpdateNonce(ctx, receiverChain.ChainId, &cctx)
+			if err != nil {
+				return err
+			}
+			return nil
+		}()
 		if err != nil {
 			cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_Aborted, err.Error(), cctx.LogIdentifierForCCTX())
 			return &types.MsgVoteOnObservedInboundTxResponse{}, nil
@@ -141,35 +152,3 @@ func (k msgServer) VoteOnObservedInboundTx(goCtx context.Context, msg *types.Msg
 		return &types.MsgVoteOnObservedInboundTxResponse{}, nil
 	}
 }
-
-// TODO: is LastBlockHeight needed?
-func (k msgServer) FinalizeInbound(ctx sdk.Context, cctx *types.CrossChainTx, receiveChain common.Chain, numberofobservers int) error {
-	cctx.InboundTxParams.InboundTxFinalizedZetaHeight = uint64(ctx.BlockHeader().Height)
-	//k.UpdateLastBlockHeight(ctx, cctx)
-
-	err := k.UpdatePrices(ctx, receiveChain.ChainId, cctx)
-	if err != nil {
-		return err
-	}
-	err = k.UpdateNonce(ctx, receiveChain.ChainId, cctx)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-//func (k msgServer) UpdateLastBlockHeight(ctx sdk.Context, msg *types.CrossChainTx) {
-//	lastblock, isFound := k.GetLastBlockHeight(ctx, msg.InboundTxParams.SenderChain)
-//	if !isFound {
-//		lastblock = types.LastBlockHeight{
-//			Creator:           msg.Creator,
-//			Index:             msg.InboundTxParams.SenderChain, // ?
-//			Chain:             msg.InboundTxParams.SenderChain,
-//			LastSendHeight:    msg.InboundTxParams.InboundTxObservedExternalHeight,
-//			LastReceiveHeight: 0,
-//		}
-//	} else {
-//		lastblock.LastSendHeight = msg.InboundTxParams.InboundTxObservedExternalHeight
-//	}
-//	k.SetLastBlockHeight(ctx, lastblock)
-//}

--- a/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx.go
@@ -78,7 +78,7 @@ func (k msgServer) VoteOnObservedOutboundTx(goCtx context.Context, msg *types.Ms
 		// Set this the first time when the ballot is created
 		// The ballot might change if there are more votes in a different outbound ballot for this cctx hash
 		cctx.GetCurrentOutTxParam().OutboundTxBallotIndex = ballotIndex
-		k.SetCrossChainTx(ctx, cctx)
+		//k.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, cctx)
 	}
 	// AddVoteToBallot adds a vote and sets the ballot
 	ballot, err = k.zetaObserverKeeper.AddVoteToBallot(ctx, ballot, msg.Creator, observerTypes.ConvertReceiveStatusToVoteType(msg.Status))
@@ -104,21 +104,75 @@ func (k msgServer) VoteOnObservedOutboundTx(goCtx context.Context, msg *types.Ms
 	tss, _ := k.GetTSS(ctx)
 	// FinalizeOutbound sets final status for a successful vote
 	// FinalizeOutbound updates CCTX Prices and Nonce for a revert
-	err = FinalizeOutbound(k, ctx, &cctx, msg, ballot.BallotStatus)
+
+	err = func() error { //err = FinalizeOutbound(k, ctx, &cctx, msg, ballot.BallotStatus) // remove this line
+		cctx.GetCurrentOutTxParam().OutboundTxObservedExternalHeight = msg.ObservedOutTxBlockHeight
+		zetaBurnt := cctx.InboundTxParams.Amount
+		zetaMinted := cctx.GetCurrentOutTxParam().Amount
+		oldStatus := cctx.CctxStatus.Status
+		switch ballot.BallotStatus {
+		case observerTypes.BallotStatus_BallotFinalized_SuccessObservation:
+			switch oldStatus {
+			case types.CctxStatus_PendingRevert:
+				cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_Reverted, "", cctx.LogIdentifierForCCTX())
+			case types.CctxStatus_PendingOutbound:
+				cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_OutboundMined, "", cctx.LogIdentifierForCCTX())
+			}
+
+			newStatus := cctx.CctxStatus.Status.String()
+			if zetaBurnt.LT(zetaMinted) {
+				// TODO :Handle Error ?
+			}
+			balanceAmount := zetaBurnt.Sub(zetaMinted)
+			if cctx.GetCurrentOutTxParam().CoinType == common.CoinType_Zeta { // TODO : Handle Fee for other coins
+				err := HandleFeeBalances(k, ctx, balanceAmount)
+				if err != nil {
+					return err
+				}
+			}
+			EmitOutboundSuccess(ctx, msg, oldStatus.String(), newStatus, cctx)
+		case observerTypes.BallotStatus_BallotFinalized_FailureObservation:
+			switch oldStatus {
+			case types.CctxStatus_PendingOutbound:
+				// create new OutboundTxParams for the revert
+				cctx.OutboundTxParams = append(cctx.OutboundTxParams, &types.OutboundTxParams{
+					Receiver:           cctx.InboundTxParams.Sender,
+					ReceiverChainId:    cctx.InboundTxParams.SenderChainId,
+					Amount:             cctx.InboundTxParams.Amount,
+					CoinType:           cctx.InboundTxParams.CoinType,
+					OutboundTxGasLimit: cctx.OutboundTxParams[0].OutboundTxGasLimit, // NOTE(pwu): revert gas limit = initial outbound gas limit set by user;
+				})
+				err := k.UpdatePrices(ctx, cctx.InboundTxParams.SenderChainId, &cctx)
+				if err != nil {
+					return err
+				}
+				err = k.UpdateNonce(ctx, cctx.InboundTxParams.SenderChainId, &cctx)
+				if err != nil {
+					return err
+				}
+				cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_PendingRevert, "Outbound failed, start revert", cctx.LogIdentifierForCCTX())
+			case types.CctxStatus_PendingRevert:
+				cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_Aborted, "Outbound failed: revert failed; abort TX", cctx.LogIdentifierForCCTX())
+			}
+			newStatus := cctx.CctxStatus.Status.String()
+			EmitOutboundFailure(ctx, msg, oldStatus.String(), newStatus, cctx)
+		}
+		return nil
+	}()
 	if err != nil {
 		cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_Aborted, err.Error(), cctx.LogIdentifierForCCTX())
 		ctx.Logger().Error(err.Error())
 		k.RemoveOutTxTracker(ctx, msg.OutTxChain, msg.OutTxTssNonce)
 		k.RemoveFromPendingNonces(ctx, tss.TssPubkey, msg.OutTxChain, int64(msg.OutTxTssNonce))
 		k.RemoveOutTxTracker(ctx, msg.OutTxChain, msg.OutTxTssNonce)
-		k.SetCrossChainTx(ctx, cctx)
+		k.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, cctx)
 		return &types.MsgVoteOnObservedOutboundTxResponse{}, nil
 	}
 	// Set the ballot index to the finalized ballot
 	cctx.GetCurrentOutTxParam().OutboundTxBallotIndex = ballotIndex
 	k.RemoveFromPendingNonces(ctx, tss.TssPubkey, msg.OutTxChain, int64(msg.OutTxTssNonce))
 	k.RemoveOutTxTracker(ctx, msg.OutTxChain, msg.OutTxTssNonce)
-	k.SetCrossChainTx(ctx, cctx)
+	k.SetCctxAndNonceToCctxAndInTxHashToCctx(ctx, cctx)
 	return &types.MsgVoteOnObservedOutboundTxResponse{}, nil
 }
 
@@ -127,65 +181,6 @@ func HandleFeeBalances(k msgServer, ctx sdk.Context, balanceAmount math.Uint) er
 	if err != nil {
 		log.Error().Msgf("ReceiveConfirmation: failed to mint coins: %s", err.Error())
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("failed to mint coins: %s", err.Error()))
-	}
-	return nil
-}
-
-func FinalizeOutbound(k msgServer, ctx sdk.Context, cctx *types.CrossChainTx, msg *types.MsgVoteOnObservedOutboundTx, status observerTypes.BallotStatus) error {
-	//cctx.GetCurrentOutTxParam().OutboundTxFinalizedZetaHeight = uint64(ctx.BlockHeader().Height)
-	cctx.GetCurrentOutTxParam().OutboundTxObservedExternalHeight = msg.ObservedOutTxBlockHeight
-	zetaBurnt := cctx.InboundTxParams.Amount
-	zetaMinted := cctx.GetCurrentOutTxParam().Amount
-	oldStatus := cctx.CctxStatus.Status
-	switch status {
-	case observerTypes.BallotStatus_BallotFinalized_SuccessObservation:
-		switch oldStatus {
-		case types.CctxStatus_PendingRevert:
-			cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_Reverted, "", cctx.LogIdentifierForCCTX())
-		case types.CctxStatus_PendingOutbound:
-			cctx.CctxStatus.ChangeStatus(&ctx, types.CctxStatus_OutboundMined, "", cctx.LogIdentifierForCCTX())
-		}
-
-		newStatus := cctx.CctxStatus.Status.String()
-		if zetaBurnt.LT(zetaMinted) {
-			// TODO :Handle Error ?
-		}
-		balanceAmount := zetaBurnt.Sub(zetaMinted)
-		if cctx.GetCurrentOutTxParam().CoinType == common.CoinType_Zeta { // TODO : Handle Fee for other coins
-			err := HandleFeeBalances(k, ctx, balanceAmount)
-			if err != nil {
-				return err
-			}
-		}
-		EmitOutboundSuccess(ctx, msg, oldStatus.String(), newStatus, cctx)
-	case observerTypes.BallotStatus_BallotFinalized_FailureObservation:
-		switch oldStatus {
-		case types.CctxStatus_PendingOutbound:
-			// create new OutboundTxParams for the revert
-			cctx.OutboundTxParams = append(cctx.OutboundTxParams, &types.OutboundTxParams{
-				Receiver:           cctx.InboundTxParams.Sender,
-				ReceiverChainId:    cctx.InboundTxParams.SenderChainId,
-				Amount:             cctx.InboundTxParams.Amount,
-				CoinType:           cctx.InboundTxParams.CoinType,
-				OutboundTxGasLimit: cctx.OutboundTxParams[0].OutboundTxGasLimit, // NOTE(pwu): revert gas limit = initial outbound gas limit set by user;
-			})
-			err := k.UpdatePrices(ctx, cctx.InboundTxParams.SenderChainId, cctx)
-			if err != nil {
-				return err
-			}
-			err = k.UpdateNonce(ctx, cctx.InboundTxParams.SenderChainId, cctx)
-			if err != nil {
-				return err
-			}
-			cctx.CctxStatus.ChangeStatus(&ctx,
-				types.CctxStatus_PendingRevert, "Outbound failed, start revert", cctx.LogIdentifierForCCTX())
-		case types.CctxStatus_PendingRevert:
-			cctx.CctxStatus.ChangeStatus(&ctx,
-				types.CctxStatus_Aborted, "Outbound failed: revert failed; abort TX", cctx.LogIdentifierForCCTX())
-
-		}
-		newStatus := cctx.CctxStatus.Status.String()
-		EmitOutboundFailure(ctx, msg, oldStatus.String(), newStatus, cctx)
 	}
 	return nil
 }


### PR DESCRIPTION

This is a bug because SetCrossChainTx() not only sets Cctx, but also NonceToCctx and InTxHashToCctx two mappers. When in a revert triggered by a observation of failed outbound tx, setting NonceToCctx will have wrong chain because the Cctx has not transitioned its state to PendingRevert yet.

Also includes slight refactor that inlines two functions that are called only once, and their names are not descriptive and functionality heavily relies on side effects. 