### PR TITLE
fix: trigger genesis for new modules in v16

### DIFF
--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -21,6 +21,9 @@ func SetupHandlers(app *App) {
 		}
 		VersionMigrator{v: vm}.TriggerMigration(observertypes.ModuleName)
 
+		VersionMigrator{v: vm}.TriggerInitGenesis(authoritytypes.ModuleName)
+		VersionMigrator{v: vm}.TriggerInitGenesis(lightclienttypes.ModuleName)
+
 		return app.mm.RunMigrations(ctx, app.configurator, vm)
 	})
 
@@ -46,5 +49,10 @@ type VersionMigrator struct {
 
 func (v VersionMigrator) TriggerMigration(moduleName string) module.VersionMap {
 	v.v[moduleName] = v.v[moduleName] - 1
+	return v.v
+}
+
+func (v VersionMigrator) TriggerInitGenesis(moduleName string) module.VersionMap {
+	delete(v.v, moduleName)
 	return v.v
 }

--- a/x/authority/genesis.go
+++ b/x/authority/genesis.go
@@ -8,6 +8,7 @@ import (
 
 // InitGenesis initializes the authority module's state from a provided genesis state
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+	ctx.Logger().Info("Initializing authority genesis state")
 	k.SetPolicies(ctx, genState.Policies)
 }
 

--- a/x/lightclient/genesis.go
+++ b/x/lightclient/genesis.go
@@ -8,6 +8,7 @@ import (
 
 // InitGenesis initializes the lightclient module's state from a provided genesis state
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+	ctx.Logger().Info("Initializing light client genesis state")
 	// set block headers
 	for _, elem := range genState.BlockHeaders {
 		k.SetBlockHeader(ctx, elem)


### PR DESCRIPTION
# Description

Adds logic to trigger genesis for new modules . It removes new modules in the fromVM map so that they can execute the InitGensis
Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
