### PR TITLE
fix: set pebbledb as default database

### DIFF
--- a/cmd/zetacored/root.go
+++ b/cmd/zetacored/root.go
@@ -114,6 +114,8 @@ func initTmConfig() *tmcfg.Config {
 		cfg.Mempool.Version = tmcfg.MempoolV1
 	}
 
+	cfg.DBBackend = "pebbledb"
+
 	return cfg
 }
 


### PR DESCRIPTION
# Description

Set pebbledb as the default database because that's what format our snapshots are stored in.

Closes #2432

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
