### PR TITLE
refactor(`crosschain`): change log level for gas stability pool iteration error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
 * Remove chain id from the index for observer mapper and rename it to observer set.
 * Add logger to smoke tests
 * [1521](https://github.com/zeta-chain/node/pull/1521) - replace go-tss lib version with one that reverts back to thorchain tss-lib
+* [1558](https://github.com/zeta-chain/node/pull/1558) - change log level for gas stability pool iteration error
 
 ### Chores
 * [1446](https://github.com/zeta-chain/node/pull/1446) - renamed file `zetaclientd/aux.go` to `zetaclientd/utils.go` to avoid complaints from go package resolver. 

--- a/x/crosschain/module.go
+++ b/x/crosschain/module.go
@@ -190,7 +190,7 @@ func (AppModule) ConsensusVersion() uint64 { return 4 }
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 	err := am.keeper.IterateAndUpdateCctxGasPrice(ctx)
 	if err != nil {
-		ctx.Logger().Error("Error iterating and updating pending cctx gas price", "err", err.Error())
+		ctx.Logger().Info("Error iterating and updating pending cctx gas price", "err", err.Error())
 	}
 }
 


### PR DESCRIPTION
# Description

Change log level from Error to Info since the process is expected to return an error when gas stability pools are empty. This doesn't reflect an issue in the protocol itself.

Closes: https://github.com/zeta-chain/node/issues/1494