### PR TITLE
ci: add additional tags for identification on nightly performance test runs

### DIFF
--- a/.github/actions/performance-tests/art.yaml
+++ b/.github/actions/performance-tests/art.yaml
@@ -19,6 +19,8 @@ config:
         pushgateway: 'https://pushgateway-testnet.rpc.zetachain.com/-=CLOUDFLARE_UUID=-'
         tags:
           - 'type:loadtest'
+          - 'testId:-=GITHUB_ACTION=-'
+          - 'jobName:evm-performance-test'
   summary: true
   reports:
     - type: "html"

--- a/.github/workflows/ci-nightly-performance-testing.yaml
+++ b/.github/workflows/ci-nightly-performance-testing.yaml
@@ -38,11 +38,14 @@ jobs:
         env:
           CLOUDFLARE_UUID: ${{ secrets.CLOUDFLARE_UUID }}
           ENDPOINT: ${{ inputs.endpoint || 'http://localhost:9545' }}
+          GITHUB_ACTION: ${{ github.action }}
         run: |
           # Replace -=endpoint_to_test=- placeholder in the art.yaml file with the endpoint_to_test value
           sed -i "s|-=endpoint_to_test=-|${ENDPOINT}|g" .github/actions/performance-tests/art.yaml
           # Replace -=CLOUDFLARE_UUID=- placeholder in the art.yaml file with the correct value
           sed -i "s|-=CLOUDFLARE_UUID=-|${CLOUDFLARE_UUID}|g" .github/actions/performance-tests/art.yaml
+          # Replace -=GITHUB_ACTION=- placeholder in the art.yaml file with the correct value
+          sed -i "s|-=GITHUB_ACTION=-|${GITHUB_ACTION}|g" .github/actions/performance-tests/art.yaml
           cat .github/actions/performance-tests/art.yaml
 
       - name: "EXECUTE:PERFORMANCE:TESTS"


### PR DESCRIPTION
# Description

add additional tags `jobName` and `testId` for identification on nightly performance test runs for when reports are uploaded to Pushgateway/Grafana.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new tags to the performance tests configuration to enhance metadata for test identification.
  - Introduced a new environment variable in the nightly performance testing workflow for better logging and context in generated artifacts. 

These improvements aim to enhance the organization and traceability of performance testing within the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->