### PR TITLE
feat: enable restarting localnet containers

### DIFF
--- a/contrib/localnet/docker-compose-upgrade.yml
+++ b/contrib/localnet/docker-compose-upgrade.yml
@@ -13,11 +13,11 @@ services:
     image: zetanode:old
 
   zetaclient0:
-    entrypoint: ["/root/start-zetaclientd.sh", "background"]
+    entrypoint: ["/root/start-zetaclientd.sh"]
     image: zetanode:old
 
   zetaclient1:
-    entrypoint: ["/root/start-zetaclientd.sh", "background"]
+    entrypoint: ["/root/start-zetaclientd.sh"]
     image: zetanode:old
 
   orchestrator:


### PR DESCRIPTION
# Description

On the zetacored containers, test if the `~/.zetacored/init_complete` file exists and skip initialization if it does.
On the zetaclientd containers, test if the `~/.zetacored/config/zetaclient_config.json` file exists and skip initialization if it does.

I need to fully separate setup and test steps in zetae2e in the orchestrator but I will do that in a separate PR.

Relates to #2232
Relates to DEVOP-642

# How Has This Been Tested?

- [ ] Tested CCTX in localnet
- [x] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

```
make start-localnet
docker stop zetacore1
docker stop zetaclient1
make start-localnet
```
