### PR TITLE
chore: backport zetaclient gen-pre-params command

### DIFF
--- a/cmd/zetaclientd/gen_pre_params.go
+++ b/cmd/zetaclientd/gen_pre_params.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(GenPrePramsCmd)
+}
+
+var GenPrePramsCmd = &cobra.Command{
+	Use:   "gen-pre-params <path>",
+	Short: "Generate pre parameters for TSS",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		startTime := time.Now()
+		preParams, err := keygen.GeneratePreParams(time.Second * 300)
+		if err != nil {
+			return err
+		}
+
+		file, err := os.OpenFile(args[0], os.O_RDWR|os.O_CREATE, 0600)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		err = json.NewEncoder(file).Encode(preParams)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Generated new pre-parameters in %v\n", time.Since(startTime))
+		return nil
+	},
+}


### PR DESCRIPTION
# Description

Partially backport https://github.com/zeta-chain/node/pull/2353 to fix:

```
➜  ~ docker logs zetaclient0
Error: unknown command "gen-pre-params" for "zetaclientd"
Run 'zetaclientd --help' for usage.
```

which will cause increased failure rates in the upgrade tests. No release is required.