### PR TITLE
refactor(`MsgUpdateCrosschainFlags`): requires group2 policy type to enable header verification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
 
 ### Refactoring
 
+* [1552](https://github.com/zeta-chain/node/pull/1552) - requires group2 to enable header verification
 * [1211](https://github.com/zeta-chain/node/issues/1211) - use `grpc` and `msg` for query and message files
 * refactor cctx scheduler - decouple evm cctx scheduler from btc cctx scheduler
 * move tss state from crosschain to observer

--- a/x/observer/keeper/msg_server_update_crosschain_flags.go
+++ b/x/observer/keeper/msg_server_update_crosschain_flags.go
@@ -14,13 +14,8 @@ import (
 func (k msgServer) UpdateCrosschainFlags(goCtx context.Context, msg *types.MsgUpdateCrosschainFlags) (*types.MsgUpdateCrosschainFlagsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	requiredGroup := types.Policy_Type_group1
-	if msg.IsInboundEnabled || msg.IsOutboundEnabled || msg.GasPriceIncreaseFlags != nil {
-		requiredGroup = types.Policy_Type_group2
-	}
-
 	// check permission
-	if msg.Creator != k.GetParams(ctx).GetAdminPolicyAccount(requiredGroup) {
+	if msg.Creator != k.GetParams(ctx).GetAdminPolicyAccount(msg.GetRequiredGroup()) {
 		return &types.MsgUpdateCrosschainFlagsResponse{}, types.ErrNotAuthorizedPolicy
 	}
 

--- a/x/observer/types/message_crosschain_flags.go
+++ b/x/observer/types/message_crosschain_flags.go
@@ -67,3 +67,21 @@ func (gpf GasPriceIncreaseFlags) Validate() error {
 	}
 	return nil
 }
+
+// GetRequiredGroup returns the required group policy for the message to execute the message
+// Group 1 should only be able to stop or disable functiunalities in case of emergency
+// this concerns disabling inbound and outbound txs or block header verification
+// every other action requires group 2
+func (msg *MsgUpdateCrosschainFlags) GetRequiredGroup() Policy_Type {
+	if msg.IsInboundEnabled || msg.IsOutboundEnabled {
+		return Policy_Type_group2
+	}
+	if msg.GasPriceIncreaseFlags != nil {
+		return Policy_Type_group2
+	}
+	if msg.BlockHeaderVerificationFlags != nil && (msg.BlockHeaderVerificationFlags.IsEthTypeChainEnabled || msg.BlockHeaderVerificationFlags.IsBtcTypeChainEnabled) {
+		return Policy_Type_group2
+
+	}
+	return Policy_Type_group1
+}


### PR DESCRIPTION
# Description

Related to https://github.com/zeta-chain/security/issues/53
