### PR TITLE
ci: optimize upgrade tests by downloading binaries

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -61,11 +61,7 @@ COPY --from=latest-build /go/bin/zetacored /go/bin/zetaclientd /go/bin/zetaclien
 
 # optional old version build. This old build is used as the genesis version in the upgrade tests.
 # use --target latest-runtime to skip
-# 
-# TODO: just download binaries from github release now that we're using glibc
-# we can't do this right now since we do not have a v16 release candidate
-# https://github.com/zeta-chain/node/issues/2179
-FROM base-build as old-build
+FROM base-build as old-build-source
 
 ARG OLD_VERSION
 RUN git clone https://github.com/zeta-chain/node.git
@@ -74,8 +70,19 @@ RUN cd node && git fetch
 RUN cd node && git checkout ${OLD_VERSION}
 RUN cd node && make install
 
-FROM base-runtime AS old-runtime
+FROM base-runtime AS old-runtime-source
 
 COPY --from=cosmovisor-build /go/bin/cosmovisor /usr/local/bin
-COPY --from=old-build /go/bin/zetacored /go/bin/zetaclientd /usr/local/bin
+COPY --from=old-build-source /go/bin/zetacored /go/bin/zetaclientd /usr/local/bin
 COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
+
+FROM base-runtime AS old-runtime
+
+ARG BUILDARCH
+
+COPY --from=cosmovisor-build /go/bin/cosmovisor /usr/local/bin
+COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
+RUN curl -Lo /usr/local/bin/zetacored https://github.com/zeta-chain/ci-testing-node/releases/download/v17.0.1-internal/zetacored-linux-${BUILDARCH} && \
+    chmod 755 /usr/local/bin/zetacored && \
+    curl -Lo /usr/local/bin/zetaclientd https://github.com/zeta-chain/ci-testing-node/releases/download/v17.0.1-internal/zetaclientd-linux-${BUILDARCH} && \
+    chmod 755 /usr/local/bin/zetaclientd

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -59,8 +59,8 @@ FROM base-runtime AS latest-runtime
 COPY --from=cosmovisor-build /go/bin/cosmovisor /usr/local/bin
 COPY --from=latest-build /go/bin/zetacored /go/bin/zetaclientd /go/bin/zetaclientd-supervisor /go/bin/zetae2e /usr/local/bin
 
-# optional old version build. This old build is used as the genesis version in the upgrade tests.
-# use --target latest-runtime to skip
+# Optional old version build (from source). This old build is used as the genesis version in the upgrade tests. 
+# Use --target latest-runtime to skip.
 FROM base-build as old-build-source
 
 ARG OLD_VERSION
@@ -76,13 +76,16 @@ COPY --from=cosmovisor-build /go/bin/cosmovisor /usr/local/bin
 COPY --from=old-build-source /go/bin/zetacored /go/bin/zetaclientd /usr/local/bin
 COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
 
+# Optional old version build (from binary).
+# Use --target latest-runtime to skip.
 FROM base-runtime AS old-runtime
 
+ARG OLD_VERSION
 ARG BUILDARCH
 
 COPY --from=cosmovisor-build /go/bin/cosmovisor /usr/local/bin
 COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
-RUN curl -Lo /usr/local/bin/zetacored https://github.com/zeta-chain/ci-testing-node/releases/download/v17.0.1-internal/zetacored-linux-${BUILDARCH} && \
+RUN curl -Lo /usr/local/bin/zetacored ${OLD_VERSION}/zetacored-linux-${BUILDARCH} && \
     chmod 755 /usr/local/bin/zetacored && \
-    curl -Lo /usr/local/bin/zetaclientd https://github.com/zeta-chain/ci-testing-node/releases/download/v17.0.1-internal/zetaclientd-linux-${BUILDARCH} && \
+    curl -Lo /usr/local/bin/zetaclientd ${OLD_VERSION}/zetaclientd-linux-${BUILDARCH} && \
     chmod 755 /usr/local/bin/zetaclientd

--- a/Makefile
+++ b/Makefile
@@ -259,15 +259,15 @@ start-stress-test: zetanode
 ###############################################################################
 
 # build from source only if requested
-ifndef UPGRADE_TEST_FROM_SOURCE
-zetanode-upgrade: zetanode
-	@echo "Building zetanode-upgrade from binaries"
-	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime --build-arg OLD_VERSION='release/v17' .
-.PHONY: zetanode-upgrade
-else
+ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source --build-arg OLD_VERSION='release/v17' .
+.PHONY: zetanode-upgrade
+else
+zetanode-upgrade: zetanode
+	@echo "Building zetanode-upgrade from binaries"
+	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime --build-arg OLD_VERSION='https://github.com/zeta-chain/ci-testing-node/releases/download/v17.0.1-internal' .
 .PHONY: zetanode-upgrade
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -258,12 +258,18 @@ start-stress-test: zetanode
 ###                         Upgrade Tests              						###
 ###############################################################################
 
-
+# build from source only if requested
+ifndef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: zetanode
-	@echo "Building zetanode-upgrade"
+	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime --build-arg OLD_VERSION='release/v17' .
-	$(DOCKER) build -t orchestrator -f contrib/localnet/orchestrator/Dockerfile.fastbuild .
 .PHONY: zetanode-upgrade
+else
+zetanode-upgrade: zetanode
+	@echo "Building zetanode-upgrade from source"
+	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source --build-arg OLD_VERSION='release/v17' .
+.PHONY: zetanode-upgrade
+endif
 
 start-upgrade-test: zetanode-upgrade
 	@echo "--> Starting upgrade test"


### PR DESCRIPTION
# Description

Download binaries rather than compiling from source in the upgrades tests when possible. This makes the light upgrade tests only ~2 minutes slower than the normal e2e tests.

Use release binaries from [zeta-chain/ci-testing-node](https://github.com/zeta-chain/ci-testing-node) which include some needed fixes for `release/v17`.

User can opt into building from source by doing `UPGRADE_TEST_FROM_SOURCE=true make start-upgrade-test-light`.

Closes #2179 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced conditional builds for `zetanode-upgrade` to allow building from binaries or source.

- **Chores**
  - Refined Dockerfile stages for improved build clarity and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->