### PR TITLE
chore(zetaclient): rename zetacoreContext

### DIFF
--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -143,14 +143,14 @@ func start(_ *cobra.Command, _ []string) error {
 	startLogger.Debug().Msgf("CreateAuthzSigner is ready")
 
 	// Initialize core parameters from zetacore
-	err = zetacoreClient.UpdateZetacoreContext(ctx, appContext, true, startLogger)
+	err = zetacoreClient.UpdateAppContext(ctx, appContext, true, startLogger)
 	if err != nil {
 		startLogger.Error().Err(err).Msg("Error getting core parameters")
 		return err
 	}
 	startLogger.Info().Msgf("Config is updated from zetacore %s", maskCfg(cfg))
 
-	go zetacoreClient.UpdateZetacoreContextWorker(ctx, appContext)
+	go zetacoreClient.UpdateAppContextWorker(ctx, appContext)
 
 	// Generate TSS address . The Tss address is generated through Keygen ceremony. The TSS key is used to sign all outbound transactions .
 	// The hotkeyPk is private key for the Hotkey. The Hotkey is used to sign all inbound transactions

--- a/zetaclient/chains/evm/observer/observer_test.go
+++ b/zetaclient/chains/evm/observer/observer_test.go
@@ -34,8 +34,8 @@ import (
 // the relative path to the testdata directory
 var TestDataDir = "../../../"
 
-// getZetacoreContext creates a zetacore context for unit tests
-func getZetacoreContext(
+// getAppContext creates an AppContext for unit tests
+func getAppContext(
 	evmChain chains.Chain,
 	endpoint string,
 	evmChainParams *observertypes.ChainParams,
@@ -52,7 +52,7 @@ func getZetacoreContext(
 		Endpoint: endpoint,
 	}
 
-	// create zetacore context
+	// create AppContext
 	appContext := zctx.New(cfg, zerolog.Nop())
 	evmChainParamsMap := make(map[int64]*observertypes.ChainParams)
 	evmChainParamsMap[evmChain.ChainId] = evmChainParams
@@ -70,7 +70,7 @@ func getZetacoreContext(
 		sample.HeaderSupportedChains(),
 		true,
 	)
-	// create app context
+	// create AppContext
 	return appContext, cfg.EVMChainConfigs[evmChain.ChainId]
 }
 
@@ -104,8 +104,8 @@ func MockEVMObserver(
 	if tss == nil {
 		tss = mocks.NewTSSMainnet()
 	}
-	// create zetacore context
-	_, evmCfg := getZetacoreContext(chain, "", &params)
+	// create AppContext
+	_, evmCfg := getAppContext(chain, "", &params)
 
 	database, err := db.NewFromSqliteInMemory(true)
 	require.NoError(t, err)
@@ -194,8 +194,8 @@ func Test_NewObserver(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// create zetacore context, client and tss
-			//zetacoreCtx, _ := getZetacoreContext(tt.evmCfg.Chain, tt.evmCfg.Endpoint, &params)
+			// create AppContext, client and tss
+			//zetacoreCtx, _ := getAppContext(tt.evmCfg.Chain, tt.evmCfg.Endpoint, &params)
 			zetacoreClient := mocks.NewZetacoreClient(t)
 
 			database, err := db.NewFromSqliteInMemory(true)

--- a/zetaclient/context/app.go
+++ b/zetaclient/context/app.go
@@ -249,8 +249,8 @@ func (a *AppContext) GetBlockHeaderEnabledChains(chainID int64) (lightclienttype
 	return lightclienttypes.HeaderSupportedChain{}, false
 }
 
-// Update updates zetacore context and params for all chains
-// this must be the ONLY function that writes to zetacore context
+// Update updates AppContext and params for all chains
+// this must be the ONLY function that writes to AppContext
 func (a *AppContext) Update(
 	keygen *observertypes.Keygen,
 	newChains []chains.Chain,

--- a/zetaclient/context/app_test.go
+++ b/zetaclient/context/app_test.go
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 		logger  = zerolog.Nop()
 	)
 
-	t.Run("should create new zetacore context with empty config", func(t *testing.T) {
+	t.Run("should create new AppContext with empty config", func(t *testing.T) {
 		appContext := context.New(testCfg, logger)
 		require.NotNil(t, appContext)
 
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 			RPCPassword: "test_password",
 		}
 
-		// create zetacore context with 0 chain id
+		// create AppContext with 0 chain id
 		appContext := context.New(testCfg, logger)
 		require.NotNil(t, appContext)
 
@@ -69,7 +69,7 @@ func TestNew(t *testing.T) {
 		require.Nil(t, btcChainParams)
 	})
 
-	t.Run("should create new zetacore context with config containing evm chain params", func(t *testing.T) {
+	t.Run("should create new AppContext with config containing evm chain params", func(t *testing.T) {
 		// ARRANGE
 		var (
 			eth   = chains.Ethereum.ChainId
@@ -114,7 +114,7 @@ func TestNew(t *testing.T) {
 		require.Equal(t, &maticChainParams, evmChainParams2)
 	})
 
-	t.Run("should create new zetacore context with config containing btc config", func(t *testing.T) {
+	t.Run("should create new AppContext with config containing btc config", func(t *testing.T) {
 		testCfg := config.New(false)
 		testCfg.BitcoinConfig = config.BTCConfig{
 			RPCUsername: "test username",
@@ -133,7 +133,7 @@ func TestAppContextUpdate(t *testing.T) {
 		logger  = zerolog.Nop()
 	)
 
-	t.Run("should update zetacore context after being created from empty config", func(t *testing.T) {
+	t.Run("should update AppContext after being created from empty config", func(t *testing.T) {
 		appContext := context.New(testCfg, logger)
 		require.NotNil(t, appContext)
 
@@ -214,7 +214,7 @@ func TestAppContextUpdate(t *testing.T) {
 	})
 
 	t.Run(
-		"should update zetacore context after being created from config with evm and btc chain params",
+		"should update AppContext after being created from config with evm and btc chain params",
 		func(t *testing.T) {
 			testCfg := config.New(false)
 			testCfg.EVMChainConfigs = map[int64]config.EVMConfig{
@@ -346,9 +346,9 @@ func TestIsOutboundObservationEnabled(t *testing.T) {
 	t.Run("should return false if outbound flag is disabled", func(t *testing.T) {
 		flagsDisabled := ccFlags
 		flagsDisabled.IsOutboundEnabled = false
-		coreContextDisabled := makeAppContext(evmChain, chainParams, flagsDisabled, verificationFlags)
+		appContextDisabled := makeAppContext(evmChain, chainParams, flagsDisabled, verificationFlags)
 
-		require.False(t, coreContextDisabled.IsOutboundObservationEnabled(*chainParams))
+		require.False(t, appContextDisabled.IsOutboundObservationEnabled(*chainParams))
 	})
 }
 
@@ -560,13 +560,13 @@ func makeAppContext(
 		Chain: evmChain,
 	}
 
-	// create zetacore context
-	coreContext := context.New(cfg, logger)
+	// create AppContext
+	appContext := context.New(cfg, logger)
 	evmChainParamsMap := make(map[int64]*observertypes.ChainParams)
 	evmChainParamsMap[evmChain.ChainId] = evmChainParams
 
 	// feed chain params
-	coreContext.Update(
+	appContext.Update(
 		&observertypes.Keygen{},
 		[]chains.Chain{evmChain},
 		evmChainParamsMap,
@@ -579,5 +579,5 @@ func makeAppContext(
 		true,
 	)
 
-	return coreContext
+	return appContext
 }

--- a/zetaclient/orchestrator/orchestrator.go
+++ b/zetaclient/orchestrator/orchestrator.go
@@ -591,7 +591,7 @@ func (oc *Orchestrator) runObserverSignerSync(ctx context.Context) error {
 
 // syncs and provisions observers & signers.
 // Note that zctx.AppContext Update is a responsibility of another component
-// See zetacore.Client{}.UpdateZetacoreContextWorker
+// See zetacore.Client{}.UpdateAppContextWorker
 func (oc *Orchestrator) syncObserverSigner(ctx context.Context) error {
 	oc.mu.Lock()
 	defer oc.mu.Unlock()

--- a/zetaclient/orchestrator/orchestrator_test.go
+++ b/zetaclient/orchestrator/orchestrator_test.go
@@ -67,7 +67,7 @@ func CreateAppContext(
 	cfg.BitcoinConfig = config.BTCConfig{
 		RPCHost: "localhost",
 	}
-	// new zetacore context
+	// new AppContext
 	appContext := zctx.New(cfg, zerolog.Nop())
 	evmChainParamsMap := make(map[int64]*observertypes.ChainParams)
 	evmChainParamsMap[evmChain.ChainId] = evmChainParams
@@ -101,7 +101,7 @@ func Test_GetUpdatedSigner(t *testing.T) {
 	}
 	btcChainParams := &observertypes.ChainParams{}
 
-	// new chain params in zetacore context
+	// new chain params in AppContext
 	evmChainParamsNew := &observertypes.ChainParams{
 		ChainId:                     evmChain.ChainId,
 		ConnectorContractAddress:    testutils.OtherAddress1,
@@ -139,7 +139,7 @@ func Test_GetUpdatedChainObserver(t *testing.T) {
 		ChainId: btcChain.ChainId,
 	}
 
-	// new chain params in zetacore context
+	// new chain params in AppContext
 	evmChainParamsNew := &observertypes.ChainParams{
 		ChainId:                     evmChain.ChainId,
 		ConfirmationCount:           10,
@@ -175,32 +175,32 @@ func Test_GetUpdatedChainObserver(t *testing.T) {
 
 	t.Run("evm chain observer should not be found", func(t *testing.T) {
 		orchestrator := MockOrchestrator(t, nil, evmChain, btcChain, evmChainParams, btcChainParams)
-		coreContext := CreateAppContext(evmChain, btcChain, evmChainParamsNew, btcChainParams)
+		appContext := CreateAppContext(evmChain, btcChain, evmChainParamsNew, btcChainParams)
 		// BSC chain observer should not be found
-		_, err := orchestrator.resolveObserver(coreContext, chains.BscMainnet.ChainId)
+		_, err := orchestrator.resolveObserver(appContext, chains.BscMainnet.ChainId)
 		require.ErrorContains(t, err, "observer not found")
 	})
 	t.Run("chain params in evm chain observer should be updated successfully", func(t *testing.T) {
 		orchestrator := MockOrchestrator(t, nil, evmChain, btcChain, evmChainParams, btcChainParams)
-		coreContext := CreateAppContext(evmChain, btcChain, evmChainParamsNew, btcChainParams)
+		appContext := CreateAppContext(evmChain, btcChain, evmChainParamsNew, btcChainParams)
 		// update evm chain observer with new chain params
-		chainOb, err := orchestrator.resolveObserver(coreContext, evmChain.ChainId)
+		chainOb, err := orchestrator.resolveObserver(appContext, evmChain.ChainId)
 		require.NoError(t, err)
 		require.NotNil(t, chainOb)
 		require.True(t, observertypes.ChainParamsEqual(*evmChainParamsNew, chainOb.GetChainParams()))
 	})
 	t.Run("btc chain observer should not be found", func(t *testing.T) {
 		orchestrator := MockOrchestrator(t, nil, evmChain, btcChain, evmChainParams, btcChainParams)
-		coreContext := CreateAppContext(btcChain, btcChain, evmChainParams, btcChainParamsNew)
+		appContext := CreateAppContext(btcChain, btcChain, evmChainParams, btcChainParamsNew)
 		// BTC testnet chain observer should not be found
-		_, err := orchestrator.resolveObserver(coreContext, chains.BitcoinTestnet.ChainId)
+		_, err := orchestrator.resolveObserver(appContext, chains.BitcoinTestnet.ChainId)
 		require.ErrorContains(t, err, "observer not found")
 	})
 	t.Run("chain params in btc chain observer should be updated successfully", func(t *testing.T) {
 		orchestrator := MockOrchestrator(t, nil, evmChain, btcChain, evmChainParams, btcChainParams)
-		coreContext := CreateAppContext(btcChain, btcChain, evmChainParams, btcChainParamsNew)
+		appContext := CreateAppContext(btcChain, btcChain, evmChainParams, btcChainParamsNew)
 		// update btc chain observer with new chain params
-		chainOb, err := orchestrator.resolveObserver(coreContext, btcChain.ChainId)
+		chainOb, err := orchestrator.resolveObserver(appContext, btcChain.ChainId)
 		require.NoError(t, err)
 		require.NotNil(t, chainOb)
 		require.True(t, observertypes.ChainParamsEqual(*btcChainParamsNew, chainOb.GetChainParams()))

--- a/zetaclient/zetacore/client.go
+++ b/zetaclient/zetacore/client.go
@@ -339,9 +339,9 @@ func (c *Client) WaitForZetacoreToCreateBlocks(ctx context.Context) error {
 	return nil
 }
 
-// UpdateZetacoreContext updates zetacore context
-// zetacore stores zetacore context for all clients
-func (c *Client) UpdateZetacoreContext(
+// UpdateAppContext updates zctx.AppContext
+// zetacore stores AppContext for all clients
+func (c *Client) UpdateAppContext(
 	ctx context.Context,
 	appContext *zctx.AppContext,
 	init bool,

--- a/zetaclient/zetacore/client_worker.go
+++ b/zetaclient/zetacore/client_worker.go
@@ -11,12 +11,12 @@ import (
 
 var logSampler = &zerolog.BasicSampler{N: 10}
 
-// UpdateZetacoreContextWorker is a polling goroutine that checks and updates zetacore context at every height.
+// UpdateAppContextWorker is a polling goroutine that checks and updates AppContext at every height.
 // todo implement graceful shutdown and work group
-func (c *Client) UpdateZetacoreContextWorker(ctx context.Context, app *appcontext.AppContext) {
+func (c *Client) UpdateAppContextWorker(ctx context.Context, app *appcontext.AppContext) {
 	defer func() {
 		if r := recover(); r != nil {
-			c.logger.Error().Interface("panic", r).Msg("UpdateZetacoreContextWorker: recovered from panic")
+			c.logger.Error().Interface("panic", r).Msg("UpdateAppContextWorker: recovered from panic")
 		}
 	}()
 
@@ -26,17 +26,17 @@ func (c *Client) UpdateZetacoreContextWorker(ctx context.Context, app *appcontex
 		logger      = c.logger.Sample(logSampler)
 	)
 
-	c.logger.Info().Msg("UpdateZetacoreContextWorker started")
+	c.logger.Info().Msg("UpdateAppContextWorker started")
 
 	for {
 		select {
 		case <-ticker.C:
-			c.logger.Debug().Msg("UpdateZetacoreContextWorker invocation")
-			if err := c.UpdateZetacoreContext(ctx, app, false, logger); err != nil {
-				c.logger.Err(err).Msg("UpdateZetacoreContextWorker failed to update config")
+			c.logger.Debug().Msg("UpdateAppContextWorker invocation")
+			if err := c.UpdateAppContext(ctx, app, false, logger); err != nil {
+				c.logger.Err(err).Msg("UpdateAppContextWorker failed to update config")
 			}
 		case <-c.stop:
-			c.logger.Info().Msg("UpdateZetacoreContextWorker stopped")
+			c.logger.Info().Msg("UpdateAppContextWorker stopped")
 			return
 		}
 	}

--- a/zetaclient/zetacore/tx_test.go
+++ b/zetaclient/zetacore/tx_test.go
@@ -232,7 +232,7 @@ func TestZetacore_SetTSS(t *testing.T) {
 	})
 }
 
-func TestZetacore_UpdateZetacoreContext(t *testing.T) {
+func TestZetacore_UpdateAppContext(t *testing.T) {
 	ctx := context.Background()
 
 	//Setup server for multiple grpc calls
@@ -384,7 +384,7 @@ func TestZetacore_UpdateZetacoreContext(t *testing.T) {
 	t.Run("zetacore update success", func(t *testing.T) {
 		cfg := config.New(false)
 		appContext := zctx.New(cfg, zerolog.Nop())
-		err := client.UpdateZetacoreContext(ctx, appContext, false, zerolog.Logger{})
+		err := client.UpdateAppContext(ctx, appContext, false, zerolog.Logger{})
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Closes https://github.com/zeta-chain/node/issues/2526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed context management functions to enhance clarity: `UpdateZetacoreContext` is now `UpdateAppContext`, and its worker counterpart follows suit.
- **Bug Fixes**
	- Updated test cases and function references to align with new naming conventions, ensuring consistency in context management terminology.
- **Documentation**
	- Improved comments throughout the codebase to accurately reflect the new focus on `AppContext`, aiding in understanding the scope and functionality of methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->