### PR TITLE
chore: Typo fix in zetaclient log

### DIFF
--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -229,7 +229,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context, sampledLogger zerolog.Lo
 	// update last scanned block height for all 3 events (ZetaSent, Deposited, TssRecvd), ignore db error
 	if lastScannedLowest > lastScanned {
 		sampledLogger.Info().
-			Msgf("observeInbound: lasstScanned heights for chain %d ZetaSent %d ERC20Deposited %d TssRecvd %d",
+			Msgf("observeInbound: lastScanned heights for chain %d ZetaSent %d ERC20Deposited %d TssRecvd %d",
 				ob.Chain().ChainId, lastScannedZetaSent, lastScannedDeposited, lastScannedTssRecvd)
 		if err := ob.SaveLastBlockScanned(lastScannedLowest); err != nil {
 			ob.Logger().Inbound.Error().


### PR DESCRIPTION
# Description

This PR fixes a small typo in zetaclient logs.

`observeInbound: lasstScanned heights for chain`... -> `observeInbound: lastScanned heights for chain`...

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the logging message from "lasstScanned" to "lastScanned," enhancing the clarity and accuracy of log outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->