### PR TITLE
fix(ci): prevent truncating the upgrade proposal with tee

### DIFF
--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -88,11 +88,11 @@ cat > upgrade_plan_info.json <<EOF
 }
 EOF
 
-cat upgrade.json | jq --arg info "$(cat upgrade_plan_info.json)" '.messages[0].plan.info = $info' | tee upgrade.json
+cat upgrade.json | jq --arg info "$(cat upgrade_plan_info.json)" '.messages[0].plan.info = $info' | tee upgrade_full.json
 
 echo "Submitting upgrade proposal"
 
-zetacored tx gov submit-proposal upgrade.json --from operator --keyring-backend test --chain-id $CHAINID --yes --fees 2000000000000000azeta -o json | tee proposal.json
+zetacored tx gov submit-proposal upgrade_full.json --from operator --keyring-backend test --chain-id $CHAINID --yes --fees 2000000000000000azeta -o json | tee proposal.json
 PROPOSAL_TX_HASH=$(jq -r .txhash proposal.json)
 PROPOSAL_ID=""
 # WARN: this seems to be unstable


### PR DESCRIPTION
# Description

It seem the tee command sometimes opens and truncates `upgrade.json` before `cat upgrade.json` finishes reading it. Write it to a separate file to ensure this doesn't happen.

# Old Description

Try to fix the upgrade tests by waiting a bit longer before submitting the proposal. I have no idea why this was stable for a long time but is now unstable.

Closes #2449

Update: this is not working:

```
upgrade-orchestrator  | 2024-07-08T22:29:48.730365325Z Submitting upgrade proposal
upgrade-orchestrator  | 2024-07-08T22:29:48.867226525Z Error: unexpected end of JSON input
```

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated synchronization logic to require a minimum height check of 2 instead of 1 before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->