### PR TITLE
fix: set upgrade test new version to v17

### DIFF
--- a/Dockerfile-upgrade
+++ b/Dockerfile-upgrade
@@ -21,7 +21,7 @@ RUN mkdir -p  $GOPATH/bin/old
 RUN mkdir -p  $GOPATH/bin/new
 
 ARG OLD_VERSION=v15.0.0
-ENV NEW_VERSION=v16
+ENV NEW_VERSION=v17
 
 # Build new release from the current source
 COPY go.mod /go/delivery/zeta-node/


### PR DESCRIPTION
Upgrade tests are failing on release/v17 branch: https://github.com/zeta-chain/node/actions/runs/9214972522/job/25352337296

I forgot to set this in #2231 