### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the Bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS
+- Version used

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Motivation and Context**
+Please describe the motivation behind this request and the context in which it applies.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: For any other issue that doesn't fit the other categories. General code change.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the Issue**
+A clear and concise description of what the issue is.
+
+**Expected Outcome**
+A description of what outcome you are seeking.

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,10 @@
 
 * [1584](https://github.com/zeta-chain/node/pull/1584) - allow to run E2E tests on any networks
 
+### Chores
+
+* [1729](https://github.com/zeta-chain/node/pull/1729) - add issue templates
+
 ## Version: v12.2.4
 
 ### Fixes


### PR DESCRIPTION
# Description

Add templates for when creating issues.

The team will generally use task template.
Bugs and features give a framework for external for enquiries.

Closes: https://github.com/zeta-chain/node/issues/1726

