### PR TITLE
fix: remove quotes from e2e args

### DIFF
--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -136,9 +136,9 @@ if [ "$OPTION" == "upgrade" ]; then
   # When the upgrade height is greater than 100 for upgrade test, the Bitcoin tests have been run once, therefore the Bitcoin wallet is already set up
   # Use light flag to skip advanced tests
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
-    zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml --light --skip-header-proof
+    zetae2e $ZETAE2E_CMD --skip-setup --config deployed.yml --light --skip-header-proof
   else
-    zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof
+    zetae2e $ZETAE2E_CMD --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof
   fi
 
   ZETAE2E_EXIT_CODE=$?
@@ -156,7 +156,7 @@ else
   echo "running e2e setup..."
 
   if [[ ! -f deployed.yml ]]; then
-    zetae2e "$ZETAE2E_CMD" --setup-only --config-out deployed.yml
+    zetae2e $ZETAE2E_CMD --setup-only --config-out deployed.yml
     if [ $? -ne 0 ]; then
       echo "e2e setup failed"
       exit 1
@@ -167,7 +167,7 @@ else
 
   echo "running e2e tests..."
 
-  zetae2e "$ZETAE2E_CMD" --skip-setup --config deployed.yml
+  zetae2e $ZETAE2E_CMD --skip-setup --config deployed.yml
   ZETAE2E_EXIT_CODE=$?
 
   # if e2e passed, exit with 0, otherwise exit with 1


### PR DESCRIPTION
# Description

https://github.com/zeta-chain/node/pull/2264 broke the performance tests:

```
unknown command "local --test-performance" for "zetae2e"
```

This is because of the double quotes, forcing the `local --test performance` args be passed as `os.Args[1]` rather than `os.Args[1:3]`