### PR TITLE
test: ensure advanced tests fail if orchestrator fails

### DIFF
--- a/.github/workflows/execute_advanced_tests.yaml
+++ b/.github/workflows/execute_advanced_tests.yaml
@@ -37,36 +37,17 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v3
 
+      # use docker logs -f rather than docker attach to make sure we get the initial logs
       - name: Execute e2e-admin-tests
-        shell: bash
+        shell: bash -e
         run: |
+          echo "::group::Test Setup"
           make start-e2e-admin-test
+          echo "::endgroup::"
+
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
-          if [ -z "$container_id" ]; then
-              echo "Orchestrator container is not currently running. Exiting..."
-              exit 1
-          fi
-          echo "Monitoring Orchestrator container with ID: $container_id"
-          while true; do
-              current_status=$(docker ps -q | grep $container_id || echo "docker-ps-error")
-              if [ "$current_status" == "docker-ps-error" ]; then
-                  echo "***********************************"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "*        TESTING COMPLETE         *"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "***********************************"
-                  docker logs $container_id || echo "no logs"
-                  exit 0
-              else
-                  echo "Testing in progress still...."
-                  if [ "${{ github.event.inputs.debug }}" == "true" ]; then
-                    docker logs $container_id || echo "no logs"
-                  fi
-              fi
-              sleep 5
-          done
+          docker logs -f "${container_id}" &
+          exit $(docker wait "${container_id}")
 
   e2e-upgrade-test:
     if: ${{ github.event.inputs.e2e-upgrade-test == 'true' || github.event_name == 'schedule' }}
@@ -77,35 +58,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Execute upgrade-test
-        shell: bash
+        shell: bash -e
         run: |
+          echo "::group::Test Setup"
           make start-upgrade-test
+          echo "::endgroup::"
+
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
-          if [ -z "$container_id" ]; then
-              echo "Orchestrator container is not currently running. Exiting..."
-              exit 1
-          fi
-          echo "Monitoring Orchestrator container with ID: $container_id"
-          while true; do
-              current_status=$(docker ps -q | grep $container_id || echo "docker-ps-error")
-              if [ "$current_status" == "docker-ps-error" ]; then
-                  echo "***********************************"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "*        TESTING COMPLETE         *"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "***********************************"
-                  docker logs $container_id || echo "no logs"
-                  exit 0
-              else
-                  echo "Testing in progress still...."
-                  if [ "${{ github.event.inputs.debug }}" == "true" ]; then
-                    docker logs $container_id || echo "no logs"
-                  fi
-              fi
-              sleep 5
-          done
+          docker logs -f "${container_id}" &
+          exit $(docker wait "${container_id}")
 
   e2e-upgrade-test-light:
     if: ${{ github.event.inputs.e2e-upgrade-test-light == 'true' }}
@@ -116,35 +77,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Execute upgrade-test-light
-        shell: bash
+        shell: bash -e
         run: |
+          echo "::group::Test Setup"
           make start-upgrade-test-light
+          echo "::endgroup::"
+
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
-          if [ -z "$container_id" ]; then
-              echo "Orchestrator container is not currently running. Exiting..."
-              exit 1
-          fi
-          echo "Monitoring Orchestrator container with ID: $container_id"
-          while true; do
-              current_status=$(docker ps -q | grep $container_id || echo "docker-ps-error")
-              if [ "$current_status" == "docker-ps-error" ]; then
-                  echo "***********************************"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "*        TESTING COMPLETE         *"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "***********************************"
-                  docker logs $container_id || echo "no logs"
-                  exit 0
-              else
-                  echo "Testing in progress still...."
-                  if [ "${{ github.event.inputs.debug }}" == "true" ]; then
-                    docker logs $container_id || echo "no logs"
-                  fi
-              fi
-              sleep 5
-          done
+          docker logs -f "${container_id}" &
+          exit $(docker wait "${container_id}")
 
   e2e-performance-test:
     if: ${{ github.event.inputs.e2e-performance-test == 'true' }}
@@ -155,32 +96,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Execute Performance Tests
-        shell: bash
+        shell: bash -e
         run: |
+          echo "::group::Test Setup"
           make start-e2e-performance-test
+          echo "::endgroup::"
+
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
-          if [ -z "$container_id" ]; then
-              echo "Orchestrator container is not currently running. Exiting..."
-              exit 1
-          fi
-          echo "Monitoring Orchestrator container with ID: $container_id"
-          while true; do
-              current_status=$(docker ps -q | grep $container_id || echo "docker-ps-error")
-              if [ "$current_status" == "docker-ps-error" ]; then
-                  echo "***********************************"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "*        TESTING COMPLETE         *"
-                  echo "*                                 *"
-                  echo "*                                 *"
-                  echo "***********************************"
-                  docker logs $container_id || echo "no logs"
-                  exit 0
-              else
-                  echo "Testing in progress still...."
-                  if [ "${{ github.event.inputs.debug }}" == "true" ]; then
-                    docker logs $container_id || echo "no logs"
-                  fi
-              fi
-              sleep 5
-          done
+          docker logs -f "${container_id}" &
+          exit $(docker wait "${container_id}")

--- a/.github/workflows/execute_advanced_tests.yaml
+++ b/.github/workflows/execute_advanced_tests.yaml
@@ -37,14 +37,12 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v3
 
-      # use docker logs -f rather than docker attach to make sure we get the initial logs
-      - name: Execute e2e-admin-tests
-        shell: bash -e
-        run: |
-          echo "::group::Test Setup"
-          make start-e2e-admin-test
-          echo "::endgroup::"
+      - name: Start Test
+        run: make start-e2e-admin-test
 
+      # use docker logs -f rather than docker attach to make sure we get the initial logs
+      - name: Watch Test
+        run: |
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
           docker logs -f "${container_id}" &
           exit $(docker wait "${container_id}")
@@ -57,13 +55,11 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v3
 
-      - name: Execute upgrade-test
-        shell: bash -e
-        run: |
-          echo "::group::Test Setup"
-          make start-upgrade-test
-          echo "::endgroup::"
+      - name: Start Test
+        run: make start-upgrade-test
 
+      - name: Watch Test
+        run: |
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
           docker logs -f "${container_id}" &
           exit $(docker wait "${container_id}")
@@ -76,13 +72,11 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v3
 
-      - name: Execute upgrade-test-light
-        shell: bash -e
-        run: |
-          echo "::group::Test Setup"
-          make start-upgrade-test-light
-          echo "::endgroup::"
+      - name: Start Test
+        run: make start-upgrade-test-light
 
+      - name: Watch Test
+        run: |
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
           docker logs -f "${container_id}" &
           exit $(docker wait "${container_id}")
@@ -95,13 +89,11 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v3
 
-      - name: Execute Performance Tests
-        shell: bash -e
-        run: |
-          echo "::group::Test Setup"
-          make start-e2e-performance-test
-          echo "::endgroup::"
+      - name: Start Test
+        run: make start-e2e-performance-test
 
+      - name: Watch Test
+        run: |
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
           docker logs -f "${container_id}" &
           exit $(docker wait "${container_id}")


### PR DESCRIPTION
# Description

Both the admin tests and upgrade tests are currently failing on develop, but have a green check on github. Examples:
- https://github.com/zeta-chain/node/actions/runs/8740792255/job/23985274941
- https://github.com/zeta-chain/node/actions/runs/8789497964/job/24119390065

We need the github actions run to fail so we can properly track pass/fail rate and add slack notifications.

Ensure that we fail the github actions step by checking the docker container code via `docker wait`. Also:
- create an output group with the `make start-...` to reduce the noise
- stream the test log output
- remove `shell` option since we can tolerate `sh` again. By setting `shell` you clobber the `-e` option which means that errors will silently be ignored.

Example: https://github.com/zeta-chain/node/actions/runs/8804170791/job/24163953655

Will add slack alerting and node/client log dumps in a future PR.

# How Has This Been Tested?

- [x] Tested via GitHub Actions 
