### PR TITLE
chore: updates for developnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     concurrency:
       group: "build-and-test"
@@ -102,7 +102,7 @@ jobs:
         run: rm -rf *
 
   e2e-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4

--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -5,6 +5,13 @@ UPGRADE_HEIGHT=$1
 CHAINID="athens_101-1"
 UPGRADE_AUTHORITY_ACCOUNT="zeta10d07y265gmmuvt4z0w9aw880jnsr700jvxasvr"
 
+if [[ -z $ZETACORED_URL ]]; then
+    ZETACORED_URL='http://upgrade-host:8000/zetacored'
+fi
+if [[ -z $ZETACLIENTD_URL ]]; then
+    ZETACLIENTD_URL='http://upgrade-host:8000/zetaclientd'
+fi
+
 # Wait for authorized_keys file to exist (populated by zetacore0)
 while [ ! -f ~/.ssh/authorized_keys ]; do
     echo "Waiting for authorized_keys file to exist..."
@@ -32,7 +39,7 @@ if [[ $(hostname) != "zetacore0" ]]; then
 fi
 
 # get new zetacored version
-curl -o /tmp/zetacored.new http://upgrade-host:8000/zetacored
+curl -o /tmp/zetacored.new "${ZETACORED_URL}"
 chmod +x /tmp/zetacored.new
 UPGRADE_NAME=$(/tmp/zetacored.new version)
 
@@ -77,8 +84,8 @@ esac
 cat > upgrade_plan_info.json <<EOF
 {
     "binaries": {
-        "linux/${GOARCH}": "http://upgrade-host:8000/zetacored",
-        "zetaclientd-linux/${GOARCH}": "http://upgrade-host:8000/zetaclientd"
+        "linux/${GOARCH}": "${ZETACORED_URL}",
+        "zetaclientd-linux/${GOARCH}": "${ZETACLIENTD_URL}"
     }
 }
 EOF

--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -39,7 +39,7 @@ if [[ $(hostname) != "zetacore0" ]]; then
 fi
 
 # get new zetacored version
-curl -o /tmp/zetacored.new "${ZETACORED_URL}"
+curl -L -o /tmp/zetacored.new "${ZETACORED_URL}"
 chmod +x /tmp/zetacored.new
 UPGRADE_NAME=$(/tmp/zetacored.new version)
 


### PR DESCRIPTION
# Description

- build on ubuntu 20.04 for lower glibc version (related to #2175)
- parameterize upgrade orchestrator binary urls and allow overriding
- follow redirects when downloading binary to get version

Relates to DEVOP-642