### PR TITLE
refactor: decouple evm scheduler from btc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * [1143](https://github.com/zeta-chain/node/pull/1143) - tss funds migration capability
 * [1358](https://github.com/zeta-chain/node/pull/1358) - zetaclient thread for zeta supply checks
 * [1384](https://github.com/zeta-chain/node/pull/1384) - tx to update an observer
+
 ### Fixes
 
 * [1195](https://github.com/zeta-chain/node/pull/1195) - added upgrade name, and allow download. allows to test release
@@ -58,6 +59,7 @@
 * [1238](https://github.com/zeta-chain/node/pull/1238) - change default mempool version in config 
 * [1279](https://github.com/zeta-chain/node/pull/1279) - remove duplicate funtion name IsEthereum
 * [1289](https://github.com/zeta-chain/node/pull/1289) - skip gas stability pool funding when gasLimit is equal gasUsed
+* [1400](https://github.com/zeta-chain/node/pull/1400) - decouple evm cctx scheduler from btc cctx scheduler
 
 ### Chores
 

--- a/zetaclient/bitcoin_client.go
+++ b/zetaclient/bitcoin_client.go
@@ -420,20 +420,6 @@ func (ob *BitcoinChainClient) IsSendOutTxProcessed(sendHash string, nonce uint64
 		return false, false, err
 	}
 
-	// Get original cctx parameters
-	params, err = ob.GetPendingCctxParams(nonce)
-	if err != nil {
-		ob.logger.ObserveOutTx.Info().Msgf("IsSendOutTxProcessed: can't find pending cctx for nonce %d", nonce)
-		return false, false, err
-	}
-
-	// Get original cctx parameters
-	params, err = ob.GetPendingCctxParams(nonce)
-	if err != nil {
-		ob.logger.ObserveOutTx.Info().Msgf("IsSendOutTxProcessed: can't find pending cctx for nonce %d", nonce)
-		return false, false, err
-	}
-
 	if !included {
 		if !broadcasted {
 			return false, false, nil
@@ -959,7 +945,7 @@ func (ob *BitcoinChainClient) observeOutTx() {
 	for {
 		select {
 		case <-ticker.C():
-			trackers, err := ob.zetaClient.GetAllOutTxTrackerByChain(ob.chain, Ascending)
+			trackers, err := ob.zetaClient.GetAllOutTxTrackerByChain(ob.chain.ChainId, Ascending)
 			if err != nil {
 				ob.logger.ObserveOutTx.Error().Err(err).Msg("observeOutTx: error GetAllOutTxTrackerByChain")
 				continue

--- a/zetaclient/evm_client.go
+++ b/zetaclient/evm_client.go
@@ -575,7 +575,7 @@ func (ob *EVMChainClient) observeOutTx() {
 	for {
 		select {
 		case <-ticker.C():
-			trackers, err := ob.zetaClient.GetAllOutTxTrackerByChain(ob.chain, Ascending)
+			trackers, err := ob.zetaClient.GetAllOutTxTrackerByChain(ob.chain.ChainId, Ascending)
 			if err != nil {
 				continue
 			}

--- a/zetaclient/interfaces.go
+++ b/zetaclient/interfaces.go
@@ -80,7 +80,7 @@ type ZetaCoreBridger interface {
 	GetAllPendingCctx(chainID int64) ([]*crosschaintypes.CrossChainTx, error)
 	GetPendingNoncesByChain(chainID int64) (crosschaintypes.PendingNonces, error)
 	GetCctxByNonce(chainID int64, nonce uint64) (*crosschaintypes.CrossChainTx, error)
-	GetAllOutTxTrackerByChain(chain common.Chain, order Order) ([]crosschaintypes.OutTxTracker, error)
+	GetAllOutTxTrackerByChain(chainID int64, order Order) ([]crosschaintypes.OutTxTracker, error)
 	GetCrosschainFlags() (observertypes.CrosschainFlags, error)
 	GetObserverList(chain common.Chain) ([]string, error)
 	GetKeyGen() (*observertypes.Keygen, error)

--- a/zetaclient/query.go
+++ b/zetaclient/query.go
@@ -325,10 +325,10 @@ func (b *ZetaCoreBridge) GetOutTxTracker(chain common.Chain, nonce uint64) (*typ
 	return &resp.OutTxTracker, nil
 }
 
-func (b *ZetaCoreBridge) GetAllOutTxTrackerByChain(chain common.Chain, order Order) ([]types.OutTxTracker, error) {
+func (b *ZetaCoreBridge) GetAllOutTxTrackerByChain(chainID int64, order Order) ([]types.OutTxTracker, error) {
 	client := types.NewQueryClient(b.grpcConn)
 	resp, err := client.OutTxTrackerAllByChain(context.Background(), &types.QueryAllOutTxTrackerByChainRequest{
-		Chain: chain.ChainId,
+		Chain: chainID,
 		Pagination: &query.PageRequest{
 			Key:        nil,
 			Offset:     0,

--- a/zetaclient/zeta_supply_checker.go
+++ b/zetaclient/zeta_supply_checker.go
@@ -218,7 +218,7 @@ func (zs *ZetaSupplyChecker) GetPendingCCTXInTransit(receivingChains []common.Ch
 			}
 		}
 
-		trackers, err := zs.zetaClient.GetAllOutTxTrackerByChain(chain, Ascending)
+		trackers, err := zs.zetaClient.GetAllOutTxTrackerByChain(chain.ChainId, Ascending)
 		if err != nil {
 			continue
 		}

--- a/zetaclient/zetacore_observer.go
+++ b/zetaclient/zetacore_observer.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	MaxLookaheadNonce   = 120
 	OutboundTxSignCount = "zetaclient_Outbound_tx_sign_count"
 )
 
@@ -88,7 +89,7 @@ func (co *CoreObserver) GetPromCounter(name string) (prom.Counter, error) {
 func (co *CoreObserver) MonitorCore() {
 	myid := co.bridge.GetKeys().GetAddress()
 	co.logger.ZetaChainWatcher.Info().Msgf("Starting Send Scheduler for %s", myid)
-	go co.startSendScheduler()
+	go co.startCctxScheduler()
 
 	go func() {
 		// bridge queries UpgradePlan from zetacore and send to its pause channel if upgrade height is reached
@@ -101,26 +102,25 @@ func (co *CoreObserver) MonitorCore() {
 	}()
 }
 
-// ZetaCore block is heart beat; each block we schedule some send according to
-// retry schedule. ses
-func (co *CoreObserver) startSendScheduler() {
+// startCctxScheduler schedules keysigns for cctxs on each ZetaChain block (the ticker)
+func (co *CoreObserver) startCctxScheduler() {
 	outTxMan := NewOutTxProcessorManager(co.logger.ChainLogger)
 	observeTicker := time.NewTicker(3 * time.Second)
 	var lastBlockNum int64
 	for {
 		select {
 		case <-co.stop:
-			co.logger.ZetaChainWatcher.Warn().Msg("stop sendScheduler")
+			co.logger.ZetaChainWatcher.Warn().Msg("startCctxScheduler: stopped")
 			return
 		case <-observeTicker.C:
 			{
 				bn, err := co.bridge.GetZetaBlockHeight()
 				if err != nil {
-					co.logger.ZetaChainWatcher.Error().Msg("GetZetaBlockHeight fail in startSendScheduler")
+					co.logger.ZetaChainWatcher.Error().Err(err).Msg("startCctxScheduler: GetZetaBlockHeight fail")
 					continue
 				}
 				if bn < 0 {
-					co.logger.ZetaChainWatcher.Error().Msg("GetZetaBlockHeight returned negative height")
+					co.logger.ZetaChainWatcher.Error().Msg("startCctxScheduler: GetZetaBlockHeight returned negative height")
 					continue
 				}
 				if lastBlockNum == 0 {
@@ -129,10 +129,10 @@ func (co *CoreObserver) startSendScheduler() {
 				if bn > lastBlockNum { // we have a new block
 					bn = lastBlockNum + 1
 					if bn%10 == 0 {
-						co.logger.ZetaChainWatcher.Debug().Msgf("ZetaCore heart beat: %d", bn)
+						co.logger.ZetaChainWatcher.Debug().Msgf("startCctxScheduler: ZetaCore heart beat: %d", bn)
 					}
-					//logger.Info().Dur("elapsed", time.Since(tStart)).Msgf("GetAllPendingCctx %d", len(sendList))
 
+					// schedule keysign for pending cctxs on each chain
 					supportedChains := co.Config().GetEnabledChains()
 					for _, c := range supportedChains {
 						if c.ChainId == common.ZetaChain().ChainId {
@@ -142,113 +142,32 @@ func (co *CoreObserver) startSendScheduler() {
 
 						cctxList, err := co.bridge.GetAllPendingCctx(c.ChainId)
 						if err != nil {
-							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("failed to GetAllPendingCctx for chain %s", c.ChainName.String())
+							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("startCctxScheduler: GetAllPendingCctx failed for chain %d", c.ChainId)
 							continue
 						}
 						ob, err := co.getUpdatedChainOb(c.ChainId)
 						if err != nil {
-							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("getTargetChainOb fail, Chain ID: %s", c.ChainName)
+							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("startCctxScheduler: getTargetChainOb failed for chain %d", c.ChainId)
 							continue
 						}
-						chain, err := common.GetChainNameFromChainID(c.ChainId)
-						if err != nil {
-							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("GetTargetChain fail, Chain ID: %s", c.ChainName)
-							continue
-						}
-						res, err := co.bridge.GetAllOutTxTrackerByChain(c, Ascending)
-						if err != nil {
-							co.logger.ZetaChainWatcher.Warn().Err(err).Msgf("failed to GetAllOutTxTrackerByChain for chain %s", c.ChainName.String())
-							continue
-						}
-						trackerMap := make(map[uint64]bool)
-						for _, v := range res {
-							trackerMap[v.Nonce] = true
-						}
-
 						gauge, err := ob.GetPromGauge(metrics.PendingTxs)
 						if err != nil {
-							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("failed to get prometheus gauge: %s", metrics.PendingTxs)
+							co.logger.ZetaChainWatcher.Error().Err(err).Msgf("scheduleCctxEVM: failed to get prometheus gauge: %s for chain %d", metrics.PendingTxs, c.ChainId)
 							continue
 						}
 						gauge.Set(float64(len(cctxList)))
 
-						for idx, cctx := range cctxList {
-							params := cctx.GetCurrentOutTxParam()
-							if params.ReceiverChainId != c.ChainId {
-								co.logger.ZetaChainWatcher.Error().Msgf("mismatch chainid: want %d, got %d", c.ChainId, params.ReceiverChainId)
-								continue
-							}
-							const MaxLookaheadNonce = 120
-							if params.OutboundTxTssNonce > cctxList[0].GetCurrentOutTxParam().OutboundTxTssNonce+MaxLookaheadNonce {
-								co.logger.ZetaChainWatcher.Error().Msgf("nonce too high: signing %d, earliest pending %d", params.OutboundTxTssNonce, cctxList[0].GetCurrentOutTxParam().OutboundTxTssNonce)
-								break
-							}
-							// #nosec G701 range is verified
-							currentHeight := uint64(bn)
-							nonce := params.OutboundTxTssNonce
-							outTxID := fmt.Sprintf("%s-%d-%d", cctx.Index, params.ReceiverChainId, nonce) // would outTxID a better ID?
-
-							// Process Bitcoin OutTx
-							if common.IsBitcoinChain(c.ChainId) {
-								if outTxMan.IsOutTxActive(outTxID) {
-									// bitcoun outTx is processed sequencially by nonce
-									// if the current outTx is being processed, there is no need to process outTx with future nonces
-									break
-								}
-								// #nosec G701 positive
-								if stop := co.processBitcoinOutTx(outTxMan, uint64(idx), cctx, signer, ob, currentHeight); stop {
-									break
-								}
-								continue
-							}
-
-							// Monitor Core Logger for OutboundTxTssNonce
-							included, _, err := ob.IsSendOutTxProcessed(cctx.Index, params.OutboundTxTssNonce, params.CoinType, co.logger.ZetaChainWatcher)
-							if err != nil {
-								co.logger.ZetaChainWatcher.Error().Err(err).Msgf("IsSendOutTxProcessed fail, Chain ID: %s", c.ChainName)
-								continue
-							}
-							if included {
-								co.logger.ZetaChainWatcher.Info().Msgf("send outTx already included; do not schedule")
-								continue
-							}
-
-							// #nosec G701 positive
-							interval := uint64(ob.GetCoreParams().OutboundTxScheduleInterval)
-							lookahead := ob.GetCoreParams().OutboundTxScheduleLookahead
-
-							// determining critical outtx; if it satisfies following criteria
-							// 1. it's the first pending outtx for this chain
-							// 2. the following 5 nonces have been in tracker
-							criticalInterval := uint64(10)      // for critical pending outTx we reduce re-try interval
-							nonCriticalInterval := interval * 2 // for non-critical pending outTx we increase re-try interval
-							if nonce%criticalInterval == currentHeight%criticalInterval {
-								count := 0
-								for i := nonce + 1; i <= nonce+10; i++ {
-									if _, found := trackerMap[i]; found {
-										count++
-									}
-								}
-								if count >= 5 {
-									interval = criticalInterval
-								}
-							}
-							// if it's already in tracker, we increase re-try interval
-							if _, ok := trackerMap[nonce]; ok {
-								interval = nonCriticalInterval
-							}
-
-							// otherwise, the normal interval is used
-							if nonce%interval == currentHeight%interval && !outTxMan.IsOutTxActive(outTxID) {
-								outTxMan.StartTryProcess(outTxID)
-								co.logger.ZetaChainWatcher.Debug().Msgf("chain %s: Sign outtx %s with value %d\n", chain, outTxID, cctx.GetCurrentOutTxParam().Amount)
-								go signer.TryProcessOutTx(cctx, outTxMan, outTxID, ob, co.bridge, currentHeight)
-							}
-
-							// #nosec G701 always in range
-							if int64(idx) >= lookahead-1 { // only look at 30 sends per chain
-								break
-							}
+						// #nosec G701 range is verified
+						zetaHeight := uint64(bn)
+						co.logger.ZetaChainWatcher.Info().Msgf("startCctxScheduler: chain %d, zetaHeight %d, pending cctxs %d", c.ChainId, zetaHeight, len(cctxList))
+						if common.IsEVMChain(c.ChainId) {
+							co.scheduleCctxEVM(outTxMan, zetaHeight, c.ChainId, cctxList, ob, signer)
+						} else if common.IsBitcoinChain(c.ChainId) {
+							co.logger.ZetaChainWatcher.Info().Msgf("startCctxScheduler: chain %d, zetaHeight %d, pending cctxs %d", c.ChainId, zetaHeight, len(cctxList))
+							co.scheduleCctxBTC(outTxMan, zetaHeight, c.ChainId, cctxList, ob, signer)
+						} else {
+							co.logger.ZetaChainWatcher.Error().Msgf("startCctxScheduler: unsupported chain %d", c.ChainId)
+							continue
 						}
 					}
 					// update last processed block number
@@ -256,44 +175,124 @@ func (co *CoreObserver) startSendScheduler() {
 					co.ts.SetCoreBlockNumber(lastBlockNum)
 				}
 			}
-
 		}
 	}
 }
 
-// Bitcoin outtx is processed in a different way
-// 1. schedule one keysign on each ticker
+// scheduleCctxEVM schedules evm outtx keysign on each ZetaChain block (the ticker)
+func (co *CoreObserver) scheduleCctxEVM(outTxMan *OutTxProcessorManager, zetaHeight uint64, chainID int64, cctxList []*types.CrossChainTx, ob ChainClient, signer ChainSigner) {
+	res, err := co.bridge.GetAllOutTxTrackerByChain(chainID, Ascending)
+	if err != nil {
+		co.logger.ZetaChainWatcher.Warn().Err(err).Msgf("scheduleCctxEVM: GetAllOutTxTrackerByChain failed for chain %d", chainID)
+		return
+	}
+	trackerMap := make(map[uint64]bool)
+	for _, v := range res {
+		trackerMap[v.Nonce] = true
+	}
+
+	for idx, cctx := range cctxList {
+		params := cctx.GetCurrentOutTxParam()
+		nonce := params.OutboundTxTssNonce
+		outTxID := fmt.Sprintf("%s-%d-%d", cctx.Index, params.ReceiverChainId, nonce)
+
+		if params.ReceiverChainId != chainID {
+			co.logger.ZetaChainWatcher.Error().Msgf("scheduleCctxEVM: outtx %s chainid mismatch: want %d, got %d", outTxID, chainID, params.ReceiverChainId)
+			continue
+		}
+		if params.OutboundTxTssNonce > cctxList[0].GetCurrentOutTxParam().OutboundTxTssNonce+MaxLookaheadNonce {
+			co.logger.ZetaChainWatcher.Error().Msgf("scheduleCctxEVM: nonce too high: signing %d, earliest pending %d", params.OutboundTxTssNonce, cctxList[0].GetCurrentOutTxParam().OutboundTxTssNonce)
+			break
+		}
+
+		// try confirming the outtx
+		included, _, err := ob.IsSendOutTxProcessed(cctx.Index, params.OutboundTxTssNonce, params.CoinType, co.logger.ZetaChainWatcher)
+		if err != nil {
+			co.logger.ZetaChainWatcher.Error().Err(err).Msgf("scheduleCctxEVM: IsSendOutTxProcessed faild for chain %d", chainID)
+			continue
+		}
+		if included {
+			co.logger.ZetaChainWatcher.Info().Msgf("scheduleCctxEVM: outtx %s already included; do not schedule keysign", outTxID)
+			continue
+		}
+
+		// #nosec G701 positive
+		interval := uint64(ob.GetCoreParams().OutboundTxScheduleInterval)
+		lookahead := ob.GetCoreParams().OutboundTxScheduleLookahead
+
+		// determining critical outtx; if it satisfies following criteria
+		// 1. it's the first pending outtx for this chain
+		// 2. the following 5 nonces have been in tracker
+		criticalInterval := uint64(10)      // for critical pending outTx we reduce re-try interval
+		nonCriticalInterval := interval * 2 // for non-critical pending outTx we increase re-try interval
+		if nonce%criticalInterval == zetaHeight%criticalInterval {
+			count := 0
+			for i := nonce + 1; i <= nonce+10; i++ {
+				if _, found := trackerMap[i]; found {
+					count++
+				}
+			}
+			if count >= 5 {
+				interval = criticalInterval
+			}
+		}
+		// if it's already in tracker, we increase re-try interval
+		if _, ok := trackerMap[nonce]; ok {
+			interval = nonCriticalInterval
+		}
+
+		// otherwise, the normal interval is used
+		if nonce%interval == zetaHeight%interval && !outTxMan.IsOutTxActive(outTxID) {
+			outTxMan.StartTryProcess(outTxID)
+			co.logger.ZetaChainWatcher.Debug().Msgf("scheduleCctxEVM: sign outtx %s with value %d\n", outTxID, cctx.GetCurrentOutTxParam().Amount)
+			go signer.TryProcessOutTx(cctx, outTxMan, outTxID, ob, co.bridge, zetaHeight)
+		}
+
+		// #nosec G701 always in range
+		if int64(idx) >= lookahead-1 { // only look at 'lookahead' cctxs per chain
+			break
+		}
+	}
+}
+
+// scheduleCctxBTC schedules bitcoin outtx keysign on each ZetaChain block (the ticker)
+// 1. schedule at most one keysign per ticker
 // 2. schedule keysign only when nonce-mark UTXO is available
-// 3. stop processing when pendingNonce/lookahead is reached
-//
-// Returns whether to stop processing
-func (co *CoreObserver) processBitcoinOutTx(outTxMan *OutTxProcessorManager, idx uint64, send *types.CrossChainTx, signer ChainSigner, ob ChainClient, currentHeight uint64) bool {
-	params := send.GetCurrentOutTxParam()
-	nonce := params.OutboundTxTssNonce
-	lookahead := ob.GetCoreParams().OutboundTxScheduleLookahead
-	outTxID := fmt.Sprintf("%s-%d-%d", send.Index, params.ReceiverChainId, nonce)
-
-	// start go routine to process outtx
-	outTxMan.StartTryProcess(outTxID)
-	co.logger.ZetaChainWatcher.Debug().Msgf("Sign bitcoin outtx %s with value %d\n", outTxID, params.Amount)
-	go signer.TryProcessOutTx(send, outTxMan, outTxID, ob, co.bridge, currentHeight)
-
-	// get bitcoin client
+// 3. stop keysign when lookahead is reached
+func (co *CoreObserver) scheduleCctxBTC(outTxMan *OutTxProcessorManager, zetaHeight uint64, chainID int64, cctxList []*types.CrossChainTx, ob ChainClient, signer ChainSigner) {
 	btcClient, ok := ob.(*BitcoinChainClient)
 	if !ok { // should never happen
-		co.logger.ZetaChainWatcher.Error().Msgf("chain client is not a bitcoin client")
-		return true
+		co.logger.ZetaChainWatcher.Error().Msgf("scheduleCctxBTC: chain client is not a bitcoin client")
+		return
 	}
-	// stop if the nonce being processed reaches the artificial pending nonce
-	if nonce >= btcClient.GetPendingNonce() {
-		return true
+	lookahead := ob.GetCoreParams().OutboundTxScheduleLookahead
+
+	// schedule at most one keysign per ticker
+	for idx, cctx := range cctxList {
+		params := cctx.GetCurrentOutTxParam()
+		nonce := params.OutboundTxTssNonce
+		outTxID := fmt.Sprintf("%s-%d-%d", cctx.Index, params.ReceiverChainId, nonce)
+
+		if params.ReceiverChainId != chainID {
+			co.logger.ZetaChainWatcher.Error().Msgf("scheduleCctxBTC: outtx %s chainid mismatch: want %d, got %d", outTxID, chainID, params.ReceiverChainId)
+			continue
+		}
+		// stop if the nonce being processed is higher than the pending nonce
+		if nonce > btcClient.GetPendingNonce() {
+			break
+		}
+		// stop if lookahead is reached
+		if int64(idx) >= lookahead { // 2 bitcoin confirmations span is 20 minutes on average. We look ahead up to 100 pending cctx to target TPM of 5.
+			co.logger.ZetaChainWatcher.Warn().Msgf("scheduleCctxBTC: lookahead reached, signing %d, earliest pending %d", nonce, cctxList[0].GetCurrentOutTxParam().OutboundTxTssNonce)
+			break
+		}
+		// try confirming the outtx or scheduling a keysign
+		if !outTxMan.IsOutTxActive(outTxID) {
+			outTxMan.StartTryProcess(outTxID)
+			co.logger.ZetaChainWatcher.Debug().Msgf("scheduleCctxBTC: sign outtx %s with value %d\n", outTxID, params.Amount)
+			go signer.TryProcessOutTx(cctx, outTxMan, outTxID, ob, co.bridge, zetaHeight)
+		}
 	}
-	// stop if lookahead is reached. 2 bitcoin confirmations span is 20 minutes on average. We look ahead up to 100 pending cctx to target TPM of 5.
-	// #nosec G701 always in range
-	if int64(idx) >= lookahead-1 {
-		return true
-	}
-	return false // otherwise, continue
 }
 
 func (co *CoreObserver) getUpdatedChainOb(chainID int64) (ChainClient, error) {

--- a/zetaclient/zetacore_observer.go
+++ b/zetaclient/zetacore_observer.go
@@ -159,11 +159,9 @@ func (co *CoreObserver) startCctxScheduler() {
 
 						// #nosec G701 range is verified
 						zetaHeight := uint64(bn)
-						co.logger.ZetaChainWatcher.Info().Msgf("startCctxScheduler: chain %d, zetaHeight %d, pending cctxs %d", c.ChainId, zetaHeight, len(cctxList))
 						if common.IsEVMChain(c.ChainId) {
 							co.scheduleCctxEVM(outTxMan, zetaHeight, c.ChainId, cctxList, ob, signer)
 						} else if common.IsBitcoinChain(c.ChainId) {
-							co.logger.ZetaChainWatcher.Info().Msgf("startCctxScheduler: chain %d, zetaHeight %d, pending cctxs %d", c.ChainId, zetaHeight, len(cctxList))
 							co.scheduleCctxBTC(outTxMan, zetaHeight, c.ChainId, cctxList, ob, signer)
 						} else {
 							co.logger.ZetaChainWatcher.Error().Msgf("startCctxScheduler: unsupported chain %d", c.ChainId)


### PR DESCRIPTION
# Description

Decouple EVM-chain outtx scheduler from Bitcoin outtx scheduler to make future maintaining work (e.g., bug fix or chain-specific improvement) easier.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
