### PR TITLE
ci: fix slack matrix notifications

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -165,6 +165,48 @@ jobs:
       - e2e
     if: always()
     steps:
+      - name: Send slack message with results
+        uses: actions/github-script@v7
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && needs.e2e.result == 'failed') }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INTEGRATION_TESTING_WEBHOOK }}
+        with:
+          script: |
+            const {data} = await github.rest.actions.listJobsForWorkflowRunAttempt({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              attempt_number: ${{ github.run_attempt }},
+            });
+
+            const e2eJobs = data.jobs.filter(job => job.name.includes('/') && job.conclusion != 'skipped');
+
+            const e2eResults = e2eJobs.map(job => {
+              const icon = job.conclusion === 'success' ? ':white_check_mark:' : ':x:';
+              const cleanName = job.name.split("/")[0];
+              return `${icon} ${cleanName}`;
+            });
+
+            const overallResultStr = '${{ needs.e2e.result }}';
+            const overallResultPassing = overallResultStr === 'success' || overallResultStr === 'skipped';
+            const overallResultIcon = overallResultPassing ? ':white_check_mark:' : ':x:';
+            let overallResultText = `<https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}|E2E Test Run Results>`;
+            if (context.eventName === 'push') {
+              overallResultText += ` for push to ${context.ref}`;
+            } else if (context.eventName === 'schedule') {
+              overallResultText += ` for scheduled run`;
+            }
+            const msg = `${overallResultIcon} ${overallResultText}\n${e2eResults.join('\n')}`;
+
+            await fetch(process.env.SLACK_WEBHOOK_URL, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({text: msg}),
+            });
+
+
       - run: |
           result="${{ needs.e2e.result }}"
           if [[ $result == "success" || $result == "skipped" ]]; then

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -100,15 +100,6 @@ jobs:
           name: ${{ inputs.make-target }}-docker-logs
           path: /tmp/logs.txt
 
-      - name: Notify Slack on Failure
-        if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}
-
       - name: Stop Private Network
         if: always()
         run: |


### PR DESCRIPTION
# Description

The slack e2e failure webhooks haven't been working quite right since #2422. Move the alert step from the reusable workflow to the top level e2e workflow and manually format and send the message. Now we'll only see one message per matrix run and the URL will actually work.

# How Has This Been Tested?

See [this slack channel for example](https://zetachain.slack.com/archives/C04S1CLSTPB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a step in the GitHub Actions workflow to send Slack notifications with E2E test results.
  - Removed redundant Slack notification step from the reusable E2E workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->