### PR TITLE
fix: some data race warnings in zetaclient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ build-testnet-ubuntu: go.sum
 
 install: go.sum
 		@echo "--> Installing zetacored & zetaclientd"
-		@go install -mod=readonly $(BUILD_FLAGS) ./cmd/zetacored
-		@go install -mod=readonly $(BUILD_FLAGS) ./cmd/zetaclientd
+		@go install -race -mod=readonly $(BUILD_FLAGS) ./cmd/zetacored
+		@go install -race -mod=readonly $(BUILD_FLAGS) ./cmd/zetaclientd
 
 install-zetaclient: go.sum
 		@echo "--> Installing zetaclientd"

--- a/zetaclient/broadcast.go
+++ b/zetaclient/broadcast.go
@@ -119,7 +119,10 @@ func (b *ZetaCoreBridge) GetContext() client.Context {
 	ctx = ctx.WithFromAddress(addr)
 	ctx = ctx.WithBroadcastMode("sync")
 
+	b.encodingLock.Lock()
 	encodingConfig := app.MakeEncodingConfig()
+	b.encodingLock.Unlock()
+
 	ctx = ctx.WithCodec(encodingConfig.Codec)
 	ctx = ctx.WithInterfaceRegistry(encodingConfig.InterfaceRegistry)
 	ctx = ctx.WithTxConfig(encodingConfig.TxConfig)

--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -92,6 +92,13 @@ func (c *Config) GetKeygen() observertypes.Keygen {
 	}
 }
 
+func (c *Config) SetKeygen(keygen *observertypes.Keygen) {
+	c.cfgLock.Lock()
+	defer c.cfgLock.Unlock()
+
+	c.Keygen = *keygen
+}
+
 func (c *Config) GetEnabledChains() []common.Chain {
 	c.cfgLock.RLock()
 	defer c.cfgLock.RUnlock()

--- a/zetaclient/tss_signer.go
+++ b/zetaclient/tss_signer.go
@@ -103,6 +103,7 @@ func (tss *TSS) Sign(digest []byte, height uint64, chain *common.Chain, optional
 		tssPubkey = optionalPubKey
 	}
 	keysignReq := keysign.NewRequest(tssPubkey, []string{base64.StdEncoding.EncodeToString(H)}, int64(height), nil, "0.14.0")
+	//Encoding Data Race during keysign, will skip the lock for now to avoid slowing it down
 	ksRes, err := tss.Server.KeySign(keysignReq)
 	if err != nil {
 		log.Warn().Msg("keysign fail")
@@ -141,10 +142,15 @@ func (tss *TSS) Sign(digest []byte, height uint64, chain *common.Chain, optional
 		log.Warn().Err(err).Msgf("signature has length 0")
 		return [65]byte{}, fmt.Errorf("keysign fail: %s", err)
 	}
-	if !verifySignature(tssPubkey, signature, H) {
+
+	tss.CoreBridge.encodingLock.RLock()
+	verified := verifySignature(tssPubkey, signature, H)
+	tss.CoreBridge.encodingLock.RUnlock()
+	if !verified {
 		log.Error().Err(err).Msgf("signature verification failure")
 		return [65]byte{}, fmt.Errorf("signuature verification fail")
 	}
+
 	var sigbyte [65]byte
 	_, err = base64.StdEncoding.Decode(sigbyte[:32], []byte(signature[0].R))
 	if err != nil {
@@ -173,6 +179,7 @@ func (tss *TSS) SignBatch(digests [][]byte, height uint64, chain *common.Chain) 
 		digestBase64[i] = base64.StdEncoding.EncodeToString(digest)
 	}
 	keysignReq := keysign.NewRequest(tssPubkey, digestBase64, int64(height), nil, "0.14.0")
+	//Encoding Data Race during keysign, will skip the lock for now to avoid slowing it down
 	ksRes, err := tss.Server.KeySign(keysignReq)
 	if err != nil {
 		log.Warn().Err(err).Msg("keysign fail")
@@ -215,7 +222,9 @@ func (tss *TSS) SignBatch(digests [][]byte, height uint64, chain *common.Chain) 
 	//	log.Error().Err(err).Msgf("signature verification failure")
 	//	return [][65]byte{}, fmt.Errorf("signuature verification fail")
 	//}
+	tss.CoreBridge.encodingLock.RLock()
 	pubkey, err := zcommon.GetPubKeyFromBech32(zcommon.Bech32PubKeyTypeAccPub, tssPubkey)
+	tss.CoreBridge.encodingLock.Unlock()
 	if err != nil {
 		log.Error().Msg("get pubkey from bech32 fail")
 	}
@@ -275,6 +284,8 @@ func (tss *TSS) Validate() error {
 }
 
 func (tss *TSS) EVMAddress() ethcommon.Address {
+	tss.CoreBridge.encodingLock.RLock()
+	defer tss.CoreBridge.encodingLock.RUnlock()
 	addr, err := GetTssAddrEVM(tss.CurrentPubkey)
 	if err != nil {
 		log.Error().Err(err).Msg("getKeyAddr error")
@@ -285,6 +296,8 @@ func (tss *TSS) EVMAddress() ethcommon.Address {
 
 // generate a bech32 p2wpkh address from pubkey
 func (tss *TSS) BTCAddress() string {
+	tss.CoreBridge.encodingLock.RLock()
+	defer tss.CoreBridge.encodingLock.RUnlock()
 	addr, err := GetTssAddrBTC(tss.CurrentPubkey)
 	if err != nil {
 		log.Error().Err(err).Msg("getKeyAddr error")
@@ -303,6 +316,8 @@ func (tss *TSS) BTCAddressWitnessPubkeyHash() *btcutil.AddressWitnessPubKeyHash 
 }
 
 func (tss *TSS) PubKeyCompressedBytes() []byte {
+	tss.CoreBridge.encodingLock.RLock()
+	defer tss.CoreBridge.encodingLock.RUnlock()
 	pubk, err := zcommon.GetPubKeyFromBech32(zcommon.Bech32PubKeyTypeAccPub, tss.CurrentPubkey)
 	if err != nil {
 		log.Error().Err(err).Msg("PubKeyCompressedBytes error")

--- a/zetaclient/zetabridge.go
+++ b/zetaclient/zetabridge.go
@@ -48,6 +48,7 @@ type ZetaCoreBridge struct {
 	cfg           config.ClientConfiguration
 	keys          *Keys
 	broadcastLock *sync.RWMutex
+	encodingLock  *sync.RWMutex
 	zetaChainID   string
 	//ChainNonces         map[string]uint64 // FIXME: Remove this?
 	lastOutTxReportTime map[string]time.Time
@@ -94,6 +95,7 @@ func NewZetaCoreBridge(k *Keys, chainIP string, signerName string, chainID strin
 		cfg:                 cfg,
 		keys:                k,
 		broadcastLock:       &sync.RWMutex{},
+		encodingLock:        &sync.RWMutex{},
 		lastOutTxReportTime: map[string]time.Time{},
 		stop:                make(chan struct{}),
 		zetaChainID:         chainID,
@@ -192,9 +194,10 @@ func (b *ZetaCoreBridge) UpdateConfigFromCore(cfg *config.Config, init bool) err
 	if err != nil {
 		b.logger.Info().Msg("Unable to fetch keygen from zetacore")
 	}
-	cfg.UpdateCoreParams(keyGen, newChains, newEVMParams, newBTCParams, init, b.logger)
 
-	cfg.Keygen = *keyGen
+	cfg.UpdateCoreParams(keyGen, newChains, newEVMParams, newBTCParams, init, b.logger)
+	cfg.SetKeygen(keyGen)
+
 	tss, err := b.GetCurrentTss()
 	if err != nil {
 		b.logger.Error().Err(err).Msg("Unable to fetch TSS from zetacore")


### PR DESCRIPTION
# Description

Fixed 2 main data race issues found during smoketest:

* Keygen field in config is being written to while being queried elsewhere
* During broadcast, the amino encoding config is being written to. A race condition occurs when attempting to use the amino lib for encoding.

Added another mutex for the encoding lib to avoid the race condition. Another solution can be to skip updating or creating this config every time we broadcast. Not sure if this is possible since it seems like it is part of app. Please comment if there is a way to do this.
```
// MakeEncodingConfig creates an EncodingConfig for testing
func MakeEncodingConfig() params.EncodingConfig {
	//encodingConfig := params.MakeEncodingConfig()
	encodingConfig := evmenc.MakeConfig(ModuleBasics)
	//std.RegisterLegacyAminoCodec(encodingConfig.Amino)
	//std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
	//ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
	//ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
	return encodingConfig
} 
```
Closes: (https://github.com/zeta-chain/node/issues/1054)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

