### PR TITLE
fix: resolve random failure of cross-chain swap E2E test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -66,6 +66,7 @@
 * [2299](https://github.com/zeta-chain/node/pull/2299) - add `zetae2e` command to deploy test contracts
 * [2360](https://github.com/zeta-chain/node/pull/2360) - add stateful e2e tests.
 * [2349](https://github.com/zeta-chain/node/pull/2349) - add TestBitcoinDepositRefund and WithdrawBitcoinMultipleTimes E2E tests
+* [2369](https://github.com/zeta-chain/node/pull/2369) - fix random cross-chain swap failure caused by using tiny UTXO
 
 ### Fixes
 

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -41,6 +41,17 @@ func (runner *E2ERunner) ListDeployerUTXOs() ([]btcjson.ListUnspentResult, error
 		return nil, err
 	}
 
+	// filter big-enough UTXOs for test if running on Regtest
+	if runner.IsLocalBitcoin() {
+		utxosFiltered := []btcjson.ListUnspentResult{}
+		for _, utxo := range utxos {
+			if utxo.Amount >= 1.0 {
+				utxosFiltered = append(utxosFiltered, utxo)
+			}
+		}
+		return utxosFiltered, nil
+	}
+
 	return utxos, nil
 }
 


### PR DESCRIPTION
# Description

This PR is to fix below random failure of e2e test `test_crosschain_swap`. The error below was caused by tiny UTXO being used in test.

![image](https://github.com/zeta-chain/node/assets/34498985/3e7c8931-108d-401e-89c3-4b472a4ae427)


Closes: #2356

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
