### PR TITLE
refactor(fungible): remove chain name from zrc20 name on gas deployment

### DIFF
--- a/x/fungible/keeper/gas_coin_and_pool.go
+++ b/x/fungible/keeper/gas_coin_and_pool.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"math/big"
 
 	cosmoserrors "cosmossdk.io/errors"
@@ -35,7 +34,6 @@ func (k Keeper) SetupChainGasCoinAndPool(
 	if !found {
 		return ethcommon.Address{}, zetaObserverTypes.ErrSupportedChains
 	}
-	name := fmt.Sprintf("%s-%s", gasAssetName, chain.ChainName)
 
 	transferGasLimit := gasLimit
 
@@ -55,7 +53,7 @@ func (k Keeper) SetupChainGasCoinAndPool(
 
 	zrc20Addr, err := k.DeployZRC20Contract(
 		ctx,
-		name,
+		gasAssetName,
 		symbol,
 		decimals,
 		chain.ChainId,
@@ -68,7 +66,7 @@ func (k Keeper) SetupChainGasCoinAndPool(
 	}
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(sdk.EventTypeMessage,
-			sdk.NewAttribute(name, zrc20Addr.String()),
+			sdk.NewAttribute(gasAssetName, zrc20Addr.String()),
 		),
 	)
 	err = k.SetGasCoin(ctx, big.NewInt(chain.ChainId), zrc20Addr)


### PR DESCRIPTION
# Description

The name of the ZRC20 can be fully set in the message proposal, we don't need to automatically add chainName as a suffix to the token name

Related: https://github.com/zeta-chain/node/issues/2005 - allows to support new chain without requiring to hardcoded a new chain name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined logic for setting up the gas asset in the system, enhancing clarity and simplicity.
  
- **Bug Fixes**
	- Improved handling of the gas asset name, ensuring more accurate event emissions related to the asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->