### PR TITLE
chore: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,4 @@
 - [ ] Tested in development environment
 - [ ] Go unit tests
 - [ ] Go integration tests
-- [ ] Tested via GitHub Actions 
-
-# Checklist:
-
-- [ ] I have added unit tests that prove my fix feature works
+- [ ] Tested via GitHub Actions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,10 @@
 # Description
 
-Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-Closes: <PD-XXXX>
-
-## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
 
 # How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. 
+<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->
 
 - [ ] Tested CCTX in localnet
 - [ ] Tested in development environment


### PR DESCRIPTION
# Description

- remove "type of change". This is not needed because of conventional naming.
- put instructions behind comments so they don't show up on the actual PR
- add note about linking additional github actions runs.

