### PR TITLE
fix: skip keygen loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 * [1591](https://github.com/zeta-chain/node/pull/1591) - support lower gas limit for voting on inbound and outbound transactions
 * [1592](https://github.com/zeta-chain/node/issues/1592) - check inbound tracker tx hash against Tss address and some refactor on inTx observation
 
+### Fixes
+* [1625](https://github.com/zeta-chain/node/pull/1625) - temporarily skip keygen check in zetaclient
 ## Version: v12.0.0
 
 ### Breaking Changes

--- a/cmd/zetaclientd/keygen_tss.go
+++ b/cmd/zetaclientd/keygen_tss.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -79,6 +80,9 @@ func GenerateTss(logger zerolog.Logger,
 		}
 		// Try generating TSS at keygen block , only when status is pending keygen and generation has not been tried at the block
 		if keyGen.Status == observertypes.KeygenStatus_PendingKeygen {
+			if keyGen.BlockNumber == math.MaxInt64 {
+				return tss, nil
+			}
 			// Return error if RPC is not working
 			currentBlock, err := zetaBridge.GetZetaBlockHeight()
 			if err != nil {

--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core"
 	maddr "github.com/multiformats/go-multiaddr"
@@ -173,14 +172,15 @@ func start(_ *cobra.Command, _ []string) error {
 
 	// Wait for TSS keygen to be successful before proceeding, This is a blocking thread only for a new keygen.
 	// For existing keygen, this should directly proceed to the next step
-	ticker := time.NewTicker(time.Second * 1)
-	for range ticker.C {
-		if cfg.Keygen.Status != observerTypes.KeygenStatus_KeyGenSuccess {
-			startLogger.Info().Msgf("Waiting for TSS Keygen to be a success, current status %s", cfg.Keygen.Status)
-			continue
-		}
-		break
-	}
+	// Temporarily allow zeta-client to proceed even if the keygen is set to pending
+	//ticker := time.NewTicker(time.Second * 1)
+	//for range ticker.C {
+	//	if cfg.Keygen.Status != observerTypes.KeygenStatus_KeyGenSuccess {
+	//		startLogger.Info().Msgf("Waiting for TSS Keygen to be a success, current status %s", cfg.Keygen.Status)
+	//		continue
+	//	}
+	//	break
+	//}
 
 	// Update Current TSS value from zetacore, if TSS keygen is successful, the TSS address is set on zeta-core
 	// Returns err if the RPC call fails as zeta client needs the current TSS address to be set


### PR DESCRIPTION
# Description
- Allow zeta-client to start if keygen status is set to `PendingKeygen` and keygen block is `MaxInt64`



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
