### PR TITLE
test: fix some failing unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,10 @@ test :clean-test-dir run-test
 test-hsm:
 	@go test ${HSM_BUILD_FLAGS} ${TEST_DIR}
 
-test-coverage-exclude-core:
-	@go test ${TEST_BUILD_FLAGS} -v -coverprofile coverage.out $(go list ./... | grep -v /x/zetacore/)
-
+# Generate the test coverage
+# "|| exit 1" is used to return a non-zero exit code if the tests fail
 test-coverage:
-	-@go test ${TEST_BUILD_FLAGS} -v -coverprofile coverage.out ${TEST_DIR}
+	@go test ${TEST_BUILD_FLAGS} -v -coverprofile coverage.out ${TEST_DIR} || exit 1
 
 coverage-report: test-coverage
 	@go tool cover -html=coverage.out -o coverage.html

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-hsm:
 # Generate the test coverage
 # "|| exit 1" is used to return a non-zero exit code if the tests fail
 test-coverage:
-	@go test ${TEST_BUILD_FLAGS} -v -coverprofile coverage.out ${TEST_DIR} || exit 1
+	@go test ${TEST_BUILD_FLAGS} -coverprofile coverage.out ${TEST_DIR} || exit 1
 
 coverage-report: test-coverage
 	@go tool cover -html=coverage.out -o coverage.html

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,4 @@
 # CHANGELOG
-## Version: v14
-
-### Fixes 
-- [1817](https://github.com/zeta-chain/node/pull/1817) - Add migration script to fix pending and chain nonces on testnet
 
 ## Unreleased
 
@@ -29,11 +25,17 @@
 * [1767](https://github.com/zeta-chain/node/pull/1767) - add unit tests for emissions module begin blocker
 * [1816](https://github.com/zeta-chain/node/pull/1816) - add args to e2e tests
 * [1791](https://github.com/zeta-chain/node/pull/1791) - add e2e tests for feature of restricted address
-* [1787](https://github.com/zeta-chain/node/pull/1787) - add unit tests for cross-chain evm hooks and e2e test failed withdraw to BTC legacy address 
+* [1787](https://github.com/zeta-chain/node/pull/1787) - add unit tests for cross-chain evm hooks and e2e test failed withdraw to BTC legacy address
+* [1840](https://github.com/zeta-chain/node/pull/1840) - fix code coverage test failures ignored in CI
 
 ### Chores
 
 * [1814](https://github.com/zeta-chain/node/pull/1814) - fix code coverage ignore for protobuf generated files
+
+## Version: v14
+
+### Fixes 
+- [1817](https://github.com/zeta-chain/node/pull/1817) - Add migration script to fix pending and chain nonces on testnet
 
 ## Version: v13.0.0
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,15 +28,12 @@ comment:
 
 flags:
   zetacore:
-    carryforward: true
     paths:
       - "x/"
   zetaclient:
-    carryforward: true
     paths:
       - "zetaclient/"
   common:
-    carryforward: true
     paths:
       - "common/"
 

--- a/testutil/network/genesis_state.go
+++ b/testutil/network/genesis_state.go
@@ -3,9 +3,10 @@ package network
 import (
 	"encoding/json"
 	"fmt"
-	authoritytypes "github.com/zeta-chain/zetacore/x/authority/types"
 	"strconv"
 	"testing"
+
+	authoritytypes "github.com/zeta-chain/zetacore/x/authority/types"
 
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/authority/types/message_update_policies_test.go
+++ b/x/authority/types/message_update_policies_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestMsgUpdatePolicies_ValidateBasic(t *testing.T) {
-	setConfig()
-
 	tests := []struct {
 		name string
 		msg  *types.MsgUpdatePolicies

--- a/x/authority/types/policies_test.go
+++ b/x/authority/types/policies_test.go
@@ -18,8 +18,6 @@ func setConfig() {
 }
 
 func TestPolicies_Validate(t *testing.T) {
-	setConfig()
-
 	// use table driven tests to test the validation of policies
 	tests := []struct {
 		name        string

--- a/x/crosschain/keeper/evm_hooks_test.go
+++ b/x/crosschain/keeper/evm_hooks_test.go
@@ -18,15 +18,11 @@ import (
 	"github.com/zeta-chain/zetacore/testutil/sample"
 	crosschainkeeper "github.com/zeta-chain/zetacore/x/crosschain/keeper"
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
-	fungiblekeeper "github.com/zeta-chain/zetacore/x/fungible/keeper"
 	fungibletypes "github.com/zeta-chain/zetacore/x/fungible/types"
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
 func SetupStateForProcessLogsZetaSent(t *testing.T, ctx sdk.Context, k *crosschainkeeper.Keeper, zk keepertest.ZetaKeepers, sdkk keepertest.SDKKeepers, chain common.Chain) {
-	admin := sample.AccAddress()
-	setAdminPolicies(ctx, zk, admin)
-
 	assetAddress := sample.EthAddress().String()
 	gasZRC20 := setupGasCoin(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper, chain.ChainId, "ethereum", "ETH")
 	zrc20Addr := deployZRC20(
@@ -39,12 +35,10 @@ func SetupStateForProcessLogsZetaSent(t *testing.T, ctx sdk.Context, k *crosscha
 		assetAddress,
 		"ETH",
 	)
-	fungibleMsgServer := fungiblekeeper.NewMsgServerImpl(*zk.FungibleKeeper)
-	_, err := fungibleMsgServer.UpdateZRC20WithdrawFee(
-		sdk.UnwrapSDKContext(ctx),
-		fungibletypes.NewMsgUpdateZRC20WithdrawFee(admin, gasZRC20.String(), sdk.NewUint(withdrawFee), sdkmath.Uint{}),
-	)
+
+	_, err := zk.FungibleKeeper.UpdateZRC20ProtocolFlatFee(ctx, gasZRC20, big.NewInt(withdrawFee))
 	require.NoError(t, err)
+
 	k.SetGasPrice(ctx, crosschaintypes.GasPrice{
 		ChainId:     chain.ChainId,
 		MedianIndex: 0,
@@ -58,6 +52,7 @@ func SetupStateForProcessLogsZetaSent(t *testing.T, ctx sdk.Context, k *crosscha
 		zrc20Addr,
 	)
 }
+
 func SetupStateForProcessLogs(t *testing.T, ctx sdk.Context, k *crosschainkeeper.Keeper, zk keepertest.ZetaKeepers, sdkk keepertest.SDKKeepers, chain common.Chain) {
 
 	deploySystemContracts(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper)

--- a/x/emissions/abci_test.go
+++ b/x/emissions/abci_test.go
@@ -153,24 +153,7 @@ func TestBeginBlocker(t *testing.T) {
 }
 
 func TestDistributeObserverRewards(t *testing.T) {
-
-	k, ctx, sk, zk := keepertest.EmissionsKeeper(t)
 	observerSet := sample.ObserverSet(4)
-	zk.ObserverKeeper.SetObserverSet(ctx, observerSet)
-	// Total block rewards is the fixed amount of rewards that are distributed
-	totalBlockRewards, err := common.GetAzetaDecFromAmountInZeta(emissionstypes.BlockRewardsInZeta)
-	totalRewardCoins := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, totalBlockRewards.TruncateInt()))
-	require.NoError(t, err)
-	// Fund the emission pool to start the emission process
-	err = sk.BankKeeper.MintCoins(ctx, emissionstypes.ModuleName, totalRewardCoins)
-	require.NoError(t, err)
-	// Set starting emission for all observers to 100 so that we can calculate the rewards and slashes
-	for _, observer := range observerSet.ObserverList {
-		k.SetWithdrawableEmission(ctx, emissionstypes.WithdrawableEmissions{
-			Address: observer,
-			Amount:  sdkmath.NewInt(100),
-		})
-	}
 
 	tt := []struct {
 		name                 string
@@ -256,9 +239,34 @@ func TestDistributeObserverRewards(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+
+			// Keeper initialization
+			k, ctx, sk, zk := keepertest.EmissionsKeeper(t)
+			zk.ObserverKeeper.SetObserverSet(ctx, observerSet)
+
+			// Total block rewards is the fixed amount of rewards that are distributed
+			totalBlockRewards, err := common.GetAzetaDecFromAmountInZeta(emissionstypes.BlockRewardsInZeta)
+			totalRewardCoins := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, totalBlockRewards.TruncateInt()))
+			require.NoError(t, err)
+
+			// Fund the emission pool to start the emission process
+			err = sk.BankKeeper.MintCoins(ctx, emissionstypes.ModuleName, totalRewardCoins)
+			require.NoError(t, err)
+
+			// Set starting emission for all observers to 100 so that we can calculate the rewards and slashes
+			for _, observer := range observerSet.ObserverList {
+				k.SetWithdrawableEmission(ctx, emissionstypes.WithdrawableEmissions{
+					Address: observer,
+					Amount:  sdkmath.NewInt(100),
+				})
+			}
+
+			// Set the params
 			params := emissionstypes.DefaultParams()
 			params.ObserverSlashAmount = tc.slashAmount
 			k.SetParams(ctx, params)
+
+			// Set the ballot list
 			ballotIdentifiers := []string{}
 			for i, votes := range tc.votes {
 				ballot := observerTypes.Ballot{
@@ -276,12 +284,14 @@ func TestDistributeObserverRewards(t *testing.T) {
 			})
 
 			ctx = ctx.WithBlockHeight(100)
-			err := emissionsModule.DistributeObserverRewards(ctx, tc.totalRewardsForBlock, *k)
+
+			// Distribute the rewards and check if the rewards are distributed correctly
+			err = emissionsModule.DistributeObserverRewards(ctx, tc.totalRewardsForBlock, *k)
 			require.NoError(t, err)
-			for _, observer := range observerSet.ObserverList {
+			for i, observer := range observerSet.ObserverList {
 				observerEmission, found := k.GetWithdrawableEmission(ctx, observer)
-				require.True(t, found)
-				require.Equal(t, tc.expectedRewards[observer], observerEmission.Amount.Int64())
+				require.True(t, found, "withdrawable emission not found for observer %d", i)
+				require.Equal(t, tc.expectedRewards[observer], observerEmission.Amount.Int64(), "invalid withdrawable emission for observer %d", i)
 			}
 		})
 	}

--- a/x/observer/keeper/msg_server_remove_chain_params_test.go
+++ b/x/observer/keeper/msg_server_remove_chain_params_test.go
@@ -55,6 +55,8 @@ func TestMsgServer_RemoveChainParams(t *testing.T) {
 		require.Equal(t, chain1, chainParamsList.ChainParams[0].ChainId)
 		require.Equal(t, chain3, chainParamsList.ChainParams[1].ChainId)
 
+		keepertest.MockIsAuthorized(&authorityMock.Mock, admin, authoritytypes.PolicyType_groupAdmin, true)
+
 		// remove chain params
 		_, err = srv.RemoveChainParams(sdk.WrapSDKContext(ctx), &types.MsgRemoveChainParams{
 			Creator: admin,
@@ -67,6 +69,8 @@ func TestMsgServer_RemoveChainParams(t *testing.T) {
 		require.True(t, found)
 		require.Len(t, chainParamsList.ChainParams, 1)
 		require.Equal(t, chain3, chainParamsList.ChainParams[0].ChainId)
+
+		keepertest.MockIsAuthorized(&authorityMock.Mock, admin, authoritytypes.PolicyType_groupAdmin, true)
 
 		// remove chain params
 		_, err = srv.RemoveChainParams(sdk.WrapSDKContext(ctx), &types.MsgRemoveChainParams{

--- a/x/observer/keeper/nonce_to_cctx_test.go
+++ b/x/observer/keeper/nonce_to_cctx_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestKeeper_GetNonceToCctx(t *testing.T) {
 	t.Run("Get nonce to cctx", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		nonceToCctxList := sample.NonceToCctxList(t, "sample", 1)
 		for _, n := range nonceToCctxList {
 			k.SetNonceToCctx(ctx, n)
@@ -22,7 +22,7 @@ func TestKeeper_GetNonceToCctx(t *testing.T) {
 		}
 	})
 	t.Run("Get nonce to cctx not found", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		nonceToCctxList := sample.NonceToCctxList(t, "sample", 1)
 		for _, n := range nonceToCctxList {
 			k.SetNonceToCctx(ctx, n)
@@ -31,7 +31,7 @@ func TestKeeper_GetNonceToCctx(t *testing.T) {
 		require.False(t, found)
 	})
 	t.Run("Get all nonce to cctx", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		nonceToCctxList := sample.NonceToCctxList(t, "sample", 10)
 		for _, n := range nonceToCctxList {
 			k.SetNonceToCctx(ctx, n)

--- a/x/observer/keeper/nonces_test.go
+++ b/x/observer/keeper/nonces_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestChainNoncesGet(t *testing.T) {
-	k, ctx, _ := keepertest.ObserverKeeper(t)
+	k, ctx, _, _ := keepertest.ObserverKeeper(t)
 	items := sample.ChainNoncesList(t, 10)
 	for _, item := range items {
 		k.SetChainNonces(ctx, item)
@@ -21,7 +21,7 @@ func TestChainNoncesGet(t *testing.T) {
 	}
 }
 func TestChainNoncesRemove(t *testing.T) {
-	k, ctx, _ := keepertest.ObserverKeeper(t)
+	k, ctx, _, _ := keepertest.ObserverKeeper(t)
 	items := sample.ChainNoncesList(t, 10)
 	for _, item := range items {
 		k.SetChainNonces(ctx, item)
@@ -34,7 +34,7 @@ func TestChainNoncesRemove(t *testing.T) {
 }
 
 func TestChainNoncesGetAll(t *testing.T) {
-	k, ctx, _ := keepertest.ObserverKeeper(t)
+	k, ctx, _, _ := keepertest.ObserverKeeper(t)
 	items := sample.ChainNoncesList(t, 10)
 	for _, item := range items {
 		k.SetChainNonces(ctx, item)

--- a/x/observer/keeper/observer_set_test.go
+++ b/x/observer/keeper/observer_set_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestKeeper_GetObserverSet(t *testing.T) {
 	t.Run("get observer set", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		os := sample.ObserverSet(10)
 		k.SetObserverSet(ctx, os)
 		tfm, found := k.GetObserverSet(ctx)
@@ -21,7 +21,7 @@ func TestKeeper_GetObserverSet(t *testing.T) {
 
 func TestKeeper_IsAddressPartOfObserverSet(t *testing.T) {
 	t.Run("address is part of observer set", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		os := sample.ObserverSet(10)
 		k.SetObserverSet(ctx, os)
 		require.True(t, k.IsAddressPartOfObserverSet(ctx, os.ObserverList[0]))
@@ -31,7 +31,7 @@ func TestKeeper_IsAddressPartOfObserverSet(t *testing.T) {
 
 func TestKeeper_AddObserverToSet(t *testing.T) {
 	t.Run("add observer to set", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		os := sample.ObserverSet(10)
 		k.SetObserverSet(ctx, os)
 		newObserver := sample.AccAddress()
@@ -46,7 +46,7 @@ func TestKeeper_AddObserverToSet(t *testing.T) {
 
 func TestKeeper_RemoveObserverFromSet(t *testing.T) {
 	t.Run("remove observer from set", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		os := sample.ObserverSet(10)
 		k.SetObserverSet(ctx, os)
 		k.RemoveObserverFromSet(ctx, os.ObserverList[0])
@@ -59,7 +59,7 @@ func TestKeeper_RemoveObserverFromSet(t *testing.T) {
 
 func TestKeeper_UpdateObserverAddress(t *testing.T) {
 	t.Run("update observer address", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		oldObserverAddress := sample.AccAddress()
 		newObserverAddress := sample.AccAddress()
 		observerSet := sample.ObserverSet(10)
@@ -72,7 +72,7 @@ func TestKeeper_UpdateObserverAddress(t *testing.T) {
 		require.Equal(t, newObserverAddress, observerSet.ObserverList[len(observerSet.ObserverList)-1])
 	})
 	t.Run("update observer address long observerList", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		oldObserverAddress := sample.AccAddress()
 		newObserverAddress := sample.AccAddress()
 		observerSet := sample.ObserverSet(10000)
@@ -85,7 +85,7 @@ func TestKeeper_UpdateObserverAddress(t *testing.T) {
 		require.Equal(t, newObserverAddress, observerMappers.ObserverList[len(observerMappers.ObserverList)-1])
 	})
 	t.Run("update observer address short observerList", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		oldObserverAddress := sample.AccAddress()
 		newObserverAddress := sample.AccAddress()
 		observerSet := sample.ObserverSet(1)

--- a/x/observer/keeper/pending_nonces_test.go
+++ b/x/observer/keeper/pending_nonces_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestKeeper_PendingNoncesAll(t *testing.T) {
 	t.Run("Get all pending nonces paginated by limit", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		nonces := sample.PendingNoncesList(t, "sample", 10)
 		sort.SliceStable(nonces, func(i, j int) bool {
 			return nonces[i].ChainId < nonces[j].ChainId
@@ -29,7 +29,7 @@ func TestKeeper_PendingNoncesAll(t *testing.T) {
 		require.Equal(t, len(nonces), int(pageRes.Total))
 	})
 	t.Run("Get all pending nonces paginated by offset", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		nonces := sample.PendingNoncesList(t, "sample", 42)
 		sort.SliceStable(nonces, func(i, j int) bool {
 			return nonces[i].ChainId < nonces[j].ChainId
@@ -48,7 +48,7 @@ func TestKeeper_PendingNoncesAll(t *testing.T) {
 		require.Equal(t, len(nonces), int(pageRes.Total))
 	})
 	t.Run("Get all pending nonces ", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		nonces := sample.PendingNoncesList(t, "sample", 10)
 		sort.SliceStable(nonces, func(i, j int) bool {
 			return nonces[i].ChainId < nonces[j].ChainId

--- a/x/observer/keeper/tss_funds_migrator_test.go
+++ b/x/observer/keeper/tss_funds_migrator_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestKeeper_GetTssFundMigrator(t *testing.T) {
 	t.Run("Successfully set funds migrator for chain", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		chain := sample.TssFundsMigrator(1)
 		k.SetFundMigrator(ctx, chain)
 		tfm, found := k.GetFundMigrator(ctx, chain.ChainId)
@@ -18,7 +18,7 @@ func TestKeeper_GetTssFundMigrator(t *testing.T) {
 		require.Equal(t, chain, tfm)
 	})
 	t.Run("Verify only one migrator can be created for a chain", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		tfm1 := sample.TssFundsMigrator(1)
 		k.SetFundMigrator(ctx, tfm1)
 		tfm2 := tfm1

--- a/x/observer/keeper/tss_test.go
+++ b/x/observer/keeper/tss_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestTSSGet(t *testing.T) {
-	k, ctx, _ := keepertest.ObserverKeeper(t)
+	k, ctx, _, _ := keepertest.ObserverKeeper(t)
 	tss := sample.Tss()
 	k.SetTSS(ctx, tss)
 	tssQueried, found := k.GetTSS(ctx)
@@ -26,7 +26,7 @@ func TestTSSGet(t *testing.T) {
 
 }
 func TestTSSRemove(t *testing.T) {
-	k, ctx, _ := keepertest.ObserverKeeper(t)
+	k, ctx, _, _ := keepertest.ObserverKeeper(t)
 	tss := sample.Tss()
 	k.SetTSS(ctx, tss)
 	k.RemoveTSS(ctx)
@@ -35,7 +35,7 @@ func TestTSSRemove(t *testing.T) {
 }
 
 func TestTSSQuerySingle(t *testing.T) {
-	k, ctx, _ := keepertest.ObserverKeeper(t)
+	k, ctx, _, _ := keepertest.ObserverKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
 	//msgs := createTSS(keeper, ctx, 1)
 	tss := sample.Tss()
@@ -69,7 +69,7 @@ func TestTSSQuerySingle(t *testing.T) {
 }
 
 func TestTSSQueryHistory(t *testing.T) {
-	keeper, ctx, _ := keepertest.ObserverKeeper(t)
+	keeper, ctx, _, _ := keepertest.ObserverKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
 	for _, tc := range []struct {
 		desc          string
@@ -115,7 +115,7 @@ func TestTSSQueryHistory(t *testing.T) {
 
 func TestKeeper_TssHistory(t *testing.T) {
 	t.Run("Get tss history paginated by limit", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		tssList := sample.TssList(10)
 		for _, tss := range tssList {
 			k.SetTSSHistory(ctx, tss)
@@ -132,7 +132,7 @@ func TestKeeper_TssHistory(t *testing.T) {
 		require.Equal(t, len(tssList), int(pageRes.Total))
 	})
 	t.Run("Get tss history paginated by offset", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		tssList := sample.TssList(100)
 		offset := 20
 		for _, tss := range tssList {
@@ -151,7 +151,7 @@ func TestKeeper_TssHistory(t *testing.T) {
 		require.Equal(t, len(tssList), int(pageRes.Total))
 	})
 	t.Run("Get all TSS without pagination", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		tssList := sample.TssList(100)
 		for _, tss := range tssList {
 			k.SetTSSHistory(ctx, tss)
@@ -166,7 +166,7 @@ func TestKeeper_TssHistory(t *testing.T) {
 		require.Equal(t, tssList, rst)
 	})
 	t.Run("Get historical TSS", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		tssList := sample.TssList(100)
 		for _, tss := range tssList {
 			k.SetTSSHistory(ctx, tss)

--- a/x/observer/keeper/utils_test.go
+++ b/x/observer/keeper/utils_test.go
@@ -43,7 +43,7 @@ func getValidEthChainIDWithIndex(t *testing.T, index int) int64 {
 
 func TestKeeper_IsAuthorized(t *testing.T) {
 	t.Run("authorized observer", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 
 		r := rand.New(rand.NewSource(9))
 
@@ -69,7 +69,7 @@ func TestKeeper_IsAuthorized(t *testing.T) {
 
 	})
 	t.Run("not authorized for tombstoned observer", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 
 		r := rand.New(rand.NewSource(9))
 
@@ -95,7 +95,7 @@ func TestKeeper_IsAuthorized(t *testing.T) {
 
 	})
 	t.Run("not authorized for non-validator observer", func(t *testing.T) {
-		k, ctx, _ := keepertest.ObserverKeeper(t)
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 
 		r := rand.New(rand.NewSource(9))
 


### PR DESCRIPTION
Change `test-coverage` to make the command fail when unit test fails
Fix some failing unit tests.

This also fix the code coverage that went down because of missing directories.