### PR TITLE
fix: special handle Bitcoin Testnet gas price estimator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -89,6 +89,7 @@
 * [2327](https://github.com/zeta-chain/node/pull/2327) - partially cherry picked the fix to Bitcoin outbound dust amount
 * [2362](https://github.com/zeta-chain/node/pull/2362) - set 1000 satoshis as minimum BTC amount that can be withdrawn from zEVM
 * [2382](https://github.com/zeta-chain/node/pull/2382) - add tx input and gas in rpc methods for synthetic eth txs
+* [2396](https://github.com/zeta-chain/node/issues/2386) - special handle bitcoin testnet gas price estimator
 
 ### CI
 * [2388](https://github.com/zeta-chain/node/pull/2388) - added GitHub attestations of binaries produced in the release workflow. 

--- a/zetaclient/chains/bitcoin/observer/observer.go
+++ b/zetaclient/chains/bitcoin/observer/observer.go
@@ -346,6 +346,8 @@ func (ob *Observer) PostGasPrice() error {
 	feeRateEstimated := uint64(0)
 
 	// special handle regnet and testnet gas rate
+	// regnet:  RPC 'EstimateSmartFee' is not available
+	// testnet: RPC 'EstimateSmartFee' returns unreasonable high gas rate
 	if ob.Chain().NetworkType != chains.NetworkType_mainnet {
 		feeRateEstimated, err = ob.specialHandleFeeRate()
 		if err != nil {
@@ -647,7 +649,7 @@ func (ob *Observer) LoadBroadcastedTxMap() error {
 func (ob *Observer) specialHandleFeeRate() (uint64, error) {
 	switch ob.Chain().NetworkType {
 	case chains.NetworkType_privnet:
-		// hardcode gas price here since RPC 'EstimateSmartFee' is not available on regtest (privnet)
+		// hardcode gas price for regnet
 		return 1, nil
 	case chains.NetworkType_testnet:
 		feeRateEstimated, err := rpc.GetRecentFeeRate(ob.btcClient, ob.netParams)

--- a/zetaclient/chains/bitcoin/rpc/rpc.go
+++ b/zetaclient/chains/bitcoin/rpc/rpc.go
@@ -119,6 +119,7 @@ func GetRawTxResult(
 }
 
 // GetRecentFeeRate gets the highest fee rate from recent blocks
+// Note: this method is only used for testnet
 func GetRecentFeeRate(rpcClient interfaces.BTCRPCClient, netParams *chaincfg.Params) (uint64, error) {
 	blockNumber, err := rpcClient.GetBlockCount()
 	if err != nil {
@@ -148,7 +149,7 @@ func GetRecentFeeRate(rpcClient interfaces.BTCRPCClient, netParams *chaincfg.Par
 		}
 	}
 
-	// use 10 sat/byte as default estimation when fee rate is 0
+	// use 10 sat/byte as default estimation if recent fee rate drops to 0
 	if highestRate == 0 {
 		highestRate = defaultTestnetFeeRate
 	}

--- a/zetaclient/chains/bitcoin/rpc/rpc.go
+++ b/zetaclient/chains/bitcoin/rpc/rpc.go
@@ -4,12 +4,22 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/pkg/errors"
 
+	"github.com/zeta-chain/zetacore/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/zetacore/zetaclient/chains/interfaces"
 	"github.com/zeta-chain/zetacore/zetaclient/config"
+)
+
+const (
+	// feeRateCountBackBlocks is the default number of blocks to look back for fee rate estimation
+	feeRateCountBackBlocks = 2
+
+	// defaultTestnetFeeRate is the default fee rate for testnet, 10 sat/byte
+	defaultTestnetFeeRate = 10
 )
 
 // NewRPCClient creates a new RPC client by the given config.
@@ -106,4 +116,43 @@ func GetRawTxResult(
 
 	// res.Confirmations < 0 (meaning not included)
 	return btcjson.TxRawResult{}, fmt.Errorf("GetRawTxResult: tx %s not included yet", hash)
+}
+
+// GetRecentFeeRate gets the highest fee rate from recent blocks
+func GetRecentFeeRate(rpcClient interfaces.BTCRPCClient, netParams *chaincfg.Params) (uint64, error) {
+	blockNumber, err := rpcClient.GetBlockCount()
+	if err != nil {
+		return 0, err
+	}
+
+	// get the highest fee rate among recent 'countBack' blocks to avoid underestimation
+	highestRate := int64(0)
+	for i := int64(0); i < feeRateCountBackBlocks; i++ {
+		// get the block
+		hash, err := rpcClient.GetBlockHash(blockNumber - i)
+		if err != nil {
+			return 0, err
+		}
+		block, err := rpcClient.GetBlockVerboseTx(hash)
+		if err != nil {
+			return 0, err
+		}
+
+		// computes the average fee rate of the block and take the higher rate
+		avgFeeRate, err := bitcoin.CalcBlockAvgFeeRate(block, netParams)
+		if err != nil {
+			return 0, err
+		}
+		if avgFeeRate > highestRate {
+			highestRate = avgFeeRate
+		}
+	}
+
+	// use 10 sat/byte as default estimation when fee rate is 0
+	if highestRate == 0 {
+		highestRate = defaultTestnetFeeRate
+	}
+
+	// #nosec G701 always in range
+	return uint64(highestRate), nil
 }

--- a/zetaclient/chains/bitcoin/rpc/rpc_live_test.go
+++ b/zetaclient/chains/bitcoin/rpc/rpc_live_test.go
@@ -59,7 +59,7 @@ func (suite *BitcoinObserverTestSuite) SetupTest() {
 		base.DefaultLogger(), nil)
 	suite.Require().NoError(err)
 	suite.Require().NotNil(ob)
-	suite.rpcClient, err = getRPCClient(18332)
+	suite.rpcClient, err = createRPCClient(18332)
 	suite.Require().NoError(err)
 	skBytes, err := hex.DecodeString(skHex)
 	suite.Require().NoError(err)
@@ -91,13 +91,14 @@ func (suite *BitcoinObserverTestSuite) SetupTest() {
 func (suite *BitcoinObserverTestSuite) TearDownSuite() {
 }
 
-func getRPCClient(chainID int64) (*rpcclient.Client, error) {
+// createRPCClient creates a new Bitcoin RPC client for given chainID
+func createRPCClient(chainID int64) (*rpcclient.Client, error) {
 	var connCfg *rpcclient.ConnConfig
 	rpcMainnet := os.Getenv("BTC_RPC_MAINNET")
 	rpcTestnet := os.Getenv("BTC_RPC_TESTNET")
 
 	// mainnet
-	if chainID == 8332 {
+	if chainID == chains.BitcoinMainnet.ChainId {
 		connCfg = &rpcclient.ConnConfig{
 			Host:         rpcMainnet, // mainnet endpoint goes here
 			User:         "user",
@@ -108,7 +109,7 @@ func getRPCClient(chainID int64) (*rpcclient.Client, error) {
 		}
 	}
 	// testnet3
-	if chainID == 18332 {
+	if chainID == chains.BitcoinTestnet.ChainId {
 		connCfg = &rpcclient.ConnConfig{
 			Host:         rpcTestnet, // testnet endpoint goes here
 			User:         "user",
@@ -218,6 +219,7 @@ func TestBitcoinObserverLive(t *testing.T) {
 	// LiveTestBitcoinFeeRate(t)
 	// LiveTestAvgFeeRateMainnetMempoolSpace(t)
 	// LiveTestAvgFeeRateTestnetMempoolSpace(t)
+	// LiveTestGetRecentFeeRate(t)
 	// LiveTestGetSenderByVin(t)
 }
 
@@ -243,7 +245,7 @@ func LiveTestNewRPCClient(t *testing.T) {
 // LiveTestGetBlockHeightByHash queries Bitcoin block height by hash
 func LiveTestGetBlockHeightByHash(t *testing.T) {
 	// setup Bitcoin client
-	client, err := getRPCClient(8332)
+	client, err := createRPCClient(chains.BitcoinMainnet.ChainId)
 	require.NoError(t, err)
 
 	// the block hashes to test
@@ -265,7 +267,7 @@ func LiveTestGetBlockHeightByHash(t *testing.T) {
 // and compares Conservative and Economical fee rates for different block targets (1 and 2)
 func LiveTestBitcoinFeeRate(t *testing.T) {
 	// setup Bitcoin client
-	client, err := getRPCClient(8332)
+	client, err := createRPCClient(chains.BitcoinMainnet.ChainId)
 	require.NoError(t, err)
 	bn, err := client.GetBlockCount()
 	if err != nil {
@@ -390,7 +392,7 @@ func compareAvgFeeRate(t *testing.T, client *rpcclient.Client, startBlock int, e
 // LiveTestAvgFeeRateMainnetMempoolSpace compares calculated fee rate with mempool.space fee rate for mainnet
 func LiveTestAvgFeeRateMainnetMempoolSpace(t *testing.T) {
 	// setup Bitcoin client
-	client, err := getRPCClient(8332)
+	client, err := createRPCClient(chains.BitcoinMainnet.ChainId)
 	require.NoError(t, err)
 
 	// test against mempool.space API for 10000 blocks
@@ -404,7 +406,7 @@ func LiveTestAvgFeeRateMainnetMempoolSpace(t *testing.T) {
 // LiveTestAvgFeeRateTestnetMempoolSpace compares calculated fee rate with mempool.space fee rate for testnet
 func LiveTestAvgFeeRateTestnetMempoolSpace(t *testing.T) {
 	// setup Bitcoin client
-	client, err := getRPCClient(18332)
+	client, err := createRPCClient(chains.BitcoinTestnet.ChainId)
 	require.NoError(t, err)
 
 	// test against mempool.space API for 10000 blocks
@@ -415,11 +417,23 @@ func LiveTestAvgFeeRateTestnetMempoolSpace(t *testing.T) {
 	compareAvgFeeRate(t, client, startBlock, endBlock, true)
 }
 
+// LiveTestGetRecentFeeRate gets the highest fee rate from recent blocks
+func LiveTestGetRecentFeeRate(t *testing.T) {
+	// setup Bitcoin testnet client
+	client, err := createRPCClient(chains.BitcoinTestnet.ChainId)
+	require.NoError(t, err)
+
+	// get fee rate from recent blocks
+	feeRate, err := rpc.GetRecentFeeRate(client, &chaincfg.TestNet3Params)
+	require.NoError(t, err)
+	require.Greater(t, feeRate, uint64(0))
+}
+
 // LiveTestGetSenderByVin gets sender address for each vin and compares with mempool.space sender address
 func LiveTestGetSenderByVin(t *testing.T) {
 	// setup Bitcoin client
-	chainID := int64(8332)
-	client, err := getRPCClient(chainID)
+	chainID := chains.BitcoinMainnet.ChainId
+	client, err := createRPCClient(chainID)
 	require.NoError(t, err)
 
 	// net params


### PR DESCRIPTION
# Description

Closes: [2386](https://github.com/zeta-chain/node/issues/2386)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced gas price posting for Bitcoin networks, including testnet and privnet.
  - Added logic to handle fee rates for different Bitcoin network types.

- **Bug Fixes**
  - Improved fee rate retrieval and error handling in Bitcoin RPC.

- **Tests**
  - Updated live tests to use specific chain IDs for Bitcoin networks.
  - Added a new test function for recent fee rate retrieval.

- **Documentation**
  - Updated changelog to reflect new handling for Bitcoin testnet gas price estimator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->