### PR TITLE
ci: add slack notifications nightly/develop failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
           fi
 
       - name: Notify Slack on Failure
-        if: failure() && github.event == 'push' && github.ref == 'refs/heads/develop'
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/develop'
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,15 @@ jobs:
             exit 1
           fi
 
+      - name: Notify Slack on Failure
+        if: failure() && github.event == 'push' && github.ref == 'refs/heads/develop'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}
+
       - name: Stop Private Network
         if: always()
         run: |

--- a/.github/workflows/execute_advanced_tests.yaml
+++ b/.github/workflows/execute_advanced_tests.yaml
@@ -47,6 +47,15 @@ jobs:
           docker logs -f "${container_id}" &
           exit $(docker wait "${container_id}")
 
+      - name: Notify Slack on Failure
+        if: failure() && github.event_name == 'schedule'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}
+
   e2e-upgrade-test:
     if: ${{ github.event.inputs.e2e-upgrade-test == 'true' || github.event_name == 'schedule' }}
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -63,6 +72,15 @@ jobs:
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
           docker logs -f "${container_id}" &
           exit $(docker wait "${container_id}")
+
+      - name: Notify Slack on Failure
+        if: failure() && github.event_name == 'schedule'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}
 
   e2e-upgrade-test-light:
     if: ${{ github.event.inputs.e2e-upgrade-test-light == 'true' }}


### PR DESCRIPTION
# Description

Add slack notifications for nightly advanced e2e failures and e2e failures when merging develop to the `#alerts-protocol-ci` internal slack channel.

Example run: https://github.com/zeta-chain/node/actions/runs/8835882224/job/24261134350

# How Has This Been Tested?

- [x] Tested via GitHub Actions 

