### PR TITLE
fix(`cmd`): add notice when using `--ledger` with Ethereum HD path

### DIFF
--- a/cmd/zetacored/main.go
+++ b/cmd/zetacored/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/server"
-	cmdcfg "github.com/zeta-chain/zetacore/cmd/zetacored/config"
-
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/zeta-chain/zetacore/app"
+	cmdcfg "github.com/zeta-chain/zetacore/cmd/zetacored/config"
 )
 
 func main() {
@@ -16,12 +17,37 @@ func main() {
 	rootCmd, _ := NewRootCmd()
 
 	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {
+
 		switch e := err.(type) {
 		case server.ErrorCode:
 			os.Exit(e.Code)
 
 		default:
+			processError(e)
 			os.Exit(1)
 		}
 	}
+}
+
+func processError(err error) {
+	// --ledger flag can't be used with Ethereum HD path
+	if strings.Contains(err.Error(), "cannot set custom bip32 path with ledger") {
+		printNotice([]string{
+			"note: --ledger flag can't be used with Ethereum HD path (used by default)",
+			"use --hd-path=\"\" in the command to use Cosmos HD path",
+		})
+		os.Exit(1)
+	}
+}
+
+func printNotice(messages []string) {
+	if len(messages) == 0 {
+		return
+	}
+	border := strings.Repeat("*", len(messages[0])+4) // 4 to account for padding
+	fmt.Println(border)
+	for _, message := range messages {
+		fmt.Printf("* %s \n", message)
+	}
+	fmt.Println(border)
 }

--- a/cmd/zetacored/root.go
+++ b/cmd/zetacored/root.go
@@ -155,13 +155,12 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig appparams.EncodingConfig
 		ethermintclient.KeyCommands(app.DefaultNodeHome),
 	)
 
-	// replace the default hd-path for the key add command
+	// replace the default hd-path for the key add command with Ethereum HD Path
 	if err := SetEthereumHDPath(rootCmd); err != nil {
 		fmt.Printf("warning: unable to set default HD path: %v\n", err)
 	}
 
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
-
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {


### PR DESCRIPTION
# Description

Add a notice to quickly figure out the issue when using `--ledger` with default HD path.

I realized that injecting logic at runtime for an existing command is non-trivial without a fork or wrap (which we don't want for this fix).
I instead added a notice below the execution if the error is `cannot set custom bip32 path with ledge`

```
$zetacored keys add testledger --ledger --account 0
Error: cannot set custom bip32 path with ledger
Usage:
  <appd> keys add <name> [flags]

Flags:
      --account uint32           Account number for HD derivation (less than equal 2147483647)
      --algo string              Key signing algorithm to generate keys for (default "eth_secp256k1")
      --coin-type uint32         coin type number for HD derivation (default 118)
      --dry-run                  Perform action, but don't add key to local keystore
      --hd-path string           Manual HD Path derivation (overrides BIP44 config) (default "m/44'/60'/0'/0/0")
  -h, --help                     help for add
      --index uint32             Address index number for HD derivation (less than equal 2147483647)
  -i, --interactive              Interactively prompt user for BIP39 passphrase and mnemonic
      --ledger                   Store a local reference to a private key on a Ledger device
      --multisig strings         List of key names stored in keyring to construct a public legacy multisig key
      --multisig-threshold int   K out of N required signatures. For use in conjunction with --multisig (default 1)
      --no-backup                Don't print out seed phrase (if others are watching the terminal)
      --nosort                   Keys passed to --multisig are taken in the order they're supplied
      --pubkey string            Parse a public key in JSON format and saves key info to <name> file.
      --recover                  Provide seed phrase to recover existing key instead of creating

Global Flags:
      --keyring-backend string   Select keyring's backend (os|file|test) (default "os")
      --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
      --log_format string        The logging format (json|plain) (default "plain")
      --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --output string            Output format (text|json) (default "text")
      --trace                    print out full stack trace on errors

*****************************************************************************
* note: --ledger flag can't be used with Ethereum HD path (used by default)
* use --hd-path="" in the command to use Cosmos HD path
*****************************************************************************
```

Closes: https://github.com/zeta-chain/node/issues/1284

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
