### PR TITLE
refactor: limit zevm revert to cointType Zeta

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@
 * [2013](https://github.com/zeta-chain/node/pull/2013) - rename `GasPriceVoter` message to `VoteGasPrice`
 * [2059](https://github.com/zeta-chain/node/pull/2059) - Remove unused params from all functions in zetanode
 * [2076](https://github.com/zeta-chain/node/pull/2076) - automatically deposit native zeta to an address if it doesn't exist on ZEVM.
+* [2160](https://github.com/zeta-chain/node/pull/2160) - Limit zEVM revert transactions to coin type ZETA 
 
 ### Features
 

--- a/x/crosschain/keeper/process_outbound_test.go
+++ b/x/crosschain/keeper/process_outbound_test.go
@@ -58,7 +58,7 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		require.Equal(t, cctx.GetCurrentOutTxParam().TxFinalizationStatus, types.TxFinalizationStatus_Executed)
 	})
 
-	t.Run("successfully process failed outbound set to aborted for type zevm tx of cointype Gas", func(t *testing.T) {
+	t.Run("set failed zevm outbound of cointype Gas to aborted", func(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 		cctx := sample.CrossChainTx(t, "test")
 		cctx.InboundTxParams.CoinType = coin.CoinType_Gas

--- a/x/crosschain/keeper/process_outbound_test.go
+++ b/x/crosschain/keeper/process_outbound_test.go
@@ -47,7 +47,7 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		require.Equal(t, cctx.GetCurrentOutTxParam().TxFinalizationStatus, types.TxFinalizationStatus_Executed)
 	})
 
-	t.Run("successfully process failed outbound set to aborted for type zevm tx of cointype ERC20", func(t *testing.T) {
+	t.Run("set failed zevm outbound of cointype ERC20 to aborted", func(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 		cctx := sample.CrossChainTx(t, "test")
 		cctx.InboundTxParams.CoinType = coin.CoinType_ERC20

--- a/x/crosschain/keeper/process_outbound_test.go
+++ b/x/crosschain/keeper/process_outbound_test.go
@@ -111,7 +111,6 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		errorFailedZETARevertAndCallContract := errors.New("test", 999, "failed ZETARevertAndCallContract")
 		cctx := GetERC20Cctx(t, receiver, chains.GoerliChain(), "", big.NewInt(42))
 		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
-		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
 		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
 		fungibleMock.On("ZETARevertAndCallContract", mock.Anything,
 			ethcommon.HexToAddress(cctx.InboundTxParams.Sender),

--- a/x/crosschain/keeper/process_outbound_test.go
+++ b/x/crosschain/keeper/process_outbound_test.go
@@ -47,10 +47,33 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		require.Equal(t, cctx.GetCurrentOutTxParam().TxFinalizationStatus, types.TxFinalizationStatus_Executed)
 	})
 
+	t.Run("successfully process failed outbound set to aborted for type zevm tx of cointype ERC20", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		cctx := sample.CrossChainTx(t, "test")
+		cctx.InboundTxParams.CoinType = coin.CoinType_ERC20
+		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
+		err := k.ProcessFailedOutbound(ctx, cctx, sample.String())
+		require.NoError(t, err)
+		require.Equal(t, cctx.CctxStatus.Status, types.CctxStatus_Aborted)
+		require.Equal(t, cctx.GetCurrentOutTxParam().TxFinalizationStatus, types.TxFinalizationStatus_Executed)
+	})
+
+	t.Run("successfully process failed outbound set to aborted for type zevm tx of cointype Gas", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		cctx := sample.CrossChainTx(t, "test")
+		cctx.InboundTxParams.CoinType = coin.CoinType_Gas
+		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
+		err := k.ProcessFailedOutbound(ctx, cctx, sample.String())
+		require.NoError(t, err)
+		require.Equal(t, cctx.CctxStatus.Status, types.CctxStatus_Aborted)
+		require.Equal(t, cctx.GetCurrentOutTxParam().TxFinalizationStatus, types.TxFinalizationStatus_Executed)
+	})
+
 	t.Run("successfully process failed outbound if original sender is a address", func(t *testing.T) {
 		k, ctx, sdkk, _ := keepertest.CrosschainKeeper(t)
 		receiver := sample.EthAddress()
 		cctx := GetERC20Cctx(t, receiver, chains.GoerliChain(), "", big.NewInt(42))
+		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
 		err := sdkk.EvmKeeper.SetAccount(ctx, ethcommon.HexToAddress(cctx.InboundTxParams.Sender), *statedb.NewEmptyAccount())
 		require.NoError(t, err)
 		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
@@ -63,6 +86,7 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 		receiver := sample.EthAddress()
 		cctx := GetERC20Cctx(t, receiver, chains.GoerliChain(), "", big.NewInt(42))
+		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
 		cctx.Index = ""
 		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
 		err := k.ProcessFailedOutbound(ctx, cctx, sample.String())
@@ -73,6 +97,7 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 		cctx := sample.CrossChainTx(t, "test")
 		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
+		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
 		err := k.ProcessFailedOutbound(ctx, cctx, sample.String())
 		require.ErrorContains(t, err, "failed AddRevertOutbound")
 	})
@@ -85,6 +110,8 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		receiver := sample.EthAddress()
 		errorFailedZETARevertAndCallContract := errors.New("test", 999, "failed ZETARevertAndCallContract")
 		cctx := GetERC20Cctx(t, receiver, chains.GoerliChain(), "", big.NewInt(42))
+		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
+		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
 		cctx.InboundTxParams.SenderChainId = chains.ZetaChainMainnet().ChainId
 		fungibleMock.On("ZETARevertAndCallContract", mock.Anything,
 			ethcommon.HexToAddress(cctx.InboundTxParams.Sender),
@@ -103,6 +130,7 @@ func TestKeeper_ProcessFailedOutbound(t *testing.T) {
 		_ = zk.FungibleKeeper.GetAuthKeeper().GetModuleAccount(ctx, fungibletypes.ModuleName)
 
 		cctx := GetERC20Cctx(t, sample.EthAddress(), chains.GoerliChain(), "", big.NewInt(42))
+		cctx.InboundTxParams.CoinType = coin.CoinType_Zeta
 		cctx.RelayedMessage = base64.StdEncoding.EncodeToString([]byte("sample message"))
 
 		deploySystemContracts(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper)


### PR DESCRIPTION
# Description

- Add check to revert only ZETA-type transactions.
- Other txs origination from Zetachain are aborted if they revert 


Closes: https://github.com/zeta-chain/node/issues/2159
Note : This also would need to develop
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
