### PR TITLE
fix(zetaclient): tolerate absolute path in GetPath()

### DIFF
--- a/zetaclient/config/config.go
+++ b/zetaclient/config/config.go
@@ -88,9 +88,10 @@ func GetPath(inputPath string) string {
 				return ""
 			}
 			path[0] = home
+			return filepath.Join(path...)
 		}
 	}
-	return filepath.Join(path...)
+	return inputPath
 }
 
 // ContainRestrictedAddress returns true if any one of the addresses is restricted


### PR DESCRIPTION
# Description

I missed this change when I was partially backporting https://github.com/zeta-chain/node/pull/2353 in https://github.com/zeta-chain/node/pull/2363. 

This results in errors like this:

```
2024-07-02T23:17:47Z ERR open pre-params file failed; skip error="open root/preparams/zetaclient0.json: no such file or directory"
```

which means a new pre-params file will have to be generated at start rather than init resulting in a greater chance of missing the keygen block.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
