### PR TITLE
fix(`crosschain`): add emptiness check for topic array in event parsing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * [1525](https://github.com/zeta-chain/node/pull/1525) - relax EVM chain block header length check 1024->4096
 * [1522](https://github.com/zeta-chain/node/pull/1522/files) - block `distribution` module account from receiving zeta
 * [1528](https://github.com/zeta-chain/node/pull/1528) - fix panic caused on decoding malformed BTC addresses
+* [1556](https://github.com/zeta-chain/node/pull/1556) - add emptiness check for topic array in event parsing
 
 ### Refactoring
 

--- a/x/crosschain/keeper/evm_hooks.go
+++ b/x/crosschain/keeper/evm_hooks.go
@@ -275,6 +275,9 @@ func (k Keeper) ParseZRC20WithdrawalEvent(ctx sdk.Context, log ethtypes.Log) (*z
 	if err != nil {
 		return nil, err
 	}
+	if len(log.Topics) == 0 {
+		return nil, fmt.Errorf("ParseZRC20WithdrawalEvent: invalid log - no topics")
+	}
 	event, err := zrc20ZEVM.ParseWithdrawal(log)
 	if err != nil {
 		return nil, err
@@ -305,6 +308,9 @@ func ParseZetaSentEvent(log ethtypes.Log, connectorZEVM ethcommon.Address) (*con
 	zetaConnectorZEVM, err := connectorzevm.NewZetaConnectorZEVMFilterer(log.Address, bind.ContractFilterer(nil))
 	if err != nil {
 		return nil, err
+	}
+	if len(log.Topics) == 0 {
+		return nil, fmt.Errorf("ParseZetaSentEvent: invalid log - no topics")
 	}
 	event, err := zetaConnectorZEVM.ParseZetaSent(log)
 	if err != nil {


### PR DESCRIPTION
# Description

Add a check for topic length

Closes: https://github.com/zeta-chain/security/issues/49

