### PR TITLE
feat: add zetae2e serve-addresses

### DIFF
--- a/cmd/zetae2e/root.go
+++ b/cmd/zetae2e/root.go
@@ -29,6 +29,7 @@ func NewRootCmd() *cobra.Command {
 		NewStressTestCmd(),
 		NewInitCmd(),
 		NewSetupBitcoinCmd(),
+		NewServeAddressesCmd(),
 	)
 
 	return cmd

--- a/cmd/zetae2e/serve_addresses.go
+++ b/cmd/zetae2e/serve_addresses.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/spf13/cobra"
+	"github.com/zeta-chain/zetacore/e2e/config"
+)
+
+type v1AddressItem struct {
+	Address   string `json:"address"`
+	Category  string `json:"category"`
+	ChainID   int    `json:"chain_id"`
+	ChainName string `json:"chain_name"`
+	Type      string `json:"type"`
+}
+
+func NewServeAddressesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "serve-addresses",
+		Short: "Serve addresses of deployed contracts from config file",
+		RunE:  runServeAddresses,
+	}
+	cmd.Flags().StringVarP(&configFile, flagConfig, "c", "", "path to the configuration file")
+	if err := cmd.MarkFlagRequired(flagConfig); err != nil {
+		fmt.Println("Error marking flag as required")
+		os.Exit(1)
+	}
+	chainName, ok := os.LookupEnv("CHAIN_NAME")
+	if !ok {
+		chainName = "localnet"
+	}
+	cmd.Flags().String("chain-name", chainName, "name of the chain to return in results")
+	return cmd
+}
+
+func runServeAddresses(cmd *cobra.Command, args []string) error {
+	// read the config file
+	configPath, err := cmd.Flags().GetString(flagConfig)
+	if err != nil {
+		return err
+	}
+	chainName, err := cmd.Flags().GetString("chain-name")
+	if err != nil {
+		return err
+	}
+
+	ethChainName := fmt.Sprintf("eth_%s", chainName)
+	zetaChainName := fmt.Sprintf("zeta_%s", chainName)
+
+	// we load the config file in the request because it may not be populated on start
+
+	http.HandleFunc("/v1/addresses", func(w http.ResponseWriter, r *http.Request) {
+		conf, err := config.ReadConfig(configPath)
+		if err != nil {
+			log.Error("unable to read config: %v", err)
+			w.WriteHeader(500)
+			return
+		}
+
+		// TODO: pull TSS addresses, ZRC20 addresses from zetacored
+		res := []v1AddressItem{
+			// eth
+			{
+				Address:   conf.Contracts.EVM.ConnectorEthAddr.String(),
+				Category:  "messaging",
+				ChainID:   1337,
+				ChainName: ethChainName,
+				Type:      "connector",
+			},
+			{
+				Address:   conf.Contracts.EVM.CustodyAddr.String(),
+				Category:  "omnichain",
+				ChainID:   1337,
+				ChainName: ethChainName,
+				Type:      "erc20Custody",
+			},
+			// zeta
+			{
+				Address:   conf.Contracts.ZEVM.ConnectorZEVMAddr.String(),
+				Category:  "messaging",
+				ChainID:   101,
+				ChainName: zetaChainName,
+				Type:      "connector",
+			},
+			{
+				Address:   conf.Contracts.ZEVM.SystemContractAddr.String(),
+				Category:  "omnichain",
+				ChainID:   101,
+				ChainName: zetaChainName,
+				Type:      "systemContract",
+			},
+		}
+
+		err = json.NewEncoder(w).Encode(res)
+		if err != nil {
+			log.Error("unable to read config: %v", err)
+			w.WriteHeader(500)
+			return
+		}
+	})
+
+	return http.ListenAndServe(":9991", nil)
+}

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -157,6 +157,21 @@ services:
       - UPGRADE_HEIGHT=${UPGRADE_HEIGHT}
     volumes:
       - ssh:/root/.ssh
+      - config:/config
+  address-server:
+    image: orchestrator:latest
+    container_name: address-server
+    hostname: address-server
+    ports:
+      - "9991:9991"
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.3
+    entrypoint: ["zetae2e", "serve-addresses", "--config=/config/deployed.yml"]
+    volumes:
+      - ssh:/root/.ssh
+      - config:/config
 volumes:
   ssh:
   preparams:
+  config:

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -87,7 +87,7 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   UPGRADE_HEIGHT=${UPGRADE_HEIGHT:=225}
 
   if [[ ! -f deployed.yml ]]; then
-    zetae2e local $E2E_ARGS --setup-only --config config.yml --config-out deployed.yml --skip-header-proof
+    zetae2e local $E2E_ARGS --setup-only --config config.yml --config-out /config/deployed.yml --skip-header-proof
     if [ $? -ne 0 ]; then
       echo "e2e setup failed"
       exit 1
@@ -101,7 +101,7 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
     echo "running E2E command to setup the networks and populate the state..."
 
     # Use light flag to ensure tests can complete before the upgrade height
-    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --light --skip-header-proof
+    zetae2e local $E2E_ARGS --skip-setup --config /config/deployed.yml --light --skip-header-proof
     if [ $? -ne 0 ]; then
       echo "first e2e failed"
       exit 1
@@ -143,9 +143,9 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   # When the upgrade height is greater than 100 for upgrade test, the Bitcoin tests have been run once, therefore the Bitcoin wallet is already set up
   # Use light flag to skip advanced tests
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
-    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --light --skip-header-proof
+    zetae2e local $E2E_ARGS --skip-setup --config /config/deployed.yml --light --skip-header-proof
   else
-    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof
+    zetae2e local $E2E_ARGS --skip-setup --config /config/deployed.yml --skip-bitcoin-setup --light --skip-header-proof
   fi
 
   ZETAE2E_EXIT_CODE=$?
@@ -162,8 +162,8 @@ else
   # Run the e2e tests normally
   echo "running e2e setup..."
 
-  if [[ ! -f deployed.yml ]]; then
-    zetae2e local $E2E_ARGS --config config.yml --setup-only --config-out deployed.yml
+  if [[ ! -f /config/deployed.yml ]]; then
+    zetae2e local $E2E_ARGS --config config.yml --setup-only --config-out /config/deployed.yml
     if [ $? -ne 0 ]; then
       echo "e2e setup failed"
       exit 1
@@ -178,7 +178,7 @@ else
 
   echo "running e2e tests..."
 
-  zetae2e local $E2E_ARGS --skip-setup --config deployed.yml
+  zetae2e local $E2E_ARGS --skip-setup --config /config/deployed.yml
   ZETAE2E_EXIT_CODE=$?
 
   # if e2e passed, exit with 0, otherwise exit with 1


### PR DESCRIPTION
# Description

In order for the toolkit to be usable on localnet and developnet, we need to be able to export the contract/tss/zrc20 addresses in the [format that is expected](https://github.com/zeta-chain/protocol-contracts/blob/main/data/addresses.mainnet.json). These addresses are not stable between localnet deployments, so we cannot simply export the data once. Add `zetae2e serve-addresses` command which will serve this data in the correct format.

This PR is currently an POC for feedback. I will need help correctly mapping all the contract addresses from the e2e config format to the format expected by the toolkit. I will coordinate this change with changes across the networks repo and toolkit repo.

I think it would also be useful to add another endpoint which would serve the raw(ish) config to allow you to easily run `zetae2e` commands locally. So you could do `zetae2e run --config http://localhost:9091/v1/zetae2econfig`.

Relates to:
- https://github.com/zeta-chain/protocol-contracts/pull/188
- https://github.com/zeta-chain/networks/pull/49

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions 

# Checklist:

- [ ] TSS Addresses
- [ ] ZRC20 Addresses
- [ ] uniswap Addresses (although I'm not sure we deploy the uniswap contracts on localnet eth)
