### PR TITLE
ci: Add conditional Docker Hub login step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: github.event.repository.full_name == 'zeta-chain/node'
+        if: github.event.repository.full_name == 'never-chain/node'
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_ONLY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
+        if: github.event.repository.full_name == 'zeta-chain/node'
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_ONLY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: github.event.repository.full_name == 'never-chain/node'
+        if: github.event.repository.full_name == 'zetachain-chain/node'
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_ONLY }}


### PR DESCRIPTION
# Description

Added a conditional Docker Hub login step for the job to run in the build.yml when a PR is created from the zeta-chain/node repository, and does not require Docker Hub login when it is an external contributor.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions 

# Checklist:

- [x] I have added unit tests that prove my fix feature works
