### PR TITLE
chore: add fbac as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @brewmaster012 @kingpinXD @lumtis @ws4charlie @skosito @swift1337
+* @brewmaster012 @kingpinXD @lumtis @ws4charlie @skosito @swift1337 @fbac
 
 .github/** @zeta-chain/devops


### PR DESCRIPTION
# Description

Add fbac as CODEOWNER.
Fixes https://github.com/zeta-chain/node/issues/2409
