### PR TITLE
feat: ci - Rename old A2 Actions

### DIFF
--- a/.github/workflows/chain-operations.yml
+++ b/.github/workflows/chain-operations.yml
@@ -1,4 +1,4 @@
-name: node operations - Athens2
+name: Node Operations - Athens2
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/chain-operations.yml
+++ b/.github/workflows/chain-operations.yml
@@ -1,4 +1,4 @@
-name: Chain Operations
+name: node operations - Athens2
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy ZetaChain Update
+name: Deploy ZetaChain Update - Athens2
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
# Description

Rename the "Chain Operations" action in the node repo to "node operations - Athens2

Rename "Deploy ZetaChain Update" to "Deploy ZetaChain Update - Athens2"


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Changed the names for old Athens 2 Actions

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
