### PR TITLE
ci: update e2e slack webhook url

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/github-script@v7
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && needs.e2e.result == 'failed') }}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INTEGRATION_TESTING_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}
         with:
           script: |
             const {data} = await github.rest.actions.listJobsForWorkflowRunAttempt({


### PR DESCRIPTION
I used the testing url not the main url in #2496 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Slack webhook URL used in GitHub Actions for CI alerts to enhance integration with Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->