### PR TITLE
fix: exclude reverted cctx from rate limiter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
 * [2222](https://github.com/zeta-chain/node/pull/2222) - removed `maxHeightDiff` to let observer scan from Bitcoin height where it left off
 * [2233](https://github.com/zeta-chain/node/pull/2233) - fix `IsSupported` flag not properly updated in zetaclient's context
 * [2243](https://github.com/zeta-chain/node/pull/2243) - fix incorrect bitcoin outbound height in the CCTX outbound parameter
+* [2256](https://github.com/zeta-chain/node/pull/2256) - fix rate limiter falsely included reverted non-withdraw cctxs
 
 ### CI
 

--- a/testutil/sample/crosschain.go
+++ b/testutil/sample/crosschain.go
@@ -224,7 +224,8 @@ func CustomCctxsInBlockRange(
 	t *testing.T,
 	lowBlock uint64,
 	highBlock uint64,
-	chainID int64,
+	senderChainID int64,
+	receiverChainID int64,
 	coinType coin.CoinType,
 	asset string,
 	amount uint64,
@@ -233,12 +234,13 @@ func CustomCctxsInBlockRange(
 	// create 1 cctx per block
 	for i := lowBlock; i <= highBlock; i++ {
 		nonce := i - 1
-		cctx := CrossChainTx(t, fmt.Sprintf("%d-%d", chainID, nonce))
+		cctx := CrossChainTx(t, fmt.Sprintf("%d-%d", receiverChainID, nonce))
 		cctx.CctxStatus.Status = status
+		cctx.InboundParams.SenderChainId = senderChainID
 		cctx.InboundParams.CoinType = coinType
 		cctx.InboundParams.Asset = asset
 		cctx.InboundParams.ObservedExternalHeight = i
-		cctx.GetCurrentOutboundParam().ReceiverChainId = chainID
+		cctx.GetCurrentOutboundParam().ReceiverChainId = receiverChainID
 		cctx.GetCurrentOutboundParam().Amount = sdk.NewUint(amount)
 		cctx.GetCurrentOutboundParam().TssNonce = nonce
 		cctxs = append(cctxs, cctx)

--- a/x/crosschain/keeper/grpc_query_cctx_rate_limit_test.go
+++ b/x/crosschain/keeper/grpc_query_cctx_rate_limit_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/pkg/coin"
 	keepertest "github.com/zeta-chain/zetacore/testutil/keeper"
 	"github.com/zeta-chain/zetacore/testutil/sample"
@@ -95,6 +96,7 @@ func setupForeignCoins(
 func TestKeeper_RateLimiterInput(t *testing.T) {
 	// create sample TSS
 	tss := sample.Tss()
+	zetaChainID := chains.ZetaTestnetChain.ChainId
 
 	// create sample zrc20 addresses for ETH, BTC, USDT
 	zrc20ETH := sample.EthAddress().Hex()
@@ -107,6 +109,7 @@ func TestKeeper_RateLimiterInput(t *testing.T) {
 		t,
 		1,
 		999,
+		zetaChainID,
 		ethChainID,
 		coin.CoinType_Gas,
 		"",
@@ -117,6 +120,7 @@ func TestKeeper_RateLimiterInput(t *testing.T) {
 		t,
 		1000,
 		1199,
+		zetaChainID,
 		ethChainID,
 		coin.CoinType_Gas,
 		"",
@@ -130,6 +134,7 @@ func TestKeeper_RateLimiterInput(t *testing.T) {
 		t,
 		1,
 		999,
+		zetaChainID,
 		btcChainID,
 		coin.CoinType_Gas,
 		"",
@@ -140,6 +145,7 @@ func TestKeeper_RateLimiterInput(t *testing.T) {
 		t,
 		1000,
 		1199,
+		zetaChainID,
 		btcChainID,
 		coin.CoinType_Gas,
 		"",
@@ -470,6 +476,7 @@ func TestKeeper_RateLimiterInput_Errors(t *testing.T) {
 func TestKeeper_ListPendingCctxWithinRateLimit(t *testing.T) {
 	// create sample TSS
 	tss := sample.Tss()
+	zetaChainID := chains.ZetaTestnetChain.ChainId
 
 	// create sample zrc20 addresses for ETH, BTC, USDT
 	zrc20ETH := sample.EthAddress().Hex()
@@ -482,6 +489,7 @@ func TestKeeper_ListPendingCctxWithinRateLimit(t *testing.T) {
 		t,
 		1,
 		999,
+		zetaChainID,
 		ethChainID,
 		coin.CoinType_Gas,
 		"",
@@ -492,6 +500,7 @@ func TestKeeper_ListPendingCctxWithinRateLimit(t *testing.T) {
 		t,
 		1000,
 		1199,
+		zetaChainID,
 		ethChainID,
 		coin.CoinType_Gas,
 		"",
@@ -505,6 +514,7 @@ func TestKeeper_ListPendingCctxWithinRateLimit(t *testing.T) {
 		t,
 		1,
 		999,
+		zetaChainID,
 		btcChainID,
 		coin.CoinType_Gas,
 		"",
@@ -515,6 +525,7 @@ func TestKeeper_ListPendingCctxWithinRateLimit(t *testing.T) {
 		t,
 		1000,
 		1199,
+		zetaChainID,
 		btcChainID,
 		coin.CoinType_Gas,
 		"",

--- a/zetaclient/orchestrator/orchestrator_test.go
+++ b/zetaclient/orchestrator/orchestrator_test.go
@@ -208,6 +208,7 @@ func Test_GetPendingCctxsWithinRatelimit(t *testing.T) {
 	// define test foreign chains
 	ethChain := chains.EthChain
 	btcChain := chains.BtcMainnetChain
+	zetaChainID := chains.ZetaTestnetChain.ChainId
 	foreignChains := []chains.Chain{
 		ethChain,
 		btcChain,
@@ -222,6 +223,7 @@ func Test_GetPendingCctxsWithinRatelimit(t *testing.T) {
 		t,
 		1,
 		10,
+		zetaChainID,
 		ethChain.ChainId,
 		coin.CoinType_Gas,
 		"",
@@ -232,6 +234,7 @@ func Test_GetPendingCctxsWithinRatelimit(t *testing.T) {
 		t,
 		11,
 		100,
+		zetaChainID,
 		ethChain.ChainId,
 		coin.CoinType_Gas,
 		"",
@@ -245,6 +248,7 @@ func Test_GetPendingCctxsWithinRatelimit(t *testing.T) {
 		t,
 		1,
 		10,
+		zetaChainID,
 		btcChain.ChainId,
 		coin.CoinType_Gas,
 		"",
@@ -255,6 +259,7 @@ func Test_GetPendingCctxsWithinRatelimit(t *testing.T) {
 		t,
 		11,
 		100,
+		zetaChainID,
 		btcChain.ChainId,
 		coin.CoinType_Gas,
 		"",

--- a/zetaclient/ratelimiter/rate_limiter_test.go
+++ b/zetaclient/ratelimiter/rate_limiter_test.go
@@ -115,6 +115,7 @@ func Test_ApplyRateLimiter(t *testing.T) {
 	// define test chain ids
 	ethChainID := chains.EthChain.ChainId
 	btcChainID := chains.BtcMainnetChain.ChainId
+	zetaChainID := chains.ZetaTestnetChain.ChainId
 
 	// create 10 missed and 90 pending cctxs for eth chain, the coinType/amount does not matter for this test
 	// but we still use a proper cctx value (0.5 ZETA) to make the test more realistic
@@ -122,6 +123,7 @@ func Test_ApplyRateLimiter(t *testing.T) {
 		t,
 		1,
 		10,
+		zetaChainID,
 		ethChainID,
 		coin.CoinType_Gas,
 		"",
@@ -132,6 +134,7 @@ func Test_ApplyRateLimiter(t *testing.T) {
 		t,
 		11,
 		100,
+		zetaChainID,
 		ethChainID,
 		coin.CoinType_Gas,
 		"",
@@ -146,6 +149,7 @@ func Test_ApplyRateLimiter(t *testing.T) {
 		t,
 		1,
 		10,
+		zetaChainID,
 		btcChainID,
 		coin.CoinType_Gas,
 		"",
@@ -156,6 +160,7 @@ func Test_ApplyRateLimiter(t *testing.T) {
 		t,
 		11,
 		100,
+		zetaChainID,
 		btcChainID,
 		coin.CoinType_Gas,
 		"",


### PR DESCRIPTION
# Description

Athens3 saw a sharp increase in `Current Withdraw Rate` metrics right after the rate limiter conversion rates of `eth/erc20/btc` kicked in. The reason was found after some debugging effort. There were many reverted cctxs (for instance https://zetachain-testnet-api.itrocket.net/zeta-chain/crosschain/cctx/11155111/135) happened in `Sepolia` testnet. Reverted cctxs contain `inbound_tx_observed_external_height` that indicates an external chain's height (not ZetaChain height). When compared with ZetaChain height, these reverted cctxs were falsely included in the rate limiter window and count to the total withdrawn value.

A quick fix can be excluding these type of cctxs by checking `SenderChainId` to make sure it is a true withdrawal from ZetaChain.

![image](https://github.com/zeta-chain/node/assets/34498985/41d50ef6-6163-4995-9c9b-fd6be90fffd7)
![image](https://github.com/zeta-chain/node/assets/34498985/7ed9115b-4cc5-4d7a-8b42-352797074922)


Closes: <PD-XXXX>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
