### PR TITLE
set mainnet btc deposit fee height to future height

### DIFF
--- a/zetaclient/bitcoin/bitcoin_client.go
+++ b/zetaclient/bitcoin/bitcoin_client.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	DynamicDepositorFeeHeight = 832000 // Bitcoin block height to switch to dynamic depositor fee
+	DynamicDepositorFeeHeight = 834500 // Bitcoin block height to switch to dynamic depositor fee
 )
 
 var _ interfaces.ChainClient = &BTCChainClient{}

--- a/zetaclient/bitcoin/bitcoin_client.go
+++ b/zetaclient/bitcoin/bitcoin_client.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	DynamicDepositorFeeHeight = 834500 // Bitcoin block height to switch to dynamic depositor fee
+	// The starting height (Bitcoin mainnet) from which dynamic depositor fee will take effect
+	DynamicDepositorFeeHeight = 834500
 )
 
 var _ interfaces.ChainClient = &BTCChainClient{}


### PR DESCRIPTION
# Description

The current upgrade height `832000` has already past. We should offset the height to future. I increased the Bitcoin height by `2` more weeks.

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
