### PR TITLE
feat: v14 migration

### DIFF
--- a/Dockerfile-versioned-source
+++ b/Dockerfile-versioned-source
@@ -17,7 +17,7 @@ WORKDIR /go/delivery/zeta-node
 RUN mkdir -p  $GOPATH/bin/old
 RUN mkdir -p  $GOPATH/bin/new
 
-ENV NEW_VERSION=v13
+ENV NEW_VERSION=v14
 
 # Build new release from the current source
 COPY go.mod /go/delivery/zeta-node/

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ stateful-upgrade:
 
 stateful-upgrade-source:
 	@echo "--> Starting stateful smoketest"
-	$(DOCKER) build --build-arg old_version=v12.2.1 -t zetanode -f ./Dockerfile-versioned-source .
+	$(DOCKER) build --build-arg old_version=v13.0.0 -t zetanode -f ./Dockerfile-versioned-source .
 	$(DOCKER) build -t orchestrator -f contrib/localnet/orchestrator/Dockerfile-upgrade.fastbuild .
 	cd contrib/localnet/ && $(DOCKER) compose -f docker-compose-stateful.yml up -d
 

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -8,7 +8,8 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const releaseVersion = "v13"
+// "v13-testnet" is the release version for the v13 testnet upgrade
+const releaseVersion = "v14"
 
 func SetupHandlers(app *App) {
 	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, plan types.Plan, vm module.VersionMap) (module.VersionMap, error) {
@@ -17,7 +18,9 @@ func SetupHandlers(app *App) {
 		for m, mb := range app.mm.Modules {
 			vm[m] = mb.ConsensusVersion()
 		}
-		VersionMigrator{v: vm}.TriggerMigration(crosschaintypes.ModuleName)
+		// Set the consensus version for the crosschain module to 4.
+		// This would trigger the migration script for Version 4 to 5
+		vm[crosschaintypes.ModuleName] = 4
 
 		return app.mm.RunMigrations(ctx, app.configurator, vm)
 	})
@@ -36,13 +39,4 @@ func SetupHandlers(app *App) {
 		// instead the default which is the latest version that store last committed i.e 0 for new stores.
 		app.SetStoreLoader(types.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
-}
-
-type VersionMigrator struct {
-	v module.VersionMap
-}
-
-func (v VersionMigrator) TriggerMigration(moduleName string) module.VersionMap {
-	v.v[moduleName] = v.v[moduleName] - 1
-	return v.v
 }

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -18,9 +18,7 @@ func SetupHandlers(app *App) {
 		for m, mb := range app.mm.Modules {
 			vm[m] = mb.ConsensusVersion()
 		}
-		// Set the consensus version for the crosschain module to 4.
-		// This would trigger the migration script for Version 4 to 5
-		vm[crosschaintypes.ModuleName] = 4
+		VersionMigrator{v: vm}.TriggerMigration(crosschaintypes.ModuleName)
 
 		return app.mm.RunMigrations(ctx, app.configurator, vm)
 	})
@@ -39,4 +37,13 @@ func SetupHandlers(app *App) {
 		// instead the default which is the latest version that store last committed i.e 0 for new stores.
 		app.SetStoreLoader(types.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
+}
+
+type VersionMigrator struct {
+	v module.VersionMap
+}
+
+func (v VersionMigrator) TriggerMigration(moduleName string) module.VersionMap {
+	v.v[moduleName] = v.v[moduleName] - 1
+	return v.v
 }

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -8,7 +8,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-// "v13-testnet" is the release version for the v13 testnet upgrade
 const releaseVersion = "v14"
 
 func SetupHandlers(app *App) {

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # CHANGELOG
+## Version: v14
 
+### Fixes 
+- [1817](https://github.com/zeta-chain/node/pull/1817) - Add migration script to fix pending and chain nonces on testnet
 
 ## Version: v13.0.0
 

--- a/x/crosschain/migrations/v5/migrate.go
+++ b/x/crosschain/migrations/v5/migrate.go
@@ -67,10 +67,10 @@ type Nonce struct {
 
 func CurrentTestnetChains() map[common.Chain]Nonce {
 	return map[common.Chain]Nonce{
-		common.GoerliChain():     Nonce{nonceHigh: 226841, nonceLow: 226841},
-		common.MumbaiChain():     Nonce{nonceHigh: 200599, nonceLow: 200599},
-		common.BscTestnetChain(): Nonce{nonceHigh: 110454, nonceLow: 110454},
-		common.BtcTestNetChain(): Nonce{nonceHigh: 4881, nonceLow: 4881},
+		common.GoerliChain():     {nonceHigh: 226841, nonceLow: 226841},
+		common.MumbaiChain():     {nonceHigh: 200599, nonceLow: 200599},
+		common.BscTestnetChain(): {nonceHigh: 110454, nonceLow: 110454},
+		common.BtcTestNetChain(): {nonceHigh: 4881, nonceLow: 4881},
 	}
 }
 

--- a/x/crosschain/migrations/v5/migrate.go
+++ b/x/crosschain/migrations/v5/migrate.go
@@ -60,7 +60,9 @@ func ResetTestnetNonce(
 		if !found {
 			continue
 		}
+		// #nosec G701 always in range for testnet chains
 		pn.NonceLow = int64(chainNonce.nonceLow)
+		// #nosec G701 always in range for testnet chains
 		pn.NonceHigh = int64(chainNonce.nonceHigh)
 		observerKeeper.SetPendingNonces(ctx, pn)
 	}

--- a/x/crosschain/migrations/v5/migrate.go
+++ b/x/crosschain/migrations/v5/migrate.go
@@ -41,15 +41,21 @@ func ResetTestnetNonce(
 ) {
 	tss, found := observerKeeper.GetTSS(ctx)
 	if !found {
+		ctx.Logger().Info("ResetTestnetNonce: TSS not found")
 		return
 	}
 	for chain, nonce := range CurrentTestnetChains() {
 		cn, found := observerKeeper.GetChainNonces(ctx, chain.ChainName.String())
 		if !found {
+			ctx.Logger().Info("ResetTestnetNonce: Chain nonce not found", "chain", chain.ChainName.String())
 			continue
 		}
+
+		ctx.Logger().Info("ResetTestnetNonce: Resetting chain nonce", "chain", chain.ChainName.String())
+
 		cn.Nonce = nonce.nonceHigh
 		observerKeeper.SetChainNonces(ctx, cn)
+
 		pn, found := observerKeeper.GetPendingNonces(ctx, tss.TssPubkey, chain.ChainId)
 		if !found {
 			continue

--- a/x/crosschain/migrations/v5/migrate.go
+++ b/x/crosschain/migrations/v5/migrate.go
@@ -44,39 +44,40 @@ func ResetTestnetNonce(
 		ctx.Logger().Info("ResetTestnetNonce: TSS not found")
 		return
 	}
-	for chain, nonce := range CurrentTestnetChains() {
-		cn, found := observerKeeper.GetChainNonces(ctx, chain.ChainName.String())
+	for _, chainNonce := range CurrentTestnetChains() {
+		cn, found := observerKeeper.GetChainNonces(ctx, chainNonce.chain.ChainName.String())
 		if !found {
-			ctx.Logger().Info("ResetTestnetNonce: Chain nonce not found", "chain", chain.ChainName.String())
+			ctx.Logger().Info("ResetTestnetNonce: Chain nonce not found", "chain", chainNonce.chain.ChainName.String())
 			continue
 		}
 
-		ctx.Logger().Info("ResetTestnetNonce: Resetting chain nonce", "chain", chain.ChainName.String())
+		ctx.Logger().Info("ResetTestnetNonce: Resetting chain nonce", "chain", chainNonce.chain.ChainName.String())
 
-		cn.Nonce = nonce.nonceHigh
+		cn.Nonce = chainNonce.nonceHigh
 		observerKeeper.SetChainNonces(ctx, cn)
 
-		pn, found := observerKeeper.GetPendingNonces(ctx, tss.TssPubkey, chain.ChainId)
+		pn, found := observerKeeper.GetPendingNonces(ctx, tss.TssPubkey, chainNonce.chain.ChainId)
 		if !found {
 			continue
 		}
-		pn.NonceLow = int64(nonce.nonceLow)
-		pn.NonceHigh = int64(nonce.nonceHigh)
+		pn.NonceLow = int64(chainNonce.nonceLow)
+		pn.NonceHigh = int64(chainNonce.nonceHigh)
 		observerKeeper.SetPendingNonces(ctx, pn)
 	}
 }
 
-type Nonce struct {
+type TestnetNonce struct {
+	chain     common.Chain
 	nonceHigh uint64
 	nonceLow  uint64
 }
 
-func CurrentTestnetChains() map[common.Chain]Nonce {
-	return map[common.Chain]Nonce{
-		common.GoerliChain():     {nonceHigh: 226841, nonceLow: 226841},
-		common.MumbaiChain():     {nonceHigh: 200599, nonceLow: 200599},
-		common.BscTestnetChain(): {nonceHigh: 110454, nonceLow: 110454},
-		common.BtcTestNetChain(): {nonceHigh: 4881, nonceLow: 4881},
+func CurrentTestnetChains() []TestnetNonce {
+	return []TestnetNonce{
+		{chain: common.GoerliChain(), nonceHigh: 226841, nonceLow: 226841},
+		{chain: common.MumbaiChain(), nonceHigh: 200599, nonceLow: 200599},
+		{chain: common.BscTestnetChain(), nonceHigh: 110454, nonceLow: 110454},
+		{chain: common.BtcTestNetChain(), nonceHigh: 4881, nonceLow: 4881},
 	}
 }
 

--- a/x/crosschain/module.go
+++ b/x/crosschain/module.go
@@ -181,7 +181,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 4 }
+func (AppModule) ConsensusVersion() uint64 { return 5 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the crosschain module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {

--- a/zetaclient/bitcoin/bitcoin_client.go
+++ b/zetaclient/bitcoin/bitcoin_client.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	DynamicDepositorFeeHeight = 832000 // Bitcoin block height to switch to dynamic depositor fee
+	// The starting height (Bitcoin mainnet) from which dynamic depositor fee will take effect
+	DynamicDepositorFeeHeight = 834500
 )
 
 var _ interfaces.ChainClient = &BTCChainClient{}


### PR DESCRIPTION
# Description
Hotfix: Resetes the pending nonces for testnet only. This would fix the issue caused by running the wrong migration script in v13 . 
The new migration script still sets `ZetaACccounting` for mainnet , but does not reset the nonces .


Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
