### PR TITLE
refactor(e2e): use private key rather than mnemonic in admin tests

### DIFF
--- a/cmd/zetae2e/balances.go
+++ b/cmd/zetae2e/balances.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/zeta-chain/zetacore/app"
 	zetae2econfig "github.com/zeta-chain/zetacore/cmd/zetae2e/config"
-	"github.com/zeta-chain/zetacore/cmd/zetae2e/local"
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/utils"
 )
 
 const flagSkipBTC = "skip-btc"
@@ -71,8 +69,6 @@ func runBalances(cmd *cobra.Command, args []string) error {
 		conf,
 		ethcommon.HexToAddress(evmAddr),
 		conf.Accounts.EVMPrivKey,
-		utils.FungibleAdminName,     // placeholder value, not used
-		local.FungibleAdminMnemonic, // placeholder value, not used
 		logger,
 	)
 	if err != nil {

--- a/cmd/zetae2e/bitcoin_address.go
+++ b/cmd/zetae2e/bitcoin_address.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/zeta-chain/zetacore/app"
 	zetae2econfig "github.com/zeta-chain/zetacore/cmd/zetae2e/config"
-	"github.com/zeta-chain/zetacore/cmd/zetae2e/local"
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/utils"
 )
 
 const flagPrivKey = "privkey"
@@ -71,8 +69,6 @@ func runBitcoinAddress(cmd *cobra.Command, args []string) error {
 		conf,
 		ethcommon.HexToAddress(evmAddr),
 		conf.Accounts.EVMPrivKey,
-		utils.FungibleAdminName,     // placeholder value, not used
-		local.FungibleAdminMnemonic, // placeholder value, not used
 		logger,
 	)
 	if err != nil {

--- a/cmd/zetae2e/config/config.go
+++ b/cmd/zetae2e/config/config.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/txserver"
 )
 
 // RunnerFromConfig create test runner from config
@@ -19,9 +18,8 @@ func RunnerFromConfig(
 	conf config.Config,
 	evmUserAddr ethcommon.Address,
 	evmUserPrivKey string,
-	zetaUserName string,
-	zetaUserMnemonic string,
 	logger *runner.Logger,
+	opts ...runner.E2ERunnerOption,
 ) (*runner.E2ERunner, error) {
 	// initialize clients
 	btcRPCClient,
@@ -39,16 +37,6 @@ func RunnerFromConfig(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get clients from config: %w", err)
 	}
-	// initialize client to send messages to ZetaChain
-	zetaTxServer, err := txserver.NewZetaTxServer(
-		conf.RPCs.ZetaCoreRPC,
-		[]string{zetaUserName},
-		[]string{zetaUserMnemonic},
-		conf.ZetaChainID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize ZetaChain tx server: %w", err)
-	}
 
 	// initialize E2E test runner
 	newRunner := runner.NewE2ERunner(
@@ -57,11 +45,9 @@ func RunnerFromConfig(
 		ctxCancel,
 		evmUserAddr,
 		evmUserPrivKey,
-		zetaUserMnemonic,
 		evmClient,
 		zevmClient,
 		cctxClient,
-		zetaTxServer,
 		fungibleClient,
 		authClient,
 		bankClient,
@@ -71,6 +57,7 @@ func RunnerFromConfig(
 		zevmAuth,
 		btcRPCClient,
 		logger,
+		opts...,
 	)
 
 	// set contracts

--- a/cmd/zetae2e/local/accounts.go
+++ b/cmd/zetae2e/local/accounts.go
@@ -38,5 +38,7 @@ var (
 	UserAdminAddress    = ethcommon.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 	UserAdminPrivateKey = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" // #nosec G101 - used for testing
 
-	FungibleAdminMnemonic = "snow grace federal cupboard arrive fancy gym lady uniform rotate exercise either leave alien grass" // #nosec G101 - used for testing
+	// FungibleAdminAddress is the address of the account for testing the fungible admin functions
+	UserFungibleAdminAddress    = ethcommon.HexToAddress("0x8305C114Ea73cAc4A88f39A173803F94741b9055")
+	UserFungibleAdminPrivateKey = "d88d09a7d6849c15a36eb6931f9dd616091a63e9849a2cc86f309ba11fb8fec5" // #nosec G101 - used for testing
 )

--- a/cmd/zetae2e/local/admin.go
+++ b/cmd/zetae2e/local/admin.go
@@ -39,6 +39,7 @@ func adminTestRoutine(
 			UserAdminAddress,
 			UserAdminPrivateKey,
 			runner.NewLogger(verbose, color.FgHiGreen, "admin"),
+			runner.WithZetaTxServer(deployerRunner.ZetaTxServer),
 		)
 		if err != nil {
 			return err

--- a/cmd/zetae2e/local/erc20.go
+++ b/cmd/zetae2e/local/erc20.go
@@ -40,6 +40,7 @@ func erc20TestRoutine(
 			UserERC20Address,
 			UserERC20PrivateKey,
 			runner.NewLogger(verbose, color.FgGreen, "erc20"),
+			runner.WithZetaTxServer(deployerRunner.ZetaTxServer),
 		)
 		if err != nil {
 			return err

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -262,6 +262,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		erc20Tests := []string{
 			e2etests.TestERC20WithdrawName,
 			e2etests.TestMultipleERC20WithdrawsName,
+			e2etests.TestERC20DepositAndCallRefundName,
 			e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
@@ -334,7 +335,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestUpdateBytecodeZRC20Name,
 			e2etests.TestUpdateBytecodeConnectorName,
 			e2etests.TestDepositEtherLiquidityCapName,
-			e2etests.TestERC20DepositAndCallRefundName,
 
 			// TestMigrateChainSupportName tests EVM chain migration. Currently this test doesn't work with Anvil because pre-EIP1559 txs are not supported
 			// See issue below for details

--- a/cmd/zetae2e/local/test_runner.go
+++ b/cmd/zetae2e/local/test_runner.go
@@ -6,7 +6,6 @@ import (
 	zetae2econfig "github.com/zeta-chain/zetacore/cmd/zetae2e/config"
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/utils"
 )
 
 // initTestRunner initializes a runner form tests
@@ -18,6 +17,7 @@ func initTestRunner(
 	userAddress ethcommon.Address,
 	userPrivKey string,
 	logger *runner.Logger,
+	opts ...runner.E2ERunnerOption,
 ) (*runner.E2ERunner, error) {
 	// initialize runner for test
 	testRunner, err := zetae2econfig.RunnerFromConfig(
@@ -27,9 +27,8 @@ func initTestRunner(
 		conf,
 		userAddress,
 		userPrivKey,
-		utils.FungibleAdminName,
-		FungibleAdminMnemonic,
 		logger,
+		opts...,
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/zeta-chain/zetacore/app"
 	zetae2econfig "github.com/zeta-chain/zetacore/cmd/zetae2e/config"
-	"github.com/zeta-chain/zetacore/cmd/zetae2e/local"
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/e2etests"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/utils"
 )
 
 const flagVerbose = "verbose"
@@ -93,8 +91,6 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 		conf,
 		ethcommon.HexToAddress(evmAddr),
 		conf.Accounts.EVMPrivKey,
-		utils.FungibleAdminName,     // placeholder value, not used
-		local.FungibleAdminMnemonic, // placeholder value, not used
 		logger,
 	)
 	if err != nil {

--- a/cmd/zetae2e/setup_bitcoin.go
+++ b/cmd/zetae2e/setup_bitcoin.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/zeta-chain/zetacore/app"
 	zetae2econfig "github.com/zeta-chain/zetacore/cmd/zetae2e/config"
-	"github.com/zeta-chain/zetacore/cmd/zetae2e/local"
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/utils"
 )
 
 // NewSetupBitcoinCmd sets up bitcoin wallet for e2e tests
@@ -58,8 +56,6 @@ func runSetupBitcoin(_ *cobra.Command, args []string) error {
 		conf,
 		ethcommon.HexToAddress(evmAddr),
 		conf.Accounts.EVMPrivKey,
-		utils.FungibleAdminName,     // placeholder value, not used
-		local.FungibleAdminMnemonic, // placeholder value, not used
 		logger,
 	)
 	if err != nil {

--- a/cmd/zetae2e/show_tss.go
+++ b/cmd/zetae2e/show_tss.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/zeta-chain/zetacore/app"
 	zetae2econfig "github.com/zeta-chain/zetacore/cmd/zetae2e/config"
-	"github.com/zeta-chain/zetacore/cmd/zetae2e/local"
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"github.com/zeta-chain/zetacore/e2e/utils"
 )
 
 // NewShowTSSCmd returns the show TSS command
@@ -59,8 +57,6 @@ func runShowTSS(_ *cobra.Command, args []string) error {
 		conf,
 		ethcommon.HexToAddress(evmAddr),
 		conf.Accounts.EVMPrivKey,
-		utils.FungibleAdminName,     // placeholder value, not used
-		local.FungibleAdminMnemonic, // placeholder value, not used
 		logger,
 	)
 	if err != nil {

--- a/cmd/zetae2e/stress.go
+++ b/cmd/zetae2e/stress.go
@@ -149,8 +149,6 @@ func StressTest(cmd *cobra.Command, _ []string) {
 		conf,
 		local.DeployerAddress,
 		local.DeployerPrivateKey,
-		utils.FungibleAdminName,
-		local.FungibleAdminMnemonic,
 		logger,
 	)
 	if err != nil {

--- a/contrib/localnet/docker-compose-admin.yml
+++ b/contrib/localnet/docker-compose-admin.yml
@@ -13,6 +13,7 @@ services:
       context: ./anvil
     container_name: eth2
     hostname: eth2
+    platform: linux/amd64
     ports:
       - "8546:8545"
     networks:

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -219,11 +219,11 @@ then
   fi
 
 # set admin account
-  zetacored add-genesis-account zeta1srsq755t654agc0grpxj4y3w0znktrpr9tcdgk 100000000000000000000000000azeta
+  zetacored add-genesis-account zeta1svzuz982w09vf2y08xsh8qplj36phyz466krj3 100000000000000000000000000azeta
   zetacored add-genesis-account zeta1n0rn6sne54hv7w2uu93fl48ncyqz97d3kty6sh 100000000000000000000000000azeta # Funds the localnet_gov_admin account
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["authority"]["policies"]["items"][0]["address"]="zeta1srsq755t654agc0grpxj4y3w0znktrpr9tcdgk"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["authority"]["policies"]["items"][1]["address"]="zeta1srsq755t654agc0grpxj4y3w0znktrpr9tcdgk"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["authority"]["policies"]["items"][2]["address"]="zeta1srsq755t654agc0grpxj4y3w0znktrpr9tcdgk"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["authority"]["policies"]["items"][0]["address"]="zeta1svzuz982w09vf2y08xsh8qplj36phyz466krj3"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["authority"]["policies"]["items"][1]["address"]="zeta1svzuz982w09vf2y08xsh8qplj36phyz466krj3"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["authority"]["policies"]["items"][2]["address"]="zeta1svzuz982w09vf2y08xsh8qplj36phyz466krj3"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
 
 # give balance to runner accounts to deploy contracts directly on zEVM
 # deployer

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -44,11 +44,12 @@ const (
 	 EVM erc20 tests
 	 Test transfer of EVM erc20 asset across chains
 	*/
-	TestERC20WithdrawName          = "erc20_withdraw"
-	TestERC20DepositName           = "erc20_deposit"
-	TestMultipleERC20DepositName   = "erc20_multiple_deposit"
-	TestMultipleERC20WithdrawsName = "erc20_multiple_withdraw"
-	TestERC20DepositRestrictedName = "erc20_deposit_restricted" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestERC20WithdrawName             = "erc20_withdraw"
+	TestERC20DepositName              = "erc20_deposit"
+	TestMultipleERC20DepositName      = "erc20_multiple_deposit"
+	TestMultipleERC20WithdrawsName    = "erc20_multiple_withdraw"
+	TestERC20DepositRestrictedName    = "erc20_deposit_restricted" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestERC20DepositAndCallRefundName = "erc20_deposit_and_call_refund"
 
 	/*
 	 Bitcoin tests
@@ -91,13 +92,12 @@ const (
 	 Admin tests
 	 Test admin functionalities
 	*/
-	TestDepositEtherLiquidityCapName  = "deposit_eth_liquidity_cap"
-	TestMigrateChainSupportName       = "migrate_chain_support"
-	TestPauseZRC20Name                = "pause_zrc20"
-	TestUpdateBytecodeZRC20Name       = "update_bytecode_zrc20"
-	TestUpdateBytecodeConnectorName   = "update_bytecode_connector"
-	TestRateLimiterName               = "rate_limiter"
-	TestERC20DepositAndCallRefundName = "erc20_deposit_and_call_refund"
+	TestDepositEtherLiquidityCapName = "deposit_eth_liquidity_cap"
+	TestMigrateChainSupportName      = "migrate_chain_support"
+	TestPauseZRC20Name               = "pause_zrc20"
+	TestUpdateBytecodeZRC20Name      = "update_bytecode_zrc20"
+	TestUpdateBytecodeConnectorName  = "update_bytecode_connector"
+	TestRateLimiterName              = "rate_limiter"
 
 	/*
 	 Special tests
@@ -315,6 +315,12 @@ var AllE2ETests = []runner.E2ETest{
 		},
 		TestERC20DepositRestricted,
 	),
+	runner.NewE2ETest(
+		TestERC20DepositAndCallRefundName,
+		"deposit a non-gas ZRC20 into ZEVM and call a contract that reverts",
+		[]runner.ArgDefinition{},
+		TestERC20DepositAndCallRefund,
+	),
 	/*
 	 Bitcoin tests
 	*/
@@ -506,12 +512,6 @@ var AllE2ETests = []runner.E2ETest{
 		"test sending cctxs with rate limiter enabled and show logs when processing cctxs",
 		[]runner.ArgDefinition{},
 		TestRateLimiter,
-	),
-	runner.NewE2ETest(
-		TestERC20DepositAndCallRefundName,
-		"deposit a non-gas ZRC20 into ZEVM and call a contract that reverts",
-		[]runner.ArgDefinition{},
-		TestERC20DepositAndCallRefund,
 	),
 	/*
 	 Special tests

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -44,12 +44,11 @@ const (
 	 EVM erc20 tests
 	 Test transfer of EVM erc20 asset across chains
 	*/
-	TestERC20WithdrawName             = "erc20_withdraw"
-	TestERC20DepositName              = "erc20_deposit"
-	TestMultipleERC20DepositName      = "erc20_multiple_deposit"
-	TestMultipleERC20WithdrawsName    = "erc20_multiple_withdraw"
-	TestERC20DepositAndCallRefundName = "erc20_deposit_and_call_refund"
-	TestERC20DepositRestrictedName    = "erc20_deposit_restricted" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestERC20WithdrawName          = "erc20_withdraw"
+	TestERC20DepositName           = "erc20_deposit"
+	TestMultipleERC20DepositName   = "erc20_multiple_deposit"
+	TestMultipleERC20WithdrawsName = "erc20_multiple_withdraw"
+	TestERC20DepositRestrictedName = "erc20_deposit_restricted" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
 
 	/*
 	 Bitcoin tests
@@ -92,12 +91,13 @@ const (
 	 Admin tests
 	 Test admin functionalities
 	*/
-	TestDepositEtherLiquidityCapName = "deposit_eth_liquidity_cap"
-	TestMigrateChainSupportName      = "migrate_chain_support"
-	TestPauseZRC20Name               = "pause_zrc20"
-	TestUpdateBytecodeZRC20Name      = "update_bytecode_zrc20"
-	TestUpdateBytecodeConnectorName  = "update_bytecode_connector"
-	TestRateLimiterName              = "rate_limiter"
+	TestDepositEtherLiquidityCapName  = "deposit_eth_liquidity_cap"
+	TestMigrateChainSupportName       = "migrate_chain_support"
+	TestPauseZRC20Name                = "pause_zrc20"
+	TestUpdateBytecodeZRC20Name       = "update_bytecode_zrc20"
+	TestUpdateBytecodeConnectorName   = "update_bytecode_connector"
+	TestRateLimiterName               = "rate_limiter"
+	TestERC20DepositAndCallRefundName = "erc20_deposit_and_call_refund"
 
 	/*
 	 Special tests
@@ -308,12 +308,6 @@ var AllE2ETests = []runner.E2ETest{
 		TestMultipleERC20Withdraws,
 	),
 	runner.NewE2ETest(
-		TestERC20DepositAndCallRefundName,
-		"deposit a non-gas ZRC20 into ZEVM and call a contract that reverts",
-		[]runner.ArgDefinition{},
-		TestERC20DepositAndCallRefund,
-	),
-	runner.NewE2ETest(
 		TestERC20DepositRestrictedName,
 		"deposit ERC20 into ZEVM restricted address",
 		[]runner.ArgDefinition{
@@ -512,6 +506,12 @@ var AllE2ETests = []runner.E2ETest{
 		"test sending cctxs with rate limiter enabled and show logs when processing cctxs",
 		[]runner.ArgDefinition{},
 		TestRateLimiter,
+	),
+	runner.NewE2ETest(
+		TestERC20DepositAndCallRefundName,
+		"deposit a non-gas ZRC20 into ZEVM and call a contract that reverts",
+		[]runner.ArgDefinition{},
+		TestERC20DepositAndCallRefund,
 	),
 	/*
 	 Special tests

--- a/e2e/e2etests/test_migrate_chain_support.go
+++ b/e2e/e2etests/test_migrate_chain_support.go
@@ -238,11 +238,9 @@ func configureEVM2(r *runner.E2ERunner) (*runner.E2ERunner, error) {
 		r.CtxCancel,
 		r.DeployerAddress,
 		r.DeployerPrivateKey,
-		r.FungibleAdminMnemonic,
 		r.EVMClient,
 		r.ZEVMClient,
 		r.CctxClient,
-		r.ZetaTxServer,
 		r.FungibleClient,
 		r.AuthClient,
 		r.BankClient,
@@ -252,6 +250,7 @@ func configureEVM2(r *runner.E2ERunner) (*runner.E2ERunner, error) {
 		r.ZEVMAuth,
 		r.BtcRPCClient,
 		runner.NewLogger(true, color.FgHiYellow, "admin-evm2"),
+		runner.WithZetaTxServer(r.ZetaTxServer),
 	)
 
 	// All existing fields of the runner are the same except for the RPC URL and client for EVM

--- a/e2e/runner/runner.go
+++ b/e2e/runner/runner.go
@@ -33,17 +33,24 @@ import (
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
+type E2ERunnerOption func(*E2ERunner)
+
+func WithZetaTxServer(txServer *txserver.ZetaTxServer) E2ERunnerOption {
+	return func(r *E2ERunner) {
+		r.ZetaTxServer = txServer
+	}
+}
+
 // E2ERunner stores all the clients and addresses needed for E2E test
 // Exposes a method to run E2E test
 // It also provides some helper functions
 type E2ERunner struct {
 	// accounts
-	DeployerAddress       ethcommon.Address
-	DeployerPrivateKey    string
-	TSSAddress            ethcommon.Address
-	BTCTSSAddress         btcutil.Address
-	BTCDeployerAddress    *btcutil.AddressWitnessPubKeyHash
-	FungibleAdminMnemonic string
+	DeployerAddress    ethcommon.Address
+	DeployerPrivateKey string
+	TSSAddress         ethcommon.Address
+	BTCTSSAddress      btcutil.Address
+	BTCDeployerAddress *btcutil.AddressWitnessPubKeyHash
 
 	// rpc clients
 	ZEVMClient   *ethclient.Client
@@ -58,8 +65,10 @@ type E2ERunner struct {
 	ObserverClient    observertypes.QueryClient
 	LightclientClient lightclienttypes.QueryClient
 
-	// zeta client
-	ZetaTxServer txserver.ZetaTxServer
+	// optional zeta (cosmos) client
+	// typically only in test runners that need it
+	// (like admin tests)
+	ZetaTxServer *txserver.ZetaTxServer
 
 	// evm auth
 	EVMAuth  *bind.TransactOpts
@@ -119,11 +128,9 @@ func NewE2ERunner(
 	ctxCancel context.CancelFunc,
 	deployerAddress ethcommon.Address,
 	deployerPrivateKey string,
-	fungibleAdminMnemonic string,
 	evmClient *ethclient.Client,
 	zevmClient *ethclient.Client,
 	cctxClient crosschaintypes.QueryClient,
-	zetaTxServer txserver.ZetaTxServer,
 	fungibleClient fungibletypes.QueryClient,
 	authClient authtypes.QueryClient,
 	bankClient banktypes.QueryClient,
@@ -133,19 +140,18 @@ func NewE2ERunner(
 	zevmAuth *bind.TransactOpts,
 	btcRPCClient *rpcclient.Client,
 	logger *Logger,
+	opts ...E2ERunnerOption,
 ) *E2ERunner {
-	return &E2ERunner{
+	r := &E2ERunner{
 		Name:      name,
 		Ctx:       ctx,
 		CtxCancel: ctxCancel,
 
-		DeployerAddress:       deployerAddress,
-		DeployerPrivateKey:    deployerPrivateKey,
-		FungibleAdminMnemonic: fungibleAdminMnemonic,
+		DeployerAddress:    deployerAddress,
+		DeployerPrivateKey: deployerPrivateKey,
 
 		ZEVMClient:        zevmClient,
 		EVMClient:         evmClient,
-		ZetaTxServer:      zetaTxServer,
 		CctxClient:        cctxClient,
 		FungibleClient:    fungibleClient,
 		AuthClient:        authClient,
@@ -161,6 +167,10 @@ func NewE2ERunner(
 
 		WG: sync.WaitGroup{},
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // CopyAddressesFrom copies addresses from another E2ETestRunner that initialized the contracts

--- a/e2e/txserver/zeta_tx_server.go
+++ b/e2e/txserver/zeta_tx_server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -34,9 +33,11 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/evmos/ethermint/crypto/hd"
 	etherminttypes "github.com/evmos/ethermint/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 
+	"github.com/zeta-chain/zetacore/app"
 	"github.com/zeta-chain/zetacore/cmd/zetacored/config"
 	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/pkg/coin"
@@ -63,43 +64,47 @@ type ZetaTxServer struct {
 }
 
 // NewZetaTxServer returns a new TxServer with provided account
-func NewZetaTxServer(rpcAddr string, names []string, mnemonics []string, chainID string) (ZetaTxServer, error) {
+func NewZetaTxServer(rpcAddr string, names []string, privateKeys []string, chainID string) (*ZetaTxServer, error) {
 	ctx := context.Background()
 
 	if len(names) == 0 {
-		return ZetaTxServer{}, errors.New("no account provided")
+		return nil, errors.New("no account provided")
 	}
 
-	if len(names) != len(mnemonics) {
-		return ZetaTxServer{}, errors.New("invalid names and mnemonics")
+	if len(names) != len(privateKeys) {
+		return nil, errors.New("invalid names and privateKeys")
 	}
 
 	// initialize rpc and check status
 	rpc, err := rpchttp.New(rpcAddr, "/websocket")
 	if err != nil {
-		return ZetaTxServer{}, fmt.Errorf("failed to initialize rpc: %s", err.Error())
+		return nil, fmt.Errorf("failed to initialize rpc: %s", err.Error())
 	}
 	if _, err = rpc.Status(ctx); err != nil {
-		return ZetaTxServer{}, fmt.Errorf("failed to query rpc: %s", err.Error())
+		return nil, fmt.Errorf("failed to query rpc: %s", err.Error())
 	}
 
 	// initialize codec
 	cdc, reg := newCodec()
 
 	// initialize keyring
-	kr := keyring.NewInMemory(cdc)
+	kr := keyring.NewInMemory(cdc, hd.EthSecp256k1Option())
 
 	addresses := make([]string, 0, len(names))
 
 	// create accounts
 	for i := range names {
-		r, err := kr.NewAccount(names[i], mnemonics[i], "", sdktypes.FullFundraiserPath, hd.Secp256k1)
+		err = kr.ImportPrivKeyHex(names[i], privateKeys[i], string(hd.EthSecp256k1Type))
 		if err != nil {
-			return ZetaTxServer{}, fmt.Errorf("failed to create account: %s", err.Error())
+			return nil, fmt.Errorf("failed to create account: %w", err)
+		}
+		r, err := kr.Key(names[i])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get account key: %w", err)
 		}
 		accAddr, err := r.GetAddress()
 		if err != nil {
-			return ZetaTxServer{}, fmt.Errorf("failed to get account address: %s", err.Error())
+			return nil, fmt.Errorf("failed to get account address: %w", err)
 		}
 
 		addresses = append(addresses, accAddr.String())
@@ -108,11 +113,10 @@ func NewZetaTxServer(rpcAddr string, names []string, mnemonics []string, chainID
 	clientCtx := newContext(rpc, cdc, reg, kr, chainID)
 	txf := newFactory(clientCtx)
 
-	return ZetaTxServer{
+	return &ZetaTxServer{
 		clientCtx:    clientCtx,
 		txFactory:    txf,
 		name:         names,
-		mnemonic:     mnemonics,
 		address:      addresses,
 		blockTimeout: 1 * time.Minute,
 	}, nil
@@ -425,7 +429,8 @@ func (zts ZetaTxServer) FundEmissionsPool(account string, amount *big.Int) error
 
 // newCodec returns the codec for msg server
 func newCodec() (*codec.ProtoCodec, codectypes.InterfaceRegistry) {
-	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	encodingConfig := app.MakeEncodingConfig()
+	interfaceRegistry := encodingConfig.InterfaceRegistry
 	cdc := codec.NewProtoCodec(interfaceRegistry)
 
 	sdktypes.RegisterInterfaces(interfaceRegistry)


### PR DESCRIPTION
# Description

#2308 is getting a bit large, so I'm gonna start breaking stuff out of it.

- use private key rather than pneumonic for fungible admin
- remove fungible admin parameters from e2e instead provide an optional `ZetaTxServer` 
- only populate the `ZetaTxServer` when it's actually needed (admin tests)

Part of https://github.com/zeta-chain/node/issues/2238

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [x] Tested CCTX in localnet
- [x] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 