### PR TITLE
chore(ci): upgrade github actions dependencies

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -28,9 +28,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       if: ${{ inputs.skip_go == 'false' }}
       with:
         go-version: '1.20'

--- a/.github/actions/set-branch-name/action.yml
+++ b/.github/actions/set-branch-name/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set branch name
       id: set-branch-name

--- a/.github/actions/upgrade-testing/action.yml
+++ b/.github/actions/upgrade-testing/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     concurrency:
       group: "build-and-test"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set CPU Architecture
         shell: bash
@@ -54,7 +54,7 @@ jobs:
           skip_docker_compose: "false"
       
       - name: Test
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 20
           max_attempts: 2
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set CPU Architecture
         shell: bash

--- a/.github/workflows/change-log-check.yml
+++ b/.github/workflows/change-log-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/execute_advanced_tests.yaml
+++ b/.github/workflows/execute_advanced_tests.yaml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: "Checkout Code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Start Test
         run: make start-e2e-admin-test
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: "Checkout Code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Start Test
         run: make start-upgrade-test
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: "Checkout Code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Start Test
         run: make start-upgrade-test-light
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: "Checkout Code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Start Test
         run: make start-e2e-performance-test

--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: bufbuild/buf-setup-action@v1
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,13 +40,13 @@ jobs:
     steps:
       - name: Checkout Source
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -71,13 +71,13 @@ jobs:
     steps:
       - name: Checkout Source
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -101,13 +101,13 @@ jobs:
     steps:
       - name: Checkout Source
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -133,7 +133,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -174,7 +174,7 @@ jobs:
     timeout-minutes: 10
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ github.event.inputs.skip_checks != 'true' }}
         with:
           fetch-depth: 0
@@ -209,7 +209,7 @@ jobs:
     steps:
       - name: "Checkout Code"
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set CPU Architecture
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -284,7 +284,7 @@ jobs:
     steps:
       - name: "Checkout Code"
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set CPU Architecture
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -362,7 +362,7 @@ jobs:
     steps:
       - name: "Checkout Code"
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Execute e2e-admin-tests
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -384,7 +384,7 @@ jobs:
     steps:
       - name: "Checkout Code"
         if: ${{ github.event.inputs.skip_checks != 'true' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Execute upgrade-test
         if: ${{ github.event.inputs.skip_checks != 'true' }}
@@ -415,7 +415,7 @@ jobs:
     timeout-minutes: 60
     environment: release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Pipeline Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
     needs:
       - pre-release-checks
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set CPU Architecture
         shell: bash

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -20,12 +20,12 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -40,12 +40,12 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -59,12 +59,12 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 

--- a/.github/workflows/upgrade_path_testing.yaml
+++ b/.github/workflows/upgrade_path_testing.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           version: 2
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           check-latest: false
           go-version: '^1.20'


### PR DESCRIPTION
Upgrade github actions workflow dependencies to fix this warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-go@v4, nick-fields/retry@v2.