### PR TITLE
feat: add no-op v17 athens upgrade handler

### DIFF
--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -10,7 +10,7 @@ import (
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
-const releaseVersion = "v16"
+const releaseVersion = "v17"
 
 func SetupHandlers(app *App) {
 	app.UpgradeKeeper.SetUpgradeHandler(releaseVersion, func(ctx sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) {
@@ -22,6 +22,10 @@ func SetupHandlers(app *App) {
 		VersionMigrator{v: vm}.TriggerMigration(observertypes.ModuleName)
 
 		return app.mm.RunMigrations(ctx, app.configurator, vm)
+	})
+
+	app.UpgradeKeeper.SetUpgradeHandler("v17-athens", func(ctx sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return vm, nil
 	})
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()


### PR DESCRIPTION
# Description

We need to upgrade athens to v17 but not run the migrations. You must define a upgrade handler for any upgrades run via upgrade proposals. Define a no-op `v17-athens` handler.

> SetUpgradeHandler sets an UpgradeHandler for the upgrade specified by name. This handler will be called when the upgrade with this name is applied. In order for an upgrade with the given name to proceed, a handler for this upgrade must be set even if it is a no-op function.

Upgrade proposal will be called `v17-athens`

Related to #2228

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
