### PR TITLE
fix: incorrect bitcoin outbound height

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@
 * [2125](https://github.com/zeta-chain/node/pull/2125) - fix develop upgrade test
 * [2222](https://github.com/zeta-chain/node/pull/2222) - removed `maxHeightDiff` to let observer scan from Bitcoin height where it left off
 * [2233](https://github.com/zeta-chain/node/pull/2233) - fix `IsSupported` flag not properly updated in zetaclient's context
+* [2243](https://github.com/zeta-chain/node/pull/2243) - fix incorrect bitcoin outbound height in the CCTX outbound parameter
 
 ### CI
 

--- a/zetaclient/chains/bitcoin/observer/live_test.go
+++ b/zetaclient/chains/bitcoin/observer/live_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -86,10 +87,13 @@ func (suite *BitcoinObserverTestSuite) TearDownSuite() {
 
 func getRPCClient(chainID int64) (*rpcclient.Client, error) {
 	var connCfg *rpcclient.ConnConfig
+	rpcMainnet := os.Getenv("BTC_RPC_MAINNET")
+	rpcTestnet := os.Getenv("BTC_RPC_TESTNET")
+
 	// mainnet
 	if chainID == 8332 {
 		connCfg = &rpcclient.ConnConfig{
-			Host:         "127.0.0.1:8332", // mainnet endpoint goes here
+			Host:         rpcMainnet, // mainnet endpoint goes here
 			User:         "user",
 			Pass:         "pass",
 			Params:       "mainnet",
@@ -100,7 +104,7 @@ func getRPCClient(chainID int64) (*rpcclient.Client, error) {
 	// testnet3
 	if chainID == 18332 {
 		connCfg = &rpcclient.ConnConfig{
-			Host:         "127.0.0.1:8332", // testnet endpoint goes here
+			Host:         rpcTestnet, // testnet endpoint goes here
 			User:         "user",
 			Pass:         "pass",
 			Params:       "testnet3",

--- a/zetaclient/chains/bitcoin/observer/live_test.go
+++ b/zetaclient/chains/bitcoin/observer/live_test.go
@@ -219,10 +219,32 @@ func (suite *BitcoinObserverTestSuite) Test3() {
 func TestBitcoinObserverLive(t *testing.T) {
 	// suite.Run(t, new(BitcoinClientTestSuite))
 
+	// LiveTestGetBlockHeightByHash(t)
 	// LiveTestBitcoinFeeRate(t)
 	// LiveTestAvgFeeRateMainnetMempoolSpace(t)
 	// LiveTestAvgFeeRateTestnetMempoolSpace(t)
 	// LiveTestGetSenderByVin(t)
+}
+
+// LiveTestGetBlockHeightByHash queries Bitcoin block height by hash
+func LiveTestGetBlockHeightByHash(t *testing.T) {
+	// setup Bitcoin client
+	client, err := getRPCClient(8332)
+	require.NoError(t, err)
+
+	// the block hashes to test
+	expectedHeight := int64(835053)
+	hash := "00000000000000000000994a5d12976ec5bda078a7b9c27981f0a4e7a6d46d23"
+	invalidHash := "invalidhash"
+
+	// get block by invalid hash
+	_, err = GetBlockHeightByHash(client, invalidHash)
+	require.ErrorContains(t, err, "error decoding block hash")
+
+	// get block height by block hash
+	height, err := GetBlockHeightByHash(client, hash)
+	require.NoError(t, err)
+	require.Equal(t, expectedHeight, height)
 }
 
 // LiveTestBitcoinFeeRate query Bitcoin mainnet fee rate every 5 minutes

--- a/zetaclient/chains/bitcoin/observer/observer.go
+++ b/zetaclient/chains/bitcoin/observer/observer.go
@@ -634,6 +634,26 @@ func GetTxResultByHash(
 	return hash, txResult, nil
 }
 
+// GetBlockHeightByTxHash gets the block height by block hash
+func GetBlockHeightByHash(
+	rpcClient interfaces.BTCRPCClient,
+	hash string,
+) (int64, error) {
+	// decode the block hash
+	var blockHash chainhash.Hash
+	err := chainhash.Decode(&blockHash, hash)
+	if err != nil {
+		return 0, errors.Wrapf(err, "GetBlockHeightByHash: error decoding block hash %s", hash)
+	}
+
+	// get block by hash
+	block, err := rpcClient.GetBlockVerbose(&blockHash)
+	if err != nil {
+		return 0, errors.Wrapf(err, "GetBlockHeightByHash: error GetBlockVerbose %s", hash)
+	}
+	return block.Height, nil
+}
+
 // GetRawTxResult gets the raw tx result
 func GetRawTxResult(
 	rpcClient interfaces.BTCRPCClient,

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -161,12 +161,18 @@ func (ob *Observer) IsOutboundProcessed(cctx *crosschaintypes.CrossChainTx, logg
 		return true, false, nil
 	}
 
+	// Get outbound block height
+	blockHeight, err := GetBlockHeightByHash(ob.rpcClient, res.BlockHash)
+	if err != nil {
+		return true, false, errors.Wrapf(err, "IsOutboundProcessed: error getting block height by hash %s", res.BlockHash)
+	}
+
 	logger.Debug().Msgf("Bitcoin outbound confirmed: txid %s, amount %s\n", res.TxID, amountInSat.String())
 	zetaHash, ballot, err := ob.zetacoreClient.PostVoteOutbound(
 		sendHash,
 		res.TxID,
 		// #nosec G701 always positive
-		uint64(res.BlockIndex),
+		uint64(blockHeight),
 		0,   // gas used not used with Bitcoin
 		nil, // gas price not used with Bitcoin
 		0,   // gas limit not used with Bitcoin

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -164,7 +164,11 @@ func (ob *Observer) IsOutboundProcessed(cctx *crosschaintypes.CrossChainTx, logg
 	// Get outbound block height
 	blockHeight, err := GetBlockHeightByHash(ob.rpcClient, res.BlockHash)
 	if err != nil {
-		return true, false, errors.Wrapf(err, "IsOutboundProcessed: error getting block height by hash %s", res.BlockHash)
+		return true, false, errors.Wrapf(
+			err,
+			"IsOutboundProcessed: error getting block height by hash %s",
+			res.BlockHash,
+		)
 	}
 
 	logger.Debug().Msgf("Bitcoin outbound confirmed: txid %s, amount %s\n", res.TxID, amountInSat.String())


### PR DESCRIPTION
# Description

During Bitcoin withdraw tests in Athens3, I noticed an old issue that existed since `v1`. Looking at this mainnet bitcoin outbound cctx:
https://zetachain.blockpi.network/lcd/v1/public/zeta-chain/crosschain/cctx/8332/200

The cctx's outbound parameter contains a wrong `"outbound_tx_observed_external_height": "578"`, the correct height should be `835053` in [bitcoin explorer](https://mempool.space/tx/b41242d2d1e8b63b2ffca88a02f57726a0710753a88e258c45d7edca6f904211)
![image](https://github.com/zeta-chain/node/assets/34498985/d909f8d3-68d2-43a0-9fcc-e97b2120ebc0)

It is a minor issue that could impact explorer, nothing about security.

Closes: <PD-XXXX>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
