### PR TITLE
refactor(`fungible`): define interface for EVM keeper reference

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -391,7 +391,7 @@ func New(
 		keys[fungibleModuleTypes.MemStoreKey],
 		app.GetSubspace(fungibleModuleTypes.ModuleName),
 		app.AccountKeeper,
-		*app.EvmKeeper,
+		app.EvmKeeper,
 		app.BankKeeper,
 		app.ZetaObserverKeeper,
 	)

--- a/x/fungible/keeper/keeper.go
+++ b/x/fungible/keeper/keeper.go
@@ -2,13 +2,13 @@ package keeper
 
 import (
 	"fmt"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/zeta-chain/zetacore/x/fungible/types"
 )
 
@@ -19,7 +19,7 @@ type (
 		memKey             storetypes.StoreKey
 		paramstore         paramtypes.Subspace
 		authKeeper         types.AccountKeeper
-		evmKeeper          evmkeeper.Keeper
+		evmKeeper          types.EVMKeeper
 		bankKeeper         types.BankKeeper
 		zetaobserverKeeper types.ZetaObserverKeeper
 	}
@@ -31,7 +31,7 @@ func NewKeeper(
 	memKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
 	authKeeper types.AccountKeeper,
-	evmKeeper evmkeeper.Keeper,
+	evmKeeper types.EVMKeeper,
 	bankKeeper types.BankKeeper,
 	zetacobservKeeper types.ZetaObserverKeeper,
 ) *Keeper {
@@ -41,7 +41,6 @@ func NewKeeper(
 	}
 
 	return &Keeper{
-
 		cdc:                cdc,
 		storeKey:           storeKey,
 		memKey:             memKey,

--- a/x/fungible/types/expected_keepers.go
+++ b/x/fungible/types/expected_keepers.go
@@ -1,9 +1,16 @@
 package types
 
 import (
+	"context"
+	"math/big"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+
 	"github.com/zeta-chain/zetacore/common"
 	zetaObserverTypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
@@ -11,7 +18,6 @@ import (
 // AccountKeeper defines the expected account keeper used for simulations (noalias)
 type AccountKeeper interface {
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI
-	// Methods imported from account should be defined here
 	GetSequence(ctx sdk.Context, addr sdk.AccAddress) (uint64, error)
 	GetModuleAccount(ctx sdk.Context, name string) types.ModuleAccountI
 }
@@ -38,4 +44,20 @@ type ZetaObserverKeeper interface {
 	GetAllBallots(ctx sdk.Context) (voters []*zetaObserverTypes.Ballot)
 	GetParams(ctx sdk.Context) (params zetaObserverTypes.Params)
 	GetCoreParamsByChainID(ctx sdk.Context, chainID int64) (params *zetaObserverTypes.CoreParams, found bool)
+}
+
+type EVMKeeper interface {
+	ChainID() *big.Int
+	GetBlockBloomTransient(ctx sdk.Context) *big.Int
+	GetLogSizeTransient(ctx sdk.Context) uint64
+	WithChainID(ctx sdk.Context)
+	SetBlockBloomTransient(ctx sdk.Context, bloom *big.Int)
+	SetLogSizeTransient(ctx sdk.Context, logSize uint64)
+	EstimateGas(c context.Context, req *evmtypes.EthCallRequest) (*evmtypes.EstimateGasResponse, error)
+	ApplyMessage(
+		ctx sdk.Context,
+		msg core.Message,
+		tracer vm.EVMLogger,
+		commit bool,
+	) (*evmtypes.MsgEthereumTxResponse, error)
 }


### PR DESCRIPTION
# Description

Use an interface for EVM keeper reference to remove coupling and allow mocking for unit tests

Closes: https://github.com/zeta-chain/node/issues/879

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
