### PR TITLE
fix(`common`)!: bitcoin address validation to verify networks

### DIFF
--- a/common/address_test.go
+++ b/common/address_test.go
@@ -1,3 +1,6 @@
+//go:build TESTNET
+// +build TESTNET
+
 package common
 
 import (

--- a/common/chain.go
+++ b/common/chain.go
@@ -60,9 +60,12 @@ func (chain Chain) EncodeAddress(b []byte) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		_, err = btcutil.DecodeAddress(addrStr, chainParams)
+		addr, err := btcutil.DecodeAddress(addrStr, chainParams)
 		if err != nil {
 			return "", err
+		}
+		if !addr.IsForNet(chainParams) {
+			return "", fmt.Errorf("address is not for network %s", chainParams.Name)
 		}
 		return addrStr, nil
 	}

--- a/common/chain_test.go
+++ b/common/chain_test.go
@@ -1,8 +1,9 @@
 package common
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestChain_EncodeAddress(t *testing.T) {

--- a/common/chain_test.go
+++ b/common/chain_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestChain_EncodeAddress(t *testing.T) {
+	type fields struct {
+		ChainName ChainName
+		ChainId   int32
+	}
+
+	tests := []struct {
+		name    string
+		chain   Chain
+		b       []byte
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "should error if b is not a valid address on the network",
+			chain: Chain{
+				ChainName: ChainName_btc_testnet,
+				ChainId:   18332,
+			},
+			b:       []byte("bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c"),
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "should pass if b is a valid address on the network",
+			chain: Chain{
+				ChainName: ChainName_btc_mainnet,
+				ChainId:   8332,
+			},
+			b:       []byte("bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c"),
+			want:    "bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c",
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := tc.chain.EncodeAddress(tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.Equal(t, tc.want, s)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Problem: currently when user withdraws assets from ZRC20, the withdraw event hooks validates
the `to` address that the user inputs.  However it failed to distinguish between bitcoin mainnet 
and testnet3 addresses. 

This PR fixes that validation logic so that a user cannot specify a wrong address on bitcoin network
without revering that withdraw transaction. 

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
