### PR TITLE
feat: support Solana wallet address in zetacore for SOL withdrawals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * [2372](https://github.com/zeta-chain/node/pull/2372) - add queries for tss fund migration info
 * [2416](https://github.com/zeta-chain/node/pull/2416) - add Solana chain information
 * [2465](https://github.com/zeta-chain/node/pull/2465) - add Solana inbound SOL token observation
+* [2518](https://github.com/zeta-chain/node/pull/2518) - add support for Solana address in zetacore
 
 ### Refactor
 

--- a/pkg/chains/address.go
+++ b/pkg/chains/address.go
@@ -88,7 +88,7 @@ func DecodeBtcAddress(inputAddress string, chainID int64) (address btcutil.Addre
 	return
 }
 
-// DecodeSolanaWalletAddress decodes a Solana wallet address from a given string
+// DecodeSolanaWalletAddress decodes a Solana wallet address from a given string.
 func DecodeSolanaWalletAddress(inputAddress string) (pk solana.PublicKey, err error) {
 	// decode the Base58 encoded address
 	pk, err = solana.PublicKeyFromBase58(inputAddress)
@@ -96,8 +96,9 @@ func DecodeSolanaWalletAddress(inputAddress string) (pk solana.PublicKey, err er
 		return solana.PublicKey{}, errors.Wrapf(err, "error decoding solana wallet address %s", inputAddress)
 	}
 
-	// accept address that is generated from keypair
-	// reject off-curve address such as program derived address from 'findProgramAddress'
+	// there are two types of Solana addresses.
+	// accept address that is generated from keypair.
+	// reject off-curve address such as program derived address from 'findProgramAddress'.
 	if !pk.IsOnCurve() {
 		return solana.PublicKey{}, fmt.Errorf("address %s is not on ed25519 curve", inputAddress)
 	}

--- a/pkg/chains/address_test.go
+++ b/pkg/chains/address_test.go
@@ -100,47 +100,43 @@ func TestDecodeBtcAddress(t *testing.T) {
 
 func Test_DecodeSolanaWalletAddress(t *testing.T) {
 	tests := []struct {
-		name    string
-		address string
-		want    string
-		fail    bool
-		message string
+		name         string
+		address      string
+		want         string
+		errorMessage string
 	}{
 		{
-			name:    "should decode a valid Solana wallet address",
-			address: "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
-			want:    "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
-			fail:    false,
+			name:         "should decode a valid Solana wallet address",
+			address:      "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
+			want:         "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
+			errorMessage: "",
 		},
 		{
-			name:    "should fail to decode an address with invalid length",
-			address: "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveK",
-			want:    "",
-			fail:    true,
-			message: "error decoding solana wallet address",
+			name:         "should fail to decode an address with invalid length",
+			address:      "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveK",
+			want:         "",
+			errorMessage: "error decoding solana wallet address",
 		},
 		{
-			name:    "should fail to decode an invalid Base58 address",
-			address: "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFl", // contains invalid character 'l'
-			want:    "",
-			fail:    true,
-			message: "error decoding solana wallet address",
+			name:         "should fail to decode an invalid Base58 address",
+			address:      "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFl", // contains invalid character 'l'
+			want:         "",
+			errorMessage: "error decoding solana wallet address",
 		},
 		{
-			name:    "should fail to decode a program derived address (not on ed25519 curve)",
-			address: "9dcAyYG4bawApZocwZSyJBi9Mynf5EuKAJfifXdfkqik",
-			want:    "",
-			fail:    true,
-			message: "is not on ed25519 curve",
+			name:         "should fail to decode a program derived address (not on ed25519 curve)",
+			address:      "9dcAyYG4bawApZocwZSyJBi9Mynf5EuKAJfifXdfkqik",
+			want:         "",
+			errorMessage: "is not on ed25519 curve",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pk, err := DecodeSolanaWalletAddress(tt.address)
-			if tt.fail {
+			if tt.errorMessage != "" {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.message)
+				require.Contains(t, err.Error(), tt.errorMessage)
 				return
 			}
 

--- a/pkg/chains/address_test.go
+++ b/pkg/chains/address_test.go
@@ -98,6 +98,58 @@ func TestDecodeBtcAddress(t *testing.T) {
 	})
 }
 
+func Test_DecodeSolanaWalletAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		want    string
+		fail    bool
+		message string
+	}{
+		{
+			name:    "should decode a valid Solana wallet address",
+			address: "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
+			want:    "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
+			fail:    false,
+		},
+		{
+			name:    "should fail to decode an address with invalid length",
+			address: "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveK",
+			want:    "",
+			fail:    true,
+			message: "error decoding solana wallet address",
+		},
+		{
+			name:    "should fail to decode an invalid Base58 address",
+			address: "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFl", // contains invalid character 'l'
+			want:    "",
+			fail:    true,
+			message: "error decoding solana wallet address",
+		},
+		{
+			name:    "should fail to decode a program derived address (not on ed25519 curve)",
+			address: "9dcAyYG4bawApZocwZSyJBi9Mynf5EuKAJfifXdfkqik",
+			want:    "",
+			fail:    true,
+			message: "is not on ed25519 curve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pk, err := DecodeSolanaWalletAddress(tt.address)
+			if tt.fail {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.message)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, pk.String())
+		})
+	}
+}
+
 func Test_IsBtcAddressSupported_P2TR(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/chains/chain.go
+++ b/pkg/chains/chain.go
@@ -80,7 +80,7 @@ func (chain Chain) EncodeAddress(b []byte) (string, error) {
 		}
 		return pk.String(), nil
 	default:
-		return "", fmt.Errorf("chain (%d) not supported", chain.ChainId)
+		return "", fmt.Errorf("chain id %d not supported", chain.ChainId)
 	}
 }
 

--- a/pkg/chains/chain_test.go
+++ b/pkg/chains/chain_test.go
@@ -1,8 +1,9 @@
 package chains_test
 
 import (
-	"github.com/zeta-chain/zetacore/testutil/sample"
 	"testing"
+
+	"github.com/zeta-chain/zetacore/testutil/sample"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -146,43 +147,43 @@ func TestChain_EncodeAddress(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "should error if b is not a valid address on the bitcoin network",
-			chain: chains.Chain{
-				ChainName: chains.ChainName_btc_testnet,
-				ChainId:   18332,
-				Consensus: chains.Consensus_bitcoin,
-			},
+			name:    "should error if b is not a valid address on the bitcoin network",
+			chain:   chains.BitcoinTestnet,
 			b:       []byte("bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c"),
 			want:    "",
 			wantErr: true,
 		},
 		{
-			name: "should pass if b is a valid address on the network",
-			chain: chains.Chain{
-				ChainName: chains.ChainName_btc_mainnet,
-				ChainId:   8332,
-				Consensus: chains.Consensus_bitcoin,
-			},
+			name:    "should pass if b is a valid address on the network",
+			chain:   chains.BitcoinMainnet,
 			b:       []byte("bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c"),
 			want:    "bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c",
 			wantErr: false,
 		},
 		{
-			name: "should error if b is not a valid address on the evm network",
-			chain: chains.Chain{
-				ChainName: chains.ChainName_goerli_testnet,
-				ChainId:   5,
-			},
+			name:    "should pass if b is a valid wallet address on the solana network",
+			chain:   chains.SolanaMainnet,
+			b:       []byte("DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw"),
+			want:    "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
+			wantErr: false,
+		},
+		{
+			name:    "should error if b is not a valid Base58 address",
+			chain:   chains.SolanaMainnet,
+			b:       []byte("9G0P8HkKqegZ7B6cE2hGvkZjHjSH14WZXDNZQmwYLokAc"), // contains invalid digit '0'
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "should error if b is not a valid address on the evm network",
+			chain:   chains.Ethereum,
 			b:       ethcommon.Hex2Bytes("0x321"),
 			want:    "",
 			wantErr: true,
 		},
 		{
-			name: "should pass if b is a valid address on the evm network",
-			chain: chains.Chain{
-				ChainName: chains.ChainName_goerli_testnet,
-				ChainId:   5,
-			},
+			name:    "should pass if b is a valid address on the evm network",
+			chain:   chains.Ethereum,
 			b:       []byte("0x321"),
 			want:    "0x0000000000000000000000000000003078333231",
 			wantErr: false,
@@ -293,6 +294,12 @@ func TestDecodeAddressFromChainID(t *testing.T) {
 			chainID: chains.BitcoinMainnet.ChainId,
 			addr:    "bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c",
 			want:    []byte("bc1qk0cc73p8m7hswn8y2q080xa4e5pxapnqgp7h9c"),
+		},
+		{
+			name:    "Solana",
+			chainID: chains.SolanaMainnet.ChainId,
+			addr:    "DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw",
+			want:    []byte("DCAK36VfExkPdAkYUQg6ewgxyinvcEyPLyHjRbmveKFw"),
 		},
 		{
 			name:    "Non-supported chain",

--- a/x/crosschain/keeper/cctx_orchestrator_validate_inbound_test.go
+++ b/x/crosschain/keeper/cctx_orchestrator_validate_inbound_test.go
@@ -623,6 +623,7 @@ func TestKeeper_CheckMigration(t *testing.T) {
 		authorityMock := keepertest.GetCrosschainAuthorityMock(t, k)
 		chain := chains.Chain{
 			ChainId:     999,
+			Network:     chains.Network_btc,
 			Consensus:   chains.Consensus_bitcoin,
 			CctxGateway: chains.CCTXGateway_observers,
 		}


### PR DESCRIPTION
# Description

- [x] Add support for Solana address in `zetacored`

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Solana addresses, enhancing interoperability with the Solana blockchain.
	- Introduced a new function for decoding Solana wallet addresses.
- **Bug Fixes**
	- Improved error handling for invalid Solana addresses.
- **Tests**
	- Added extensive test cases for decoding and validating Solana wallet addresses.
	- Updated existing tests for better clarity and maintainability.
- **Chores**
	- Updated changelog to reflect the new features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->