### PR TITLE
fix: add retry for Bitcoin signing

### DIFF
--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -119,6 +119,10 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	r.Logger.Info("cctx2 outbound tx hash %s", cctx2.GetCurrentOutTxParam().OutboundTxHash)
 
 	r.Logger.Info("******* Second test: BTC -> ERC20ZRC20")
+
+	// wait a few seconds before listing utxos
+	time.Sleep(5 * time.Second)
+
 	utxos, err := r.BtcRPCClient.ListUnspent()
 	if err != nil {
 		panic(err)

--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -102,7 +102,7 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	if err != nil {
 		panic(err)
 	}
-	//stop := r.MineBlocks()
+	stop := r.MineBlocks()
 
 	// cctx1 index acts like the inTxHash for the second cctx (the one that withdraws BTC)
 	cctx2 := utils.WaitCctxMinedByInTxHash(r.Ctx, cctx1.Index, r.CctxClient, r.Logger, r.CctxTimeout)
@@ -194,7 +194,7 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 		txid, err := r.SendToTSSFromDeployerWithMemo(
 			r.BTCTSSAddress,
 			amount,
-			utxos[0:2],
+			utxos, //[0:2],
 			r.BtcRPCClient,
 			memo,
 			r.BTCDeployerAddress,
@@ -235,5 +235,5 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	}
 
 	// stop mining
-	//stop <- struct{}{}
+	stop <- struct{}{}
 }

--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -102,7 +102,7 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	if err != nil {
 		panic(err)
 	}
-	stop := r.MineBlocks()
+	//stop := r.MineBlocks()
 
 	// cctx1 index acts like the inTxHash for the second cctx (the one that withdraws BTC)
 	cctx2 := utils.WaitCctxMinedByInTxHash(r.Ctx, cctx1.Index, r.CctxClient, r.Logger, r.CctxTimeout)
@@ -119,10 +119,6 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	r.Logger.Info("cctx2 outbound tx hash %s", cctx2.GetCurrentOutTxParam().OutboundTxHash)
 
 	r.Logger.Info("******* Second test: BTC -> ERC20ZRC20")
-
-	// wait a few seconds before listing utxos
-	time.Sleep(5 * time.Second)
-
 	utxos, err := r.BtcRPCClient.ListUnspent()
 	if err != nil {
 		panic(err)
@@ -239,5 +235,5 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	}
 
 	// stop mining
-	stop <- struct{}{}
+	//stop <- struct{}{}
 }

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -246,7 +246,6 @@ func (runner *E2ERunner) SendToTSSFromDeployerWithMemo(
 	}
 	if !signed {
 		panic("btc transaction not signed")
-		g
 	}
 	txid, err := btcRPC.SendRawTransaction(stx, true)
 	if err != nil {

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -240,9 +240,12 @@ func (runner *E2ERunner) SendToTSSFromDeployerWithMemo(
 		}
 	}
 
-	stx, err := signRawTransactionWithWallet2WithRetry(btcRPC, tx, inputsForSign)
+	stx, signed, err := btcRPC.SignRawTransactionWithWallet2(tx, inputsForSign)
 	if err != nil {
 		panic(err)
+	}
+	if signed {
+		panic("not signed")
 	}
 	txid, err := btcRPC.SendRawTransaction(stx, true)
 	if err != nil {
@@ -403,24 +406,4 @@ func (runner *E2ERunner) ProveBTCTransaction(txHash *chainhash.Hash) {
 		panic("txProof should be valid")
 	}
 	runner.Logger.Info("OK: txProof verified for inTx: %s", txHash.String())
-}
-
-// SignRawTransactionWithWallet2WithRetry signs a raw transaction with wallet2 and retries if it's not signed
-func signRawTransactionWithWallet2WithRetry(
-	btcRPC *rpcclient.Client,
-	tx *wire.MsgTx,
-	inputsForSign []btcjson.RawTxWitnessInput,
-) (*wire.MsgTx, error) {
-	for i := 0; i < 5; i++ {
-		stx, signed, err := btcRPC.SignRawTransactionWithWallet2(tx, inputsForSign)
-		if err != nil {
-			return nil, err
-		}
-		if signed {
-			return stx, nil
-		}
-		time.Sleep(2 * time.Second)
-	}
-
-	return nil, fmt.Errorf("signRawTransactionWithWallet2WithRetry: not signed")
 }

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -244,8 +244,9 @@ func (runner *E2ERunner) SendToTSSFromDeployerWithMemo(
 	if err != nil {
 		panic(err)
 	}
-	if signed {
-		panic("not signed")
+	if !signed {
+		panic("btc transaction not signed")
+		g
 	}
 	txid, err := btcRPC.SendRawTransaction(stx, true)
 	if err != nil {


### PR DESCRIPTION
# Description

Tentative fix for https://github.com/zeta-chain/node/issues/2089
Add a retry for the signature, in case the error is related to the network.

Closes: https://github.com/zeta-chain/node/issues/2089


