### PR TITLE
feat(zetacore): add upgrade tracker

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -850,6 +850,7 @@ func (app *App) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.Res
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
 	}
+	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }
 

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -113,14 +113,15 @@ func SetupHandlers(app *App) {
 				},
 			},
 		},
+		stateFileDir: DefaultNodeHome,
 	}
 
 	var upgradeHandlerFns []upgradeHandlerFn
 	var storeUpgrades *storetypes.StoreUpgrades
 	var err error
-	_, useDevelopTracker := os.LookupEnv("ZETACORED_USE_DEVELOP_UPGRADE_TRACKER")
-	if useDevelopTracker {
-		upgradeHandlerFns, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	_, useIncrementalTracker := os.LookupEnv("ZETACORED_USE_INCREMENTAL_UPGRADE_TRACKER")
+	if useIncrementalTracker {
+		upgradeHandlerFns, storeUpgrades, err = allUpgrades.getIncrementalUpgrades()
 		if err != nil {
 			panic(err)
 		}

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -20,6 +21,8 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	emissionstypes "github.com/zeta-chain/zetacore/x/emissions/types"
 	ibccrosschaintypes "github.com/zeta-chain/zetacore/x/ibccrosschain/types"
 )
@@ -94,6 +97,12 @@ func SetupHandlers(app *App) {
 						}
 					}
 					return vm, nil
+				},
+			},
+			{
+				index: 1715624665,
+				storeUpgrade: &storetypes.StoreUpgrades{
+					Added: []string{capabilitytypes.ModuleName, ibcexported.ModuleName, ibctransfertypes.ModuleName},
 				},
 			},
 		},

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+	"github.com/zeta-chain/zetacore/pkg/constant"
 	emissionstypes "github.com/zeta-chain/zetacore/x/emissions/types"
 	ibccrosschaintypes "github.com/zeta-chain/zetacore/x/ibccrosschain/types"
 )
@@ -105,6 +106,12 @@ func SetupHandlers(app *App) {
 					Added: []string{capabilitytypes.ModuleName, ibcexported.ModuleName, ibctransfertypes.ModuleName},
 				},
 			},
+			{
+				index: 1715707436,
+				storeUpgrade: &storetypes.StoreUpgrades{
+					Added: []string{ibccrosschaintypes.ModuleName},
+				},
+			},
 		},
 	}
 
@@ -140,16 +147,6 @@ func SetupHandlers(app *App) {
 		panic(err)
 	}
 	if upgradeInfo.Name == constant.Version && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{
-				consensustypes.ModuleName,
-				crisistypes.ModuleName,
-				capabilitytypes.ModuleName,
-				ibcexported.ModuleName,
-				ibctransfertypes.ModuleName,
-				ibccrosschaintypes.ModuleName,
-			},
-		}
 		// Use upgrade store loader for the initial loading of all stores when app starts,
 		// it checks if version == upgradeHeight and applies store upgrades before loading the stores,
 		// so that new stores start with the correct version (the current height of chain),

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -108,10 +108,17 @@ func SetupHandlers(app *App) {
 		},
 	}
 
+	var upgradeHandlerFns []upgradeHandlerFn
+	var storeUpgrades *storetypes.StoreUpgrades
+	var err error
 	_, useDevelopTracker := os.LookupEnv("ZETACORED_USE_DEVELOP_UPGRADE_TRACKER")
-	upgradeHandlerFns, storeUpgrades, err := allUpgrades.getUpgrades(useDevelopTracker)
-	if err != nil {
-		panic(err)
+	if useDevelopTracker {
+		upgradeHandlerFns, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		upgradeHandlerFns, storeUpgrades = allUpgrades.mergeAllUpgrades()
 	}
 
 	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, plan types.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -28,8 +28,6 @@ import (
 	ibccrosschaintypes "github.com/zeta-chain/zetacore/x/ibccrosschain/types"
 )
 
-const releaseVersion = "v17"
-
 func SetupHandlers(app *App) {
 	// Set param key table for params module migration
 	for _, subspace := range app.ParamsKeeper.GetSubspaces() {
@@ -129,8 +127,8 @@ func SetupHandlers(app *App) {
 		upgradeHandlerFns, storeUpgrades = allUpgrades.mergeAllUpgrades()
 	}
 
-	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, plan types.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		app.Logger().Info("Running upgrade handler for " + releaseVersion)
+	app.UpgradeKeeper.SetUpgradeHandler(constant.Version, func(ctx sdk.Context, plan types.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		app.Logger().Info("Running upgrade handler for " + constant.Version)
 
 		var err error
 		for _, upgradeHandler := range upgradeHandlerFns {

--- a/app/upgrade_tracker.go
+++ b/app/upgrade_tracker.go
@@ -34,7 +34,8 @@ func (t upgradeTracker) getDevelopUpgrades() ([]upgradeHandlerFn, *storetypes.St
 	stateFilePath := path.Join(t.stateFileDir, "developupgradetracker")
 
 	currentIndex := int64(0)
-	if stateFileContents, err := os.ReadFile(stateFilePath); err == nil { // #nosec G304 -- stateFilePath is not user controllable
+	stateFileContents, err := os.ReadFile(stateFilePath) // #nosec G304 -- stateFilePath is not user controllable
+	if err == nil {
 		currentIndex, err = strconv.ParseInt(string(stateFileContents), 10, 64)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to decode upgrade tracker: %w", err)
@@ -61,7 +62,7 @@ func (t upgradeTracker) getDevelopUpgrades() ([]upgradeHandlerFn, *storetypes.St
 		}
 		maxIndex = index
 	}
-	err := os.WriteFile(stateFilePath, []byte(strconv.FormatInt(maxIndex, 10)), 0o600)
+	err = os.WriteFile(stateFilePath, []byte(strconv.FormatInt(maxIndex, 10)), 0o600)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to write upgrade state file: %w", err)
 	}

--- a/app/upgrade_tracker.go
+++ b/app/upgrade_tracker.go
@@ -1,0 +1,94 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+type upgradeHandlerFn func(ctx sdk.Context, vm module.VersionMap) (module.VersionMap, error)
+
+type upgradeTrackerItem struct {
+	// Monotonically increasing index to order and track migrations. Typically the current unix epoch timestamp.
+	index int64
+	// Function that will run during the SetUpgradeHandler callback. The VersionMap must always be returned.
+	upgradeHandler upgradeHandlerFn
+	// StoreUpgrades that will be provided to UpgradeStoreLoader
+	storeUpgrade *storetypes.StoreUpgrades
+}
+
+// upgradeTracker allows us to track needed upgrades/migrations across both release and develop builds
+type upgradeTracker struct {
+	upgrades     []upgradeTrackerItem
+	stateFileDir string
+}
+
+func (t upgradeTracker) getDevelopUpgrades() ([]upgradeHandlerFn, *storetypes.StoreUpgrades, error) {
+	neededUpgrades := &storetypes.StoreUpgrades{}
+	neededUpgradeHandlers := []upgradeHandlerFn{}
+	stateFilePath := path.Join(t.stateFileDir, "developupgradetracker")
+
+	currentIndex := int64(0)
+	if stateFileContents, err := os.ReadFile(stateFilePath); err == nil { // #nosec G304 -- stateFilePath is not user controllable
+		currentIndex, err = strconv.ParseInt(string(stateFileContents), 10, 64)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to decode upgrade tracker: %w", err)
+		}
+	} else {
+		fmt.Printf("unable to load upgrade tracker: %v\n", err)
+	}
+
+	maxIndex := currentIndex
+	for _, item := range t.upgrades {
+		index := item.index
+		upgrade := item.storeUpgrade
+		versionModifier := item.upgradeHandler
+		if index <= currentIndex {
+			continue
+		}
+		if versionModifier != nil {
+			neededUpgradeHandlers = append(neededUpgradeHandlers, versionModifier)
+		}
+		if upgrade != nil {
+			neededUpgrades.Added = append(neededUpgrades.Added, upgrade.Added...)
+			neededUpgrades.Deleted = append(neededUpgrades.Deleted, upgrade.Deleted...)
+			neededUpgrades.Renamed = append(neededUpgrades.Renamed, upgrade.Renamed...)
+		}
+		maxIndex = index
+	}
+	err := os.WriteFile(stateFilePath, []byte(strconv.FormatInt(maxIndex, 10)), 0o600)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to write upgrade state file: %w", err)
+	}
+	return neededUpgradeHandlers, neededUpgrades, nil
+}
+
+func (t upgradeTracker) mergeAllUpgrades() ([]upgradeHandlerFn, *storetypes.StoreUpgrades, error) {
+	upgrades := &storetypes.StoreUpgrades{}
+	upgradeHandlers := []upgradeHandlerFn{}
+	for _, item := range t.upgrades {
+		upgrade := item.storeUpgrade
+		versionModifier := item.upgradeHandler
+		if versionModifier != nil {
+			upgradeHandlers = append(upgradeHandlers, versionModifier)
+		}
+		if upgrade != nil {
+			upgrades.Added = append(upgrades.Added, upgrade.Added...)
+			upgrades.Deleted = append(upgrades.Deleted, upgrade.Deleted...)
+			upgrades.Renamed = append(upgrades.Renamed, upgrade.Renamed...)
+		}
+	}
+	return upgradeHandlers, upgrades, nil
+}
+
+func (t upgradeTracker) getUpgrades(isDevelop bool) ([]upgradeHandlerFn, *storetypes.StoreUpgrades, error) {
+	if isDevelop {
+		return t.getDevelopUpgrades()
+	}
+	return t.mergeAllUpgrades()
+}

--- a/app/upgrade_tracker.go
+++ b/app/upgrade_tracker.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
+const developUpgradeTrackerStateFile = "developupgradetracker"
+
 type upgradeHandlerFn func(ctx sdk.Context, vm module.VersionMap) (module.VersionMap, error)
 
 type upgradeTrackerItem struct {
@@ -31,7 +33,7 @@ type upgradeTracker struct {
 func (t upgradeTracker) getDevelopUpgrades() ([]upgradeHandlerFn, *storetypes.StoreUpgrades, error) {
 	neededUpgrades := &storetypes.StoreUpgrades{}
 	neededUpgradeHandlers := []upgradeHandlerFn{}
-	stateFilePath := path.Join(t.stateFileDir, "developupgradetracker")
+	stateFilePath := path.Join(t.stateFileDir, developUpgradeTrackerStateFile)
 
 	currentIndex := int64(0)
 	stateFileContents, err := os.ReadFile(stateFilePath) // #nosec G304 -- stateFilePath is not user controllable
@@ -69,7 +71,7 @@ func (t upgradeTracker) getDevelopUpgrades() ([]upgradeHandlerFn, *storetypes.St
 	return neededUpgradeHandlers, neededUpgrades, nil
 }
 
-func (t upgradeTracker) mergeAllUpgrades() ([]upgradeHandlerFn, *storetypes.StoreUpgrades, error) {
+func (t upgradeTracker) mergeAllUpgrades() ([]upgradeHandlerFn, *storetypes.StoreUpgrades) {
 	upgrades := &storetypes.StoreUpgrades{}
 	upgradeHandlers := []upgradeHandlerFn{}
 	for _, item := range t.upgrades {
@@ -84,12 +86,5 @@ func (t upgradeTracker) mergeAllUpgrades() ([]upgradeHandlerFn, *storetypes.Stor
 			upgrades.Renamed = append(upgrades.Renamed, upgrade.Renamed...)
 		}
 	}
-	return upgradeHandlers, upgrades, nil
-}
-
-func (t upgradeTracker) getUpgrades(isDevelop bool) ([]upgradeHandlerFn, *storetypes.StoreUpgrades, error) {
-	if isDevelop {
-		return t.getDevelopUpgrades()
-	}
-	return t.mergeAllUpgrades()
+	return upgradeHandlers, upgrades
 }

--- a/app/upgrade_tracker_test.go
+++ b/app/upgrade_tracker_test.go
@@ -54,7 +54,7 @@ func TestUpgradeTracker(t *testing.T) {
 	r.Len(upgradeHandlers, 2)
 
 	// should return all migrations on first call
-	upgradeHandlers, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	upgradeHandlers, storeUpgrades, err = allUpgrades.getIncrementalUpgrades()
 	r.NoError(err)
 	r.Len(storeUpgrades.Added, 2)
 	r.Len(storeUpgrades.Renamed, 0)
@@ -62,7 +62,7 @@ func TestUpgradeTracker(t *testing.T) {
 	r.Len(upgradeHandlers, 2)
 
 	// should return no upgrades on second call
-	upgradeHandlers, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	upgradeHandlers, storeUpgrades, err = allUpgrades.getIncrementalUpgrades()
 	r.NoError(err)
 	r.Len(storeUpgrades.Added, 0)
 	r.Len(storeUpgrades.Renamed, 0)
@@ -78,7 +78,7 @@ func TestUpgradeTracker(t *testing.T) {
 		},
 	})
 
-	upgradeHandlers, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	upgradeHandlers, storeUpgrades, err = allUpgrades.getIncrementalUpgrades()
 	r.NoError(err)
 	r.Len(storeUpgrades.Added, 0)
 	r.Len(storeUpgrades.Renamed, 0)
@@ -93,7 +93,7 @@ func TestUpgradeTrackerBadState(t *testing.T) {
 	r.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
-	stateFilePath := path.Join(tmpdir, developUpgradeTrackerStateFile)
+	stateFilePath := path.Join(tmpdir, incrementalUpgradeTrackerStateFile)
 
 	err = os.WriteFile(stateFilePath, []byte("badstate"), 0o600)
 	r.NoError(err)
@@ -102,6 +102,6 @@ func TestUpgradeTrackerBadState(t *testing.T) {
 		upgrades:     []upgradeTrackerItem{},
 		stateFileDir: tmpdir,
 	}
-	_, _, err = allUpgrades.getDevelopUpgrades()
+	_, _, err = allUpgrades.getIncrementalUpgrades()
 	r.Error(err)
 }

--- a/app/upgrade_tracker_test.go
+++ b/app/upgrade_tracker_test.go
@@ -1,0 +1,86 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/stretchr/testify/require"
+	authoritytypes "github.com/zeta-chain/zetacore/x/authority/types"
+	lightclienttypes "github.com/zeta-chain/zetacore/x/lightclient/types"
+)
+
+func TestUpgradeTracker(t *testing.T) {
+	r := require.New(t)
+
+	tmpdir, err := os.MkdirTemp("", "storeupgradetracker-*")
+	r.NoError(err)
+
+	allUpgrades := upgradeTracker{
+		upgrades: []upgradeTrackerItem{
+			{
+				index: 1000,
+				storeUpgrade: &storetypes.StoreUpgrades{
+					Added: []string{authoritytypes.ModuleName},
+				},
+			},
+			{
+				index: 2000,
+				storeUpgrade: &storetypes.StoreUpgrades{
+					Added: []string{lightclienttypes.ModuleName},
+				},
+				upgradeHandler: func(ctx sdk.Context, vm module.VersionMap) (module.VersionMap, error) {
+					return vm, nil
+				},
+			},
+			{
+				index: 3000,
+				upgradeHandler: func(ctx sdk.Context, vm module.VersionMap) (module.VersionMap, error) {
+					return vm, nil
+				},
+			},
+		},
+		stateFileDir: tmpdir,
+	}
+
+	upgradeHandlers, storeUpgrades, err := allUpgrades.mergeAllUpgrades()
+	r.NoError(err)
+	r.Len(storeUpgrades.Added, 2)
+	r.Len(storeUpgrades.Renamed, 0)
+	r.Len(storeUpgrades.Deleted, 0)
+	r.Len(upgradeHandlers, 2)
+
+	// should return all migrations on first call
+	upgradeHandlers, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	r.NoError(err)
+	r.Len(storeUpgrades.Added, 2)
+	r.Len(storeUpgrades.Renamed, 0)
+	r.Len(storeUpgrades.Deleted, 0)
+	r.Len(upgradeHandlers, 2)
+
+	// should return no upgrades on second call
+	upgradeHandlers, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	r.NoError(err)
+	r.Len(storeUpgrades.Added, 0)
+	r.Len(storeUpgrades.Renamed, 0)
+	r.Len(storeUpgrades.Deleted, 0)
+	r.Len(upgradeHandlers, 0)
+
+	// now add a upgrade and ensure that it gets run without running
+	// the other upgrades
+	allUpgrades.upgrades = append(allUpgrades.upgrades, upgradeTrackerItem{
+		index: 4000,
+		storeUpgrade: &storetypes.StoreUpgrades{
+			Deleted: []string{"example"},
+		},
+	})
+
+	upgradeHandlers, storeUpgrades, err = allUpgrades.getDevelopUpgrades()
+	r.NoError(err)
+	r.Len(storeUpgrades.Added, 0)
+	r.Len(storeUpgrades.Renamed, 0)
+	r.Len(storeUpgrades.Deleted, 1)
+	r.Len(upgradeHandlers, 0)
+}


### PR DESCRIPTION
# Description

When we start deploying every change from develop on "developnet", we will need the ability to run each store upgrade/migration function individually as the are added.

Introduce the upgrade version tracker which will manage tracking these upgrades. You must now assign a monotonically increasing index for each store upgrade. We store the maximum index on the disk and skip any store upgrades with indexes less than the stored value.

This tracker is only fully used when you explicitly enable it via environment variable. Otherwise, we assume you're doing a major version upgrade (v14 -> v16) and apply all upgrades.

Blocked by resolution of #2077. Update: I am fixing that in this PR too.

Part of DEVOP-642

# More About developnet

developnet will be a stateful network where every change from develop is automatically built and deployed via governance proposals. We will use the git commit timestamp for the version number each build, so upgrades will look like this:

- `v0.0.1714761000-develop`
- `v0.0.1714764425-develop`
- `v0.0.1714771234-develop`

Since each change will be deployed individually, we must adjust the upgrade handler logic to only run the specific migration logic for each change rather than all migrations every upgrade. An upgrade handler must be defined for every upgrade even if there are no migrations being run.

It is expected that developnet will occasionally need to have it's state reset due to breakages. We will try to minimize the need to reset it's state over time by improving CI checks.

# How Has This Been Tested?

- [ ] Tested CCTX in localnet
- [x] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [x] [Tested via GitHub Actions](https://github.com/zeta-chain/node/actions/runs/9022949128/job/24793658014)

# Checklist:

- [x] I have added unit tests that prove my fix feature works
- [x] three way upgrade tests pass
- [x] think about returning error vs panic
