### PR TITLE
fix(e2e): improve upgrade version logic

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -145,6 +145,7 @@ jobs:
           - make-target: "start-upgrade-import-mainnet-test"
             runs-on: buildjet-16vcpu-ubuntu-2204
             run: ${{ needs.matrix-conditionals.outputs.UPGRADE_IMPORT_MAINNET_TESTS == 'true' }}
+            timeout-minutes: 40
           - make-target: "start-e2e-admin-test"
             runs-on: ubuntu-20.04
             run: ${{ needs.matrix-conditionals.outputs.ADMIN_TESTS == 'true' }}
@@ -154,6 +155,7 @@ jobs:
           - make-target: "start-e2e-import-mainnet-test"
             runs-on: buildjet-16vcpu-ubuntu-2204
             run: ${{ needs.matrix-conditionals.outputs.STATEFUL_DATA_TESTS == 'true' }}
+            timeout-minutes: 40
           - make-target: "start-tss-migration-test"
             runs-on: ubuntu-20.04
             run: ${{ needs.matrix-conditionals.outputs.TSS_MIGRATION_TESTS == 'true' }}


### PR DESCRIPTION
It seems that sometimes tendermint will respond with 200 with an empty version when it's starting. This can result in empty strings and `null` being returned by this function sometimes. Assert that the version starts with `v` to ensure we return a good version.

Some symptoms from the upgrade tests:

```
Waiting for upgrade height...
current height is 251, waiting for 224
waiting 10 seconds for node to restart...
version did not change after upgrade height, maybe the upgrade did not run?
```

```
waiting 10 seconds for node to restart...
upgrade complete: 17.0.1-internal -> null
running E2E command to test the network after upgrade...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and version validation for node information retrieval.
	- Added feedback on upgrade results, improving transparency during the upgrade process.

- **Bug Fixes**
	- Improved logic to prevent empty or improperly formatted version strings from being returned.

- **Documentation**
	- Updated echo statements for clearer debugging and confirmation of upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->