### PR TITLE
fix(e2e): ignore context cancelled

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -332,7 +332,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	// if all tests pass, cancel txs priority monitoring and check if tx priority is not correct in some blocks
 	logger.Print("⏳ e2e tests passed,checking tx priority")
 	monitorPriorityCancel()
-	if err := <-txPriorityErrCh; err != nil && !errors.Is(err, context.Canceled) {
+	if err := <-txPriorityErrCh; err != nil && errors.Is(err, errWrongTxPriority) {
 		logger.Print("❌ %v", err)
 		logger.Print("❌ e2e tests failed after %s", time.Since(testStartTime).String())
 		os.Exit(1)

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -331,7 +332,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	// if all tests pass, cancel txs priority monitoring and check if tx priority is not correct in some blocks
 	logger.Print("⏳ e2e tests passed,checking tx priority")
 	monitorPriorityCancel()
-	if err := <-txPriorityErrCh; err != nil {
+	if err := <-txPriorityErrCh; err != nil && !errors.Is(err, context.Canceled) {
 		logger.Print("❌ %v", err)
 		logger.Print("❌ e2e tests failed after %s", time.Since(testStartTime).String())
 		os.Exit(1)

--- a/cmd/zetae2e/local/monitor_priority_txs.go
+++ b/cmd/zetae2e/local/monitor_priority_txs.go
@@ -13,6 +13,8 @@ import (
 	"github.com/zeta-chain/zetacore/e2e/config"
 )
 
+var errWrongTxPriority = errors.New("wrong tx priority, system tx not on top")
+
 // monitorTxPriorityInBlocks checks for transaction priorities in blocks and reports errors
 func monitorTxPriorityInBlocks(ctx context.Context, conf config.Config, errCh chan error) {
 	rpcClient, err := rpchttp.New(conf.RPCs.ZetaCoreRPC, "/websocket")
@@ -71,7 +73,7 @@ func processTx(txResult *coretypes.ResultTx, nonSystemTxFound *bool, errCh chan 
 				if isMsgTypeURLSystemTx(attr) {
 					// a non system tx has been found in the block before a system tx
 					if *nonSystemTxFound {
-						errCh <- errors.New("wrong tx priority, system tx not on top")
+						errCh <- errWrongTxPriority
 						return
 					}
 				} else {


### PR DESCRIPTION
# Description

```
setup      | ⏳ e2e tests passed,checking tx priority
setup      | ❌ error in json rpc client, with http response metadata: (Status: 200 OK, Protocol HTTP/1.1). Failed to read response body: context canceled
setup      | ❌ e2e tests failed after 10m44.930840222s
```

Context cancellation could be in the middle of an rpc. Ignore `context.Canceled` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in end-to-end tests by allowing the process to continue if the error is due to a canceled context, enhancing test robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->