### PR TITLE
fix: Staging PR for hotfix v9.0.6, DON'T Merge!

### DIFF
--- a/zetaclient/evm_client.go
+++ b/zetaclient/evm_client.go
@@ -903,7 +903,7 @@ func (ob *EVMChainClient) WatchGasPrice() {
 				height, _ := ob.zetaClient.GetBlockHeight()
 				ob.logger.WatchGasPrice.Error().Err(err).Msgf("PostGasPrice error at zeta block : %d  ", height)
 			}
-			ticker.UpdateInterval(ob.GetCoreParams().InTxTicker, ob.logger.WatchGasPrice)
+			ticker.UpdateInterval(ob.GetCoreParams().GasPriceTicker, ob.logger.WatchGasPrice)
 		case <-ob.stop:
 			ob.logger.WatchGasPrice.Info().Msg("WatchGasPrice stopped")
 			return


### PR DESCRIPTION
# Description

1. Fix Bitcoin fetching UTXO performance issue. Fetching UTXOs by trunk takes 260 seconds and we can actually fetch them all in 160 ms.
2. There was a typo introduced in EVM GasPrice ticker and that caused too many GasPriceVoter txns. Correcting this will potentially solve the sequence number mismatch issue which happened since 2nd September (see screenshot).

![image](https://github.com/zeta-chain/node/assets/34498985/48c94c32-8ba2-45de-8261-a111242ec952)



Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
