### PR TITLE
ci: fix nightly performance tests

### DIFF
--- a/.github/workflows/ci-nightly-performance-testing.yaml
+++ b/.github/workflows/ci-nightly-performance-testing.yaml
@@ -8,7 +8,9 @@ on:
         required: false
         default: 'http://localhost:9545'
   schedule:
-    - cron: '0 0 * * *' # Runs every day at midnight UTC
+    # run at 6AM UTC Daily
+    # 6AM UTC -> 11PM PT
+    - cron: "0 6 * * *"
 
 jobs:
   nightly_evm_api_performance_test:
@@ -35,10 +37,10 @@ jobs:
       - name: "CONFIGURE:PERFORMANCE:TEMPLATE"
         env:
           CLOUDFLARE_UUID: ${{ secrets.CLOUDFLARE_UUID }}
+          ENDPOINT: ${{ inputs.endpoint || 'http://localhost:9545' }}
         run: |
           # Replace -=endpoint_to_test=- placeholder in the art.yaml file with the endpoint_to_test value
-          sed -i "s|-=endpoint_to_test=-|${{inputs.endpoint}}|g" .github/actions/performance-tests/art.yaml
-          echo "CLOUDFLARE_UUID=${{ secrets.CLOUDFLARE_UUID }}" >> ${GITHUB_ENV}
+          sed -i "s|-=endpoint_to_test=-|${ENDPOINT}|g" .github/actions/performance-tests/art.yaml
           # Replace -=CLOUDFLARE_UUID=- placeholder in the art.yaml file with the correct value
           sed -i "s|-=CLOUDFLARE_UUID=-|${CLOUDFLARE_UUID}|g" .github/actions/performance-tests/art.yaml
           cat .github/actions/performance-tests/art.yaml
@@ -109,5 +111,6 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          job_name: "NIGHTLY:EVM:API:PERFORMANCE:TEST"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}


### PR DESCRIPTION
# Description

- endpoint was not set correctly for schedule trigger
- slack notifier needs [job_name](https://action-slack.netlify.app/usage/with/#job_name)
- adjust schedule

[Actions run](https://github.com/zeta-chain/node/actions/runs/10015117687)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Adjusted the schedule for nightly performance tests to run at 6 AM UTC, improving execution timing.
  - Enhanced robustness by implementing a fallback for the `ENDPOINT` environment variable, ensuring a valid endpoint is always used.
  - Streamlined configuration by updating the placeholder replacement process for improved clarity in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->