### PR TITLE
refactor: remove duplicate ValidateChainParams function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 ### Chores
 
 * [1814](https://github.com/zeta-chain/node/pull/1814) - fix code coverage ignore for protobuf generated files
+* [1863](https://github.com/zeta-chain/node/pull/1863) - remove duplicate ValidateChainParams function
 
 ## Version: v14
 

--- a/zetaclient/zetabridge/zetacore_bridge.go
+++ b/zetaclient/zetabridge/zetacore_bridge.go
@@ -218,7 +218,7 @@ func (b *ZetaCoreBridge) UpdateZetaCoreContext(coreContext *corecontext.ZetaCore
 
 	// check and update chain params for each chain
 	for _, chainParam := range chainParams {
-		err := config.ValidateChainParams(chainParam)
+		err := observertypes.ValidateChainParams(chainParam)
 		if err != nil {
 			b.logger.Warn().Err(err).Msgf("Invalid chain params for chain %d", chainParam.ChainId)
 			continue


### PR DESCRIPTION
# Description

Removing duplicate ValidateChainParams function in zetaclient and using one from observer types, so it is not maintained on 2 places.

Closes: #1838 

## Type of change

Cleanup

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [x] Go integration tests
- [x] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
