### PR TITLE
refactor: allow zeta deposits to new zevm address

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@
 * [1989](https://github.com/zeta-chain/node/pull/1989) - simplify `IsSendOutTxProcessed` method and add unit tests
 * [2013](https://github.com/zeta-chain/node/pull/2013) - rename `GasPriceVoter` message to `VoteGasPrice`
 * [2059](https://github.com/zeta-chain/node/pull/2059) - Remove unused params from all functions in zetanode
+* [2076](https://github.com/zeta-chain/node/pull/2076) - automatically deposit native zeta to an address if it doesn't exist on ZEVM.
 
 ### Features
 

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -257,6 +257,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestMessagePassingEVMtoZEVMName,
 			e2etests.TestMessagePassingEVMtoZEVMRevertName,
 			e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			e2etests.TestZetaDepositName,
+			e2etests.TestZetaDepositNewAddressName,
 		}
 		bitcoinTests := []string{
 			e2etests.TestBitcoinWithdrawSegWitName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -44,6 +44,7 @@ const (
 	TestEtherWithdrawRestrictedName = "eth_withdraw_restricted"
 	TestBitcoinDepositName          = "bitcoin_deposit"
 	TestZetaDepositName             = "zeta_deposit"
+	TestZetaDepositNewAddressName   = "zeta_deposit_new_address"
 	TestZetaDepositRestrictedName   = "zeta_deposit_restricted"
 
 	TestDonationEtherName = "donation_ether"
@@ -119,6 +120,14 @@ var AllE2ETests = []runner.E2ETest{
 			runner.ArgDefinition{Description: "amount in azeta", DefaultValue: "1000000000000000000"},
 		},
 		TestZetaDeposit,
+	),
+	runner.NewE2ETest(
+		TestZetaDepositNewAddressName,
+		"deposit ZETA from Ethereum to a new ZEVM address which does not exist yet",
+		[]runner.ArgDefinition{
+			runner.ArgDefinition{Description: "amount in azeta", DefaultValue: "1000000000000000000"},
+		},
+		TestZetaDepositNewAddress,
 	),
 	runner.NewE2ETest(
 		TestZetaWithdrawBTCRevertName,

--- a/e2e/e2etests/test_zeta_deposit.go
+++ b/e2e/e2etests/test_zeta_deposit.go
@@ -6,6 +6,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
+	"github.com/zeta-chain/zetacore/testutil/sample"
 	"github.com/zeta-chain/zetacore/zetaclient/testutils"
 )
 
@@ -20,6 +21,24 @@ func TestZetaDeposit(r *runner.E2ERunner, args []string) {
 	}
 
 	hash := r.DepositZetaWithAmount(r.DeployerAddress, amount)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInTxHash(r.Ctx, hash.Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+}
+
+func TestZetaDepositNewAddress(r *runner.E2ERunner, args []string) {
+	if len(args) != 1 {
+		panic("TestZetaDeposit requires exactly one argument for the amount.")
+	}
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	if !ok {
+		panic("Invalid amount specified for TestZetaDeposit.")
+	}
+
+	newAddress := sample.EthAddress()
+	hash := r.DepositZetaWithAmount(newAddress, amount)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInTxHash(r.Ctx, hash.Hex(), r.CctxClient, r.Logger, r.CctxTimeout)

--- a/e2e/e2etests/test_zeta_deposit.go
+++ b/e2e/e2etests/test_zeta_deposit.go
@@ -29,12 +29,12 @@ func TestZetaDeposit(r *runner.E2ERunner, args []string) {
 
 func TestZetaDepositNewAddress(r *runner.E2ERunner, args []string) {
 	if len(args) != 1 {
-		panic("TestZetaDeposit requires exactly one argument for the amount.")
+		panic("TestZetaDepositNewAddress requires exactly one argument for the amount.")
 	}
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	if !ok {
-		panic("Invalid amount specified for TestZetaDeposit.")
+		panic("Invalid amount specified for TestZetaDepositNewAddress.")
 	}
 
 	newAddress := sample.EthAddress()

--- a/x/fungible/keeper/zevm_message_passing_test.go
+++ b/x/fungible/keeper/zevm_message_passing_test.go
@@ -197,7 +197,7 @@ func TestKeeper_ZEVMRevertAndCallContract(t *testing.T) {
 		require.Equal(t, amount.Int64(), b.Amount.Int64())
 	})
 
-	t.Run("successfully deposit coin if account not found", func(t *testing.T) {
+	t.Run("automatically deposit coin if account not found", func(t *testing.T) {
 		k, ctx, sdkk, _ := keepertest.FungibleKeeper(t)
 		_ = k.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName)
 

--- a/x/fungible/keeper/zevm_msg_passing.go
+++ b/x/fungible/keeper/zevm_msg_passing.go
@@ -8,8 +8,8 @@ import (
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 )
 
-// ZEVMDepositAndCallContract deposits ZETA to the to address if its an account or if the account does not exist yet
-// If it's not an account it calls onReceive function of the connector contract and provides the address as the destinationAddress
+// ZETADepositAndCallContract deposits native ZETA to the to address if its an account or if the account does not exist yet
+// If it's not an account it calls onReceive function of the connector contract and provides the address as the destinationAddress .The amount of tokens is minted to the fungible module account, wrapped and sent to the contract
 func (k Keeper) ZETADepositAndCallContract(ctx sdk.Context,
 	sender ethcommon.Address,
 	to ethcommon.Address,
@@ -29,8 +29,8 @@ func (k Keeper) ZETADepositAndCallContract(ctx sdk.Context,
 	return k.CallOnReceiveZevmConnector(ctx, sender.Bytes(), big.NewInt(inboundSenderChainID), to, inboundAmount, data, indexBytes)
 }
 
-// ZEVMRevertAndCallContract deposits ZETA to the sender address if its an account if the account does not exist yet
-// If it's not an account it calls onRevert function of the connector contract and provides the sender address as the zetaTxSenderAddress
+// ZETARevertAndCallContract deposits native ZETA to the sender address if its account or if the account does not exist yet
+// If it's not an account it calls onRevert function of the connector contract and provides the sender address as the zetaTxSenderAddress.The amount of tokens is minted to the fungible module account, wrapped and sent to the contract
 func (k Keeper) ZETARevertAndCallContract(ctx sdk.Context,
 	sender ethcommon.Address,
 	to ethcommon.Address,

--- a/x/fungible/keeper/zevm_msg_passing.go
+++ b/x/fungible/keeper/zevm_msg_passing.go
@@ -1,17 +1,14 @@
 package keeper
 
 import (
-	"fmt"
 	"math/big"
 
-	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
-	"github.com/zeta-chain/zetacore/x/fungible/types"
 )
 
-// ZEVMDepositAndCallContract deposits ZETA to the to address if its an account
+// ZEVMDepositAndCallContract deposits ZETA to the to address if its an account or if the account does not exist yet
 // If it's not an account it calls onReceive function of the connector contract and provides the address as the destinationAddress
 func (k Keeper) ZETADepositAndCallContract(ctx sdk.Context,
 	sender ethcommon.Address,
@@ -21,10 +18,7 @@ func (k Keeper) ZETADepositAndCallContract(ctx sdk.Context,
 	data []byte,
 	indexBytes [32]byte) (*evmtypes.MsgEthereumTxResponse, error) {
 	acc := k.evmKeeper.GetAccount(ctx, to)
-	if acc == nil {
-		return nil, errors.Wrap(types.ErrAccountNotFound, fmt.Sprintf("address: %s", to.String()))
-	}
-	if !acc.IsContract() {
+	if acc == nil || !acc.IsContract() {
 		err := k.DepositCoinZeta(ctx, to, inboundAmount)
 		if err != nil {
 			return nil, err
@@ -35,7 +29,7 @@ func (k Keeper) ZETADepositAndCallContract(ctx sdk.Context,
 	return k.CallOnReceiveZevmConnector(ctx, sender.Bytes(), big.NewInt(inboundSenderChainID), to, inboundAmount, data, indexBytes)
 }
 
-// ZEVMRevertAndCallContract deposits ZETA to the sender address if its an account
+// ZEVMRevertAndCallContract deposits ZETA to the sender address if its an account if the account does not exist yet
 // If it's not an account it calls onRevert function of the connector contract and provides the sender address as the zetaTxSenderAddress
 func (k Keeper) ZETARevertAndCallContract(ctx sdk.Context,
 	sender ethcommon.Address,
@@ -46,10 +40,7 @@ func (k Keeper) ZETARevertAndCallContract(ctx sdk.Context,
 	data []byte,
 	indexBytes [32]byte) (*evmtypes.MsgEthereumTxResponse, error) {
 	acc := k.evmKeeper.GetAccount(ctx, sender)
-	if acc == nil {
-		return nil, errors.Wrap(types.ErrAccountNotFound, fmt.Sprintf("address: %s", to.String()))
-	}
-	if !acc.IsContract() {
+	if acc == nil || !acc.IsContract() {
 		err := k.DepositCoinZeta(ctx, sender, remainingAmount)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

Automatically deposit native zeta to an address if it doesn't exist on ZEVM. 

Closes: https://github.com/zeta-chain/node/issues/2075

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
