### PR TITLE
feat: support P2PKH (legacy), P2SH, P2TR address types

### DIFF
--- a/common/address.go
+++ b/common/address.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcutil"
 	eth "github.com/ethereum/go-ethereum/common"
+	"github.com/zeta-chain/zetacore/common/bitcoin"
 	"github.com/zeta-chain/zetacore/common/cosmos"
 )
 
@@ -71,6 +72,12 @@ func DecodeBtcAddress(inputAddress string, chainID int64) (address btcutil.Addre
 	if chainParams == nil {
 		return nil, fmt.Errorf("chain params not found")
 	}
+	// test taproot address type
+	address, err = bitcoin.DecodeTaprootAddress(inputAddress)
+	if err == nil && address.IsForNet(chainParams) {
+		return address, nil
+	}
+	// test taproot address fail; continue other types
 	address, err = btcutil.DecodeAddress(inputAddress, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("decode address failed: %s , for input address %s", err.Error(), inputAddress)

--- a/common/address_test.go
+++ b/common/address_test.go
@@ -60,4 +60,13 @@ func TestDecodeBtcAddress(t *testing.T) {
 		_, err := DecodeBtcAddress("bcrt1qy9pqmk2pd9sv63g27jt8r657wy0d9uee4x2dt2", BtcRegtestChain().ChainId)
 		require.NoError(t, err)
 	})
+
+	t.Run("taproot address with correct params", func(t *testing.T) {
+		_, err := DecodeBtcAddress("bc1p4ur084x8y63mj5hj7eydscuc4awals7ly749x8vhyquc0twcmvhquspa5c", BtcMainnetChain().ChainId)
+		require.NoError(t, err)
+	})
+	t.Run("taproot address with incorrect params", func(t *testing.T) {
+		_, err := DecodeBtcAddress("bc1p4ur084x8y63mj5hj7eydscuc4awals7ly749x8vhyquc0twcmvhquspa5c", BtcTestNetChain().ChainId)
+		require.Error(t, err)
+	})
 }

--- a/common/bitcoin/address_taproot.go
+++ b/common/bitcoin/address_taproot.go
@@ -1,0 +1,210 @@
+package bitcoin
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil/bech32"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
+)
+
+// taproot address type
+
+type AddressSegWit struct {
+	hrp            string
+	witnessVersion byte
+	witnessProgram []byte
+}
+
+type AddressTaproot struct {
+	AddressSegWit
+}
+
+var _ btcutil.Address = AddressTaproot{}
+
+// NewAddressTaproot returns a new AddressTaproot.
+func NewAddressTaproot(witnessProg []byte,
+	net *chaincfg.Params) (*AddressTaproot, error) {
+
+	return newAddressTaproot(net.Bech32HRPSegwit, witnessProg)
+}
+
+// newAddressWitnessScriptHash is an internal helper function to create an
+// AddressWitnessScriptHash with a known human-readable part, rather than
+// looking it up through its parameters.
+func newAddressTaproot(hrp string, witnessProg []byte) (*AddressTaproot, error) {
+	// Check for valid program length for witness version 1, which is 32
+	// for P2TR.
+	if len(witnessProg) != 32 {
+		return nil, errors.New("witness program must be 32 bytes for " +
+			"p2tr")
+	}
+
+	addr := &AddressTaproot{
+		AddressSegWit{
+			hrp:            strings.ToLower(hrp),
+			witnessVersion: 0x01,
+			witnessProgram: witnessProg,
+		},
+	}
+
+	return addr, nil
+}
+
+// EncodeAddress returns the bech32 (or bech32m for SegWit v1) string encoding
+// of an AddressSegWit.
+//
+// NOTE: This method is part of the Address interface.
+func (a AddressSegWit) EncodeAddress() string {
+	str, err := encodeSegWitAddress(
+		a.hrp, a.witnessVersion, a.witnessProgram[:],
+	)
+	if err != nil {
+		return ""
+	}
+	return str
+}
+
+// encodeSegWitAddress creates a bech32 (or bech32m for SegWit v1) encoded
+// address string representation from witness version and witness program.
+func encodeSegWitAddress(hrp string, witnessVersion byte, witnessProgram []byte) (string, error) {
+	// Group the address bytes into 5 bit groups, as this is what is used to
+	// encode each character in the address string.
+	converted, err := bech32.ConvertBits(witnessProgram, 8, 5, true)
+	if err != nil {
+		return "", err
+	}
+
+	// Concatenate the witness version and program, and encode the resulting
+	// bytes using bech32 encoding.
+	combined := make([]byte, len(converted)+1)
+	combined[0] = witnessVersion
+	copy(combined[1:], converted)
+
+	var bech string
+	switch witnessVersion {
+	case 0:
+		bech, err = bech32.Encode(hrp, combined)
+
+	case 1:
+		bech, err = bech32.EncodeM(hrp, combined)
+
+	default:
+		return "", fmt.Errorf("unsupported witness version %d",
+			witnessVersion)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// Check validity by decoding the created address.
+	_, version, program, err := decodeSegWitAddress(bech)
+	if err != nil {
+		return "", fmt.Errorf("invalid segwit address: %v", err)
+	}
+
+	if version != witnessVersion || !bytes.Equal(program, witnessProgram) {
+		return "", fmt.Errorf("invalid segwit address")
+	}
+
+	return bech, nil
+}
+
+// decodeSegWitAddress parses a bech32 encoded segwit address string and
+// returns the witness version and witness program byte representation.
+func decodeSegWitAddress(address string) (string, byte, []byte, error) {
+	// Decode the bech32 encoded address.
+	hrp, data, bech32version, err := bech32.DecodeGeneric(address)
+	if err != nil {
+		return "", 0, nil, err
+	}
+
+	// The first byte of the decoded address is the witness version, it must
+	// exist.
+	if len(data) < 1 {
+		return "", 0, nil, fmt.Errorf("no witness version")
+	}
+
+	// ...and be <= 16.
+	version := data[0]
+	if version > 16 {
+		return "", 0, nil, fmt.Errorf("invalid witness version: %v", version)
+	}
+
+	// The remaining characters of the address returned are grouped into
+	// words of 5 bits. In order to restore the original witness program
+	// bytes, we'll need to regroup into 8 bit words.
+	regrouped, err := bech32.ConvertBits(data[1:], 5, 8, false)
+	if err != nil {
+		return "", 0, nil, err
+	}
+
+	// The regrouped data must be between 2 and 40 bytes.
+	if len(regrouped) < 2 || len(regrouped) > 40 {
+		return "", 0, nil, fmt.Errorf("invalid data length")
+	}
+
+	// For witness version 0, address MUST be exactly 20 or 32 bytes.
+	if version == 0 && len(regrouped) != 20 && len(regrouped) != 32 {
+		return "", 0, nil, fmt.Errorf("invalid data length for witness "+
+			"version 0: %v", len(regrouped))
+	}
+
+	// For witness version 0, the bech32 encoding must be used.
+	if version == 0 && bech32version != bech32.Version0 {
+		return "", 0, nil, fmt.Errorf("invalid checksum expected bech32 " +
+			"encoding for address with witness version 0")
+	}
+
+	// For witness version 1, the bech32m encoding must be used.
+	if version == 1 && bech32version != bech32.VersionM {
+		return "", 0, nil, fmt.Errorf("invalid checksum expected bech32m " +
+			"encoding for address with witness version 1")
+	}
+
+	return hrp, version, regrouped, nil
+}
+
+// ScriptAddress returns the witness program for this address.
+//
+// NOTE: This method is part of the Address interface.
+func (a AddressSegWit) ScriptAddress() []byte {
+	return a.witnessProgram[:]
+}
+
+// IsForNet returns whether the AddressSegWit is associated with the passed
+// bitcoin network.
+//
+// NOTE: This method is part of the Address interface.
+func (a AddressSegWit) IsForNet(net *chaincfg.Params) bool {
+	return a.hrp == net.Bech32HRPSegwit
+}
+
+// String returns a human-readable string for the AddressWitnessPubKeyHash.
+// This is equivalent to calling EncodeAddress, but is provided so the type
+// can be used as a fmt.Stringer.
+//
+// NOTE: This method is part of the Address interface.
+func (a AddressSegWit) String() string {
+	return a.EncodeAddress()
+}
+
+func DecodeTaprootAddress(addr string) (AddressTaproot, error) {
+	hrp, version, program, err := decodeSegWitAddress(addr)
+	if err != nil {
+		return AddressTaproot{}, err
+	}
+	if version != 1 {
+		return AddressTaproot{}, errors.New("invalid witness version; taproot address must be version 1")
+	}
+	return AddressTaproot{
+		AddressSegWit{
+			hrp:            hrp,
+			witnessVersion: version,
+			witnessProgram: program,
+		},
+	}, nil
+}

--- a/common/bitcoin/address_taproot_test.go
+++ b/common/bitcoin/address_taproot_test.go
@@ -58,7 +58,7 @@ func TestAddressTaproot(t *testing.T) {
 		// these hex string comes from link
 		// https://mempool.space/tx/41f7cbaaf9a8d378d09ee86de32eebef455225520cb71015cc9a7318fb42e326
 		witnessProg, err := hex.DecodeString("af06f3d4c726a3b952f2f648d86398af5ddfc3df27aa531d97203987add8db2e")
-		addr, err := newAddressTaproot("bc", witnessProg[:])
+		addr, err := NewAddressTaproot(witnessProg[:], &chaincfg.MainNetParams)
 		require.Nil(t, err)
 		require.Equal(t, addr.EncodeAddress(), "bc1p4ur084x8y63mj5hj7eydscuc4awals7ly749x8vhyquc0twcmvhquspa5c")
 	}

--- a/common/bitcoin/address_taproot_test.go
+++ b/common/bitcoin/address_taproot_test.go
@@ -1,0 +1,59 @@
+package bitcoin
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressTaproot(t *testing.T) {
+	{
+		// should parse mainnet taproot address
+		addrStr := "bc1p4ur084x8y63mj5hj7eydscuc4awals7ly749x8vhyquc0twcmvhquspa5c"
+		addr, err := DecodeTaprootAddress(addrStr)
+		require.Nil(t, err)
+		t.Log(addr.String())
+		require.Equal(t, addrStr, addr.String())
+		require.Equal(t, addrStr, addr.EncodeAddress())
+		require.True(t, addr.IsForNet(&chaincfg.MainNetParams))
+	}
+	{
+		// should parse testnet taproot address
+		addrStr := "tb1pzeclkt6upu8xwuksjcz36y4q56dd6jw5r543eu8j8238yaxpvcvq7t8f33"
+		addr, err := DecodeTaprootAddress(addrStr)
+		require.Nil(t, err)
+		t.Log(addr.String())
+		require.Equal(t, addrStr, addr.String())
+		require.Equal(t, addrStr, addr.EncodeAddress())
+		require.True(t, addr.IsForNet(&chaincfg.TestNet3Params))
+	}
+	{
+		// should parse regtest taproot address
+		addrStr := "bcrt1pqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0sj9hjuh"
+		addr, err := DecodeTaprootAddress(addrStr)
+		require.Nil(t, err)
+		t.Log(addr.String())
+		require.Equal(t, addrStr, addr.String())
+		require.Equal(t, addrStr, addr.EncodeAddress())
+		require.True(t, addr.IsForNet(&chaincfg.RegressionNetParams))
+	}
+
+	{
+		// should fail to parse invalid taproot address
+		// should parse mainnet taproot address
+		addrStr := "bc1qysd4sp9q8my59ul9wsf5rvs9p387hf8vfwatzu"
+		_, err := DecodeTaprootAddress(addrStr)
+		require.Error(t, err)
+	}
+	{
+		var witnessProg [32]byte
+		for i := 0; i < 32; i++ {
+			witnessProg[i] = byte(i)
+		}
+		_, err := newAddressTaproot("bcrt", witnessProg[:])
+		require.Nil(t, err)
+		//t.Logf("addr: %v", addr)
+	}
+
+}

--- a/common/bitcoin/address_taproot_test.go
+++ b/common/bitcoin/address_taproot_test.go
@@ -1,6 +1,7 @@
 package bitcoin
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -13,7 +14,6 @@ func TestAddressTaproot(t *testing.T) {
 		addrStr := "bc1p4ur084x8y63mj5hj7eydscuc4awals7ly749x8vhyquc0twcmvhquspa5c"
 		addr, err := DecodeTaprootAddress(addrStr)
 		require.Nil(t, err)
-		t.Log(addr.String())
 		require.Equal(t, addrStr, addr.String())
 		require.Equal(t, addrStr, addr.EncodeAddress())
 		require.True(t, addr.IsForNet(&chaincfg.MainNetParams))
@@ -23,7 +23,6 @@ func TestAddressTaproot(t *testing.T) {
 		addrStr := "tb1pzeclkt6upu8xwuksjcz36y4q56dd6jw5r543eu8j8238yaxpvcvq7t8f33"
 		addr, err := DecodeTaprootAddress(addrStr)
 		require.Nil(t, err)
-		t.Log(addr.String())
 		require.Equal(t, addrStr, addr.String())
 		require.Equal(t, addrStr, addr.EncodeAddress())
 		require.True(t, addr.IsForNet(&chaincfg.TestNet3Params))
@@ -33,7 +32,6 @@ func TestAddressTaproot(t *testing.T) {
 		addrStr := "bcrt1pqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0sj9hjuh"
 		addr, err := DecodeTaprootAddress(addrStr)
 		require.Nil(t, err)
-		t.Log(addr.String())
 		require.Equal(t, addrStr, addr.String())
 		require.Equal(t, addrStr, addr.EncodeAddress())
 		require.True(t, addr.IsForNet(&chaincfg.RegressionNetParams))
@@ -54,6 +52,24 @@ func TestAddressTaproot(t *testing.T) {
 		_, err := newAddressTaproot("bcrt", witnessProg[:])
 		require.Nil(t, err)
 		//t.Logf("addr: %v", addr)
+	}
+	{
+		// should create correct taproot address from given witness program
+		// these hex string comes from link
+		// https://mempool.space/tx/41f7cbaaf9a8d378d09ee86de32eebef455225520cb71015cc9a7318fb42e326
+		witnessProg, err := hex.DecodeString("af06f3d4c726a3b952f2f648d86398af5ddfc3df27aa531d97203987add8db2e")
+		addr, err := newAddressTaproot("bc", witnessProg[:])
+		require.Nil(t, err)
+		require.Equal(t, addr.EncodeAddress(), "bc1p4ur084x8y63mj5hj7eydscuc4awals7ly749x8vhyquc0twcmvhquspa5c")
+	}
+	{
+		// should give correct ScriptAddress for taproot address
+		// example comes from
+		// https://blockstream.info/tx/09298a2f32f5267f419aeaf8a58c4807dcf6cac3edb59815a3b129cd8f1219b0?expand
+		addrStr := "bc1p6pls9gpm24g8ntl37pajpjtuhd3y08hs5rnf9a4n0wq595hwdh9suw7m2h"
+		addr, err := DecodeTaprootAddress(addrStr)
+		require.Nil(t, err)
+		require.Equal(t, "d07f02a03b555079aff1f07b20c97cbb62479ef0a0e692f6b37b8142d2ee6dcb", hex.EncodeToString(addr.ScriptAddress()))
 	}
 
 }


### PR DESCRIPTION
# Description

WIP: 

- [x]: backport AddressTaproot type that fulfills the btcutil.Address interface
- [ ]: sign P2TR output
- [ ]: sign P2PKH output
- [ ]: sign P2SH output
- [ ]: read P2TR sender
- [ ]: read P2SH sender
- [ ]: read P2PKH sender

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
