### PR TITLE
chore: improve localnet incremental build times

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -3,6 +3,7 @@ FROM golang:1.20-alpine3.18
 ENV GOPATH /go
 ENV GOOS=linux
 ENV CGO_ENABLED=1
+ENV GOCACHE=/root/.cache/go-build
 
 RUN apk --no-cache add git make build-base jq openssh libusb-dev linux-headers bash curl tmux python3 py3-pip
 RUN pip install requests
@@ -14,8 +15,8 @@ COPY go.sum .
 RUN go mod download
 COPY . .
 
-RUN make install
-RUN make install-zetae2e
+RUN --mount=type=cache,target="/root/.cache/go-build" make install
+RUN --mount=type=cache,target="/root/.cache/go-build" make install-zetae2e
 
 RUN ssh-keygen -A
 WORKDIR /root


### PR DESCRIPTION
# Description

Set `GOCACHE` and add a cache mount for localnet builds

This reduces localnet incremental build times by about 1 minute:

Before: `[+] Building 80.7s (31/31) FINISHED`
After: `[+] Building 21.2s (31/31) FINISHED`

https://docs.docker.com/build/guide/mounts/
https://dev.to/jacktt/20x-faster-golang-docker-builds-289n

## Type of change

Chore

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested in development environment
