### PR TITLE
test(e2e): temporarily disable rate limiter e2e test

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -273,11 +273,19 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	}
 	if testAdmin {
 		eg.Go(adminTestRoutine(conf, deployerRunner, verbose,
-			e2etests.TestRateLimiterName,
 			e2etests.TestPauseZRC20Name,
 			e2etests.TestUpdateBytecodeZRC20Name,
 			e2etests.TestUpdateBytecodeConnectorName,
 			e2etests.TestDepositEtherLiquidityCapName,
+
+			// TestRateLimiterName tests rate limiter functionality.
+			// Currently, there is a bug with the test and it is therefore disabled (see issue below)
+			// We disable the test as a workaround for the time being as it doesn't effectively test the functionality
+			// TODO: fix the error causing the test failure
+			// https://github.com/zeta-chain/node/issues/2424
+			// TODO: define proper threshold for test assertion
+			// https://github.com/zeta-chain/node/issues/2090
+			// e2etests.TestRateLimiterName,
 
 			// TestMigrateChainSupportName tests EVM chain migration. Currently this test doesn't work with Anvil because pre-EIP1559 txs are not supported
 			// See issue below for details


### PR DESCRIPTION
# Description

Temporarily disable the rate limiter E2E test for letting other admin test pass.
Issue for the bug tracked: https://github.com/zeta-chain/node/issues/2424

Disabling the test for now is a easier workaround as the rate limiter E2E test doesn't properly test the functionality: https://github.com/zeta-chain/node/issues/2090 and we need the other test to be testable directly in the CI to simplify the testing process for the coming release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Temporarily disabled rate limiter test causing failures to investigate and fix the issue.
  
- **Chores**
  - Updated test suite to remove the problematic rate limiter test from routine checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->