### PR TITLE
fix(ci): correct slack failure message conditional

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -101,7 +101,7 @@ jobs:
           path: /tmp/logs.txt
 
       - name: Notify Slack on Failure
-        if: failure() && (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'schedule'
+        if: failure() && ((github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'schedule')
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
# Description

We only want to send on failure so the conditional needs to be adjusted slightly.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to notify Slack only on failure events triggered by a push to the 'develop' branch or a scheduled event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->