### PR TITLE
fix(e2e): update performance test parameters and bump go-tss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ start-e2e-admin-test: zetanode
 start-e2e-performance-test: zetanode
 	@echo "--> Starting e2e performance test"
 	export E2E_ARGS="--test-performance" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress -f docker-compose.yml up -d
 
 start-e2e-import-mainnet-test: zetanode
 	@echo "--> Starting e2e import-data test"

--- a/cmd/zetae2e/local/performance.go
+++ b/cmd/zetae2e/local/performance.go
@@ -75,6 +75,13 @@ func ethereumWithdrawPerformanceRoutine(
 			return err
 		}
 
+		if r.ReceiptTimeout == 0 {
+			r.ReceiptTimeout = 15 * time.Minute
+		}
+		if r.CctxTimeout == 0 {
+			r.CctxTimeout = 15 * time.Minute
+		}
+
 		r.Logger.Print("🏃 starting Ethereum withdraw performance tests")
 		startTime := time.Now()
 

--- a/cmd/zetae2e/local/test_runner.go
+++ b/cmd/zetae2e/local/test_runner.go
@@ -30,6 +30,10 @@ func initTestRunner(
 		return nil, err
 	}
 
+	// copy timeouts from deployer runner
+	testRunner.CctxTimeout = deployerRunner.ReceiptTimeout
+	testRunner.ReceiptTimeout = deployerRunner.ReceiptTimeout
+
 	// copy contracts from deployer runner
 	if err := testRunner.CopyAddressesFrom(deployerRunner); err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -364,4 +364,4 @@ replace github.com/evmos/ethermint => github.com/zeta-chain/ethermint v0.0.0-202
 
 replace github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
 
-replace gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20240718213003-31767e0c90ba
+replace gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20240729195411-9f5ae8189449

--- a/go.sum
+++ b/go.sum
@@ -1738,8 +1738,8 @@ github.com/zeta-chain/ethermint v0.0.0-20240531172701-61d040058c94 h1:M54ljayJvy
 github.com/zeta-chain/ethermint v0.0.0-20240531172701-61d040058c94/go.mod h1:s1zA6OpXv3Tb5I0M6M6j5fo/AssaZL/pgkc7G0W2kN8=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
-github.com/zeta-chain/go-tss v0.0.0-20240718213003-31767e0c90ba h1:7Qcc2uQq2Tp1OSRMiJA7GRZr+PV6Le0a1TGw3q/8Vho=
-github.com/zeta-chain/go-tss v0.0.0-20240718213003-31767e0c90ba/go.mod h1:LN1IBRN8xQkKgdgLhl5BDGZyPm70QOTbVLejdS2FVpo=
+github.com/zeta-chain/go-tss v0.0.0-20240729195411-9f5ae8189449 h1:4U+4g2QQjbrmeLU1ZdCDU6CYsE5kbwMOKZ/PACR/vN8=
+github.com/zeta-chain/go-tss v0.0.0-20240729195411-9f5ae8189449/go.mod h1:LN1IBRN8xQkKgdgLhl5BDGZyPm70QOTbVLejdS2FVpo=
 github.com/zeta-chain/keystone/keys v0.0.0-20231105174229-903bc9405da2 h1:gd2uE0X+ZbdFJ8DubxNqLbOVlCB12EgWdzSNRAR82tM=
 github.com/zeta-chain/keystone/keys v0.0.0-20231105174229-903bc9405da2/go.mod h1:x7Bkwbzt2W2lQfjOirnff0Dj+tykdbTG1FMJPVPZsvE=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240418181724-c222fd3ae1f5 h1:ljM7xka3WZvth9k1uYxrG3/FKQQTkR96FZlIjUKOoYw=


### PR DESCRIPTION
- bump go-tss for https://github.com/zeta-chain/go-tss/pull/22
- Increase the timeouts of the performance tests
- use stress profile in performance tests to more accurately represent real world scenarios

Timeout increases are needed because some withdrawals are taking longer than the default 5 minute cctx timeout:

```
perf_eth_w | index 47: withdraw cctx success in 5m22.401391814s
perf_eth_w | index 48: withdraw cctx success in 5m20.393530031s
```

Closes https://github.com/zeta-chain/node/issues/2562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance testing with updated timeout defaults for Ethereum withdrawal tests.
	- Improved timeout management in the test runner for better synchronization.

- **Chores**
	- Updated dependencies in the project to ensure improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->