### PR TITLE
ci: add merge_group triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  merge_group:
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
               echo "ADMIN_TESTS=true" >> $GITHUB_OUTPUT
             fi
           elif [[ ${{ github.event_name }} == 'merge_group' ]]; then
-            echo "UPGRADE_LIGHT_TESTS=true" >> $GITHUB_OUTPUT
+            echo "DEFAULT_TESTS=true" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/heads/develop' ]]; then
             echo "DEFAULT_TESTS=true" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event_name }} == 'schedule' ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:
+      DEFAULT_TESTS: ${{ steps.matrix-conditionals.outputs.DEFAULT_TESTS }}
       UPGRADE_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_TESTS }}
       UPGRADE_LIGHT_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_LIGHT_TESTS }}
       ADMIN_TESTS: ${{ steps.matrix-conditionals.outputs.ADMIN_TESTS }}
@@ -32,6 +33,7 @@ jobs:
       - id: matrix-conditionals
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            echo "DEFAULT_TESTS=true" >> $GITHUB_OUTPUT
             labels=$(gh pr view -R ${{github.repository}} ${{github.event.pull_request.number}} --json labels -q '.labels[].name')
             if [[ "$labels" == *"UPGRADE_TESTS"* ]]; then
               echo "UPGRADE_TESTS=true" >> $GITHUB_OUTPUT
@@ -44,6 +46,10 @@ jobs:
             if [[ "$labels" == *"ADMIN_TESTS"* ]]; then
               echo "ADMIN_TESTS=true" >> $GITHUB_OUTPUT
             fi
+          elif [[ ${{ github.event_name }} == 'merge_group' ]]; then
+            echo "UPGRADE_LIGHT_TESTS=true" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/heads/develop' ]]; then
+            echo "DEFAULT_TESTS=true" >> $GITHUB_OUTPUT
           elif [[ ${{ github.event_name }} == 'schedule' ]]; then
             echo "UPGRADE_TESTS=true" >> $GITHUB_OUTPUT
             echo "UPGRADE_LIGHT_TESTS=true" >> $GITHUB_OUTPUT
@@ -58,7 +64,7 @@ jobs:
         include:
           - make-target: "start-e2e-test"
             runs-on: ubuntu-20.04
-            run: true
+            run: ${{ needs.matrix-conditionals.outputs.DEFAULT_TESTS == 'true' }}
           - make-target: "start-upgrade-test"
             runs-on: ubuntu-20.04
             run: ${{ needs.matrix-conditionals.outputs.UPGRADE_TESTS == 'true' }}

--- a/.github/workflows/generate-files.yml
+++ b/.github/workflows/generate-files.yml
@@ -1,5 +1,6 @@
 name: Generated Files are Updated
 on:
+  merge_group:
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - "*"
+  merge_group:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
# Description

Add [merge_group](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group) triggers to all required workflows. All required status checks must be reported when using merge queue.

Run the light upgrades tests on mergequeue. This means that the upgrade tests will have to pass before merge. Update: the upgrade tests are not stable right now, let's just run default e2e for now.

Once this is approved, I will enable [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) and this will be the first PR to merge via merge queue.

Related to #2134 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
