### PR TITLE
fix(`zetaclient`): increase gas limit inbound and outbound vote message to 500k

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -93,6 +93,7 @@
 * [2382](https://github.com/zeta-chain/node/pull/2382) - add tx input and gas in rpc methods for synthetic eth txs
 * [2396](https://github.com/zeta-chain/node/issues/2386) - special handle bitcoin testnet gas price estimator
 * [2434](https://github.com/zeta-chain/node/pull/2434) - the default database when running `zetacored init` is now pebbledb
+* [2481](https://github.com/zeta-chain/node/pull/2481) - increase gas limit inbound and outbound vote message to 500k
 
 ### CI
 * [2388](https://github.com/zeta-chain/node/pull/2388) - added GitHub attestations of binaries produced in the release workflow. 

--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -13,7 +13,7 @@ const (
 	PostGasPriceGasLimit = 1_500_000
 
 	// PostVoteInboundGasLimit is the gas limit for voting on observed inbound tx (for zetachain itself)
-	PostVoteInboundGasLimit = 400_000
+	PostVoteInboundGasLimit = 500_000
 
 	// PostVoteInboundExecutionGasLimit is the gas limit for voting on observed inbound tx and executing it
 	PostVoteInboundExecutionGasLimit = 4_000_000

--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -37,7 +37,7 @@ const (
 	DefaultRetryInterval = 5
 
 	// PostVoteOutboundGasLimit is the gas limit for voting on observed outbound tx (for zetachain itself)
-	PostVoteOutboundGasLimit = 400_000
+	PostVoteOutboundGasLimit = 500_000
 
 	// PostVoteOutboundRevertGasLimit is the gas limit for voting on observed outbound tx for revert (when outbound fails)
 	// The value needs to be higher because reverting implies interacting with the EVM to perform swaps for the gas token


### PR DESCRIPTION
# Description

Increase the gas limit to 500_000 for vote inbound message to prevent out of gas issue that occurred with voting processing

Closes: https://github.com/zeta-chain/node/issues/2468

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased gas limit for inbound and outbound vote messages to 500k, providing enhanced transaction capacity and reliability.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->