### PR TITLE
ci: Update sast-linters.yml

### DIFF
--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -109,8 +109,9 @@ jobs:
               echo "Skipping nosec check for $file"
               continue
             fi
-
-            if git diff ${{ github.event.pull_request.base.sha }} $file | grep -q nosec; then
+            
+            # Only consider additions of "nosec", marked by '+'
+            if git diff ${{ github.event.pull_request.base.sha }} $file | grep -q '^+.*nosec'; then
               echo "nosec detected in $file"
               nosec_list+=("$file,")
               nosec_detected=1
@@ -156,6 +157,3 @@ jobs:
         run: |
           DIFF=$(git diff ${{ github.event.pull_request.base.sha }})
           echo "$DIFF" | grep -P '#nosec(?!(\sG\d{3}))(?![^\s\t])([\s\t]*|$)' && echo "nosec without specified rule found!" && exit 1 || exit 0
-
-
-          

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -104,6 +104,12 @@ jobs:
           echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
                     
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # Skip this workflow file
+            if [ "$file" == ".github/workflows/sast-linters.yml" ]; then
+              echo "Skipping nosec check for $file"
+              continue
+            fi
+
             if git diff ${{ github.event.pull_request.base.sha }} $file | grep -q nosec; then
               echo "nosec detected in $file"
               nosec_list+=("$file,")
@@ -117,6 +123,7 @@ jobs:
           nosec_list_string="${nosec_list_string%,}"
           echo "nosec_files=$nosec_list_string" >> $GITHUB_ENV
           echo "nosec_detected=$nosec_detected" >> $GITHUB_ENV
+
 
       - name: Report nosec uses
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -105,7 +105,7 @@ jobs:
                     
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             # Skip this workflow file
-            if [ "$file" == ".github/workflows/sast-linters.yml" ]; then
+            if [ "$file" == ".github/workflows/sast-linters.yml" ] || [ "$file" == "changelog.md" ]; then
               echo "Skipping nosec check for $file"
               continue
             fi

--- a/changelog.md
+++ b/changelog.md
@@ -92,6 +92,7 @@
 * [2191](https://github.com/zeta-chain/node/pull/2191) - Fixed conditional logic for the docker build step for non release builds to not overwrite the github tag
 * [2192](https://github.com/zeta-chain/node/pull/2192) - Added release status checker and updater pipeline that will update release statuses when they go live on network
 * [2335](https://github.com/zeta-chain/node/pull/2335) - ci: updated the artillery report to publish to artillery cloud
+* [2377](https://github.com/zeta-chain/node/pull/2377) - ci: adjusted sast-linters.yml to not scan itself, nor alert on removal of nosec.
 
 ## v17.0.0
 


### PR DESCRIPTION
# Description

This PR is designed to prevent the nosec use scanning workflow from triggering on its own file. It also will only trigger on the addition of `nosec` rather than the removal of it.

This PR changes only the bare minimum needed to resolve the the issues, and could instead be expanded to exempt well known out of scope file extensions.

Changes: 
- Exclude .github/workflows/sast-linters.yml from scanning itself or changelog.md for the presence of the string "nosec"
- Grep only for diff lines which start with '+' and contain nosec

Closes:  https://github.com/zeta-chain/node/issues/1489

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions 

# Checklist:

- [ ] I have added unit tests that prove my fix feature works
