### PR TITLE
test: add new command to run admin tests after upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ zetanode-upgrade: zetanode
 	$(DOCKER) build -t orchestrator -f contrib/localnet/orchestrator/Dockerfile.fastbuild .
 .PHONY: zetanode-upgrade
 
+
 start-upgrade-test: zetanode-upgrade
 	@echo "--> Starting upgrade test"
 	export LOCALNET_MODE=upgrade && \
@@ -275,6 +276,14 @@ start-upgrade-test-light: zetanode-upgrade
 	@echo "--> Starting light upgrade test (no ZetaChain state populating before upgrade)"
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=90 && \
+	cd contrib/localnet/ && $(DOCKER) compose --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
+
+
+start-upgrade-test-admin: zetanode-upgrade
+	@echo "--> Starting admin upgrade test"
+	export LOCALNET_MODE=upgrade && \
+	export UPGRADE_HEIGHT=90 && \
+	export E2E_ARGS="--skip-regular --test-admin" && \
 	cd contrib/localnet/ && $(DOCKER) compose --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
 
 start-upgrade-import-mainnet-test: zetanode-upgrade

--- a/changelog.md
+++ b/changelog.md
@@ -76,6 +76,7 @@
 * [2349](https://github.com/zeta-chain/node/pull/2349) - add TestBitcoinDepositRefund and WithdrawBitcoinMultipleTimes E2E tests
 * [2368](https://github.com/zeta-chain/node/pull/2368) - eliminate panic usage across testing suite
 * [2369](https://github.com/zeta-chain/node/pull/2369) - fix random cross-chain swap failure caused by using tiny UTXO
+* [2415](https://github.com/zeta-chain/node/pull/2415) - add e2e test for upgrade and test admin functionalities
 
 
 ### Fixes

--- a/e2e/e2etests/test_rate_limiter.go
+++ b/e2e/e2etests/test_rate_limiter.go
@@ -71,8 +71,8 @@ func TestRateLimiter(r *runner.E2ERunner, _ []string) {
 	// https://github.com/zeta-chain/node/issues/2090
 	r.Logger.Print("rate limiter enabled")
 	require.NoError(r, createAndWaitWithdraws(r, withdrawTypeZETA, zetaAmount))
-	require.NoError(r, createAndWaitWithdraws(r, withdrawTypeZETA, ethAmount))
-	require.NoError(r, createAndWaitWithdraws(r, withdrawTypeZETA, erc20Amount))
+	require.NoError(r, createAndWaitWithdraws(r, withdrawTypeETH, ethAmount))
+	require.NoError(r, createAndWaitWithdraws(r, withdrawTypeERC20, erc20Amount))
 
 	// Disable rate limiter
 	r.Logger.Info("disabling rate limiter")


### PR DESCRIPTION
# Description
Closes https://github.com/zeta-chain/node/issues/2373

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new targets for upgrade testing: `start-upgrade-test-admin`, `start-upgrade-test-light`, and `start-upgrade-test` to facilitate different upgrade scenarios.

- **Bug Fixes**
  - Updated end-to-end test for rate limiter to handle `ETH` and `ERC20` withdrawals correctly.

- **Documentation**
  - Added changelog entry for newly added end-to-end test for upgrade and admin functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->