### PR TITLE
fix: limit max txs in priority mempool

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,6 +102,7 @@
 * [2396](https://github.com/zeta-chain/node/issues/2386) - special handle bitcoin testnet gas price estimator
 * [2434](https://github.com/zeta-chain/node/pull/2434) - the default database when running `zetacored init` is now pebbledb
 * [2481](https://github.com/zeta-chain/node/pull/2481) - increase gas limit inbound and outbound vote message to 500k
+* [2547](https://github.com/zeta-chain/node/pull/2547) - limit max txs in priority mempool
 
 ### CI
 

--- a/cmd/zetacored/root.go
+++ b/cmd/zetacored/root.go
@@ -246,8 +246,12 @@ func (ac appCreator) newApp(
 	appOpts servertypes.AppOptions,
 ) servertypes.Application {
 	baseappOptions := server.DefaultBaseappOptions(appOpts)
+	maxTxs := cast.ToInt(appOpts.Get(server.FlagMempoolMaxTxs))
+	if maxTxs <= 0 {
+		maxTxs = zetamempool.DefaultMaxTxs
+	}
 	baseappOptions = append(baseappOptions, func(app *baseapp.BaseApp) {
-		app.SetMempool(zetamempool.DefaultPriorityMempool())
+		app.SetMempool(zetamempool.NewPriorityMempool(zetamempool.PriorityNonceWithMaxTx(maxTxs)))
 	})
 	skipUpgradeHeights := make(map[int64]bool)
 	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {

--- a/pkg/mempool/priority_nonce_mempool.go
+++ b/pkg/mempool/priority_nonce_mempool.go
@@ -19,6 +19,8 @@ var (
 	_ mempool.Iterator = (*PriorityNonceIterator)(nil)
 )
 
+const DefaultMaxTxs = 3000
+
 // PriorityNonceMempool is a mempool implementation that stores txs
 // in a partially ordered set by 2 dimensions: priority, and sender-nonce
 // (sequence number). Internally it uses one priority ordered skip list and one


### PR DESCRIPTION
# Description

Adding a max txs to priority nonce mempool, using 3000 as default, same as cronos where this code is mostly ported from, with a possibility to configure it.

closes: #2546 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a maximum transaction limit for the priority mempool, enhancing transaction management and prioritization.
	- Added a default limit of 3000 transactions for better control over mempool operations.

- **Bug Fixes**
	- Ensured that the application utilizes a valid transaction limit, enhancing performance and reliability.

- **Documentation**
	- Updated changelog to reflect the recent enhancements to the transaction processing system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->