### PR TITLE
ci: set fail-fast on job

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -25,6 +25,8 @@ jobs:
     if: ${{ inputs.run }}
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
# Description

Setting `fail-fast` on the matrix is [not working](https://github.com/zeta-chain/node/actions/runs/10035524980/job/27731685091), let's try setting it on the job too. Correct behavior is that matrix jobs are not cancelled if one fails. For the nightly runs, we want to see exactly what failed.

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/53cb95a6-84d9-4b36-906d-70bf01340bf5">

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved CI/CD pipeline behavior to allow continuation of job executions even if one job fails, enabling more comprehensive testing and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->