### PR TITLE
fix: removed hard-coded bitcoin Regnet chainID in E2E withdraw tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * [2047](https://github.com/zeta-chain/node/pull/2047) - fix liquidity cap advanced test
 * [2181](https://github.com/zeta-chain/node/pull/2181) - add more assertion and test cases in ZEVM message passing E2E tests
 * [2184](https://github.com/zeta-chain/node/pull/2184) - add tx priority checks to e2e tests
+* [2240](https://github.com/zeta-chain/node/pull/2240) - removed hard-coded Bitcoin regnet chainID in E2E withdraw tests
 
 ### Fixes
 

--- a/e2e/e2etests/helper_bitcoin.go
+++ b/e2e/e2etests/helper_bitcoin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
 	"github.com/zeta-chain/zetacore/pkg/chains"

--- a/e2e/e2etests/test_bitcoin_withdraw_invalid_address.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_invalid_address.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/btcsuite/btcutil"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
 	"github.com/zeta-chain/zetacore/pkg/chains"

--- a/e2e/e2etests/test_bitcoin_withdraw_invalid_address.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_invalid_address.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 
 	"github.com/btcsuite/btcutil"
-
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
+	"github.com/zeta-chain/zetacore/pkg/chains"
 )
 
 func TestBitcoinWithdrawToInvalidAddress(r *runner.E2ERunner, args []string) {
@@ -45,8 +45,12 @@ func withdrawToInvalidAddress(r *runner.E2ERunner, amount *big.Int) {
 		panic(fmt.Errorf("approve receipt status is not 1"))
 	}
 
-	// mine blocks
-	stop := r.MineBlocks()
+	// mine blocks if testing on regnet
+	var stop chan struct{}
+	isRegnet := chains.IsBitcoinRegnet(r.GetBitcoinChainID())
+	if isRegnet {
+		stop = r.MineBlocks()
+	}
 
 	// withdraw amount provided as test arg BTC from ZRC20 to BTC legacy address
 	// the address "1EYVvXLusCxtVuEwoYvWRyN5EZTXwPVvo3" is for mainnet, not regtest
@@ -58,6 +62,9 @@ func withdrawToInvalidAddress(r *runner.E2ERunner, amount *big.Int) {
 	if receipt.Status == 1 {
 		panic(fmt.Errorf("withdraw receipt status is successful for an invalid BTC address"))
 	}
+
 	// stop mining
-	stop <- struct{}{}
+	if isRegnet {
+		stop <- struct{}{}
+	}
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_legacy.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_legacy.go
@@ -15,7 +15,7 @@ func TestBitcoinWithdrawLegacy(r *runner.E2ERunner, args []string) {
 
 	// parse arguments and withdraw BTC
 	defaultReceiver := "mxpYha3UJKUgSwsAz2qYRqaDSwAkKZ3YEY"
-	receiver, amount := parseBitcoinWithdrawArgs(args, defaultReceiver)
+	receiver, amount := parseBitcoinWithdrawArgs(r, args, defaultReceiver)
 	_, ok := receiver.(*btcutil.AddressPubKeyHash)
 	if !ok {
 		panic("Invalid receiver address specified for TestBitcoinWithdrawLegacy.")

--- a/e2e/e2etests/test_bitcoin_withdraw_p2sh.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_p2sh.go
@@ -15,7 +15,7 @@ func TestBitcoinWithdrawP2SH(r *runner.E2ERunner, args []string) {
 
 	// parse arguments and withdraw BTC
 	defaultReceiver := "2N6AoUj3KPS7wNGZXuCckh8YEWcSYNsGbqd"
-	receiver, amount := parseBitcoinWithdrawArgs(args, defaultReceiver)
+	receiver, amount := parseBitcoinWithdrawArgs(r, args, defaultReceiver)
 	_, ok := receiver.(*btcutil.AddressScriptHash)
 	if !ok {
 		panic("Invalid receiver address specified for TestBitcoinWithdrawP2SH.")

--- a/e2e/e2etests/test_bitcoin_withdraw_p2wsh.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_p2wsh.go
@@ -15,7 +15,7 @@ func TestBitcoinWithdrawP2WSH(r *runner.E2ERunner, args []string) {
 
 	// parse arguments and withdraw BTC
 	defaultReceiver := "bcrt1qm9mzhyky4w853ft2ms6dtqdyyu3z2tmrq8jg8xglhyuv0dsxzmgs2f0sqy"
-	receiver, amount := parseBitcoinWithdrawArgs(args, defaultReceiver)
+	receiver, amount := parseBitcoinWithdrawArgs(r, args, defaultReceiver)
 	_, ok := receiver.(*btcutil.AddressWitnessScriptHash)
 	if !ok {
 		panic("Invalid receiver address specified for TestBitcoinWithdrawP2WSH.")

--- a/e2e/e2etests/test_bitcoin_withdraw_segwit.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_segwit.go
@@ -15,7 +15,7 @@ func TestBitcoinWithdrawSegWit(r *runner.E2ERunner, args []string) {
 
 	// parse arguments
 	defaultReceiver := r.BTCDeployerAddress.EncodeAddress()
-	receiver, amount := parseBitcoinWithdrawArgs(args, defaultReceiver)
+	receiver, amount := parseBitcoinWithdrawArgs(r, args, defaultReceiver)
 	_, ok := receiver.(*btcutil.AddressWitnessPubKeyHash)
 	if !ok {
 		panic("Invalid receiver address specified for TestBitcoinWithdrawSegWit.")

--- a/e2e/e2etests/test_bitcoin_withdraw_taproot.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_taproot.go
@@ -14,7 +14,7 @@ func TestBitcoinWithdrawTaproot(r *runner.E2ERunner, args []string) {
 
 	// parse arguments and withdraw BTC
 	defaultReceiver := "bcrt1pqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0sj9hjuh"
-	receiver, amount := parseBitcoinWithdrawArgs(args, defaultReceiver)
+	receiver, amount := parseBitcoinWithdrawArgs(r, args, defaultReceiver)
 	_, ok := receiver.(*chains.AddressTaproot)
 	if !ok {
 		panic("Invalid receiver address specified for TestBitcoinWithdrawTaproot.")

--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
 	"github.com/zeta-chain/zetacore/pkg/chains"

--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
+	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
@@ -113,7 +113,13 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	if err != nil {
 		panic(err)
 	}
-	stop := r.MineBlocks()
+
+	// mine blocks if testing on regnet
+	var stop chan struct{}
+	isRegnet := chains.IsBitcoinRegnet(r.GetBitcoinChainID())
+	if isRegnet {
+		stop = r.MineBlocks()
+	}
 
 	// cctx1 index acts like the inboundHash for the second cctx (the one that withdraws BTC)
 	cctx2 := utils.WaitCctxMinedByInboundHash(r.Ctx, cctx1.Index, r.CctxClient, r.Logger, r.CctxTimeout)
@@ -246,5 +252,7 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	}
 
 	// stop mining
-	stop <- struct{}{}
+	if isRegnet {
+		stop <- struct{}{}
+	}
 }

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -327,6 +327,15 @@ func (runner *E2ERunner) SendToTSSFromDeployerWithMemo(
 	return txid, nil
 }
 
+// GetBitcoinChainID gets the bitcoin chain ID from the network params
+func (runner *E2ERunner) GetBitcoinChainID() int64 {
+	chainID, err := chains.BitcoinChainIDFromNetworkName(runner.BitcoinParams.Name)
+	if err != nil {
+		panic(err)
+	}
+	return chainID
+}
+
 // MineBlocks mines blocks on the BTC chain at a rate of 1 blocks every 5 seconds
 // and returns a channel that can be used to stop the mining
 func (runner *E2ERunner) MineBlocks() chan struct{} {

--- a/pkg/chains/bitcoin.go
+++ b/pkg/chains/bitcoin.go
@@ -26,6 +26,20 @@ func BitcoinNetParamsFromChainID(chainID int64) (*chaincfg.Params, error) {
 	}
 }
 
+// BitcoinChainIDFromNetworkName returns the chain id for the given bitcoin network name
+func BitcoinChainIDFromNetworkName(name string) (int64, error) {
+	switch name {
+	case BitcoinRegnetParams.Name:
+		return BtcRegtestChain.ChainId, nil
+	case BitcoinMainnetParams.Name:
+		return BtcMainnetChain.ChainId, nil
+	case BitcoinTestnetParams.Name:
+		return BtcTestNetChain.ChainId, nil
+	default:
+		return 0, fmt.Errorf("invalid Bitcoin network name: %s", name)
+	}
+}
+
 // IsBitcoinRegnet returns true if the chain id is for the regnet
 func IsBitcoinRegnet(chainID int64) bool {
 	return chainID == BtcRegtestChain.ChainId

--- a/pkg/chains/bitcoin_test.go
+++ b/pkg/chains/bitcoin_test.go
@@ -33,6 +33,33 @@ func TestBitcoinNetParamsFromChainID(t *testing.T) {
 	}
 }
 
+func TestBitcoinChainIDFromNetParams(t *testing.T) {
+	tests := []struct {
+		name            string
+		networkName     string
+		expectedChainID int64
+		wantErr         bool
+	}{
+		{"Regnet", BitcoinRegnetParams.Name, BtcRegtestChain.ChainId, false},
+		{"Mainnet", BitcoinMainnetParams.Name, BtcMainnetChain.ChainId, false},
+		{"Testnet", BitcoinTestnetParams.Name, BtcTestNetChain.ChainId, false},
+		{"Unknown", "Unknown", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chainID, err := BitcoinChainIDFromNetworkName(tt.networkName)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Zero(t, chainID)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedChainID, chainID)
+			}
+		})
+	}
+}
+
 func TestIsBitcoinRegnet(t *testing.T) {
 	require.True(t, IsBitcoinRegnet(BtcRegtestChain.ChainId))
 	require.False(t, IsBitcoinRegnet(BtcMainnetChain.ChainId))


### PR DESCRIPTION
# Description

Removed hard-coded bitcoin chainID in E2E withdraw tests.

Closes: <PD-XXXX>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
