### PR TITLE
test: run advanced tests nightly to detect breakages

### DIFF
--- a/.github/workflows/execute_advanced_tests.yaml
+++ b/.github/workflows/execute_advanced_tests.yaml
@@ -23,10 +23,13 @@ on:
         type: boolean
         required: false
         default: false
+  schedule:
+    # run at midnight UTC daily
+    - cron: "0 0 * * *"
 
 jobs:
   e2e-admin-tests:
-    if: ${{ github.event.inputs.e2e-admin-tests == 'true' }}
+    if: ${{ github.event.inputs.e2e-admin-tests == 'true' || github.event_name == 'schedule' }}
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 120
     steps:
@@ -65,7 +68,7 @@ jobs:
           done
 
   e2e-upgrade-test:
-    if: ${{ github.event.inputs.e2e-upgrade-test == 'true' }}
+    if: ${{ github.event.inputs.e2e-upgrade-test == 'true' || github.event_name == 'schedule' }}
     runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 120
     steps:

--- a/.github/workflows/execute_advanced_tests.yaml
+++ b/.github/workflows/execute_advanced_tests.yaml
@@ -24,8 +24,9 @@ on:
         required: false
         default: false
   schedule:
-    # run at midnight UTC daily
-    - cron: "0 0 * * *"
+    # run at 6AM UTC Daily
+    # 6AM UTC -> 11PM PT
+    - cron: "0 6 * * *"
 
 jobs:
   e2e-admin-tests:


### PR DESCRIPTION
# Description

Run some of the advanced tests nightly to detect breakages more quickly. Related to #2054.

I will add slack alerting for failures in a future PR.

I tested that workflow_dispatch [still works](https://github.com/zeta-chain/node/actions/runs/8789497964) and `actionslint` passes.