### PR TITLE
fix: generation of OpenAPI by downgrading a buf plugin

### DIFF
--- a/docs/openapi/openapi.swagger.yaml
+++ b/docs/openapi/openapi.swagger.yaml
@@ -26462,1236 +26462,1236 @@ paths:
           type: boolean
       tags:
         - Query
-  /zeta-chain/crosschain/TSS: |
+  /zeta-chain/crosschain/TSS:
     get:
-        summary: Queries a tSS by index.
-        operationId: Query_TSS
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetTSSResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/crosschain/cctx: |
+      summary: Queries a tSS by index.
+      operationId: Query_TSS
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetTSSResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/crosschain/cctx:
     get:
-        summary: Queries a list of send items.
-        operationId: Query_CctxAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllCctxResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of send items.
+      operationId: Query_CctxAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllCctxResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/cctx/{chainID}/{nonce}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/cctx/{chainID}/{nonce}:
     get:
-        summary: Queries a send by nonce.
-        operationId: Query_CctxByNonce
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetCctxResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: chainID
-              in: path
-              required: true
-              type: string
-              format: int64
-            - name: nonce
-              in: path
-              required: true
-              type: string
-              format: uint64
-        tags:
-            - Query
-  /zeta-chain/crosschain/cctx/{index}: |
+      summary: Queries a send by nonce.
+      operationId: Query_CctxByNonce
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetCctxResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: chainID
+          in: path
+          required: true
+          type: string
+          format: int64
+        - name: nonce
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /zeta-chain/crosschain/cctx/{index}:
     get:
-        summary: Queries a send by index.
-        operationId: Query_Cctx
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetCctxResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: index
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/cctxPending: |
+      summary: Queries a send by index.
+      operationId: Query_Cctx
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetCctxResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/cctxPending:
     get:
-        summary: Queries a list of send items.
-        operationId: Query_CctxAllPending
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllCctxPendingResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: chainId
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of send items.
+      operationId: Query_CctxAllPending
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllCctxPendingResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: chainId
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/chainNonces: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/chainNonces:
     get:
-        summary: Queries a list of chainNonces items.
-        operationId: Query_ChainNoncesAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllChainNoncesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of chainNonces items.
+      operationId: Query_ChainNoncesAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllChainNoncesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/chainNonces/{index}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/chainNonces/{index}:
     get:
-        summary: Queries a chainNonces by index.
-        operationId: Query_ChainNonces
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetChainNoncesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: index
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/convertGasToZeta: |
+      summary: Queries a chainNonces by index.
+      operationId: Query_ChainNonces
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetChainNoncesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/convertGasToZeta:
     get:
-        operationId: Query_ConvertGasToZeta
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryConvertGasToZetaResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: chainId
-              in: query
-              required: false
-              type: string
-              format: int64
-            - name: gasLimit
-              in: query
-              required: false
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/gasPrice: |
+      operationId: Query_ConvertGasToZeta
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryConvertGasToZetaResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: chainId
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: gasLimit
+          in: query
+          required: false
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/gasPrice:
     get:
-        summary: Queries a list of gasPrice items.
-        operationId: Query_GasPriceAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllGasPriceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of gasPrice items.
+      operationId: Query_GasPriceAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllGasPriceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/gasPrice/{index}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/gasPrice/{index}:
     get:
-        summary: Queries a gasPrice by index.
-        operationId: Query_GasPrice
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetGasPriceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: index
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/get_tss_address: |
+      summary: Queries a gasPrice by index.
+      operationId: Query_GasPrice
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetGasPriceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/get_tss_address:
     get:
-        summary: Queries a list of GetTssAddress items.
-        operationId: Query_GetTssAddress
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetTssAddressResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/crosschain/inTxHashToCctx: |
+      summary: Queries a list of GetTssAddress items.
+      operationId: Query_GetTssAddress
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetTssAddressResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/crosschain/in_tx_hash_to_cctx_data/{inTxHash}:
     get:
-        summary: Queries a list of InTxHashToCctx items.
-        operationId: Query_InTxHashToCctxAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllInTxHashToCctxResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a InTxHashToCctx data by index.
+      operationId: Query_InTxHashToCctxData
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryInTxHashToCctxDataResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: inTxHash
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/inTxHashToCctx:
+    get:
+      summary: Queries a list of InTxHashToCctx items.
+      operationId: Query_InTxHashToCctxAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllInTxHashToCctxResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/inTxHashToCctx/{inTxHash}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/inTxHashToCctx/{inTxHash}:
     get:
-        summary: Queries a InTxHashToCctx by index.
-        operationId: Query_InTxHashToCctx
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetInTxHashToCctxResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: inTxHash
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/in_tx_hash_to_cctx_data/{inTxHash}: |
+      summary: Queries a InTxHashToCctx by index.
+      operationId: Query_InTxHashToCctx
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetInTxHashToCctxResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: inTxHash
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/lastBlockHeight:
     get:
-        summary: Queries a InTxHashToCctx data by index.
-        operationId: Query_InTxHashToCctxData
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryInTxHashToCctxDataResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: inTxHash
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/lastBlockHeight: |
-    get:
-        summary: Queries a list of lastBlockHeight items.
-        operationId: Query_LastBlockHeightAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllLastBlockHeightResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of lastBlockHeight items.
+      operationId: Query_LastBlockHeightAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllLastBlockHeightResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/lastBlockHeight/{index}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/lastBlockHeight/{index}:
     get:
-        summary: Queries a lastBlockHeight by index.
-        operationId: Query_LastBlockHeight
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetLastBlockHeightResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: index
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/crosschain/lastZetaHeight: |
+      summary: Queries a lastBlockHeight by index.
+      operationId: Query_LastBlockHeight
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetLastBlockHeightResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/crosschain/lastZetaHeight:
     get:
-        summary: Queries a list of lastMetaHeight items.
-        operationId: Query_LastZetaHeight
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryLastZetaHeightResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/crosschain/outTxTracker: |
+      summary: Queries a list of lastMetaHeight items.
+      operationId: Query_LastZetaHeight
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryLastZetaHeightResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/crosschain/outTxTracker:
     get:
-        summary: Queries a list of OutTxTracker items.
-        operationId: Query_OutTxTrackerAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllOutTxTrackerResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of OutTxTracker items.
+      operationId: Query_OutTxTrackerAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllOutTxTrackerResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/outTxTracker/{chainID}/{nonce}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/outTxTracker/{chainID}/{nonce}:
     get:
-        summary: Queries a OutTxTracker by index.
-        operationId: Query_OutTxTracker
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryGetOutTxTrackerResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: chainID
-              in: path
-              required: true
-              type: string
-              format: int64
-            - name: nonce
-              in: path
-              required: true
-              type: string
-              format: uint64
-        tags:
-            - Query
-  /zeta-chain/crosschain/outTxTrackerByChain: |
+      summary: Queries a OutTxTracker by index.
+      operationId: Query_OutTxTracker
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryGetOutTxTrackerResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: chainID
+          in: path
+          required: true
+          type: string
+          format: int64
+        - name: nonce
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /zeta-chain/crosschain/outTxTrackerByChain:
     get:
-        operationId: Query_OutTxTrackerAllByChain
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllOutTxTrackerByChainResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: chain
-              in: query
-              required: false
-              type: string
-              format: int64
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      operationId: Query_OutTxTrackerAllByChain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllOutTxTrackerByChainResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: chain
+          in: query
+          required: false
+          type: string
+          format: int64
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/crosschain/params: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/crosschain/params:
     get:
-        summary: Parameters queries the parameters of the module.
-        operationId: Query_Params
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/zetacorecrosschainQueryParamsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/crosschain/pendingNonces: |
+      summary: Parameters queries the parameters of the module.
+      operationId: Query_Params
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/zetacorecrosschainQueryParamsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/crosschain/pendingNonces:
     get:
-        operationId: Query_PendingNoncesAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryAllPendingNoncesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/crosschain/protocolFee: |
+      operationId: Query_PendingNoncesAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryAllPendingNoncesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/crosschain/protocolFee:
     get:
-        operationId: Query_ProtocolFee
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryMessagePassingProtocolFeeResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/crosschain/tssHistory: |
+      operationId: Query_ProtocolFee
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryMessagePassingProtocolFeeResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/crosschain/tssHistory:
     get:
-        operationId: Query_TssHistory
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/crosschainQueryTssHistoryResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/all_observer_mappers: |
+      operationId: Query_TssHistory
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/crosschainQueryTssHistoryResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/all_observer_mappers:
     get:
-        operationId: Query_AllObserverMappers
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryAllObserverMappersResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/ballot_by_identifier/{ballot_identifier}: |
+      operationId: Query_AllObserverMappers
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryAllObserverMappersResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/ballot_by_identifier/{ballot_identifier}:
     get:
-        summary: Queries a list of VoterByIdentifier items.
-        operationId: Query_BallotByIdentifier
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryBallotByIdentifierResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: ballot_identifier
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/observer/blame_by_identifier/{blame_identifier}: |
+      summary: Queries a list of VoterByIdentifier items.
+      operationId: Query_BallotByIdentifier
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryBallotByIdentifierResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: ballot_identifier
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/observer/blame_by_identifier/{blame_identifier}:
     get:
-        summary: Queries a list of VoterByIdentifier items.
-        operationId: Query_BlameByIdentifier
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryBlameByIdentifierResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: blame_identifier
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/observer/get_all_blame_records: |
+      summary: Queries a list of VoterByIdentifier items.
+      operationId: Query_BlameByIdentifier
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryBlameByIdentifierResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: blame_identifier
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/observer/get_all_blame_records:
     get:
-        summary: Queries a list of VoterByIdentifier items.
-        operationId: Query_GetAllBlameRecords
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryAllBlameRecordsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/get_client_params_for_chain/{chain_id}: |
+      summary: Queries a list of VoterByIdentifier items.
+      operationId: Query_GetAllBlameRecords
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryAllBlameRecordsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/get_client_params_for_chain/{chain_id}:
     get:
-        summary: Queries a list of GetClientParamsForChain items.
-        operationId: Query_GetCoreParamsForChain
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryGetCoreParamsForChainResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: chain_id
-              in: path
-              required: true
-              type: string
-              format: int64
-        tags:
-            - Query
-  /zeta-chain/observer/get_core_params: |
+      summary: Queries a list of GetClientParamsForChain items.
+      operationId: Query_GetCoreParamsForChain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryGetCoreParamsForChainResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: chain_id
+          in: path
+          required: true
+          type: string
+          format: int64
+      tags:
+        - Query
+  /zeta-chain/observer/get_core_params:
     get:
-        summary: Queries a list of GetCoreParams items.
-        operationId: Query_GetCoreParams
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryGetCoreParamsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/keygen: |
+      summary: Queries a list of GetCoreParams items.
+      operationId: Query_GetCoreParams
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryGetCoreParamsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/keygen:
     get:
-        summary: Queries a keygen by index.
-        operationId: Query_Keygen
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryGetKeygenResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/nodeAccount: |
+      summary: Queries a keygen by index.
+      operationId: Query_Keygen
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryGetKeygenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/nodeAccount:
     get:
-        summary: Queries a list of nodeAccount items.
-        operationId: Query_NodeAccountAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryAllNodeAccountResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of nodeAccount items.
+      operationId: Query_NodeAccountAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryAllNodeAccountResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/observer/nodeAccount/{index}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/observer/nodeAccount/{index}:
     get:
-        summary: Queries a nodeAccount by index.
-        operationId: Query_NodeAccount
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryGetNodeAccountResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: index
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/observer/observers_by_chain/{observation_chain}: |
+      summary: Queries a nodeAccount by index.
+      operationId: Query_NodeAccount
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryGetNodeAccountResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/observer/observers_by_chain/{observation_chain}:
     get:
-        summary: Queries a list of ObserversByChainAndType items.
-        operationId: Query_ObserversByChain
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryObserversByChainResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: observation_chain
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/observer/params: |
+      summary: Queries a list of ObserversByChainAndType items.
+      operationId: Query_ObserversByChain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryObserversByChainResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: observation_chain
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/observer/params:
     get:
-        summary: Parameters queries the parameters of the module.
-        operationId: Query_Params
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/zetacoreobserverQueryParamsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/permission_flags: |
+      summary: Parameters queries the parameters of the module.
+      operationId: Query_Params
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/zetacoreobserverQueryParamsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/permission_flags:
     get:
-        operationId: Query_PermissionFlags
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryGetPermissionFlagsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/observer/supportedChains: |
+      operationId: Query_PermissionFlags
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryGetPermissionFlagsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/observer/supportedChains:
     get:
-        operationId: Query_SupportedChains
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQuerySupportedChainsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/zetacore/emissions/get_emmisons_factors: |
+      operationId: Query_SupportedChains
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQuerySupportedChainsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/zetacore/emissions/get_emmisons_factors:
     get:
-        summary: Queries a list of GetEmmisonsFactors items.
-        operationId: Query_GetEmmisonsFactors
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/emissionsQueryGetEmmisonsFactorsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/zetacore/emissions/list_addresses: |
+      summary: Queries a list of GetEmmisonsFactors items.
+      operationId: Query_GetEmmisonsFactors
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/emissionsQueryGetEmmisonsFactorsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/zetacore/emissions/list_addresses:
     get:
-        summary: Queries a list of ListBalances items.
-        operationId: Query_ListPoolAddresses
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/emissionsQueryListPoolAddressesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/zetacore/emissions/params: |
+      summary: Queries a list of ListBalances items.
+      operationId: Query_ListPoolAddresses
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/emissionsQueryListPoolAddressesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/zetacore/emissions/params:
     get:
-        summary: Parameters queries the parameters of the module.
-        operationId: Query_Params
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/zetacoreemissionsQueryParamsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/zetacore/emissions/show_available_emissions/{address}: |
+      summary: Parameters queries the parameters of the module.
+      operationId: Query_Params
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/zetacoreemissionsQueryParamsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/zetacore/emissions/show_available_emissions/{address}:
     get:
-        summary: Queries a list of ShowAvailableEmissions items.
-        operationId: Query_ShowAvailableEmissions
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/emissionsQueryShowAvailableEmissionsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: address
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/zetacore/fungible/foreign_coins: |
+      summary: Queries a list of ShowAvailableEmissions items.
+      operationId: Query_ShowAvailableEmissions
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/emissionsQueryShowAvailableEmissionsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: address
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/zetacore/fungible/foreign_coins:
     get:
-        summary: Queries a list of ForeignCoins items.
-        operationId: Query_ForeignCoinsAll
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/fungibleQueryAllForeignCoinsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: pagination.key
-              description: |-
-                key is a value returned in PageResponse.next_key to begin
-                querying the next page most efficiently. Only one of offset or key
-                should be set.
-              in: query
-              required: false
-              type: string
-              format: byte
-            - name: pagination.offset
-              description: |-
-                offset is a numeric offset that can be used when key is unavailable.
-                It is less efficient than using key. Only one of offset or key should
-                be set.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.limit
-              description: |-
-                limit is the total number of results to be returned in the result page.
-                If left empty it will default to a value to be set by each app.
-              in: query
-              required: false
-              type: string
-              format: uint64
-            - name: pagination.count_total
-              description: |-
-                count_total is set to true  to indicate that the result set should include
-                a count of the total number of items available for pagination in UIs.
-                count_total is only respected when offset is used. It is ignored when key
-                is set.
-              in: query
-              required: false
-              type: boolean
-            - name: pagination.reverse
-              description: |-
-                reverse is set to true if results are to be returned in the descending order.
+      summary: Queries a list of ForeignCoins items.
+      operationId: Query_ForeignCoinsAll
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/fungibleQueryAllForeignCoinsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: |-
+            offset is a numeric offset that can be used when key is unavailable.
+            It is less efficient than using key. Only one of offset or key should
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: |-
+            limit is the total number of results to be returned in the result page.
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: |-
+            count_total is set to true  to indicate that the result set should include
+            a count of the total number of items available for pagination in UIs.
+            count_total is only respected when offset is used. It is ignored when key
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: |-
+            reverse is set to true if results are to be returned in the descending order.
 
-                Since: cosmos-sdk 0.43
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - Query
-  /zeta-chain/zetacore/fungible/foreign_coins/{index}: |
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /zeta-chain/zetacore/fungible/foreign_coins/{index}:
     get:
-        summary: Queries a ForeignCoins by index.
-        operationId: Query_ForeignCoins
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/fungibleQueryGetForeignCoinsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        parameters:
-            - name: index
-              in: path
-              required: true
-              type: string
-        tags:
-            - Query
-  /zeta-chain/zetacore/fungible/params: |
+      summary: Queries a ForeignCoins by index.
+      operationId: Query_ForeignCoins
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/fungibleQueryGetForeignCoinsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /zeta-chain/zetacore/fungible/params:
     get:
-        summary: Parameters queries the parameters of the module.
-        operationId: Query_Params
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/zetacorefungibleQueryParamsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/zetacore/fungible/system_contract: |
+      summary: Parameters queries the parameters of the module.
+      operationId: Query_Params
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/zetacorefungibleQueryParamsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/zetacore/fungible/system_contract:
     get:
-        summary: Queries a ZetaDepositAndCallContract by index.
-        operationId: Query_SystemContract
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/fungibleQueryGetSystemContractResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
-  /zeta-chain/zetacore/observer/show_observer_count: |
+      summary: Queries a ZetaDepositAndCallContract by index.
+      operationId: Query_SystemContract
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/fungibleQueryGetSystemContractResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
+  /zeta-chain/zetacore/observer/show_observer_count:
     get:
-        summary: Queries a list of ShowObserverCount items.
-        operationId: Query_ShowObserverCount
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/observerQueryShowObserverCountResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/googlerpcStatus'
-        tags:
-            - Query
+      summary: Queries a list of ShowObserverCount items.
+      operationId: Query_ShowObserverCount
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/observerQueryShowObserverCountResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Query
 definitions:
   cosmos.auth.v1beta1.AddressBytesToStringResponse:
     type: object

--- a/scripts/protoc-gen-openapi.sh
+++ b/scripts/protoc-gen-openapi.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
+go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.16.2
 
 go mod download
 


### PR DESCRIPTION
Downgraded to the version without this bug. We shouldn't be using `latest` anyway. We can upgrade manually once the underlying issue is resolved in `go-yaml`.

closes https://github.com/zeta-chain/node/issues/1078