### PR TITLE
fix(`e2e`): remove hardcoded value for approval in withdrawal tests

### DIFF
--- a/e2e/e2etests/test_erc20_withdraw.go
+++ b/e2e/e2etests/test_erc20_withdraw.go
@@ -15,8 +15,8 @@ func TestERC20Withdraw(r *runner.E2ERunner, args []string) {
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok, "Invalid withdrawal amount specified for TestERC20Withdraw.")
 
-	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ERC20ZRC20Addr, withdrawalAmount)
+	// approve 1 unit of the gas token to cover the gas fee
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ERC20ZRC20Addr, big.NewInt(1e18))
 	require.NoError(r, err)
 
 	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)

--- a/e2e/e2etests/test_erc20_withdraw.go
+++ b/e2e/e2etests/test_erc20_withdraw.go
@@ -12,14 +12,11 @@ import (
 func TestERC20Withdraw(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
-	approvedAmount := big.NewInt(1e18)
-
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok, "Invalid withdrawal amount specified for TestERC20Withdraw.")
-	require.Equal(r, -1, withdrawalAmount.Cmp(approvedAmount))
 
 	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ERC20ZRC20Addr, approvedAmount)
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ERC20ZRC20Addr, withdrawalAmount)
 	require.NoError(r, err)
 
 	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)

--- a/e2e/e2etests/test_eth_withdraw.go
+++ b/e2e/e2etests/test_eth_withdraw.go
@@ -17,8 +17,11 @@ func TestEtherWithdraw(r *runner.E2ERunner, args []string) {
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok, "Invalid withdrawal amount specified for TestEtherWithdraw.")
 
+	// add one unit to the withdrawal amount to account for the approval because withdrawal fees are automatically deducted
+	approvalAmount := new(big.Int).Add(withdrawalAmount, big.NewInt(1e18))
+
 	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, withdrawalAmount)
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, approvalAmount)
 	require.NoError(r, err)
 
 	r.Logger.EVMTransaction(*tx, "approve")

--- a/e2e/e2etests/test_eth_withdraw.go
+++ b/e2e/e2etests/test_eth_withdraw.go
@@ -14,18 +14,11 @@ import (
 func TestEtherWithdraw(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
-	approvedAmount := big.NewInt(1e18)
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok, "Invalid withdrawal amount specified for TestEtherWithdraw.")
-	require.Equal(
-		r,
-		-1,
-		withdrawalAmount.Cmp(approvedAmount),
-		"Withdrawal amount must be less than the approved amount (1e18).",
-	)
 
 	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, approvedAmount)
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, withdrawalAmount)
 	require.NoError(r, err)
 
 	r.Logger.EVMTransaction(*tx, "approve")

--- a/e2e/e2etests/test_eth_withdraw.go
+++ b/e2e/e2etests/test_eth_withdraw.go
@@ -17,11 +17,8 @@ func TestEtherWithdraw(r *runner.E2ERunner, args []string) {
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok, "Invalid withdrawal amount specified for TestEtherWithdraw.")
 
-	// add one unit to the withdrawal amount to account for the approval because withdrawal fees are automatically deducted
-	approvalAmount := new(big.Int).Add(withdrawalAmount, big.NewInt(1e18))
-
-	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, approvalAmount)
+	// approve 1 unit of the gas token to cover the gas fee transfer
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, big.NewInt(1e18))
 	require.NoError(r, err)
 
 	r.Logger.EVMTransaction(*tx, "approve")

--- a/e2e/e2etests/test_eth_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_eth_withdraw_restricted_address.go
@@ -19,8 +19,11 @@ func TestEtherWithdrawRestricted(r *runner.E2ERunner, args []string) {
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok)
 
+	// add one unit to the withdrawal amount to account for the approval because withdrawal fees are automatically deducted
+	approvalAmount := new(big.Int).Add(withdrawalAmount, big.NewInt(1e18))
+
 	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, withdrawalAmount)
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, approvalAmount)
 	require.NoError(r, err)
 
 	r.Logger.EVMTransaction(*tx, "approve")

--- a/e2e/e2etests/test_eth_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_eth_withdraw_restricted_address.go
@@ -18,7 +18,7 @@ func TestEtherWithdrawRestricted(r *runner.E2ERunner, args []string) {
 
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok)
-	
+
 	// approve 1 unit of the gas token to cover the gas fee transfer
 	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, big.NewInt(1e18))
 	require.NoError(r, err)

--- a/e2e/e2etests/test_eth_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_eth_withdraw_restricted_address.go
@@ -16,18 +16,11 @@ import (
 func TestEtherWithdrawRestricted(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
-	approvedAmount := big.NewInt(1e18)
-
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok)
-	require.True(
-		r,
-		withdrawalAmount.Cmp(approvedAmount) <= 0,
-		"Withdrawal amount must be less than the approved amount (1e18)",
-	)
 
 	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, approvedAmount)
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, withdrawalAmount)
 	require.NoError(r, err)
 
 	r.Logger.EVMTransaction(*tx, "approve")

--- a/e2e/e2etests/test_eth_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_eth_withdraw_restricted_address.go
@@ -18,12 +18,9 @@ func TestEtherWithdrawRestricted(r *runner.E2ERunner, args []string) {
 
 	withdrawalAmount, ok := new(big.Int).SetString(args[0], 10)
 	require.True(r, ok)
-
-	// add one unit to the withdrawal amount to account for the approval because withdrawal fees are automatically deducted
-	approvalAmount := new(big.Int).Add(withdrawalAmount, big.NewInt(1e18))
-
-	// approve
-	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, approvalAmount)
+	
+	// approve 1 unit of the gas token to cover the gas fee transfer
+	tx, err := r.ETHZRC20.Approve(r.ZEVMAuth, r.ETHZRC20Addr, big.NewInt(1e18))
 	require.NoError(r, err)
 
 	r.Logger.EVMTransaction(*tx, "approve")


### PR DESCRIPTION
# Description

Replace the hardcoded value with the amount provided in argument during the approval to allow using the test with any value.

[EDIT]: hardcoded values where ok because this is only amount for the fees that we need to give for the approval. This PR however remove the check allowing to set up a higher number for the actual withdraw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined withdrawal tests for ERC20 and Ether by simplifying approval logic.
  
- **Bug Fixes**
	- Removed redundant comparison checks that could lead to potential issues with withdrawal limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->