### PR TITLE
feat: enable nonce-mark UTXO check and outTx Vin check

### DIFF
--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -138,7 +138,6 @@ func (signer *BTCSigner) SignWithdrawTx(to *btcutil.AddressWitnessPubKeyHash, am
 		if err != nil {
 			return nil, err
 		}
-
 	}
 	tss, ok := signer.tssSigner.(*TSS)
 	if !ok {
@@ -156,9 +155,6 @@ func (signer *BTCSigner) SignWithdrawTx(to *btcutil.AddressWitnessPubKeyHash, am
 		sig := btcec.Signature{
 			R: R,
 			S: S,
-		}
-		if err != nil {
-			return nil, err
 		}
 
 		pkCompressed := signer.tssSigner.PubKeyCompressedBytes()

--- a/zetaclient/btc_signer_test.go
+++ b/zetaclient/btc_signer_test.go
@@ -210,9 +210,9 @@ func createTestClient(t *testing.T) *BitcoinChainClient {
 
 	// Create BitcoinChainClient
 	client := &BitcoinChainClient{
-		Tss:     tss,
-		mu:      &sync.Mutex{},
-		minedTx: make(map[string]btcjson.GetTransactionResult),
+		Tss:        tss,
+		mu:         &sync.Mutex{},
+		includedTx: make(map[string]btcjson.GetTransactionResult),
 	}
 
 	// Create 10 dummy UTXOs (22.44 BTC in total)
@@ -227,7 +227,7 @@ func createTestClient(t *testing.T) *BitcoinChainClient {
 func mineTxNSetNonceMark(ob *BitcoinChainClient, nonce uint64, txid string, preMarkIndex int) {
 	// Mine transaction
 	outTxID := ob.GetTxID(nonce)
-	ob.minedTx[outTxID] = btcjson.GetTransactionResult{TxID: txid}
+	ob.includedTx[outTxID] = btcjson.GetTransactionResult{TxID: txid}
 
 	// Set nonce mark
 	if preMarkIndex >= 0 {
@@ -253,24 +253,24 @@ func TestSelectUTXOs(t *testing.T) {
 	require.Equal(t, 0.01, amount)
 	require.Equal(t, ob.utxos[0:1], result)
 
-	// // Case2: nonce = 1, must FAIL and wait for previous transaction to be mined
-	// // 		input: utxoCap = 5, amount = 0.5, nonce = 1
-	// // 		output: error
-	// result, amount, err = ob.SelectUTXOs(0.5, 5, 1, tssAddress)
-	// require.NotNil(t, err)
-	// require.Nil(t, result)
-	// require.Equal(t, 0.0, amount)
-	// require.Equal(t, "findNonceMarkUTXO: transaction 0-mgaRVNhouhVaiKx8xVtLNHBbSUe1o36qZJ-0 not mined yet", err.Error())
-	// mineTxNSetNonceMark(ob, 0, dummyTxID, -1) // mine a transaction for nonce 0
+	// Case2: nonce = 1, must FAIL and wait for previous transaction to be mined
+	// 		input: utxoCap = 5, amount = 0.5, nonce = 1
+	// 		output: error
+	result, amount, err = ob.SelectUTXOs(0.5, 5, 1, tssAddress)
+	require.NotNil(t, err)
+	require.Nil(t, result)
+	require.Equal(t, 0.0, amount)
+	require.Equal(t, "findNonceMarkUTXO: outTx 0-mgaRVNhouhVaiKx8xVtLNHBbSUe1o36qZJ-0 not included yet", err.Error())
+	mineTxNSetNonceMark(ob, 0, dummyTxID, -1) // mine a transaction for nonce 0
 
-	// // Case3: nonce = 1, must FAIL without nonce mark utxo
-	// // 		input: utxoCap = 5, amount = 0.5, nonce = 1
-	// // 		output: error
-	// result, amount, err = ob.SelectUTXOs(0.5, 5, 1, tssAddress)
-	// require.NotNil(t, err)
-	// require.Nil(t, result)
-	// require.Equal(t, 0.0, amount)
-	// require.Equal(t, "findNonceMarkUTXO: cannot find nonce-mark utxo with nonce 0", err.Error())
+	// Case3: nonce = 1, must FAIL without nonce mark utxo
+	// 		input: utxoCap = 5, amount = 0.5, nonce = 1
+	// 		output: error
+	result, amount, err = ob.SelectUTXOs(0.5, 5, 1, tssAddress)
+	require.NotNil(t, err)
+	require.Nil(t, result)
+	require.Equal(t, 0.0, amount)
+	require.Equal(t, "findNonceMarkUTXO: cannot find nonce-mark utxo with nonce 0", err.Error())
 
 	// add nonce-mark utxo for nonce 0
 	nonceMark0 := btcjson.ListUnspentResult{Address: tssAddress, Amount: float64(NonceMarkAmount(0)) * 1e-8}


### PR DESCRIPTION
# Description

1. Enable nonce-mark UTXO check
2. Perform more stringent checks on outTX fetched from tracker.

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
