### PR TITLE
fix: evm signer tests were failing intermittently in CI 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,7 @@
 * [1861](https://github.com/zeta-chain/node/pull/1861) - fix `ObserverSlashAmount` invalid read
 * [1880](https://github.com/zeta-chain/node/issues/1880) - lower the gas price multiplier for EVM chains.
 * [1633](https://github.com/zeta-chain/node/issues/1633) - zetaclient should be able to pick up new connector and erc20Custody addresses
+* [1944](https://github.com/zeta-chain/node/pull/1944) - fix evm signer unit tests
 
 ### Chores
 

--- a/zetaclient/evm/evm_signer.go
+++ b/zetaclient/evm/evm_signer.go
@@ -643,7 +643,7 @@ func (signer *Signer) EvmSigner() ethtypes.Signer {
 func getEVMRPC(endpoint string) (interfaces.EVMRPCClient, ethtypes.Signer, error) {
 	if endpoint == stub.EVMRPCEnabled {
 		chainID := big.NewInt(common.BscMainnetChain().ChainId)
-		ethSigner := ethtypes.NewEIP155Signer(chainID)
+		ethSigner := ethtypes.NewLondonSigner(chainID)
 		client := &stub.MockEvmClient{}
 		return client, ethSigner, nil
 	}


### PR DESCRIPTION
# Description

Changed test eth signer type to support more transaction types. 

Closes: https://github.com/zeta-chain/node/issues/1887

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [x] Go unit tests
- [x] Go integration tests
- [x] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
