### PR TITLE
refactor: skip gas stability pool funding when gasLimit is equal gasUsed

### DIFF
--- a/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx.go
@@ -226,9 +226,13 @@ func (k Keeper) FundGasStabilityPoolFromRemainingFees(ctx sdk.Context, outboundT
 	gasLimit := outboundTxParams.OutboundTxEffectiveGasLimit
 	gasPrice := math.NewUintFromBigInt(outboundTxParams.OutboundTxEffectiveGasPrice.BigInt())
 
+	if (gasLimit == gasUsed) {
+		return nil
+	}
+
 	// We skip gas stability pool funding if one of the params is zero
 	if gasLimit > 0 && gasUsed > 0 && !gasPrice.IsZero() {
-		if gasLimit >= gasUsed {
+		if gasLimit > gasUsed {
 			remainingGas := gasLimit - gasUsed
 			remainingFees := math.NewUint(remainingGas).Mul(gasPrice).BigInt()
 

--- a/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx.go
@@ -226,7 +226,7 @@ func (k Keeper) FundGasStabilityPoolFromRemainingFees(ctx sdk.Context, outboundT
 	gasLimit := outboundTxParams.OutboundTxEffectiveGasLimit
 	gasPrice := math.NewUintFromBigInt(outboundTxParams.OutboundTxEffectiveGasPrice.BigInt())
 
-	if (gasLimit == gasUsed) {
+	if gasLimit == gasUsed {
 		return nil
 	}
 

--- a/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx_test.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx_test.go
@@ -27,7 +27,7 @@ func TestKeeper_FundGasStabilityPoolFromRemainingFees(t *testing.T) {
 		isError                               bool
 	}{
 		{
-			name:												"no call if gasLimit is equal to gasUsed",
+			name:                        "no call if gasLimit is equal to gasUsed",
 			effectiveGasLimit:           42,
 			gasUsed:                     42,
 			effectiveGasPrice:           math.NewInt(42),

--- a/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx_test.go
+++ b/x/crosschain/keeper/keeper_cross_chain_tx_vote_outbound_tx_test.go
@@ -27,6 +27,13 @@ func TestKeeper_FundGasStabilityPoolFromRemainingFees(t *testing.T) {
 		isError                               bool
 	}{
 		{
+			name:												"no call if gasLimit is equal to gasUsed",
+			effectiveGasLimit:           42,
+			gasUsed:                     42,
+			effectiveGasPrice:           math.NewInt(42),
+			expectFundStabilityPoolCall: false,
+		},
+		{
 			name:                        "no call if gasLimit is 0",
 			effectiveGasLimit:           0,
 			gasUsed:                     42,


### PR DESCRIPTION
# Description

Skip gas stability pool funding when gasLimit is equal gasUsed.

Closes: #1287 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [x] I have added unit tests that prove my fix feature works
