### PR TITLE
fix: cherry pick v9.0.8 hotfix (fix Bitcoin amount verification)

### DIFF
--- a/zetaclient/utils.go
+++ b/zetaclient/utils.go
@@ -16,7 +16,7 @@ const (
 func getSatoshis(btc float64) (int64, error) {
 	// The amount is only considered invalid if it cannot be represented
 	// as an integer type.  This may happen if f is NaN or +-Infinity.
-	// BTC max amount is 21 mil and its at least 10^(-8) or one satoshi.
+	// BTC max amount is 21 mil and its at least 0 (Note: bitcoin allows creating 0-value outputs)
 	switch {
 	case math.IsNaN(btc):
 		fallthrough
@@ -26,8 +26,8 @@ func getSatoshis(btc float64) (int64, error) {
 		return 0, errors.New("invalid bitcoin amount")
 	case btc > 21000000.0:
 		return 0, errors.New("exceeded max bitcoin amount")
-	case btc < 0.00000001:
-		return 0, errors.New("cannot be less than 1 satoshi")
+	case btc < 0.0:
+		return 0, errors.New("cannot be less than zero")
 	}
 	return round(btc * satoshiPerBitcoin), nil
 }


### PR DESCRIPTION
# Description

`zetaclient` treat 0-value unspent UTXO as invalid while bitcoin actually allows creating and sending `0-value` UTXO to receiver (TSS). Zetaclient had several `0-value` unspent UTXOs in its possession and was not able to spend them due to the wrong logic is wrong in `getSatoshis` function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
