### PR TITLE
fix: adjust docker login conditional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,9 +114,13 @@ jobs:
           skip_aws_cli: "true"
           skip_docker_compose: "false"
 
+      - run: |
+          echo "github.repository: ${{ github.repository }}"
+          echo "github.event.pull_request.head.repo.full_name: ${{ github.event.pull_request.head.repo.full_name }}"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: github.event.repository.full_name == 'zeta-chain/node'
+        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_ONLY }}


### PR DESCRIPTION
Adjust the docker login conditional again to actually fix forks.

If we want the workflows to be run by external people, we should not use the buildjet runners. [github did recently upgrade the free runners for opensource projects btw](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/)

You cannot test the presence of secrets in if statements btw.