### PR TITLE
fix(`rpc`): reduce websocket message limit to 10MB

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * [1525](https://github.com/zeta-chain/node/pull/1525) - relax EVM chain block header length check 1024->4096
 * [1522](https://github.com/zeta-chain/node/pull/1522/files) - block `distribution` module account from receiving zeta
 * [1528](https://github.com/zeta-chain/node/pull/1528) - fix panic caused on decoding malformed BTC addresses
+* [1555](https://github.com/zeta-chain/node/pull/1555) - Reduce websocket message limit to 10MB
 
 ### Refactoring
 

--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	messageSizeLimit = 32 * 1024 * 1024 // 32MB
+	messageSizeLimit = 10 * 1024 * 1024 // 10MB
 
 )
 


### PR DESCRIPTION
# Description

Closes: https://github.com/zeta-chain/security/issues/50