### PR TITLE
test(e2e): fix local e2e upgrade test

### DIFF
--- a/Dockerfile-upgrade
+++ b/Dockerfile-upgrade
@@ -20,8 +20,8 @@ WORKDIR /go/delivery/zeta-node
 RUN mkdir -p  $GOPATH/bin/old
 RUN mkdir -p  $GOPATH/bin/new
 
-ARG OLD_VERSION=v14.0.0
-ENV NEW_VERSION=v15
+ARG OLD_VERSION=v15.0.0
+ENV NEW_VERSION=v16
 
 # Build new release from the current source
 COPY go.mod /go/delivery/zeta-node/

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -10,7 +10,7 @@ import (
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
-const releaseVersion = "v15"
+const releaseVersion = "v16"
 
 func SetupHandlers(app *App) {
 	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
-## Unreleased
+## v16.0.0
+
 ### Breaking Changes
 
 * Admin policies have been moved from `observer` to a new module `authority`.

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -30,6 +30,7 @@ const (
 	flagSetupOnly         = "setup-only"
 	flagSkipSetup         = "skip-setup"
 	flagSkipBitcoinSetup  = "skip-bitcoin-setup"
+	flagSkipHeaderProof   = "skip-header-proof"
 )
 
 var (
@@ -57,6 +58,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().String(flagConfigOut, "", "config file to write the deployed contracts from the setup")
 	cmd.Flags().Bool(flagSkipSetup, false, "set to true to skip setup")
 	cmd.Flags().Bool(flagSkipBitcoinSetup, false, "set to true to skip bitcoin wallet setup")
+	cmd.Flags().Bool(flagSkipHeaderProof, false, "set to true to skip header proof tests")
 
 	return cmd
 }
@@ -108,6 +110,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		panic(err)
 	}
 	skipBitcoinSetup, err := cmd.Flags().GetBool(flagSkipBitcoinSetup)
+	if err != nil {
+		panic(err)
+	}
+	skipHeaderProof, err := cmd.Flags().GetBool(flagSkipHeaderProof)
 	if err != nil {
 		panic(err)
 	}
@@ -189,8 +195,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		logger.Print("⚙️ setting up networks")
 		startTime := time.Now()
 
-		if err := deployerRunner.EnableVerificationFlags(); err != nil {
-			panic(err)
+		if !skipHeaderProof {
+			if err := deployerRunner.EnableVerificationFlags(); err != nil {
+				panic(err)
+			}
 		}
 
 		deployerRunner.SetupEVM(contractsDeployed, true)
@@ -290,10 +298,13 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			ethereumTests = append(ethereumTests, ethereumAdvancedTests...)
 		}
 
+		// skip the header proof test if we run light test or skipHeaderProof is enabled
+		testHeader := !light && !skipHeaderProof
+
 		eg.Go(erc20TestRoutine(conf, deployerRunner, verbose, erc20Tests...))
 		eg.Go(zetaTestRoutine(conf, deployerRunner, verbose, zetaTests...))
-		eg.Go(bitcoinTestRoutine(conf, deployerRunner, verbose, !skipBitcoinSetup, !light, bitcoinTests...))
-		eg.Go(ethereumTestRoutine(conf, deployerRunner, verbose, !light, ethereumTests...))
+		eg.Go(bitcoinTestRoutine(conf, deployerRunner, verbose, !skipBitcoinSetup, testHeader, bitcoinTests...))
+		eg.Go(ethereumTestRoutine(conf, deployerRunner, verbose, testHeader, ethereumTests...))
 	}
 	if testAdmin {
 		eg.Go(adminTestRoutine(conf, deployerRunner, verbose,

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -270,15 +270,15 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		}
 		bitcoinTests := []string{
 			e2etests.TestBitcoinWithdrawSegWitName,
-			e2etests.TestBitcoinWithdrawTaprootName,
-			e2etests.TestBitcoinWithdrawLegacyName,
-			e2etests.TestBitcoinWithdrawP2SHName,
-			e2etests.TestBitcoinWithdrawP2WSHName,
 			e2etests.TestBitcoinWithdrawInvalidAddressName,
 			e2etests.TestZetaWithdrawBTCRevertName,
 			e2etests.TestCrosschainSwapName,
 		}
 		bitcoinAdvancedTests := []string{
+			e2etests.TestBitcoinWithdrawTaprootName,
+			e2etests.TestBitcoinWithdrawLegacyName,
+			e2etests.TestBitcoinWithdrawP2SHName,
+			e2etests.TestBitcoinWithdrawP2WSHName,
 			e2etests.TestBitcoinWithdrawRestrictedName,
 		}
 		ethereumTests := []string{

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -57,12 +57,12 @@ if [ "$OPTION" == "upgrade" ]; then
   # Run zetae2e, if the upgrade height is lower than 100, we use the setup-only flag
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
     echo "running E2E command to setup the networks..."
-    zetae2e "$ZETAE2E_CMD" --setup-only --config-out deployed.yml
+    zetae2e "$ZETAE2E_CMD" --setup-only --config-out deployed.yml --skip-header-proof
   else
     echo "running E2E command to setup the networks and populate the state..."
 
     # Use light flag to ensure tests can complete before the upgrade height
-    zetae2e "$ZETAE2E_CMD" --config-out deployed.yml --light
+    zetae2e "$ZETAE2E_CMD" --config-out deployed.yml --light --skip-header-proof
  fi
   ZETAE2E_EXIT_CODE=$?
 
@@ -86,9 +86,9 @@ if [ "$OPTION" == "upgrade" ]; then
   # When the upgrade height is greater than 100 for upgrade test, the Bitcoin tests have been run once, therefore the Bitcoin wallet is already set up
   # Use light flag to skip advanced tests
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
-    zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml --light
+    zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml --light --skip-header-proof
   else
-    zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml --skip-bitcoin-setup --light
+    zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof
   fi
 
   ZETAE2E_EXIT_CODE=$?

--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -34,7 +34,7 @@ if [ $HOSTNAME == "zetaclient0" ]
 then
     rm ~/.tss/*
     MYIP=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
-    zetaclientd init  --zetacore-url zetacore0 --chain-id athens_101-1 --operator "$operatorAddress" --log-format=text --public-ip "$MYIP" --keyring-backend "$BACKEND"
+    zetaclientd init --zetacore-url zetacore0 --chain-id athens_101-1 --operator "$operatorAddress" --log-format=text --public-ip "$MYIP" --keyring-backend "$BACKEND"
 
     # check if the option is additional-evm
    # in this case, the additional evm is represented with the sepolia chain, we set manually the eth2 endpoint to the sepolia chain (11155111 -> http://eth2:8545)

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -49,8 +49,16 @@ func WaitCctxsMinedByInTxHash(
 
 	// fetch cctxs by inTxHash
 	for i := 0; ; i++ {
+		// declare cctxs here so we can print the last fetched one if we reach timeout
+		var cctxs []*crosschaintypes.CrossChainTx
+
 		if time.Since(startTime) > timeout {
-			panic(fmt.Sprintf("waiting cctx timeout, cctx not mined, inTxHash: %s", inTxHash))
+			cctxMessage := ""
+			if len(cctxs) > 0 {
+				cctxMessage = fmt.Sprintf(", last cctx: %v", cctxs[0].String())
+			}
+
+			panic(fmt.Sprintf("waiting cctx timeout, cctx not mined, inTxHash: %s%s", inTxHash, cctxMessage))
 		}
 		time.Sleep(1 * time.Second)
 
@@ -77,7 +85,7 @@ func WaitCctxsMinedByInTxHash(
 			}
 			continue
 		}
-		cctxs := make([]*crosschaintypes.CrossChainTx, 0, len(res.CrossChainTxs))
+		cctxs = make([]*crosschaintypes.CrossChainTx, 0, len(res.CrossChainTxs))
 		allFound := true
 		for j, cctx := range res.CrossChainTxs {
 			cctx := cctx

--- a/zetaclient/zetabridge/zetacore_bridge.go
+++ b/zetaclient/zetabridge/zetacore_bridge.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zeta-chain/zetacore/pkg/authz"
 	"github.com/zeta-chain/zetacore/pkg/chains"
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
+	lightclienttypes "github.com/zeta-chain/zetacore/x/lightclient/types"
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 	"github.com/zeta-chain/zetacore/zetaclient/config"
 	corecontext "github.com/zeta-chain/zetacore/zetaclient/core_context"
@@ -200,12 +201,12 @@ func (b *ZetaCoreBridge) GetKeys() *keys.Keys {
 func (b *ZetaCoreBridge) UpdateZetaCoreContext(coreContext *corecontext.ZetaCoreContext, init bool, sampledLogger zerolog.Logger) error {
 	bn, err := b.GetZetaBlockHeight()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get zetablock height: %w", err)
 	}
 	plan, err := b.GetUpgradePlan()
-	// if there is no active upgrade plan, plan will be nil, err will be nil as well.
 	if err != nil {
-		return err
+		// if there is no active upgrade plan, plan will be nil, err will be nil as well.
+		return fmt.Errorf("failed to get upgrade plan: %w", err)
 	}
 	if plan != nil && bn == plan.Height-1 { // stop zetaclients; notify operator to upgrade and restart
 		b.logger.Warn().Msgf("Active upgrade plan detected and upgrade height reached: %s at height %d; ZetaClient is stopped;"+
@@ -215,7 +216,7 @@ func (b *ZetaCoreBridge) UpdateZetaCoreContext(coreContext *corecontext.ZetaCore
 
 	chainParams, err := b.GetChainParams()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get chain params: %w", err)
 	}
 
 	newEVMParams := make(map[int64]*observertypes.ChainParams)
@@ -241,7 +242,7 @@ func (b *ZetaCoreBridge) UpdateZetaCoreContext(coreContext *corecontext.ZetaCore
 
 	supportedChains, err := b.GetSupportedChains()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get supported chains: %w", err)
 	}
 	newChains := make([]chains.Chain, len(supportedChains))
 	for i, chain := range supportedChains {
@@ -250,26 +251,33 @@ func (b *ZetaCoreBridge) UpdateZetaCoreContext(coreContext *corecontext.ZetaCore
 	keyGen, err := b.GetKeyGen()
 	if err != nil {
 		b.logger.Info().Msg("Unable to fetch keygen from zetabridge")
-		return err
+		return fmt.Errorf("failed to get keygen: %w", err)
 	}
 
 	tss, err := b.GetCurrentTss()
 	if err != nil {
 		b.logger.Info().Err(err).Msg("Unable to fetch TSS from zetabridge")
-		return err
+		return fmt.Errorf("failed to get current tss: %w", err)
 	}
 	tssPubKey := tss.GetTssPubkey()
 
 	crosschainFlags, err := b.GetCrosschainFlags()
 	if err != nil {
 		b.logger.Info().Msg("Unable to fetch cross-chain flags from zetabridge")
-		return err
+		return fmt.Errorf("failed to get crosschain flags: %w", err)
 	}
 
 	verificationFlags, err := b.GetVerificationFlags()
 	if err != nil {
 		b.logger.Info().Msg("Unable to fetch verification flags from zetabridge")
-		return err
+
+		// The block header functionality is currently disabled on the ZetaCore side
+		// The verification flags might not exist and we should not return an error here to prevent the ZetaClient from starting
+		// TODO: Uncomment this line when the block header functionality is enabled and we need to get the verification flags
+		// https://github.com/zeta-chain/node/issues/1717
+		// return fmt.Errorf("failed to get verification flags: %w", err)
+
+		verificationFlags = lightclienttypes.VerificationFlags{}
 	}
 
 	coreContext.Update(


### PR DESCRIPTION
# Description

https://github.com/zeta-chain/node/pull/2051 was merged to the wrong branch following the new naming standard for release branches

- Cherry pick changes from to the new release branch.
- Set `v16.0.0`in the changelogs
