### PR TITLE
perf(`crosschain`): increase the outbound tracker buffer from 2 to 5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,10 @@
 
 * [2321](https://github.com/zeta-chain/node/pull/2321) - improve documentation for ZetaClient functions and packages
 
+### Performance
+
+* [2482](https://github.com/zeta-chain/node/pull/2482) - increase the outbound tracker buffer length from 2 to 5
+
 ## v17.0.0
 
 ### Fixes

--- a/x/crosschain/keeper/msg_server_add_outbound_tracker.go
+++ b/x/crosschain/keeper/msg_server_add_outbound_tracker.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MaxOutboundTrackerHashes is the maximum number of hashes that can be stored in the outbound transaction tracker
-const MaxOutboundTrackerHashes = 2
+const MaxOutboundTrackerHashes = 5
 
 // AddOutboundTracker adds a new record to the outbound transaction tracker.
 // only the admin policy account and the observer validators are authorized to broadcast this message without proof.


### PR DESCRIPTION
# Description

Increase the outbound tracker buffer size from 2 to 5 to mitigate the risk of observers from pushing tx hashes from orphan blocks.

5 chosen as a arbitrary value. The issue of invalid hashes appear about once a month with size of 2. I think 5 is a good number to prevent this scenario.

Closes: https://github.com/zeta-chain/node/issues/2477

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Enhancements**
  - Increased the outbound tracker buffer length from 2 to 5, allowing for improved handling of outbound transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->