### PR TITLE
fix: use estimated gas rate for bitcoin outTx and put a cap on total fee

### DIFF
--- a/zetaclient/evm_signer.go
+++ b/zetaclient/evm_signer.go
@@ -24,6 +24,10 @@ import (
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
+const (
+	Gwei = 1_000_000_000
+)
+
 type EVMSigner struct {
 	client                      *ethclient.Client
 	chain                       *common.Chain
@@ -329,7 +333,7 @@ func (signer *EVMSigner) TryProcessOutTx(send *types.CrossChainTx, outTxMan *Out
 				logger.Error().Err(err).Msgf("cannot get gas price from chain %s ", toChain)
 				return
 			}
-			gasprice = roundUpToNearestGwei(suggested)
+			gasprice = roundGasPriceUp(suggested, Gwei) // round up to nearest gwei
 		} else {
 			logger.Error().Err(err).Msgf("cannot convert gas price  %s ", send.GetCurrentOutTxParam().OutboundTxGasPrice)
 			return
@@ -563,14 +567,4 @@ func (signer *EVMSigner) SignWhitelistTx(action string, _ ethcommon.Address, ass
 	}
 
 	return tx, nil
-}
-
-func roundUpToNearestGwei(gasPrice *big.Int) *big.Int {
-	oneGwei := big.NewInt(1_000_000_000) // 1 Gwei
-	mod := new(big.Int)
-	mod.Mod(gasPrice, oneGwei)
-	if mod.Cmp(big.NewInt(0)) == 0 { // gasprice is already a multiple of 1 Gwei
-		return gasPrice
-	}
-	return new(big.Int).Add(gasPrice, new(big.Int).Sub(oneGwei, mod))
 }

--- a/zetaclient/utils.go
+++ b/zetaclient/utils.go
@@ -3,6 +3,7 @@ package zetaclient
 import (
 	"errors"
 	"math"
+	"math/big"
 	"time"
 
 	"github.com/btcsuite/btcd/txscript"
@@ -39,6 +40,17 @@ func round(f float64) int64 {
 	}
 	// #nosec G701 always in range
 	return int64(f + 0.5)
+}
+
+// roundGasPriceUp rounds up the gasPrice to the nearest multiple of base
+func roundGasPriceUp(gasPrice *big.Int, base int64) *big.Int {
+	oneUnit := big.NewInt(base) // e.g. 1 Gwei
+	mod := new(big.Int)
+	mod.Mod(gasPrice, oneUnit)
+	if mod.Cmp(big.NewInt(0)) == 0 { // gasPrice is already a multiple of base
+		return gasPrice
+	}
+	return new(big.Int).Add(gasPrice, new(big.Int).Sub(oneUnit, mod))
 }
 
 func payToWitnessPubKeyHashScript(pubKeyHash []byte) ([]byte, error) {


### PR DESCRIPTION
# Description

We paid up to 3M satoshis ($800) in mock mainnet for bitcoin outTx which is way more than enough. A more reasonable gas price needs to be used.

1. Use estimated fee rate to send bitcoin outTx.
2. Put `0.001 BTC` as the cap of fee. (in case of accident)
3. Round gas price to multiple of `1000 satoshis` across TSS signers.

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
