### PR TITLE
feat: V16 - add metric for concurrent key signs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * [1755](https://github.com/zeta-chain/node/issues/1755) - use evm JSON RPC for inbound tx (including blob tx) observation.
 * [1815](https://github.com/zeta-chain/node/pull/1815) - add authority module for authorized actions
 * [1884](https://github.com/zeta-chain/node/pull/1884) - added zetatool cmd, added subcommand to filter deposits
+* [1954](https://github.com/zeta-chain/node/pull/1954) - add metric for concurrent keysigns
 
 ### Tests
 

--- a/zetaclient/metrics/metrics.go
+++ b/zetaclient/metrics/metrics.go
@@ -78,6 +78,12 @@ var (
 		Name:      "last_start_timestamp_seconds",
 		Help:      "Start time in Unix time",
 	})
+
+	NumActiveMsgSigns = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: ZetaClientNamespace,
+		Name:      "num_active_message_signs",
+		Help:      "Number of concurrent key signs",
+	})
 )
 
 func NewMetrics() (*Metrics, error) {

--- a/zetaclient/tss/tss_keysigns_tracker.go
+++ b/zetaclient/tss/tss_keysigns_tracker.go
@@ -1,0 +1,49 @@
+package tss
+
+import (
+	"sync"
+
+	"github.com/rs/zerolog"
+	"github.com/zeta-chain/zetacore/zetaclient/metrics"
+)
+
+// ConcurrentKeysignsTracker keeps track of concurrent keysigns performed by go-tss
+type ConcurrentKeysignsTracker struct {
+	numActiveMsgSigns int64
+	mu                sync.Mutex
+	Logger            zerolog.Logger
+}
+
+// NewKeysignsTracker - constructor
+func NewKeysignsTracker(logger zerolog.Logger) *ConcurrentKeysignsTracker {
+	return &ConcurrentKeysignsTracker{
+		numActiveMsgSigns: 0,
+		mu:                sync.Mutex{},
+		Logger:            logger.With().Str("submodule", "ConcurrentKeysignsTracker").Logger(),
+	}
+}
+
+// StartMsgSign is incrementing the number of active signing ceremonies as well as updating the prometheus metric
+func (k *ConcurrentKeysignsTracker) StartMsgSign() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.numActiveMsgSigns++
+	metrics.NumActiveMsgSigns.Inc()
+	k.Logger.Debug().Msgf("Start TSS message sign, numActiveMsgSigns: %d", k.numActiveMsgSigns)
+}
+
+// EndMsgSign is decrementing the number of active signing ceremonies as well as updating the prometheus metric
+func (k *ConcurrentKeysignsTracker) EndMsgSign() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.numActiveMsgSigns > 0 {
+		k.numActiveMsgSigns--
+		metrics.NumActiveMsgSigns.Dec()
+	}
+	k.Logger.Debug().Msgf("End TSS message sign, numActiveMsgSigns: %d", k.numActiveMsgSigns)
+}
+
+// GetNumActiveMessageSigns gets the current number of active signing ceremonies
+func (k *ConcurrentKeysignsTracker) GetNumActiveMessageSigns() int64 {
+	return k.numActiveMsgSigns
+}

--- a/zetaclient/tss/tss_keysigns_tracker_test.go
+++ b/zetaclient/tss/tss_keysigns_tracker_test.go
@@ -1,0 +1,27 @@
+package tss
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeySignManager_StartMsgSign(t *testing.T) {
+	ksman := NewKeysignsTracker(zerolog.Logger{})
+	ksman.StartMsgSign()
+	ksman.StartMsgSign()
+	ksman.StartMsgSign()
+	ksman.StartMsgSign()
+	require.Equal(t, int64(4), ksman.GetNumActiveMessageSigns())
+}
+
+func TestKeySignManager_EndMsgSign(t *testing.T) {
+	ksman := NewKeysignsTracker(zerolog.Logger{})
+	ksman.StartMsgSign()
+	ksman.StartMsgSign()
+	ksman.EndMsgSign()
+	ksman.EndMsgSign()
+	ksman.EndMsgSign()
+	require.Equal(t, int64(0), ksman.GetNumActiveMessageSigns())
+}


### PR DESCRIPTION
# Description

1. Keysign tracker was added to keep track of outbound signature attempts
2. A new metric was integrated to export the number of active signatures. 

Closes: https://github.com/zeta-chain/node/issues/1604

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [x] Tested in development environment
- [x] Go unit tests
- [x] Go integration tests
- [x] Tested via GitHub Actions 

```
/usr/local/bin # curl localhost:8886/metrics | grep zetaclient_num_active_message_signs
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 18048    0 18048    0     0  7861k      0 --:--:-- --:--:-- --:--:-- 8812k
# HELP zetaclient_num_active_message_signs Number of concurrent key signs
# TYPE zetaclient_num_active_message_signs gauge
zetaclient_num_active_message_signs 4
```

# Checklist:

- [x] I have added unit tests that prove my fix feature works
