### PR TITLE
refactor: add separate accounts  for each policy in e2e tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -76,7 +76,7 @@
 * [2349](https://github.com/zeta-chain/node/pull/2349) - add TestBitcoinDepositRefund and WithdrawBitcoinMultipleTimes E2E tests
 * [2368](https://github.com/zeta-chain/node/pull/2368) - eliminate panic usage across testing suite
 * [2369](https://github.com/zeta-chain/node/pull/2369) - fix random cross-chain swap failure caused by using tiny UTXO
-
+* [2549](https://github.com/zeta-chain/node/pull/2459) - add separate accounts for each policy in e2e tests
 
 ### Fixes
 

--- a/cmd/zetae2e/config/localnet.yml
+++ b/cmd/zetae2e/config/localnet.yml
@@ -32,10 +32,6 @@ additional_accounts:
     bech32_address: "zeta17w0adeg64ky0daxwd2ugyuneellmjgnx4e483s"
     evm_address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
     private_key: "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-  user_fungible_admin:
-    bech32_address: "zeta1svzuz982w09vf2y08xsh8qplj36phyz466krj3"
-    evm_address: "0x8305C114Ea73cAc4A88f39A173803F94741b9055"
-    private_key: "d88d09a7d6849c15a36eb6931f9dd616091a63e9849a2cc86f309ba11fb8fec5"
 policy_accounts:
   emergency_policy_account:
     bech32_address: "zeta16m2cnrdwtgweq4njc6t470vl325gw4kp6s7tap"

--- a/cmd/zetae2e/config/localnet.yml
+++ b/cmd/zetae2e/config/localnet.yml
@@ -36,6 +36,19 @@ additional_accounts:
     bech32_address: "zeta1svzuz982w09vf2y08xsh8qplj36phyz466krj3"
     evm_address: "0x8305C114Ea73cAc4A88f39A173803F94741b9055"
     private_key: "d88d09a7d6849c15a36eb6931f9dd616091a63e9849a2cc86f309ba11fb8fec5"
+policy_accounts:
+  emergency_policy_account:
+    bech32_address: "zeta16m2cnrdwtgweq4njc6t470vl325gw4kp6s7tap"
+    evm_address: "0xd6d5898dAE5A1D905672c6975F3d9f8aA88756C1"
+    private_key: "88BE93D11624B794F4BCC77BEA7385AF7EAD0B183B913485C74F0A803ABBC3F0"
+  operational_policy_account:
+    bech32_address: "zeta1pgx85vzx4fzh5zzyjqgs6a6cmaujd0xs8efrkc"
+    evm_address: "0x0A0c7a3046AA457A084490110d7758Df7926bcd0"
+    private_key: "59D1B982BD446545A1740ABD01F1ED9C162B72ACC1522B9B71B6DB5A9C37FA7D"
+  admin_policy_account:
+    bech32_address: "zeta142ds9x7raljv2qz9euys93e64gjmgdfnc47dwq"
+    evm_address: "0xAa9b029BC3EFe4c50045Cf0902c73aAa25b43533"
+    private_key: "0595CB0CD9BF5264A85A603EC8E43C30ADBB5FD2D9E2EF84C374EA4A65BB616C"
 rpcs:
   zevm: "http://zetacore0:8545"
   evm: "http://eth:8545"

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -126,8 +126,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 
 	zetaTxServer, err := txserver.NewZetaTxServer(
 		conf.RPCs.ZetaCoreRPC,
-		[]string{utils.FungibleAdminName},
-		[]string{conf.AdditionalAccounts.UserFungibleAdmin.RawPrivateKey.String()},
+		[]string{utils.EmergencyPolicyName, utils.OperationalPolicyName, utils.AdminPolicyName},
+		[]string{conf.PolicyAccounts.EmergencyPolicyAccount.RawPrivateKey.String(), conf.PolicyAccounts.OperationalPolicyAccount.RawPrivateKey.String(), conf.PolicyAccounts.AdminPolicyAccount.RawPrivateKey.String()},
 		conf.ZetaChainID,
 	)
 	noError(err)

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -127,7 +127,11 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	zetaTxServer, err := txserver.NewZetaTxServer(
 		conf.RPCs.ZetaCoreRPC,
 		[]string{utils.EmergencyPolicyName, utils.OperationalPolicyName, utils.AdminPolicyName},
-		[]string{conf.PolicyAccounts.EmergencyPolicyAccount.RawPrivateKey.String(), conf.PolicyAccounts.OperationalPolicyAccount.RawPrivateKey.String(), conf.PolicyAccounts.AdminPolicyAccount.RawPrivateKey.String()},
+		[]string{
+			conf.PolicyAccounts.EmergencyPolicyAccount.RawPrivateKey.String(),
+			conf.PolicyAccounts.OperationalPolicyAccount.RawPrivateKey.String(),
+			conf.PolicyAccounts.AdminPolicyAccount.RawPrivateKey.String(),
+		},
 		conf.ZetaChainID,
 	)
 	noError(err)

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -221,10 +221,19 @@ then
   zetacored add-genesis-account zeta1n0rn6sne54hv7w2uu93fl48ncyqz97d3kty6sh 100000000000000000000000000azeta # Funds the localnet_gov_admin account
   
   address=$(yq -r '.additional_accounts.user_fungible_admin.bech32_address' /root/config.yml)
+  emergency_policy=$(yq -r '.policy_accounts.emergency_policy_account.bech32_address' /root/config.yml)
+  admin_policy=$(yq -r '.policy_accounts.admin_policy_account.bech32_address' /root/config.yml)
+  operational_policy=$(yq -r '.policy_accounts.operational_policy_account.bech32_address' /root/config.yml)
+
+
   zetacored add-genesis-account "$address" 100000000000000000000000000azeta
-  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$address" '.app_state["authority"]["policies"]["items"][0]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$address" '.app_state["authority"]["policies"]["items"][1]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$address" '.app_state["authority"]["policies"]["items"][2]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  zetacored add-genesis-account "$emergency_policy" 100000000000000000000000000azeta
+  zetacored add-genesis-account "$admin_policy" 100000000000000000000000000azeta
+  zetacored add-genesis-account "$operational_policy" 100000000000000000000000000azeta
+
+  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$emergency_policy" '.app_state["authority"]["policies"]["items"][0]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$operational_policy" '.app_state["authority"]["policies"]["items"][1]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$admin_policy" '.app_state["authority"]["policies"]["items"][2]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
 
 # give balance to runner accounts to deploy contracts directly on zEVM
 # default account
@@ -241,6 +250,15 @@ then
   zetacored add-genesis-account "$address" 100000000000000000000000000azeta
 # ethers tester
   address=$(yq -r '.additional_accounts.user_ether.bech32_address' /root/config.yml)
+  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
+# emergency policy account
+  address=$(yq -r '.policy_accounts.emergency_policy_account.bech32_address' /root/config.yml)
+  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
+#  admin policy account
+  address=$(yq -r '.policy_accounts.admin_policy_account.bech32_address' /root/config.yml)
+  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
+#  operational policy account
+  address=$(yq -r '.policy_accounts.operational_policy_account.bech32_address' /root/config.yml)
   zetacored add-genesis-account "$address" 100000000000000000000000000azeta
 
 # 3. Copy the genesis.json to all the nodes .And use it to create a gentx for every node

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -219,8 +219,7 @@ then
 
 # set admin account
   zetacored add-genesis-account zeta1n0rn6sne54hv7w2uu93fl48ncyqz97d3kty6sh 100000000000000000000000000azeta # Funds the localnet_gov_admin account
-  
-  address=$(yq -r '.additional_accounts.user_fungible_admin.bech32_address' /root/config.yml)
+
   emergency_policy=$(yq -r '.policy_accounts.emergency_policy_account.bech32_address' /root/config.yml)
   admin_policy=$(yq -r '.policy_accounts.admin_policy_account.bech32_address' /root/config.yml)
   operational_policy=$(yq -r '.policy_accounts.operational_policy_account.bech32_address' /root/config.yml)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -58,14 +58,13 @@ type Account struct {
 
 // AdditionalAccounts are extra accounts required to run specific tests
 type AdditionalAccounts struct {
-	UserERC20         Account `yaml:"user_erc20"`
-	UserZetaTest      Account `yaml:"user_zeta_test"`
-	UserZEVMMPTest    Account `yaml:"user_zevm_mp_test"`
-	UserBitcoin       Account `yaml:"user_bitcoin"`
-	UserEther         Account `yaml:"user_ether"`
-	UserMisc          Account `yaml:"user_misc"`
-	UserAdmin         Account `yaml:"user_admin"`
-	UserFungibleAdmin Account `yaml:"user_fungible_admin"`
+	UserERC20      Account `yaml:"user_erc20"`
+	UserZetaTest   Account `yaml:"user_zeta_test"`
+	UserZEVMMPTest Account `yaml:"user_zevm_mp_test"`
+	UserBitcoin    Account `yaml:"user_bitcoin"`
+	UserEther      Account `yaml:"user_ether"`
+	UserMisc       Account `yaml:"user_misc"`
+	UserAdmin      Account `yaml:"user_admin"`
 }
 
 type PolicyAccounts struct {
@@ -199,7 +198,6 @@ func (a AdditionalAccounts) AsSlice() []Account {
 		a.UserEther,
 		a.UserMisc,
 		a.UserAdmin,
-		a.UserFungibleAdmin,
 	}
 }
 
@@ -209,7 +207,6 @@ func (a PolicyAccounts) AsSlice() []Account {
 		a.OperationalPolicyAccount,
 		a.AdminPolicyAccount,
 	}
-
 }
 
 // Validate validates the config
@@ -232,9 +229,21 @@ func (c Config) Validate() error {
 		}
 		err := account.Validate()
 		if err != nil {
-			return fmt.Errorf("validating account %d: %w", i, err)
+			return fmt.Errorf("validating additional account %d: %w", i, err)
 		}
 	}
+
+	policyAccounts := c.PolicyAccounts.AsSlice()
+	for i, account := range policyAccounts {
+		if account.RawEVMAddress == "" {
+			continue
+		}
+		err := account.Validate()
+		if err != nil {
+			return fmt.Errorf("validating policy account %d: %w", i, err)
+		}
+	}
+
 	return nil
 }
 
@@ -270,10 +279,6 @@ func (c *Config) GenerateKeys() error {
 		return err
 	}
 	c.AdditionalAccounts.UserAdmin, err = generateAccount()
-	if err != nil {
-		return err
-	}
-	c.AdditionalAccounts.UserFungibleAdmin, err = generateAccount()
 	if err != nil {
 		return err
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	// Default account to use when running tests and running setup
 	DefaultAccount     Account            `yaml:"default_account"`
 	AdditionalAccounts AdditionalAccounts `yaml:"additional_accounts"`
+	PolicyAccounts     PolicyAccounts     `yaml:"policy_accounts"`
 	RPCs               RPCs               `yaml:"rpcs"`
 	Contracts          Contracts          `yaml:"contracts"`
 	ZetaChainID        string             `yaml:"zeta_chain_id"`
@@ -65,6 +66,12 @@ type AdditionalAccounts struct {
 	UserMisc          Account `yaml:"user_misc"`
 	UserAdmin         Account `yaml:"user_admin"`
 	UserFungibleAdmin Account `yaml:"user_fungible_admin"`
+}
+
+type PolicyAccounts struct {
+	EmergencyPolicyAccount   Account `yaml:"emergency_policy_account"`
+	OperationalPolicyAccount Account `yaml:"operational_policy_account"`
+	AdminPolicyAccount       Account `yaml:"admin_policy_account"`
 }
 
 // RPCs contains the configuration for the RPC endpoints
@@ -196,6 +203,15 @@ func (a AdditionalAccounts) AsSlice() []Account {
 	}
 }
 
+func (a PolicyAccounts) AsSlice() []Account {
+	return []Account{
+		a.EmergencyPolicyAccount,
+		a.OperationalPolicyAccount,
+		a.AdminPolicyAccount,
+	}
+
+}
+
 // Validate validates the config
 func (c Config) Validate() error {
 	if c.RPCs.Bitcoin.Params != Mainnet &&
@@ -258,6 +274,18 @@ func (c *Config) GenerateKeys() error {
 		return err
 	}
 	c.AdditionalAccounts.UserFungibleAdmin, err = generateAccount()
+	if err != nil {
+		return err
+	}
+	c.PolicyAccounts.EmergencyPolicyAccount, err = generateAccount()
+	if err != nil {
+		return err
+	}
+	c.PolicyAccounts.OperationalPolicyAccount, err = generateAccount()
+	if err != nil {
+		return err
+	}
+	c.PolicyAccounts.AdminPolicyAccount, err = generateAccount()
 	if err != nil {
 		return err
 	}

--- a/e2e/e2etests/test_erc20_deposit_refund.go
+++ b/e2e/e2etests/test_erc20_deposit_refund.go
@@ -36,7 +36,11 @@ func TestERC20DepositAndCallRefund(r *runner.E2ERunner, _ []string) {
 	r.Logger.CCTX(*cctx, "deposit")
 	r.Logger.Info("Refunding the cctx via admin")
 
-	msg := types.NewMsgRefundAbortedCCTX(r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName), cctx.Index, r.EVMAddress().String())
+	msg := types.NewMsgRefundAbortedCCTX(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
+		cctx.Index,
+		r.EVMAddress().String(),
+	)
 
 	_, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, msg)
 	require.NoError(r, err)

--- a/e2e/e2etests/test_erc20_deposit_refund.go
+++ b/e2e/e2etests/test_erc20_deposit_refund.go
@@ -36,9 +36,9 @@ func TestERC20DepositAndCallRefund(r *runner.E2ERunner, _ []string) {
 	r.Logger.CCTX(*cctx, "deposit")
 	r.Logger.Info("Refunding the cctx via admin")
 
-	msg := types.NewMsgRefundAbortedCCTX(r.ZetaTxServer.GetAccountAddress(0), cctx.Index, r.EVMAddress().String())
+	msg := types.NewMsgRefundAbortedCCTX(r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName), cctx.Index, r.EVMAddress().String())
 
-	_, err = r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msg)
+	_, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, msg)
 	require.NoError(r, err)
 
 	// Check that the erc20 in the aborted cctx was refunded on ZetaChain

--- a/e2e/e2etests/test_eth_deposit_liquidity_cap.go
+++ b/e2e/e2etests/test_eth_deposit_liquidity_cap.go
@@ -25,11 +25,11 @@ func TestDepositEtherLiquidityCap(r *runner.E2ERunner, args []string) {
 	amountLessThanCap := liquidityCapArg.BigInt().Div(liquidityCapArg.BigInt(), big.NewInt(10)) // 1/10 of the cap
 	amountMoreThanCap := liquidityCapArg.BigInt().Mul(liquidityCapArg.BigInt(), big.NewInt(10)) // 10 times the cap
 	msg := fungibletypes.NewMsgUpdateZRC20LiquidityCap(
-		r.ZetaTxServer.GetAccountAddress(0),
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		r.ETHZRC20Addr.Hex(),
 		liquidityCap,
 	)
-	res, err := r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msg)
+	res, err := r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, msg)
 	require.NoError(r, err)
 
 	r.Logger.Info("set liquidity cap tx hash: %s", res.TxHash)
@@ -69,12 +69,12 @@ func TestDepositEtherLiquidityCap(r *runner.E2ERunner, args []string) {
 
 	r.Logger.Info("Removing the liquidity cap")
 	msg = fungibletypes.NewMsgUpdateZRC20LiquidityCap(
-		r.ZetaTxServer.GetAccountAddress(0),
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		r.ETHZRC20Addr.Hex(),
 		math.ZeroUint(),
 	)
 
-	res, err = r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msg)
+	res, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, msg)
 	require.NoError(r, err)
 
 	r.Logger.Info("remove liquidity cap tx hash: %s", res.TxHash)

--- a/e2e/e2etests/test_migrate_chain_support.go
+++ b/e2e/e2etests/test_migrate_chain_support.go
@@ -58,19 +58,17 @@ func TestMigrateChainSupport(r *runner.E2ERunner, _ []string) {
 
 	// update the chain params to set up the chain
 	chainParams := getNewEVMChainParams(newRunner)
-	adminAddr, err := newRunner.ZetaTxServer.GetAccountAddressFromName(utils.FungibleAdminName)
-	require.NoError(r, err)
 
-	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, observertypes.NewMsgUpdateChainParams(
-		adminAddr,
+	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, observertypes.NewMsgUpdateChainParams(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		chainParams,
 	))
 	require.NoError(r, err)
 
 	// setup the gas token
 	require.NoError(r, err)
-	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, fungibletypes.NewMsgDeployFungibleCoinZRC20(
-		adminAddr,
+	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, fungibletypes.NewMsgDeployFungibleCoinZRC20(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		"",
 		chainParams.ChainId,
 		18,
@@ -95,8 +93,8 @@ func TestMigrateChainSupport(r *runner.E2ERunner, _ []string) {
 	newRunner.ETHZRC20 = ethZRC20
 
 	// set the chain nonces for the new chain
-	_, err = r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, observertypes.NewMsgResetChainNonces(
-		adminAddr,
+	_, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, observertypes.NewMsgResetChainNonces(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		chainParams.ChainId,
 		0,
 		0,
@@ -106,8 +104,8 @@ func TestMigrateChainSupport(r *runner.E2ERunner, _ []string) {
 	// deactivate the previous chain
 	chainParams = observertypes.GetDefaultGoerliLocalnetChainParams()
 	chainParams.IsSupported = false
-	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, observertypes.NewMsgUpdateChainParams(
-		adminAddr,
+	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, observertypes.NewMsgUpdateChainParams(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		chainParams,
 	))
 	require.NoError(r, err)
@@ -155,8 +153,8 @@ func TestMigrateChainSupport(r *runner.E2ERunner, _ []string) {
 
 	// whitelist erc20 zrc20
 	newRunner.Logger.Info("whitelisting ERC20 on new network")
-	res, err := newRunner.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, crosschaintypes.NewMsgWhitelistERC20(
-		adminAddr,
+	res, err := newRunner.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, crosschaintypes.NewMsgWhitelistERC20(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		newRunner.ERC20Addr.Hex(),
 		chains.Sepolia.ChainId,
 		"USDT",

--- a/e2e/e2etests/test_migrate_chain_support.go
+++ b/e2e/e2etests/test_migrate_chain_support.go
@@ -67,16 +67,19 @@ func TestMigrateChainSupport(r *runner.E2ERunner, _ []string) {
 
 	// setup the gas token
 	require.NoError(r, err)
-	_, err = newRunner.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, fungibletypes.NewMsgDeployFungibleCoinZRC20(
-		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
-		"",
-		chainParams.ChainId,
-		18,
-		"Sepolia ETH",
-		"sETH",
-		coin.CoinType_Gas,
-		100000,
-	))
+	_, err = newRunner.ZetaTxServer.BroadcastTx(
+		utils.OperationalPolicyName,
+		fungibletypes.NewMsgDeployFungibleCoinZRC20(
+			r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
+			"",
+			chainParams.ChainId,
+			18,
+			"Sepolia ETH",
+			"sETH",
+			coin.CoinType_Gas,
+			100000,
+		),
+	)
 	require.NoError(r, err)
 
 	// set the gas token in the runner

--- a/e2e/e2etests/test_pause_zrc20.go
+++ b/e2e/e2etests/test_pause_zrc20.go
@@ -35,10 +35,10 @@ func TestPauseZRC20(r *runner.E2ERunner, _ []string) {
 	// Pause ETH ZRC20
 	r.Logger.Info("Pausing ETH")
 	msgPause := fungibletypes.NewMsgPauseZRC20(
-		r.ZetaTxServer.GetAccountAddress(0),
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.EmergencyPolicyName),
 		[]string{r.ETHZRC20Addr.Hex()},
 	)
-	res, err := r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msgPause)
+	res, err := r.ZetaTxServer.BroadcastTx(utils.EmergencyPolicyName, msgPause)
 	require.NoError(r, err)
 	r.Logger.Info("pause zrc20 tx hash: %s", res.TxHash)
 
@@ -106,10 +106,10 @@ func TestPauseZRC20(r *runner.E2ERunner, _ []string) {
 	// Unpause ETH ZRC20
 	r.Logger.Info("Unpausing ETH")
 	msgUnpause := fungibletypes.NewMsgUnpauseZRC20(
-		r.ZetaTxServer.GetAccountAddress(0),
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
 		[]string{r.ETHZRC20Addr.Hex()},
 	)
-	res, err = r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msgUnpause)
+	res, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, msgUnpause)
 	require.NoError(r, err)
 
 	r.Logger.Info("unpause zrc20 tx hash: %s", res.TxHash)

--- a/e2e/e2etests/test_rate_limiter.go
+++ b/e2e/e2etests/test_rate_limiter.go
@@ -167,11 +167,11 @@ func waitForWithdrawMined(
 
 // setupRateLimiterFlags sets up the rate limiter flags with flags defined in the test
 func setupRateLimiterFlags(r *runner.E2ERunner, flags crosschaintypes.RateLimiterFlags) error {
-	adminAddr, err := r.ZetaTxServer.GetAccountAddressFromName(utils.FungibleAdminName)
+	adminAddr, err := r.ZetaTxServer.GetAccountAddressFromName(utils.OperationalPolicyName)
 	if err != nil {
 		return err
 	}
-	_, err = r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, crosschaintypes.NewMsgUpdateRateLimiterFlags(
+	_, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, crosschaintypes.NewMsgUpdateRateLimiterFlags(
 		adminAddr,
 		flags,
 	))

--- a/e2e/e2etests/test_update_bytecode_connector.go
+++ b/e2e/e2etests/test_update_bytecode_connector.go
@@ -46,11 +46,11 @@ func TestUpdateBytecodeConnector(r *runner.E2ERunner, _ []string) {
 
 	r.Logger.Info("Updating the bytecode of the Connector")
 	msg := fungibletypes.NewMsgUpdateContractBytecode(
-		r.ZetaTxServer.GetAccountAddress(0),
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.AdminPolicyName),
 		r.ConnectorZEVMAddr.Hex(),
 		codeHashRes.CodeHash,
 	)
-	res, err := r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msg)
+	res, err := r.ZetaTxServer.BroadcastTx(utils.AdminPolicyName, msg)
 	require.NoError(r, err)
 	r.Logger.Info("Update connector bytecode tx hash: %s", res.TxHash)
 

--- a/e2e/e2etests/test_update_bytecode_zrc20.go
+++ b/e2e/e2etests/test_update_bytecode_zrc20.go
@@ -68,11 +68,11 @@ func TestUpdateBytecodeZRC20(r *runner.E2ERunner, _ []string) {
 
 	r.Logger.Info("Updating the bytecode of the ZRC20")
 	msg := fungibletypes.NewMsgUpdateContractBytecode(
-		r.ZetaTxServer.GetAccountAddress(0),
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.AdminPolicyName),
 		r.ETHZRC20Addr.Hex(),
 		codeHashRes.CodeHash,
 	)
-	res, err := r.ZetaTxServer.BroadcastTx(utils.FungibleAdminName, msg)
+	res, err := r.ZetaTxServer.BroadcastTx(utils.AdminPolicyName, msg)
 	require.NoError(r, err)
 
 	r.Logger.Info("Update zrc20 bytecode tx hash: %s", res.TxHash)

--- a/e2e/runner/setup_zeta.go
+++ b/e2e/runner/setup_zeta.go
@@ -75,7 +75,7 @@ func (r *E2ERunner) SetZEVMContracts() {
 
 	// deploy system contracts and ZRC20 contracts on ZetaChain
 	uniswapV2FactoryAddr, uniswapV2RouterAddr, zevmConnectorAddr, wzetaAddr, erc20zrc20Addr, err := r.ZetaTxServer.DeploySystemContractsAndZRC20(
-		e2eutils.FungibleAdminName,
+		e2eutils.OperationalPolicyName,
 		r.ERC20Addr.Hex(),
 	)
 	require.NoError(r, err)
@@ -209,12 +209,12 @@ func (r *E2ERunner) SetupBTCZRC20() {
 func (r *E2ERunner) EnableHeaderVerification(chainIDList []int64) error {
 	r.Logger.Print("⚙️ enabling verification flags for block headers")
 
-	return r.ZetaTxServer.EnableHeaderVerification(e2eutils.FungibleAdminName, chainIDList)
+	return r.ZetaTxServer.EnableHeaderVerification(e2eutils.OperationalPolicyName, chainIDList)
 }
 
 // FundEmissionsPool funds the emissions pool on ZetaChain with the same value as used originally on mainnet (20M ZETA)
 func (r *E2ERunner) FundEmissionsPool() error {
 	r.Logger.Print("⚙️ funding the emissions pool on ZetaChain with 20M ZETA (%s)", txserver.EmissionsPoolAddress)
 
-	return r.ZetaTxServer.FundEmissionsPool(e2eutils.FungibleAdminName, EmissionsPoolFunding)
+	return r.ZetaTxServer.FundEmissionsPool(e2eutils.OperationalPolicyName, EmissionsPoolFunding)
 }

--- a/e2e/txserver/zeta_tx_server.go
+++ b/e2e/txserver/zeta_tx_server.go
@@ -153,7 +153,8 @@ func (zts ZetaTxServer) GetAccountAddressFromName(name string) (string, error) {
 	return addr.String(), nil
 }
 
-// GetAccountAddressFromName returns the account address from the given name
+// MustGetAccountAddressFromName returns the account address from the given name.It panics on error
+// and should be used in tests only
 func (zts ZetaTxServer) MustGetAccountAddressFromName(name string) string {
 	acc, err := zts.clientCtx.Keyring.Key(name)
 	if err != nil {

--- a/e2e/txserver/zeta_tx_server.go
+++ b/e2e/txserver/zeta_tx_server.go
@@ -153,6 +153,19 @@ func (zts ZetaTxServer) GetAccountAddressFromName(name string) (string, error) {
 	return addr.String(), nil
 }
 
+// GetAccountAddressFromName returns the account address from the given name
+func (zts ZetaTxServer) MustGetAccountAddressFromName(name string) string {
+	acc, err := zts.clientCtx.Keyring.Key(name)
+	if err != nil {
+		panic(err)
+	}
+	addr, err := acc.GetAddress()
+	if err != nil {
+		panic(err)
+	}
+	return addr.String()
+}
+
 // GetAllAccountAddress returns all account addresses
 func (zts ZetaTxServer) GetAllAccountAddress() []string {
 	return zts.address

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -18,6 +18,10 @@ type CCTXClient = crosschaintypes.QueryClient
 const (
 	FungibleAdminName = "fungibleadmin"
 
+	EmergencyPolicyName   = "emergency"
+	AdminPolicyName       = "admin"
+	OperationalPolicyName = "operational"
+
 	DefaultCctxTimeout = 4 * time.Minute
 )
 

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -16,8 +16,6 @@ import (
 type CCTXClient = crosschaintypes.QueryClient
 
 const (
-	FungibleAdminName = "fungibleadmin"
-
 	EmergencyPolicyName   = "emergency"
 	AdminPolicyName       = "admin"
 	OperationalPolicyName = "operational"


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/2447
# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced separate policy accounts: emergency, operational, and admin, for more granular control.

- **Refactor**
  - Replaced `FungibleAdminName` with new policy names across tests and configurations.
  - Updated scripts to support newly defined policy accounts.
  - Enhanced end-to-end test configuration to utilize multiple policy accounts.

- **Bug Fixes**
  - Fixed issues with transaction broadcasting by using specific policy accounts.

- **Documentation**
  - Updated changelog to reflect changes in account handling and policy account introductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->