### PR TITLE
ci: add mainnet builds to goreleaser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@ yarn.lock
 .github/
 .gitignore
 dist/**
-```

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ package.json
 yarn.lock
 .github/
 .gitignore
+dist/**
+```

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+    branch:
+      - ci-mainnet-builds
 
 concurrency:
   group: publish-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,8 +3,8 @@ name: Publish Release
 on:
   push:
     tags:
-      - "v*.*.*"
-    branch:
+      - "v*.*.*"  
+    branches:
       - ci-mainnet-builds
 
 concurrency:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,9 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"  
-    branches:
-      - ci-mainnet-builds
-
+      
 concurrency:
   group: publish-release
   cancel-in-progress: false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -138,7 +138,7 @@ W
       - goos: windows
         goarch: arm64
     flags: &default_mainnet_flags
-      - -tags=MAINNET,pebbledb,ledger,cgo
+      - -tags=pebbledb,ledger,cgo
     ldflags: *default_ldflags
 
   - id: "zetaclientd_mainnet"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,7 +62,7 @@ builds:
       - -X github.com/zeta-chain/zetacore/common.CommitHash={{ .Env.COMMIT }}
       - -X github.com/zeta-chain/zetacore/common.BuildTime=={{ .Env.BUILDTIME }}
       - -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb 
-W
+
   - id: "zetaclientd_testnet"
     main: ./cmd/zetaclientd
     binary: "zetaclientd_testnet-{{ .Os }}-{{ .Arch }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,6 +121,46 @@ W
     flags: *default_mock_mainnet_flags
     ldflags: *default_ldflags
 
+  - id: "zetacored_mainnet"
+    main: ./cmd/zetacored
+    binary: "zetacored_mainnet-{{ .Os }}-{{ .Arch }}"
+    env:
+      - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
+      - 'CXX={{ index .Env (print "CXX_" .Os "_" .Arch) }}'
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - arm64
+      - amd64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags: &default_mainnet_flags
+      - -tags=MAINNET,pebbledb,ledger,cgo
+    ldflags: *default_ldflags
+
+  - id: "zetaclientd_mainnet"
+    main: ./cmd/zetaclientd
+    binary: "zetaclientd_mainnet-{{ .Os }}-{{ .Arch }}"
+    env:
+      - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
+      - 'CXX={{ index .Env (print "CXX_" .Os "_" .Arch) }}'
+    goos:
+      - linux
+      # - darwin
+      # - windows
+    goarch:
+      - arm64
+      - amd64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags: *default_mainnet_flags
+    ldflags: *default_ldflags
+
+
 archives:
   - format: binary
     name_template: "{{ .Binary }}"


### PR DESCRIPTION
# Description

Added mainnet builds to go releaser so binaries are available for testing only. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Goreleaser has been tested in the CI-testing fork of the repo. Mainnet builds that have been added replicate the build flags in the Makefile and should work. 


- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
