### PR TITLE
fix: removed division by 1000 in fee calculation

### DIFF
--- a/zetaclient/btc_signer.go
+++ b/zetaclient/btc_signer.go
@@ -116,7 +116,6 @@ func (signer *BTCSigner) SignWithdrawTx(to *btcutil.AddressWitnessPubKeyHash, am
 
 	// fee calculation
 	fees := new(big.Int).Mul(big.NewInt(int64(txSize)), gasPrice)
-	fees.Div(fees, big.NewInt(bytesPerKB))
 	signer.logger.Info().Msgf("bitcoin outTx nonce %d gasPrice %s size %d fees %s", nonce, gasPrice.String(), txSize, fees.String())
 
 	// calculate remaining btc to TSS self


### PR DESCRIPTION
# Description

Remove the division by 100 in bitcoin outTx fee calculation.

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
