### PR TITLE
ci: run E2E tests for all PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - develop
   pull_request:
     branches:
-      - develop
+      - "*"
     types:
       - synchronize
       - opened

--- a/changelog.md
+++ b/changelog.md
@@ -58,11 +58,13 @@
 * [1814](https://github.com/zeta-chain/node/pull/1814) - fix code coverage ignore for protobuf generated files
 
 ### CI
+
 * [1945](https://github.com/zeta-chain/node/pull/1945) - update advanced testing pipeline to not execute tests that weren't selected so they show skipped instead of skipping steps.
 * [1940](https://github.com/zeta-chain/node/pull/1940) - adjust release pipeline to be created as pre-release instead of latest
 * [1867](https://github.com/zeta-chain/node/pull/1867) - default restore_type for full node docker-compose to snapshot instead of statesync for reliability.
 * [1891](https://github.com/zeta-chain/node/pull/1891) - fix typo that was introduced to docker-compose and a typo in start.sh for the docker start script for full nodes.
 * [1894](https://github.com/zeta-chain/node/pull/1894) - added download binaries and configs to the start sequence so it will download binaries that don't exist
+* [1953](https://github.com/zeta-chain/node/pull/1953) - run E2E tests for all PRs
 
 ## Version: v15.0.0
 


### PR DESCRIPTION
# Description

Build and E2E testing CI workflow was only executed for PR to the `develop` branch. This modification allows to run it on any branch so E2E testing can be run when working on release branch (`16.0.0`)