### PR TITLE
fix: paying 50% more than base gas price to buffer EIP1559 gas price increase

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* [1672](https://github.com/zeta-chain/node/pull/1672) - paying 50% more than base gas price to buffer EIP1559 gas price increase
 * [1642](https://github.com/zeta-chain/node/pull/1642) - Change WhitelistERC20 authorization from group1 to group2
 * [1610](https://github.com/zeta-chain/node/issues/1610) - add pending outtx hash to tracker after monitoring for 10 minutes
 * [1656](https://github.com/zeta-chain/node/issues/1656) - schedule bitcoin keysign with intervals to avoid keysign failures

--- a/zetaclient/broadcast.go
+++ b/zetaclient/broadcast.go
@@ -25,6 +25,12 @@ const (
 	DefaultBaseGasPrice = 1_000_000
 )
 
+var (
+	// paying 50% more than the current base gas price to buffer for potential block-by-block
+	// gas price increase due to EIP1559 feemarket on ZetaChain
+	bufferMultiplier = sdktypes.MustNewDecFromStr("1.5")
+)
+
 // Broadcast Broadcasts tx to metachain. Returns txHash and error
 func (b *ZetaCoreBridge) Broadcast(gaslimit uint64, authzWrappedMsg sdktypes.Msg, authzSigner AuthZSigner) (string, error) {
 	b.broadcastLock.Lock()
@@ -44,7 +50,7 @@ func (b *ZetaCoreBridge) Broadcast(gaslimit uint64, authzWrappedMsg sdktypes.Msg
 	}
 	reductionRate := sdktypes.MustNewDecFromStr(ante.GasPriceReductionRate)
 	// multiply gas price by the system tx reduction rate
-	adjustedBaseGasPrice := sdktypes.NewDec(baseGasPrice).Mul(reductionRate)
+	adjustedBaseGasPrice := sdktypes.NewDec(baseGasPrice).Mul(reductionRate).Mul(bufferMultiplier)
 
 	if blockHeight > b.blockHeight {
 		b.blockHeight = blockHeight


### PR DESCRIPTION
# Description

During busy time the block gas limit will be near full and as result, gas price can increase block by block due to EIP1559 -like feemarket. `zetaclientd` queries base gas price before making a tx, but the gas price might already be too low for the next block. This PR over pays 50% base gas price to buffer for such block gas price increases, targeting around 10min non-stop gas price increase. 

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
