### PR TITLE
fix: `gosec` lint issues

### DIFF
--- a/contrib/rpctest/main.go
+++ b/contrib/rpctest/main.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	// #nosec
 	ZetaEthPriv           = "9D00E4D7A8A14384E01CD90B83745BCA847A66AD8797A9904A200C28C2648E64"
 	SystemContractAddress = "0x91d18e54DAf4F677cB28167158d6dd21F6aB3921"
 )

--- a/x/crosschain/client/querytests/intx_hash.go
+++ b/x/crosschain/client/querytests/intx_hash.go
@@ -60,6 +60,7 @@ func (s *CliTestSuite) TestShowInTxHashToCctx() {
 				var resp types.QueryGetInTxHashToCctxResponse
 				s.Require().NoError(s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				s.Require().NotNil(resp.InTxHashToCctx)
+				tc := tc
 				s.Require().Equal(nullify.Fill(&tc.obj),
 					nullify.Fill(&resp.InTxHashToCctx),
 				)

--- a/x/observer/client/querytests/permission_flags.go
+++ b/x/observer/client/querytests/permission_flags.go
@@ -42,6 +42,7 @@ func (s *CliTestSuite) TestShowPermissionFlags() {
 				var resp types.QueryGetPermissionFlagsResponse
 				s.Require().NoError(s.network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				s.Require().NotNil(resp.PermissionFlags)
+				tc := tc
 				s.Require().Equal(nullify.Fill(&tc.obj),
 					nullify.Fill(&resp.PermissionFlags),
 				)

--- a/zetaclient/config/config_mainnet.go
+++ b/zetaclient/config/config_mainnet.go
@@ -13,6 +13,7 @@ const (
 )
 
 const (
+	// #nosec
 	TssTestPrivkey = "2082bc9775d6ee5a05ef221a9d1c00b3cc3ecb274a4317acc0a182bc1e05d1bb"
 	TssTestAddress = "0xE80B6467863EbF8865092544f441da8fD3cF6074"
 )


### PR DESCRIPTION
# Description

Fix the issues raised by `gosec` in Lint CI

- Use `nosec` for test priv key definitions
- Remove usage of pointer reference in iterated values

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
