### PR TITLE
test: add e2e test with imported mainnet data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,10 @@ start-e2e-performance-test: zetanode
 	@echo "--> Starting e2e performance test"
 	cd contrib/localnet/ && $(DOCKER) compose -f docker-compose.yml -f docker-compose-performance.yml up -d
 
+start-e2e-import-mainnet-test: zetanode
+	@echo "--> Starting e2e import-data test"
+	cd contrib/localnet/  && ./scripts/import-data.sh mainnet && $(DOCKER) compose -f docker-compose.yml -f docker-compose-import-data.yml up -d
+
 start-stress-test: zetanode
 	@echo "--> Starting stress test"
 	cd contrib/localnet/ && $(DOCKER) compose -f docker-compose.yml -f docker-compose-stresstest.yml up -d

--- a/contrib/localnet/docker-compose-import-data.yml
+++ b/contrib/localnet/docker-compose-import-data.yml
@@ -1,0 +1,141 @@
+version: "3"
+
+# This docker-compose file configures the localnet environment
+# it contains the following services:
+# - ZetaChain with 2 nodes (zetacore0, zetacore1)
+# - A observer set with 2 clients (zetaclient0, zetaclient1)
+# - An Ethereum node (eth)
+# - A Bitcoin node (bitcoin)
+# - A Rosetta API (rosetta)
+# - An orchestrator to manage interaction with the localnet (orchestrator)
+
+networks:
+  mynetwork:
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+
+services:
+  rosetta:
+    image: zetanode:latest
+    container_name: rosetta
+    hostname: rosetta
+    ports:
+      - "8080:8080"
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.200
+    entrypoint: ["zetacored", "rosetta", "--tendermint", "zetacore0:26657", "--grpc", "zetacore0:9090", "--network", "athens_101-1", "--blockchain",  "zetacore"]
+    volumes:
+      - ssh:/root/.ssh
+
+  zetacore0:
+    image: zetanode:latest
+    container_name: zetacore0
+    hostname: zetacore0
+    ports:
+      - "1317:1317"
+      - "9545:8545"
+      - "9546:8546"
+      - "26657:26657"
+      - "6060:6060"
+      - "9090:9090"
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.11
+    entrypoint: ["/root/start-zetacored.sh", "2","import-data"]
+    environment:
+      - HOTKEY_BACKEND=file
+      - HOTKEY_PASSWORD=password # test purposes only
+    volumes:
+      - ssh:/root/.ssh
+      - ~/genesis_export/:/root/genesis_data
+
+  zetacore1:
+    image: zetanode:latest
+    container_name: zetacore1
+    hostname: zetacore1
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.12
+    entrypoint: ["/root/start-zetacored.sh", "2","import-data"]
+    environment:
+      - HOTKEY_BACKEND=file
+      - HOTKEY_PASSWORD=password # test purposes only
+    volumes:
+      - ssh:/root/.ssh
+
+  zetaclient0:
+    image: zetanode:latest
+    container_name: zetaclient0
+    hostname: zetaclient0
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.21
+    entrypoint: /root/start-zetaclientd.sh
+    environment:
+      - ETHDEV_ENDPOINT=http://eth:8545
+      - HOTKEY_BACKEND=file
+      - HOTKEY_PASSWORD=password # test purposes only
+    volumes:
+      - ssh:/root/.ssh
+
+  zetaclient1:
+    image: zetanode:latest
+    container_name: zetaclient1
+    hostname: zetaclient1
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.22
+    entrypoint: /root/start-zetaclientd.sh
+    environment:
+      - ETHDEV_ENDPOINT=http://eth:8545
+      - HOTKEY_BACKEND=file
+      - HOTKEY_PASSWORD=password # test purposes only
+    volumes:
+      - ssh:/root/.ssh
+
+  eth:
+    image: ethereum/client-go:v1.10.26
+    container_name: eth
+    hostname: eth
+    ports:
+      - "8545:8545"
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.100
+    entrypoint: ["geth", "--dev", "--http", "--http.addr", "172.20.0.100", "--http.vhosts", "*", "--http.api", "eth,web3,net", "--http.corsdomain", "https://remix.ethereum.org", "--dev.period", "2"]
+
+  bitcoin:
+    image: ruimarinho/bitcoin-core:22 # version 23 is not working with btcd 0.22.0 due to change in createwallet rpc
+    container_name: bitcoin
+    hostname: bitcoin
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.101
+    ports:
+      - "18443:18443"
+    command:
+      -printtoconsole
+      -regtest=1
+      -rpcallowip=0.0.0.0/0
+      -rpcbind=0.0.0.0
+      -rpcauth=smoketest:63acf9b8dccecce914d85ff8c044b78b$$5892f9bbc84f4364e79f0970039f88bdd823f168d4acc76099ab97b14a766a99
+      -txindex=1
+
+  orchestrator:
+    image: orchestrator:latest
+    tty: true
+    container_name: orchestrator
+    depends_on:
+      - zetacore0
+      - eth
+    hostname: orchestrator
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.2
+    entrypoint: ["/work/start-zetae2e.sh", "local"]
+    volumes:
+      - ssh:/root/.ssh
+volumes:
+  ssh:

--- a/contrib/localnet/docker-compose-import-data.yml
+++ b/contrib/localnet/docker-compose-import-data.yml
@@ -1,6 +1,7 @@
 version: "3"
 
-# This docker-compose file configures the localnet environment
+# This docker-compose file configures the localnet environment.
+# It mounts an additional volume to zetacore0 to import the genesis data, and provides the option "import-data" to the start-zetacored.sh script.
 # it contains the following services:
 # - ZetaChain with 2 nodes (zetacore0, zetacore1)
 # - A observer set with 2 clients (zetaclient0, zetaclient1)

--- a/contrib/localnet/docker-compose-import-data.yml
+++ b/contrib/localnet/docker-compose-import-data.yml
@@ -26,7 +26,7 @@ services:
     networks:
       mynetwork:
         ipv4_address: 172.20.0.200
-    entrypoint: ["zetacored", "rosetta", "--tendermint", "zetacore0:26657", "--grpc", "zetacore0:9090", "--network", "athens_101-1", "--blockchain",  "zetacore"]
+    entrypoint: ["/root/start-rosetta.sh"]
     volumes:
       - ssh:/root/.ssh
 

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -29,8 +29,15 @@ while [ ! -f ~/.ssh/authorized_keys ]; do
     sleep 1
 done
 
-echo "waiting for geth RPC to start..."
-sleep 2
+echo "Waiting for network to start producing blocks"
+CURRENT_HEIGHT=0
+WAIT_HEIGHT=1
+while [[ $CURRENT_HEIGHT -lt $WAIT_HEIGHT ]]
+do
+    CURRENT_HEIGHT=$(curl -s zetacore0:26657/status | jq '.result.sync_info.latest_block_height' | tr -d '"')
+    sleep 5
+done
+
 
 ### Create the accounts and fund them with Ether on local Ethereum network
 
@@ -72,7 +79,7 @@ geth --exec 'eth.sendTransaction({from: eth.coinbase, to: "0xF421292cb0d3c97b90E
 
 ### Run zetae2e command depending on the option passed
 
-if [ "$OPTION" == "upgrade" ]; then
+if [[ "$OPTION" == "upgrade" || "$OPTION" == "import-data-upgrade" ]]; then
 
   # Run the e2e tests, then restart zetaclientd at upgrade height and run the e2e tests again
 

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -79,7 +79,7 @@ geth --exec 'eth.sendTransaction({from: eth.coinbase, to: "0xF421292cb0d3c97b90E
 
 ### Run zetae2e command depending on the option passed
 
-if [[ "$OPTION" == "upgrade" || "$OPTION" == "import-data-upgrade" ]]; then
+if [ "$OPTION" == "upgrade" ]; then
 
   # Run the e2e tests, then restart zetaclientd at upgrade height and run the e2e tests again
 

--- a/contrib/localnet/scripts/import-data.sh
+++ b/contrib/localnet/scripts/import-data.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-#if [ $# -lt 1 ]
-#then
-#  echo "Usage: import-data.sh [network]"
-#  exit 1
-#fi
-#
-#NETWORK=$1
-#echo "NETWORK: ${NETWORK}"
-#rm -rf ~/genesis_export/
-#mkdir ~/genesis_export/
-#echo "Download Latest State Export"
-#LATEST_EXPORT_URL=$(curl https://snapshots.zetachain.com/latest-state-export | jq -r ."${NETWORK}")
-#echo "LATEST EXPORT URL: ${LATEST_EXPORT_URL}"
-#wget -q ${LATEST_EXPORT_URL} -O ~/genesis_export/exported-genesis.json
+if [ $# -lt 1 ]
+then
+  echo "Usage: import-data.sh [network]"
+  exit 1
+fi
+
+NETWORK=$1
+echo "NETWORK: ${NETWORK}"
+rm -rf ~/genesis_export/
+mkdir ~/genesis_export/
+echo "Download Latest State Export"
+LATEST_EXPORT_URL=$(curl https://snapshots.zetachain.com/latest-state-export | jq -r ."${NETWORK}")
+echo "LATEST EXPORT URL: ${LATEST_EXPORT_URL}"
+wget -q ${LATEST_EXPORT_URL} -O ~/genesis_export/exported-genesis.json

--- a/contrib/localnet/scripts/import-data.sh
+++ b/contrib/localnet/scripts/import-data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#if [ $# -lt 1 ]
+#then
+#  echo "Usage: import-data.sh [network]"
+#  exit 1
+#fi
+#
+#NETWORK=$1
+#echo "NETWORK: ${NETWORK}"
+#rm -rf ~/genesis_export/
+#mkdir ~/genesis_export/
+#echo "Download Latest State Export"
+#LATEST_EXPORT_URL=$(curl https://snapshots.zetachain.com/latest-state-export | jq -r ."${NETWORK}")
+#echo "LATEST EXPORT URL: ${LATEST_EXPORT_URL}"
+#wget -q ${LATEST_EXPORT_URL} -O ~/genesis_export/exported-genesis.json

--- a/contrib/localnet/scripts/start-rosetta.sh
+++ b/contrib/localnet/scripts/start-rosetta.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Waiting for network to start producing blocks"
+CURRENT_HEIGHT=0
+WAIT_HEIGHT=1
+while [[ $CURRENT_HEIGHT -lt $WAIT_HEIGHT ]]
+do
+    CURRENT_HEIGHT=$(curl -s zetacore0:26657/status | jq '.result.sync_info.latest_block_height' | tr -d '"')
+    sleep 5
+done
+
+zetacored rosetta --tendermint zetacore0:26657 --grpc zetacore0:9090 --network athens_101-1 --blockchain zetacore

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -258,8 +258,8 @@ then
 # 4. Collect all the gentx files in zetacore0 and create the final genesis.json
   zetacored collect-gentxs
 
-  if [[ "$OPTION" == "import-data" || "$OPTION" == "import-data-upgrade" ]]; then
-    echo "Importing data"
+  if [ "$OPTION" == "import-data" ]; then
+    echo "Importing data into genesis file"
     zetacored parse-genesis-file /root/genesis_data/exported-genesis.json
   fi
 

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -71,6 +71,7 @@ then
   exit 1
 fi
 NUMOFNODES=$1
+OPTION=$2
 
 # create keys
 CHAINID="athens_101-1"
@@ -256,6 +257,12 @@ then
 
 # 4. Collect all the gentx files in zetacore0 and create the final genesis.json
   zetacored collect-gentxs
+
+  if [[ "$OPTION" == "import-data" || "$OPTION" == "import-data-upgrade" ]]; then
+    echo "Importing data"
+    zetacored parse-genesis-file /root/genesis_data/exported-genesis.json
+  fi
+
   zetacored validate-genesis
 # 5. Copy the final genesis.json to all the nodes
   for NODE in "${NODELIST[@]}"; do

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -4,6 +4,8 @@
 # It initializes the nodes and creates the genesis.json file
 # It also starts the nodes
 # The number of nodes is passed as an first argument to the script
+# The second argument is optional and can have the following value:
+#  - import-data: import data into the genesis file
 
 /usr/sbin/sshd
 


### PR DESCRIPTION
# Description

- Add a command `start-e2e-import-mainnet-test`, which runs the e2e test on a network containing data imported from the mainnet. 
Closes: https://github.com/zeta-chain/node/issues/2259

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
