### PR TITLE
fix: modify emissions to follow fixed rewards per block

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 * [1577](https://github.com/zeta-chain/node/pull/1577) - add chain header tests in E2E tests and fix admin tests
 
 ### Features
-
+* [1658](https://github.com/zeta-chain/node/pull/1658) - modify emission distribution to use fixed block rewards 
 ### Fixes
 * [1535](https://github.com/zeta-chain/node/issues/1535) - Avoid voting on wrong ballots due to false blockNumber in EVM tx receipt
 * [1588](https://github.com/zeta-chain/node/pull/1588) - fix chain params comparison logic

--- a/common/coin.go
+++ b/common/coin.go
@@ -3,6 +3,8 @@ package common
 import (
 	"fmt"
 	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func GetCoinType(coin string) (CoinType, error) {
@@ -15,4 +17,16 @@ func GetCoinType(coin string) (CoinType, error) {
 	}
 	// #nosec G701 always in range
 	return CoinType(coinInt), nil
+}
+
+func GetAzetaDecFromAmountInZeta(zetaAmount string) (sdk.Dec, error) {
+	zetaDec, err := sdk.NewDecFromStr(zetaAmount)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	zetaToAzetaConvertionFactor, err := sdk.NewDecFromStr("1000000000000000000")
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	return zetaDec.Mul(zetaToAzetaConvertionFactor), nil
 }

--- a/common/coin_test.go
+++ b/common/coin_test.go
@@ -3,40 +3,62 @@ package common_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/zeta-chain/zetacore/common"
 )
 
 func Test_GetAzetaDecFromAmountInZeta(t *testing.T) {
 	tt := []struct {
-		name       string
-		zetaAmount string
+		name        string
+		zetaAmount  string
+		err         assert.ErrorAssertionFunc
+		azetaAmount sdk.Dec
 	}{
 		{
-			name:       "valid zeta amount",
-			zetaAmount: "210000000",
+			name:        "valid zeta amount",
+			zetaAmount:  "210000000",
+			err:         assert.NoError,
+			azetaAmount: sdk.MustNewDecFromStr("210000000000000000000000000"),
 		},
 		{
-			name:       "very high zeta amount",
-			zetaAmount: "21000000000000000000",
+			name:        "very high zeta amount",
+			zetaAmount:  "21000000000000000000",
+			err:         assert.NoError,
+			azetaAmount: sdk.MustNewDecFromStr("21000000000000000000000000000000000000"),
 		},
 		{
-			name:       "very low zeta amount",
-			zetaAmount: "1",
+			name:        "very low zeta amount",
+			zetaAmount:  "1",
+			err:         assert.NoError,
+			azetaAmount: sdk.MustNewDecFromStr("1000000000000000000"),
 		},
 		{
-			name:       "zero zeta amount",
-			zetaAmount: "0",
+			name:        "zero zeta amount",
+			zetaAmount:  "0",
+			err:         assert.NoError,
+			azetaAmount: sdk.MustNewDecFromStr("0"),
 		},
 		{
-			name:       "decimal zeta amount",
-			zetaAmount: "0.1",
+			name:        "decimal zeta amount",
+			zetaAmount:  "0.1",
+			err:         assert.NoError,
+			azetaAmount: sdk.MustNewDecFromStr("100000000000000000"),
+		},
+		{
+			name:        "invalid zeta amount",
+			zetaAmount:  "%%%%%$#",
+			err:         assert.Error,
+			azetaAmount: sdk.MustNewDecFromStr("0"),
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := common.GetAzetaDecFromAmountInZeta(tc.zetaAmount)
-			assert.NoError(t, err)
+			azeta, err := common.GetAzetaDecFromAmountInZeta(tc.zetaAmount)
+			tc.err(t, err)
+			if err == nil {
+				assert.Equal(t, tc.azetaAmount, azeta)
+			}
 		})
 	}
 

--- a/common/coin_test.go
+++ b/common/coin_test.go
@@ -1,0 +1,43 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeta-chain/zetacore/common"
+)
+
+func Test_GetAzetaDecFromAmountInZeta(t *testing.T) {
+	tt := []struct {
+		name       string
+		zetaAmount string
+	}{
+		{
+			name:       "valid zeta amount",
+			zetaAmount: "210000000",
+		},
+		{
+			name:       "very high zeta amount",
+			zetaAmount: "21000000000000000000",
+		},
+		{
+			name:       "very low zeta amount",
+			zetaAmount: "1",
+		},
+		{
+			name:       "zero zeta amount",
+			zetaAmount: "0",
+		},
+		{
+			name:       "decimal zeta amount",
+			zetaAmount: "0.1",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := common.GetAzetaDecFromAmountInZeta(tc.zetaAmount)
+			assert.NoError(t, err)
+		})
+	}
+
+}

--- a/x/emissions/abci.go
+++ b/x/emissions/abci.go
@@ -27,7 +27,7 @@ func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 		return
 	}
 	if blockRewards.GT(emissonPoolBalance) {
-		ctx.Logger().Error(fmt.Sprintf("Block rewards %s are greater than emission pool balance %s", blockRewards.String(), emissonPoolBalance.String()))
+		ctx.Logger().Info(fmt.Sprintf("Block rewards %s are greater than emission pool balance %s", blockRewards.String(), emissonPoolBalance.String()))
 		return
 	}
 	ctx.Logger().Info(fmt.Sprintf("Block Rewards Total:%s Block Height:%d", blockRewards.String(), ctx.BlockHeight()))

--- a/x/emissions/abci.go
+++ b/x/emissions/abci.go
@@ -17,7 +17,7 @@ func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 	if emissonPoolBalance.IsZero() {
 		return
 	}
-	blockRewards, err := keeper.GetFixedBlockRewards(ctx)
+	blockRewards, err := keeper.GetFixedBlockRewards()
 	if err != nil {
 		ctx.Logger().Error(fmt.Sprintf("Error while getting fixed block rewards %s", err))
 		return
@@ -26,20 +26,31 @@ func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 		ctx.Logger().Error("Block rewards are zero")
 		return
 	}
+	if blockRewards.GT(emissonPoolBalance) {
+		ctx.Logger().Error(fmt.Sprintf("Block rewards %s are greater than emission pool balance %s", blockRewards.String(), emissonPoolBalance.String()))
+		return
+	}
+	ctx.Logger().Info(fmt.Sprintf("Block Rewards Total:%s Block Height:%d", blockRewards.String(), ctx.BlockHeight()))
 	validatorRewards := sdk.MustNewDecFromStr(keeper.GetParams(ctx).ValidatorEmissionPercentage).Mul(blockRewards).TruncateInt()
 	observerRewards := sdk.MustNewDecFromStr(keeper.GetParams(ctx).ObserverEmissionPercentage).Mul(blockRewards).TruncateInt()
 	tssSignerRewards := sdk.MustNewDecFromStr(keeper.GetParams(ctx).TssSignerEmissionPercentage).Mul(blockRewards).TruncateInt()
+	ctx.Logger().Info(fmt.Sprintf("Validator Rewards Total:%s , Percentage %s", validatorRewards.String(), keeper.GetParams(ctx).ValidatorEmissionPercentage))
+	ctx.Logger().Info(fmt.Sprintf("Observer Rewards Total:%s , Percentage %s", observerRewards.String(), keeper.GetParams(ctx).ObserverEmissionPercentage))
+	ctx.Logger().Info(fmt.Sprintf("TssSigner Rewards Total:%s , Percentage %s", tssSignerRewards.String(), keeper.GetParams(ctx).TssSignerEmissionPercentage))
 	err = DistributeValidatorRewards(ctx, validatorRewards, keeper.GetBankKeeper(), keeper.GetFeeCollector())
 	if err != nil {
-		panic(err)
+		ctx.Logger().Error(fmt.Sprintf("Error while distributing validator rewards %s", err))
+		return
 	}
 	err = DistributeObserverRewards(ctx, observerRewards, keeper)
 	if err != nil {
-		panic(err)
+		ctx.Logger().Error(fmt.Sprintf("Error while distributing observer rewards %s", err))
+		return
 	}
 	err = DistributeTssRewards(ctx, tssSignerRewards, keeper.GetBankKeeper())
 	if err != nil {
-		panic(err)
+		ctx.Logger().Error(fmt.Sprintf("Error while distributing tss signer rewards %s", err))
+		return
 	}
 	types.EmitValidatorEmissions(ctx, "", "",
 		"",
@@ -53,6 +64,7 @@ func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 // This function uses the distribution module of cosmos-sdk , by directly sending funds to the feecollector.
 func DistributeValidatorRewards(ctx sdk.Context, amount sdkmath.Int, bankKeeper types.BankKeeper, feeCollector string) error {
 	coin := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, amount))
+	ctx.Logger().Info(fmt.Sprintf(fmt.Sprintf("Distributing Validator Rewards Total:%s To FeeCollector : %s", amount.String(), feeCollector)))
 	return bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, feeCollector, coin)
 }
 
@@ -69,7 +81,9 @@ func DistributeObserverRewards(ctx sdk.Context, amount sdkmath.Int, keeper keepe
 	if err != nil {
 		return err
 	}
+	ctx.Logger().Info(fmt.Sprintf("Distributing Observer Rewards Total:%s To UndistributedObserverRewardsPool", amount.String()))
 	ballotIdentifiers := keeper.GetObserverKeeper().GetMaturedBallotList(ctx)
+	ctx.Logger().Info(fmt.Sprintf("Matured Ballot Identifiers : %d", len(ballotIdentifiers)))
 	// do not distribute rewards if no ballots are matured, the rewards can accumulate in the undistributed pool
 	if len(ballotIdentifiers) == 0 {
 		return nil
@@ -85,7 +99,7 @@ func DistributeObserverRewards(ctx sdk.Context, amount sdkmath.Int, keeper keepe
 	if totalRewardsUnits > 0 && amount.IsPositive() {
 		rewardPerUnit = amount.Quo(sdk.NewInt(totalRewardsUnits))
 	}
-
+	ctx.Logger().Info(fmt.Sprintf("Total Rewards Units : %d , Total Reward Units : %d", totalRewardsUnits, totalRewardsUnits))
 	sortedKeys := make([]string, 0, len(rewardsDistributer))
 	for k := range rewardsDistributer {
 		sortedKeys = append(sortedKeys, k)
@@ -109,6 +123,7 @@ func DistributeObserverRewards(ctx sdk.Context, amount sdkmath.Int, keeper keepe
 				ObserverAddress: observerAddress.String(),
 				Amount:          sdkmath.ZeroInt(),
 			})
+			ctx.Logger().Info(fmt.Sprintf("Observer Address : %s , EmissionType_Slash %s", observerAddress.String(), sdkmath.ZeroInt().String()))
 			continue
 		}
 		if observerRewardUnits < 0 {
@@ -119,6 +134,7 @@ func DistributeObserverRewards(ctx sdk.Context, amount sdkmath.Int, keeper keepe
 				ObserverAddress: observerAddress.String(),
 				Amount:          slashAmount,
 			})
+			ctx.Logger().Info(fmt.Sprintf("Observer Address : %s , EmissionType_Slash %s", observerAddress.String(), slashAmount.String()))
 			continue
 		}
 		// Defensive check
@@ -130,6 +146,7 @@ func DistributeObserverRewards(ctx sdk.Context, amount sdkmath.Int, keeper keepe
 				ObserverAddress: observerAddress.String(),
 				Amount:          rewardAmount,
 			})
+			ctx.Logger().Info(fmt.Sprintf("Observer Address : %s , EmissionType_Rewards %s ", observerAddress.String(), rewardAmount.String()))
 		}
 	}
 	types.EmitObserverEmissions(ctx, finalDistributionList)

--- a/x/emissions/abci_test.go
+++ b/x/emissions/abci_test.go
@@ -1,5 +1,6 @@
 package emissions_test
 
+//TODO : https://github.com/zeta-chain/node/issues/1659
 //func getaZetaFromString(amount string) sdk.Coins {
 //	emissionPoolInt, _ := sdk.NewIntFromString(amount)
 //	return sdk.NewCoins(sdk.NewCoin(config.BaseDenom, emissionPoolInt))

--- a/x/emissions/abci_test.go
+++ b/x/emissions/abci_test.go
@@ -1,252 +1,228 @@
 package emissions_test
 
-import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"sort"
-	"strconv"
-	"testing"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/tendermint/crypto/ed25519"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	tmtypes "github.com/tendermint/tendermint/types"
-	zetaapp "github.com/zeta-chain/zetacore/app"
-	"github.com/zeta-chain/zetacore/cmd/zetacored/config"
-	"github.com/zeta-chain/zetacore/testutil/simapp"
-	emissionsModule "github.com/zeta-chain/zetacore/x/emissions"
-	emissionsModuleTypes "github.com/zeta-chain/zetacore/x/emissions/types"
-)
-
-func getaZetaFromString(amount string) sdk.Coins {
-	emissionPoolInt, _ := sdk.NewIntFromString(amount)
-	return sdk.NewCoins(sdk.NewCoin(config.BaseDenom, emissionPoolInt))
-}
-
-func SetupApp(t *testing.T, params emissionsModuleTypes.Params, emissionPoolCoins sdk.Coins) (*zetaapp.App, sdk.Context, *tmtypes.ValidatorSet, *authtypes.BaseAccount) {
-	pk1 := ed25519.GenPrivKey().PubKey()
-	acc1 := authtypes.NewBaseAccountWithAddress(sdk.AccAddress(pk1.Address()))
-	// genDelActs and genDelBalances need to have the same addresses
-	// bondAmount is specified separately , the Balances here are additional tokens for delegators to have in their accounts
-	genDelActs := make(authtypes.GenesisAccounts, 1)
-	genDelBalances := make([]banktypes.Balance, 1)
-	genDelActs[0] = acc1
-	genDelBalances[0] = banktypes.Balance{
-		Address: acc1.GetAddress().String(),
-		Coins:   emissionPoolCoins,
-	}
-	delBondAmount := getaZetaFromString("1000000000000000000000000")
-
-	//genBalances := make([]banktypes.Balance, 1)
-	//genBalances[0] = banktypes.Balance{
-	//	Address: emissionsModuleTypes.EmissionsModuleAddress.String(),
-	//	Coins:   emissionPoolCoins,
-	//}
-
-	vset := tmtypes.NewValidatorSet([]*tmtypes.Validator{})
-	for i := 0; i < 1; i++ {
-		privKey := ed25519.GenPrivKey()
-		pubKey := privKey.PubKey()
-		val := tmtypes.NewValidator(pubKey, 1)
-		err := vset.UpdateWithChangeSet([]*tmtypes.Validator{val})
-		if err != nil {
-			panic("Failed to add validator")
-		}
-	}
-
-	app := simapp.SetupWithGenesisValSet(t, vset, genDelActs, delBondAmount.AmountOf(config.BaseDenom), params, genDelBalances, nil)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
-	ctx = ctx.WithBlockHeight(app.LastBlockHeight())
-	return app, ctx, vset, acc1
-}
-
-type EmissionTestData struct {
-	BlockHeight    int64   `json:"blockHeight,omitempty"`
-	BondFactor     sdk.Dec `json:"bondFactor"`
-	ReservesFactor sdk.Dec `json:"reservesFactor"`
-	DurationFactor string  `json:"durationFactor"`
-}
-
-func TestAppModule_GetBlockRewardComponents(t *testing.T) {
-
-	tests := []struct {
-		name                 string
-		startingEmissionPool string
-		params               emissionsModuleTypes.Params
-		testMaxHeight        int64
-		inputFilename        string
-		checkValues          []EmissionTestData
-		generateOnly         bool
-	}{
-		{
-			name:                 "default values",
-			params:               emissionsModuleTypes.DefaultParams(),
-			startingEmissionPool: "1000000000000000000000000",
-			testMaxHeight:        300,
-			inputFilename:        "simulations.json",
-			generateOnly:         false,
-		},
-		{
-			name:                 "higher starting pool",
-			params:               emissionsModuleTypes.DefaultParams(),
-			startingEmissionPool: "100000000000000000000000000000000",
-			testMaxHeight:        300,
-			inputFilename:        "simulations.json",
-			generateOnly:         false,
-		},
-		{
-			name:                 "lower starting pool",
-			params:               emissionsModuleTypes.DefaultParams(),
-			startingEmissionPool: "100000000000000000",
-			testMaxHeight:        300,
-			inputFilename:        "simulations.json",
-			generateOnly:         false,
-		},
-		{
-			name: "different distribution percentages",
-			params: emissionsModuleTypes.Params{
-				MaxBondFactor:               "1.25",
-				MinBondFactor:               "0.75",
-				AvgBlockTime:                "6.00",
-				TargetBondRatio:             "00.67",
-				ValidatorEmissionPercentage: "00.10",
-				ObserverEmissionPercentage:  "00.85",
-				TssSignerEmissionPercentage: "00.05",
-				DurationFactorConstant:      "0.001877876953694702",
-			},
-			startingEmissionPool: "1000000000000000000000000",
-			testMaxHeight:        300,
-			inputFilename:        "simulations.json",
-			generateOnly:         false,
-		},
-		{
-			name: "higher block time",
-			params: emissionsModuleTypes.Params{
-				MaxBondFactor:               "1.25",
-				MinBondFactor:               "0.75",
-				AvgBlockTime:                "20.00",
-				TargetBondRatio:             "00.67",
-				ValidatorEmissionPercentage: "00.10",
-				ObserverEmissionPercentage:  "00.85",
-				TssSignerEmissionPercentage: "00.05",
-				DurationFactorConstant:      "0.1",
-			},
-			startingEmissionPool: "1000000000000000000000000",
-			testMaxHeight:        300,
-			inputFilename:        "simulations.json",
-			generateOnly:         false,
-		},
-		{
-			name: "different duration constant",
-			params: emissionsModuleTypes.Params{
-				MaxBondFactor:               "1.25",
-				MinBondFactor:               "0.75",
-				AvgBlockTime:                "6.00",
-				TargetBondRatio:             "00.67",
-				ValidatorEmissionPercentage: "00.10",
-				ObserverEmissionPercentage:  "00.85",
-				TssSignerEmissionPercentage: "00.05",
-				DurationFactorConstant:      "0.1",
-			},
-			startingEmissionPool: "1000000000000000000000000",
-			testMaxHeight:        300,
-			inputFilename:        "simulations.json",
-			generateOnly:         false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app, ctx, _, minter := SetupApp(t, tt.params, getaZetaFromString(tt.startingEmissionPool))
-			err := app.BankKeeper.SendCoinsFromAccountToModule(ctx, minter.GetAddress(), emissionsModuleTypes.ModuleName, getaZetaFromString(tt.startingEmissionPool))
-			assert.NoError(t, err)
-			GenerateTestDataMaths(app, ctx, tt.testMaxHeight, tt.inputFilename)
-			defer func(t *testing.T, fp string) {
-				err := os.RemoveAll(fp)
-				assert.NoError(t, err)
-			}(t, tt.inputFilename)
-
-			if tt.generateOnly {
-				return
-			}
-			inputTestData, err := GetInputData(tt.inputFilename)
-			assert.NoError(t, err)
-			sort.SliceStable(inputTestData, func(i, j int) bool { return inputTestData[i].BlockHeight < inputTestData[j].BlockHeight })
-			startHeight := ctx.BlockHeight()
-			assert.Equal(t, startHeight, inputTestData[0].BlockHeight, "starting block height should be equal to the first block height in the input data")
-			for i := startHeight; i < tt.testMaxHeight; i++ {
-				//The First distribution will occur only when begin-block is triggered
-				reservesFactor, bondFactor, durationFactor := app.EmissionsKeeper.GetBlockRewardComponents(ctx)
-				assert.Equal(t, inputTestData[i-1].ReservesFactor, reservesFactor, "reserves factor should be equal to the input data"+fmt.Sprintf(" , block height: %d", i))
-				assert.Equal(t, inputTestData[i-1].BondFactor, bondFactor, "bond factor should be equal to the input data"+fmt.Sprintf(" , block height: %d", i))
-				assert.Equal(t, inputTestData[i-1].DurationFactor, durationFactor.String(), "duration factor should be equal to the input data"+fmt.Sprintf(" , block height: %d", i))
-				emissionsModule.BeginBlocker(ctx, app.EmissionsKeeper)
-				ctx = ctx.WithBlockHeight(i + 1)
-			}
-		})
-	}
-}
-
-func GetInputData(fp string) ([]EmissionTestData, error) {
-	data := []EmissionTestData{}
-	file, err := filepath.Abs(fp)
-	if err != nil {
-
-		return nil, err
-	}
-	file = filepath.Clean(file)
-	input, err := ioutil.ReadFile(file) // #nosec G304
-	if err != nil {
-		return nil, err
-	}
-	err = json.Unmarshal(input, &data)
-	if err != nil {
-		return nil, err
-	}
-	formatedData := make([]EmissionTestData, len(data))
-	for i, dd := range data {
-		fl, err := strconv.ParseFloat(dd.DurationFactor, 64)
-		if err != nil {
-			return nil, err
-		}
-		dd.DurationFactor = fmt.Sprintf("%0.18f", fl)
-		formatedData[i] = dd
-	}
-	return formatedData, nil
-}
-
-func GenerateTestDataMaths(app *zetaapp.App, ctx sdk.Context, testMaxHeight int64, fileName string) {
-	var generatedTestData []EmissionTestData
-	reserverCoins := app.BankKeeper.GetBalance(ctx, emissionsModuleTypes.EmissionsModuleAddress, config.BaseDenom)
-	startHeight := ctx.BlockHeight()
-	for i := startHeight; i < testMaxHeight; i++ {
-		reservesFactor := sdk.NewDecFromInt(reserverCoins.Amount)
-		bondFactor := app.EmissionsKeeper.GetBondFactor(ctx, app.StakingKeeper)
-		durationFactor := app.EmissionsKeeper.GetDurationFactor(ctx)
-		blockRewards := reservesFactor.Mul(bondFactor).Mul(durationFactor)
-		generatedTestData = append(generatedTestData, EmissionTestData{
-			BlockHeight:    i,
-			BondFactor:     bondFactor,
-			DurationFactor: durationFactor.String(),
-			ReservesFactor: reservesFactor,
-		})
-		validatorRewards := sdk.MustNewDecFromStr(app.EmissionsKeeper.GetParams(ctx).ValidatorEmissionPercentage).Mul(blockRewards).TruncateInt()
-		observerRewards := sdk.MustNewDecFromStr(app.EmissionsKeeper.GetParams(ctx).ObserverEmissionPercentage).Mul(blockRewards).TruncateInt()
-		tssSignerRewards := sdk.MustNewDecFromStr(app.EmissionsKeeper.GetParams(ctx).TssSignerEmissionPercentage).Mul(blockRewards).TruncateInt()
-		truncatedRewards := validatorRewards.Add(observerRewards).Add(tssSignerRewards)
-		reserverCoins = reserverCoins.Sub(sdk.NewCoin(config.BaseDenom, truncatedRewards))
-		ctx = ctx.WithBlockHeight(i + 1)
-	}
-	GenerateSampleFile(fileName, generatedTestData)
-}
-
-func GenerateSampleFile(fp string, data []EmissionTestData) {
-	file, _ := json.MarshalIndent(data, "", " ")
-	_ = ioutil.WriteFile(fp, file, 0600)
-}
+//func getaZetaFromString(amount string) sdk.Coins {
+//	emissionPoolInt, _ := sdk.NewIntFromString(amount)
+//	return sdk.NewCoins(sdk.NewCoin(config.BaseDenom, emissionPoolInt))
+//}
+//
+//func SetupApp(t *testing.T, params emissionsModuleTypes.Params, emissionPoolCoins sdk.Coins) (*zetaapp.App, sdk.Context, *tmtypes.ValidatorSet, *authtypes.BaseAccount) {
+//	pk1 := ed25519.GenPrivKey().PubKey()
+//	acc1 := authtypes.NewBaseAccountWithAddress(sdk.AccAddress(pk1.Address()))
+//	// genDelActs and genDelBalances need to have the same addresses
+//	// bondAmount is specified separately , the Balances here are additional tokens for delegators to have in their accounts
+//	genDelActs := make(authtypes.GenesisAccounts, 1)
+//	genDelBalances := make([]banktypes.Balance, 1)
+//	genDelActs[0] = acc1
+//	genDelBalances[0] = banktypes.Balance{
+//		Address: acc1.GetAddress().String(),
+//		Coins:   emissionPoolCoins,
+//	}
+//	delBondAmount := getaZetaFromString("1000000000000000000000000")
+//
+//	//genBalances := make([]banktypes.Balance, 1)
+//	//genBalances[0] = banktypes.Balance{
+//	//	Address: emissionsModuleTypes.EmissionsModuleAddress.String(),
+//	//	Coins:   emissionPoolCoins,
+//	//}
+//
+//	vset := tmtypes.NewValidatorSet([]*tmtypes.Validator{})
+//	for i := 0; i < 1; i++ {
+//		privKey := ed25519.GenPrivKey()
+//		pubKey := privKey.PubKey()
+//		val := tmtypes.NewValidator(pubKey, 1)
+//		err := vset.UpdateWithChangeSet([]*tmtypes.Validator{val})
+//		if err != nil {
+//			panic("Failed to add validator")
+//		}
+//	}
+//
+//	app := simapp.SetupWithGenesisValSet(t, vset, genDelActs, delBondAmount.AmountOf(config.BaseDenom), params, genDelBalances, nil)
+//	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+//	ctx = ctx.WithBlockHeight(app.LastBlockHeight())
+//	return app, ctx, vset, acc1
+//}
+//
+//type EmissionTestData struct {
+//	BlockHeight    int64   `json:"blockHeight,omitempty"`
+//	BondFactor     sdk.Dec `json:"bondFactor"`
+//	ReservesFactor sdk.Dec `json:"reservesFactor"`
+//	DurationFactor string  `json:"durationFactor"`
+//}
+//
+//func TestAppModule_GetBlockRewardComponents(t *testing.T) {
+//
+//	tests := []struct {
+//		name                 string
+//		startingEmissionPool string
+//		params               emissionsModuleTypes.Params
+//		testMaxHeight        int64
+//		inputFilename        string
+//		checkValues          []EmissionTestData
+//		generateOnly         bool
+//	}{
+//		{
+//			name:                 "default values",
+//			params:               emissionsModuleTypes.DefaultParams(),
+//			startingEmissionPool: "1000000000000000000000000",
+//			testMaxHeight:        300,
+//			inputFilename:        "simulations.json",
+//			generateOnly:         false,
+//		},
+//		{
+//			name:                 "higher starting pool",
+//			params:               emissionsModuleTypes.DefaultParams(),
+//			startingEmissionPool: "100000000000000000000000000000000",
+//			testMaxHeight:        300,
+//			inputFilename:        "simulations.json",
+//			generateOnly:         false,
+//		},
+//		{
+//			name:                 "lower starting pool",
+//			params:               emissionsModuleTypes.DefaultParams(),
+//			startingEmissionPool: "100000000000000000",
+//			testMaxHeight:        300,
+//			inputFilename:        "simulations.json",
+//			generateOnly:         false,
+//		},
+//		{
+//			name: "different distribution percentages",
+//			params: emissionsModuleTypes.Params{
+//				MaxBondFactor:               "1.25",
+//				MinBondFactor:               "0.75",
+//				AvgBlockTime:                "6.00",
+//				TargetBondRatio:             "00.67",
+//				ValidatorEmissionPercentage: "00.10",
+//				ObserverEmissionPercentage:  "00.85",
+//				TssSignerEmissionPercentage: "00.05",
+//				DurationFactorConstant:      "0.001877876953694702",
+//			},
+//			startingEmissionPool: "1000000000000000000000000",
+//			testMaxHeight:        300,
+//			inputFilename:        "simulations.json",
+//			generateOnly:         false,
+//		},
+//		{
+//			name: "higher block time",
+//			params: emissionsModuleTypes.Params{
+//				MaxBondFactor:               "1.25",
+//				MinBondFactor:               "0.75",
+//				AvgBlockTime:                "20.00",
+//				TargetBondRatio:             "00.67",
+//				ValidatorEmissionPercentage: "00.10",
+//				ObserverEmissionPercentage:  "00.85",
+//				TssSignerEmissionPercentage: "00.05",
+//				DurationFactorConstant:      "0.1",
+//			},
+//			startingEmissionPool: "1000000000000000000000000",
+//			testMaxHeight:        300,
+//			inputFilename:        "simulations.json",
+//			generateOnly:         false,
+//		},
+//		{
+//			name: "different duration constant",
+//			params: emissionsModuleTypes.Params{
+//				MaxBondFactor:               "1.25",
+//				MinBondFactor:               "0.75",
+//				AvgBlockTime:                "6.00",
+//				TargetBondRatio:             "00.67",
+//				ValidatorEmissionPercentage: "00.10",
+//				ObserverEmissionPercentage:  "00.85",
+//				TssSignerEmissionPercentage: "00.05",
+//				DurationFactorConstant:      "0.1",
+//			},
+//			startingEmissionPool: "1000000000000000000000000",
+//			testMaxHeight:        300,
+//			inputFilename:        "simulations.json",
+//			generateOnly:         false,
+//		},
+//	}
+//
+//	for _, tt := range tests {
+//		t.Run(tt.name, func(t *testing.T) {
+//			app, ctx, _, minter := SetupApp(t, tt.params, getaZetaFromString(tt.startingEmissionPool))
+//			err := app.BankKeeper.SendCoinsFromAccountToModule(ctx, minter.GetAddress(), emissionsModuleTypes.ModuleName, getaZetaFromString(tt.startingEmissionPool))
+//			assert.NoError(t, err)
+//			GenerateTestDataMaths(app, ctx, tt.testMaxHeight, tt.inputFilename)
+//			defer func(t *testing.T, fp string) {
+//				err := os.RemoveAll(fp)
+//				assert.NoError(t, err)
+//			}(t, tt.inputFilename)
+//
+//			if tt.generateOnly {
+//				return
+//			}
+//			inputTestData, err := GetInputData(tt.inputFilename)
+//			assert.NoError(t, err)
+//			sort.SliceStable(inputTestData, func(i, j int) bool { return inputTestData[i].BlockHeight < inputTestData[j].BlockHeight })
+//			startHeight := ctx.BlockHeight()
+//			assert.Equal(t, startHeight, inputTestData[0].BlockHeight, "starting block height should be equal to the first block height in the input data")
+//			for i := startHeight; i < tt.testMaxHeight; i++ {
+//				//The First distribution will occur only when begin-block is triggered
+//				reservesFactor, bondFactor, durationFactor := app.EmissionsKeeper.GetBlockRewardComponents(ctx)
+//				assert.Equal(t, inputTestData[i-1].ReservesFactor, reservesFactor, "reserves factor should be equal to the input data"+fmt.Sprintf(" , block height: %d", i))
+//				assert.Equal(t, inputTestData[i-1].BondFactor, bondFactor, "bond factor should be equal to the input data"+fmt.Sprintf(" , block height: %d", i))
+//				assert.Equal(t, inputTestData[i-1].DurationFactor, durationFactor.String(), "duration factor should be equal to the input data"+fmt.Sprintf(" , block height: %d", i))
+//				emissionsModule.BeginBlocker(ctx, app.EmissionsKeeper)
+//				ctx = ctx.WithBlockHeight(i + 1)
+//			}
+//		})
+//	}
+//}
+//
+//func GetInputData(fp string) ([]EmissionTestData, error) {
+//	data := []EmissionTestData{}
+//	file, err := filepath.Abs(fp)
+//	if err != nil {
+//
+//		return nil, err
+//	}
+//	file = filepath.Clean(file)
+//	input, err := ioutil.ReadFile(file) // #nosec G304
+//	if err != nil {
+//		return nil, err
+//	}
+//	err = json.Unmarshal(input, &data)
+//	if err != nil {
+//		return nil, err
+//	}
+//	formatedData := make([]EmissionTestData, len(data))
+//	for i, dd := range data {
+//		fl, err := strconv.ParseFloat(dd.DurationFactor, 64)
+//		if err != nil {
+//			return nil, err
+//		}
+//		dd.DurationFactor = fmt.Sprintf("%0.18f", fl)
+//		formatedData[i] = dd
+//	}
+//	return formatedData, nil
+//}
+//
+//func GenerateTestDataMaths(app *zetaapp.App, ctx sdk.Context, testMaxHeight int64, fileName string) {
+//	var generatedTestData []EmissionTestData
+//	reserverCoins := app.BankKeeper.GetBalance(ctx, emissionsModuleTypes.EmissionsModuleAddress, config.BaseDenom)
+//	startHeight := ctx.BlockHeight()
+//	for i := startHeight; i < testMaxHeight; i++ {
+//		reservesFactor := sdk.NewDecFromInt(reserverCoins.Amount)
+//		bondFactor := app.EmissionsKeeper.GetBondFactor(ctx, app.StakingKeeper)
+//		durationFactor := app.EmissionsKeeper.GetDurationFactor(ctx)
+//		blockRewards := reservesFactor.Mul(bondFactor).Mul(durationFactor)
+//		generatedTestData = append(generatedTestData, EmissionTestData{
+//			BlockHeight:    i,
+//			BondFactor:     bondFactor,
+//			DurationFactor: durationFactor.String(),
+//			ReservesFactor: reservesFactor,
+//		})
+//		validatorRewards := sdk.MustNewDecFromStr(app.EmissionsKeeper.GetParams(ctx).ValidatorEmissionPercentage).Mul(blockRewards).TruncateInt()
+//		observerRewards := sdk.MustNewDecFromStr(app.EmissionsKeeper.GetParams(ctx).ObserverEmissionPercentage).Mul(blockRewards).TruncateInt()
+//		tssSignerRewards := sdk.MustNewDecFromStr(app.EmissionsKeeper.GetParams(ctx).TssSignerEmissionPercentage).Mul(blockRewards).TruncateInt()
+//		truncatedRewards := validatorRewards.Add(observerRewards).Add(tssSignerRewards)
+//		reserverCoins = reserverCoins.Sub(sdk.NewCoin(config.BaseDenom, truncatedRewards))
+//		ctx = ctx.WithBlockHeight(i + 1)
+//	}
+//	GenerateSampleFile(fileName, generatedTestData)
+//}
+//
+//func GenerateSampleFile(fp string, data []EmissionTestData) {
+//	file, _ := json.MarshalIndent(data, "", " ")
+//	_ = ioutil.WriteFile(fp, file, 0600)
+//}

--- a/x/emissions/keeper/block_rewards_components.go
+++ b/x/emissions/keeper/block_rewards_components.go
@@ -61,7 +61,7 @@ func (k Keeper) GetReservesFactor(ctx sdk.Context) sdk.Dec {
 	return sdk.NewDecFromInt(reserveAmount.Amount)
 }
 
-func (k Keeper) GetFixedBlockRewards(ctx sdk.Context) (sdk.Dec, error) {
+func (k Keeper) GetFixedBlockRewards() (sdk.Dec, error) {
 	return CalculateFixedValidatorRewards(types.AvgBlockTime)
 }
 

--- a/x/emissions/keeper/block_rewards_components_test.go
+++ b/x/emissions/keeper/block_rewards_components_test.go
@@ -6,46 +6,45 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	emissionskeeper "github.com/zeta-chain/zetacore/x/emissions/keeper"
-	"github.com/zeta-chain/zetacore/x/emissions/types"
 )
 
 func TestKeeper_CalculateFixedValidatorRewards(t *testing.T) {
 	tt := []struct {
-		name            string
-		blockTimeInSecs string
+		name                 string
+		blockTimeInSecs      string
+		expectedBlockRewards sdk.Dec
 	}{
 		{
-			name:            "Block Time 5.7",
-			blockTimeInSecs: "5.7",
+			name:                 "Block Time 5.7",
+			blockTimeInSecs:      "5.7",
+			expectedBlockRewards: sdk.MustNewDecFromStr("9620949074074074074.074070733466756687"),
 		},
 		{
-			name:            "Block Time 6",
-			blockTimeInSecs: "6",
+			name:                 "Block Time 6",
+			blockTimeInSecs:      "6",
+			expectedBlockRewards: sdk.MustNewDecFromStr("10127314814814814814.814814814814814815"),
 		},
 		{
-			name:            "Block Time 3",
-			blockTimeInSecs: "3",
+			name:                 "Block Time 3",
+			blockTimeInSecs:      "3",
+			expectedBlockRewards: sdk.MustNewDecFromStr("5063657407407407407.407407407407407407"),
 		},
 		{
-			name:            "Block Time 2",
-			blockTimeInSecs: "2",
+			name:                 "Block Time 2",
+			blockTimeInSecs:      "2",
+			expectedBlockRewards: sdk.MustNewDecFromStr("3375771604938271604.938271604938271605"),
 		},
 		{
-			name:            "Block Time 8",
-			blockTimeInSecs: "8",
+			name:                 "Block Time 8",
+			blockTimeInSecs:      "8",
+			expectedBlockRewards: sdk.MustNewDecFromStr("13503086419753086419.753086419753086420"),
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			blockRewards, err := emissionskeeper.CalculateFixedValidatorRewards(tc.blockTimeInSecs)
 			assert.NoError(t, err)
-			avgBlockTime, err := sdk.NewDecFromStr(tc.blockTimeInSecs)
-			assert.NoError(t, err)
-			azetaAmountTotalRewards, err := sdk.NewDecFromStr("210000000000000000000000000")
-			numberOfBlocksInAMonth := sdk.NewDec(types.SecsInMonth).Quo(avgBlockTime)
-			numberOfBlocksTotal := numberOfBlocksInAMonth.Mul(sdk.NewDec(12)).Mul(sdk.NewDec(types.EmissionScheduledYears))
-			constantRewardPerBlock := azetaAmountTotalRewards.Quo(numberOfBlocksTotal)
-			assert.Equal(t, constantRewardPerBlock, blockRewards)
+			assert.Equal(t, tc.expectedBlockRewards, blockRewards)
 		})
 	}
 }

--- a/x/emissions/keeper/block_rewards_components_test.go
+++ b/x/emissions/keeper/block_rewards_components_test.go
@@ -1,0 +1,51 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	emissionskeeper "github.com/zeta-chain/zetacore/x/emissions/keeper"
+	"github.com/zeta-chain/zetacore/x/emissions/types"
+)
+
+func TestKeeper_CalculateFixedValidatorRewards(t *testing.T) {
+	tt := []struct {
+		name            string
+		blockTimeInSecs string
+	}{
+		{
+			name:            "Block Time 5.7",
+			blockTimeInSecs: "5.7",
+		},
+		{
+			name:            "Block Time 6",
+			blockTimeInSecs: "6",
+		},
+		{
+			name:            "Block Time 3",
+			blockTimeInSecs: "3",
+		},
+		{
+			name:            "Block Time 2",
+			blockTimeInSecs: "2",
+		},
+		{
+			name:            "Block Time 8",
+			blockTimeInSecs: "8",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			blockRewards, err := emissionskeeper.CalculateFixedValidatorRewards(tc.blockTimeInSecs)
+			assert.NoError(t, err)
+			avgBlockTime, err := sdk.NewDecFromStr(tc.blockTimeInSecs)
+			assert.NoError(t, err)
+			azetaAmountTotalRewards, err := sdk.NewDecFromStr("210000000000000000000000000")
+			numberOfBlocksInAMonth := sdk.NewDec(types.SecsInMonth).Quo(avgBlockTime)
+			numberOfBlocksTotal := numberOfBlocksInAMonth.Mul(sdk.NewDec(12)).Mul(sdk.NewDec(types.EmissionScheduledYears))
+			constantRewardPerBlock := azetaAmountTotalRewards.Quo(numberOfBlocksTotal)
+			assert.Equal(t, constantRewardPerBlock, blockRewards)
+		})
+	}
+}

--- a/x/emissions/types/keys.go
+++ b/x/emissions/types/keys.go
@@ -23,7 +23,11 @@ const (
 	MemStoreKey              = "mem_emissions"
 	WithdrawableEmissionsKey = "WithdrawableEmissions-value-"
 
-	SecsInMonth = 30 * 24 * 60 * 60
+	SecsInMonth        = 30 * 24 * 60 * 60
+	BlockRewardsInZeta = "210000000"
+
+	EmissionScheduledYears = 4
+	AvgBlockTime           = "5.7"
 )
 
 func KeyPrefix(p string) []byte {

--- a/x/emissions/types/keys.go
+++ b/x/emissions/types/keys.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
@@ -50,4 +51,5 @@ var (
 	EmissionsModuleAddress                  = authtypes.NewModuleAddress(ModuleName)
 	UndistributedObserverRewardsPoolAddress = authtypes.NewModuleAddress(UndistributedObserverRewardsPool)
 	UndistributedTssRewardsPoolAddress      = authtypes.NewModuleAddress(UndistributedTssRewardsPool)
+	BlockReward                             = sdk.MustNewDecFromStr("9620949074074074074.074070733466756687")
 )


### PR DESCRIPTION
# Description
- Replace dynamically calculated block rewards by fixed rewards 
- Add additional logs for mock mainnet deployment 

Closes : https://github.com/zeta-chain/node/issues/1660

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
