### PR TITLE
fix: hotfix staging PR, DON'T merge

### DIFF
--- a/zetaclient/bitcoin_client.go
+++ b/zetaclient/bitcoin_client.go
@@ -949,7 +949,8 @@ func (ob *BitcoinChainClient) ValidateCctxParams(params *types.OutboundTxParams)
 	}
 
 	// validate amount
-	if params.Amount.Uint64() == 0 {
+	_, err = getSatoshis(float64(params.Amount.Uint64()) / 1e8)
+	if err != nil {
 		return fmt.Errorf("ValidateCctxParams: invalid amount %d", params.Amount)
 	}
 	return nil
@@ -961,7 +962,7 @@ func (ob *BitcoinChainClient) ValidateCctxParams(params *types.OutboundTxParams)
 //   - The third output is the change to TSS (optional)
 func (ob *BitcoinChainClient) checkTSSVout(vouts []btcjson.Vout, params types.OutboundTxParams, nonce uint64) error {
 	if err := ob.ValidateCctxParams(&params); err != nil {
-		ob.logger.ObserveOutTx.Info().Err(err).Msgf("checkTSSVout: skip checking invalid cctx parameters: %v", params)
+		ob.logger.ObserveOutTx.Error().Err(err).Msgf("checkTSSVout: skip checking invalid cctx parameters: %v", params)
 		return nil
 	}
 

--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -253,13 +253,13 @@ func (signer *BTCSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 	}
 
 	// FIXME: config chain params
-	validSendSofar := true // TODO: receiver validation should be done in zeta core to block invalid cctx
 	addr, err := btcutil.DecodeAddress(params.Receiver, config.BitconNetParams)
 	if err != nil {
-		validSendSofar = false
 		logger.Error().Err(err).Msgf("cannot decode address %s ", params.Receiver)
-		//return
+		return
 	}
+
+	validSendSofar := true // TODO: receiver validation should be done in zeta core to block invalid cctx
 	to, ok := addr.(*btcutil.AddressWitnessPubKeyHash)
 	if err != nil || !ok {
 		validSendSofar = false

--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -126,11 +126,11 @@ func (signer *BTCSigner) SignWithdrawTx(to *btcutil.AddressWitnessPubKeyHash, am
 	tx.AddTxOut(txOut1)
 
 	// 2nd output: the payment to the recipient
-	pkScript, err := payToWitnessPubKeyHashScript(to.WitnessProgram())
-	if err != nil {
-		return nil, err
-	}
 	if validSendSofar { // skip payment to recipient on invalid cctx
+		pkScript, err := payToWitnessPubKeyHashScript(to.WitnessProgram())
+		if err != nil {
+			return nil, err
+		}
 		txOut2 := wire.NewTxOut(amountSatoshis, pkScript)
 		tx.AddTxOut(txOut2)
 	}
@@ -240,7 +240,7 @@ func (signer *BTCSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 	// Early return if the send is already processed
 	// FIXME: handle revert case
 	outboundTxTssNonce := params.OutboundTxTssNonce
-	included, confirmed, _ := btcClient.IsSendOutTxProcessed(send.Index, outboundTxTssNonce, common.CoinType_Gas, logger)
+	included, confirmed, _ := btcClient.IsSendOutTxProcessed(send.Index, outboundTxTssNonce, common.CoinType_Gas, logger, float64(params.Amount.Uint64())/1e8)
 	if included || confirmed {
 		logger.Info().Msgf("CCTX already processed; exit signer")
 		return
@@ -263,7 +263,7 @@ func (signer *BTCSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 	to, ok := addr.(*btcutil.AddressWitnessPubKeyHash)
 	if err != nil || !ok {
 		validSendSofar = false
-		logger.Error().Err(err).Msgf("cannot decode address %s ", params.Receiver)
+		logger.Error().Err(err).Msgf("cannot convert address %s to P2WPKH address", params.Receiver)
 		//return
 	}
 

--- a/zetaclient/chainclient.go
+++ b/zetaclient/chainclient.go
@@ -15,7 +15,7 @@ type ChainClient interface {
 	Start()
 	Stop()
 	//GetBaseGasPrice() *big.Int
-	IsSendOutTxProcessed(sendHash string, nonce uint64, cointype common.CoinType, logger zerolog.Logger) (bool, bool, error)
+	IsSendOutTxProcessed(sendHash string, nonce uint64, cointype common.CoinType, logger zerolog.Logger, sendAmount float64) (bool, bool, error)
 	//PostNonceIfNotRecorded(logger zerolog.Logger) error
 	SetCoreParams(observertypes.CoreParams)
 	GetCoreParams() observertypes.CoreParams

--- a/zetaclient/evm_client.go
+++ b/zetaclient/evm_client.go
@@ -214,7 +214,7 @@ func (ob *EVMChainClient) Stop() {
 
 // returns: isIncluded, isConfirmed, Error
 // If isConfirmed, it also post to ZetaCore
-func (ob *EVMChainClient) IsSendOutTxProcessed(sendHash string, nonce uint64, cointype common.CoinType, logger zerolog.Logger) (bool, bool, error) {
+func (ob *EVMChainClient) IsSendOutTxProcessed(sendHash string, nonce uint64, cointype common.CoinType, logger zerolog.Logger, _ float64) (bool, bool, error) {
 	ob.mu.Lock()
 	params := ob.params
 	receipt, found1 := ob.outTXConfirmedReceipts[ob.GetTxID(nonce)]

--- a/zetaclient/evm_signer.go
+++ b/zetaclient/evm_signer.go
@@ -282,7 +282,7 @@ func (signer *EVMSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 	}
 
 	// Early return if the cctx is already processed
-	included, confirmed, err := evmClient.IsSendOutTxProcessed(send.Index, send.GetCurrentOutTxParam().OutboundTxTssNonce, send.GetCurrentOutTxParam().CoinType, logger)
+	included, confirmed, err := evmClient.IsSendOutTxProcessed(send.Index, send.GetCurrentOutTxParam().OutboundTxTssNonce, send.GetCurrentOutTxParam().CoinType, logger, 0)
 	if err != nil {
 		logger.Error().Err(err).Msg("IsSendOutTxProcessed failed")
 	}

--- a/zetaclient/zetacore_observer.go
+++ b/zetaclient/zetacore_observer.go
@@ -165,7 +165,7 @@ func (co *CoreObserver) startSendScheduler() {
 							}
 
 							// Monitor Core Logger for OutboundTxTssNonce
-							included, _, err := ob.IsSendOutTxProcessed(send.Index, params.OutboundTxTssNonce, params.CoinType, co.logger.ZetaChainWatcher)
+							included, _, err := ob.IsSendOutTxProcessed(send.Index, params.OutboundTxTssNonce, params.CoinType, co.logger.ZetaChainWatcher, float64(params.Amount.Uint64())/1e8)
 							if err != nil {
 								co.logger.ZetaChainWatcher.Error().Err(err).Msgf("IsSendOutTxProcessed fail, Chain ID: %s", c.ChainName)
 								continue


### PR DESCRIPTION
# Description

Hotfix to invalid cctx that contains unsupported address and ZERO amount.

Bitcoin outbound got stuck at CCTX of nonce 51 : http://46.4.15.110:1317/zeta-chain/crosschain/cctx/18332/51 The signers have been retrying processing this CCTX and but fail at decoding recipient's address 2Mz1XjXzgQCxXfazTAmsTAj46dQkmAdK5X2 (in screenshot). We now have a simulated nonce for Bitcoin to strictly sequence outbound CCTXes, therefore blocking all subsequent outbound CCTXes with higher (> 51) nonces

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
