### PR TITLE
fix(v17): inbound and outbound validation for BSC chain

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v17.0.0
+
+### Fixes
+
+* [2249](https://github.com/zeta-chain/node/pull/2249) - fix inbound and outbound validation for BSC chain
+
 ## v16.0.0
 
 ### Breaking Changes

--- a/typescript/crosschain/genesis_pb.d.ts
+++ b/typescript/crosschain/genesis_pb.d.ts
@@ -14,7 +14,7 @@ import type { InTxTracker } from "./in_tx_tracker_pb.js";
 import type { RateLimiterFlags } from "./rate_limiter_flags_pb.js";
 
 /**
- * GenesisState defines the metacore module's genesis state.
+ * GenesisState defines the crosschain modules genesis state.
  *
  * @generated from message zetachain.zetacore.crosschain.GenesisState
  */
@@ -80,7 +80,8 @@ export declare class GenesisState extends Message<GenesisState> {
 }
 
 /**
- * GenesisState defines the metacore module's genesis state.
+ * Remove legacy types
+ * https://github.com/zeta-chain/node/issues/2139
  *
  * @generated from message zetachain.zetacore.crosschain.GenesisState_legacy
  */

--- a/x/crosschain/types/cctx_test.go
+++ b/x/crosschain/types/cctx_test.go
@@ -91,7 +91,7 @@ func Test_InitializeCCTX(t *testing.T) {
 		tss := sample.Tss()
 		msg := types.MsgVoteOnObservedInboundTx{
 			Creator:       creator,
-			Sender:        "invalid",
+			Sender:        "",
 			SenderChainId: senderChain.ChainId,
 			Receiver:      receiver.String(),
 			ReceiverChain: receiverChain.ChainId,
@@ -106,7 +106,7 @@ func Test_InitializeCCTX(t *testing.T) {
 			EventIndex:    eventIndex,
 		}
 		_, err := types.NewCCTX(ctx, msg, tss.TssPubkey)
-		require.ErrorContains(t, err, "invalid address")
+		require.ErrorContains(t, err, "sender cannot be empty")
 	})
 }
 

--- a/x/crosschain/types/genesis.pb.go
+++ b/x/crosschain/types/genesis.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// GenesisState defines the metacore module's genesis state.
+// GenesisState defines the crosschain modules genesis state.
 type GenesisState struct {
 	OutTxTrackerList    []OutTxTracker     `protobuf:"bytes,2,rep,name=outTxTrackerList,proto3" json:"outTxTrackerList"`
 	GasPriceList        []*GasPrice        `protobuf:"bytes,5,rep,name=gasPriceList,proto3" json:"gasPriceList,omitempty"`
@@ -133,7 +133,8 @@ func (m *GenesisState) GetRateLimiterFlags() RateLimiterFlags {
 	return RateLimiterFlags{}
 }
 
-// GenesisState defines the metacore module's genesis state.
+// Remove legacy types
+// https://github.com/zeta-chain/node/issues/2139
 type GenesisStateLegacy struct {
 	Params              *Params            `protobuf:"bytes,1,opt,name=params,proto3" json:"params,omitempty"`
 	OutTxTrackerList    []OutTxTracker     `protobuf:"bytes,2,rep,name=outTxTrackerList,proto3" json:"outTxTrackerList"`

--- a/x/crosschain/types/inbound_params.go
+++ b/x/crosschain/types/inbound_params.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/zeta-chain/zetacore/pkg/chains"
 )
 
@@ -11,32 +10,35 @@ func (m InboundTxParams) Validate() error {
 	if m.Sender == "" {
 		return fmt.Errorf("sender cannot be empty")
 	}
+
 	if chains.GetChainFromChainID(m.SenderChainId) == nil {
 		return fmt.Errorf("invalid sender chain id %d", m.SenderChainId)
 	}
-	err := ValidateAddressForChain(m.Sender, m.SenderChainId)
-	if err != nil {
-		return err
-	}
 
-	if m.TxOrigin != "" {
-		errTxOrigin := ValidateAddressForChain(m.TxOrigin, m.SenderChainId)
-		if errTxOrigin != nil {
-			return errTxOrigin
-		}
-	}
 	if m.Amount.IsNil() {
 		return fmt.Errorf("amount cannot be nil")
 	}
-	err = ValidateHashForChain(m.InboundTxObservedHash, m.SenderChainId)
-	if err != nil {
-		return errors.Wrap(err, "invalid inbound tx observed hash")
-	}
-	if m.InboundTxBallotIndex != "" {
-		err = ValidateZetaIndex(m.InboundTxBallotIndex)
-		if err != nil {
-			return errors.Wrap(err, "invalid inbound tx ballot index")
-		}
-	}
+
+	// Disabled checks
+	// TODO: Improve the checks, move the validation call to a new place and reenable
+	// https://github.com/zeta-chain/node/issues/2234
+	// https://github.com/zeta-chain/node/issues/2235
+	//if err := ValidateAddressForChain(m.Sender, m.SenderChainId) err != nil {
+	//	return err
+	//}
+	//if m.TxOrigin != "" {
+	//	errTxOrigin := ValidateAddressForChain(m.TxOrigin, m.SenderChainId)
+	//	if errTxOrigin != nil {
+	//		return errTxOrigin
+	//	}
+	//}
+	//if err := ValidateHashForChain(m.ObservedHash, m.SenderChainId); err != nil {
+	//	return errors.Wrap(err, "invalid inbound tx observed hash")
+	//}
+	//if m.BallotIndex != "" {
+	//	if err := ValidateCCTXIndex(m.BallotIndex); err != nil {
+	//		return errors.Wrap(err, "invalid inbound tx ballot index")
+	//	}
+	//}
 	return nil
 }

--- a/x/crosschain/types/inbound_params_test.go
+++ b/x/crosschain/types/inbound_params_test.go
@@ -6,7 +6,6 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
-	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/testutil/sample"
 )
 
@@ -18,24 +17,11 @@ func TestInboundTxParams_Validate(t *testing.T) {
 	inTxParams = sample.InboundTxParamsValidChainID(r)
 	inTxParams.SenderChainId = 1000
 	require.ErrorContains(t, inTxParams.Validate(), "invalid sender chain id 1000")
-	inTxParams = sample.InboundTxParamsValidChainID(r)
-	inTxParams.SenderChainId = chains.GoerliChain().ChainId
-	inTxParams.Sender = "0x123"
-	require.ErrorContains(t, inTxParams.Validate(), "invalid address 0x123")
-	inTxParams = sample.InboundTxParamsValidChainID(r)
-	inTxParams.SenderChainId = chains.GoerliChain().ChainId
-	inTxParams.TxOrigin = "0x123"
-	require.ErrorContains(t, inTxParams.Validate(), "invalid address 0x123")
+
 	inTxParams = sample.InboundTxParamsValidChainID(r)
 	inTxParams.Amount = sdkmath.Uint{}
 	require.ErrorContains(t, inTxParams.Validate(), "amount cannot be nil")
-	inTxParams = sample.InboundTxParamsValidChainID(r)
-	inTxParams.InboundTxObservedHash = "12"
-	require.ErrorContains(t, inTxParams.Validate(), "hash must be a valid ethereum hash 12")
-	inTxParams = sample.InboundTxParamsValidChainID(r)
-	inTxParams.InboundTxObservedHash = sample.Hash().String()
-	inTxParams.InboundTxBallotIndex = "12"
-	require.ErrorContains(t, inTxParams.Validate(), "invalid index length 2")
+
 	inTxParams = sample.InboundTxParamsValidChainID(r)
 	inTxParams.InboundTxObservedHash = sample.Hash().String()
 	inTxParams.InboundTxBallotIndex = sample.ZetaIndex(t)

--- a/x/crosschain/types/outbound_params.go
+++ b/x/crosschain/types/outbound_params.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/zeta-chain/zetacore/pkg/chains"
 )
 
@@ -24,24 +23,29 @@ func (m OutboundTxParams) Validate() error {
 	if chains.GetChainFromChainID(m.ReceiverChainId) == nil {
 		return fmt.Errorf("invalid receiver chain id %d", m.ReceiverChainId)
 	}
-	err := ValidateAddressForChain(m.Receiver, m.ReceiverChainId)
-	if err != nil {
-		return err
-	}
+
 	if m.Amount.IsNil() {
 		return fmt.Errorf("amount cannot be nil")
 	}
-	if m.OutboundTxBallotIndex != "" {
-		err = ValidateZetaIndex(m.OutboundTxBallotIndex)
-		if err != nil {
-			return errors.Wrap(err, "invalid outbound tx ballot index")
-		}
-	}
-	if m.OutboundTxHash != "" {
-		err = ValidateHashForChain(m.OutboundTxHash, m.ReceiverChainId)
-		if err != nil {
-			return errors.Wrap(err, "invalid outbound tx hash")
-		}
-	}
+
+	// Disabled checks
+	// TODO: Improve the checks, move the validation call to a new place and reenable
+	// https://github.com/zeta-chain/node/issues/2234
+	// https://github.com/zeta-chain/node/issues/2235
+	//if err := ValidateAddressForChain(m.Receiver, m.ReceiverChainId); err != nil {
+	//	return err
+	//}
+	//if m.BallotIndex != "" {
+	//
+	//	if err := ValidateCCTXIndex(m.BallotIndex); err != nil {
+	//		return errors.Wrap(err, "invalid outbound tx ballot index")
+	//	}
+	//}
+	//if m.Hash != "" {
+	//	if err := ValidateHashForChain(m.Hash, m.ReceiverChainId); err != nil {
+	//		return errors.Wrap(err, "invalid outbound tx hash")
+	//	}
+	//}
+
 	return nil
 }

--- a/x/crosschain/types/outbound_params_test.go
+++ b/x/crosschain/types/outbound_params_test.go
@@ -11,25 +11,34 @@ import (
 
 func TestOutboundTxParams_Validate(t *testing.T) {
 	r := rand.New(rand.NewSource(42))
+
 	outTxParams := sample.OutboundTxParamsValidChainID(r)
 	outTxParams.Receiver = ""
 	require.ErrorContains(t, outTxParams.Validate(), "receiver cannot be empty")
+
 	outTxParams = sample.OutboundTxParamsValidChainID(r)
 	outTxParams.ReceiverChainId = 1000
 	require.ErrorContains(t, outTxParams.Validate(), "invalid receiver chain id 1000")
-	outTxParams = sample.OutboundTxParamsValidChainID(r)
-	outTxParams.Receiver = "0x123"
-	require.ErrorContains(t, outTxParams.Validate(), "invalid address 0x123")
+
 	outTxParams = sample.OutboundTxParamsValidChainID(r)
 	outTxParams.Amount = sdkmath.Uint{}
 	require.ErrorContains(t, outTxParams.Validate(), "amount cannot be nil")
-	outTxParams = sample.OutboundTxParamsValidChainID(r)
-	outTxParams.OutboundTxBallotIndex = "12"
-	require.ErrorContains(t, outTxParams.Validate(), "invalid index length 2")
+
 	outTxParams = sample.OutboundTxParamsValidChainID(r)
 	outTxParams.OutboundTxBallotIndex = sample.ZetaIndex(t)
 	outTxParams.OutboundTxHash = sample.Hash().String()
 	require.NoError(t, outTxParams.Validate())
+
+	// Disabled checks
+	// TODO: Improve the checks, move the validation call to a new place and reenable
+	// https://github.com/zeta-chain/node/issues/2234
+	// https://github.com/zeta-chain/node/issues/2235
+	//outTxParams = sample.OutboundParamsValidChainID(r)
+	//outTxParams.Receiver = "0x123"
+	//require.ErrorContains(t, outTxParams.Validate(), "invalid address 0x123")
+	//outTxParams = sample.OutboundParamsValidChainID(r)
+	//outTxParams.BallotIndex = "12"
+	//require.ErrorContains(t, outTxParams.Validate(), "invalid index length 2")
 }
 
 func TestOutboundTxParams_GetGasPrice(t *testing.T) {


### PR DESCRIPTION
# Description

Porting https://github.com/zeta-chain/node/pull/2237 to a v17 release

Prevent inbound validation to fail for BSC chains