### PR TITLE
chore: update upgrade handler to `v13`

### DIFF
--- a/Dockerfile-versioned-source
+++ b/Dockerfile-versioned-source
@@ -17,7 +17,7 @@ WORKDIR /go/delivery/zeta-node
 RUN mkdir -p  $GOPATH/bin/old
 RUN mkdir -p  $GOPATH/bin/new
 
-ENV NEW_VERSION=v13.0.0
+ENV NEW_VERSION=v13
 
 # Build new release from the current source
 COPY go.mod /go/delivery/zeta-node/

--- a/Dockerfile-versioned-source
+++ b/Dockerfile-versioned-source
@@ -17,7 +17,7 @@ WORKDIR /go/delivery/zeta-node
 RUN mkdir -p  $GOPATH/bin/old
 RUN mkdir -p  $GOPATH/bin/new
 
-ENV NEW_VERSION=v12.3.0
+ENV NEW_VERSION=v13.0.0
 
 # Build new release from the current source
 COPY go.mod /go/delivery/zeta-node/

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -8,7 +8,7 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const releaseVersion = "v13.0.0"
+const releaseVersion = "v13"
 
 func SetupHandlers(app *App) {
 	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, plan types.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -8,7 +8,7 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const releaseVersion = "v12.3.0"
+const releaseVersion = "v13.0.0"
 
 func SetupHandlers(app *App) {
 	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, plan types.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## Version: v13.0.0
 
 * `zetaclientd start` : 2 inputs required from stdin
 


### PR DESCRIPTION
# Description

Closes: https://github.com/zeta-chain/node/issues/1776


