### PR TITLE
chore(`changelog.md`): update changelogs to specify v19 changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v19.0.0
+
 ### Breaking Changes
 
 * [2460](https://github.com/zeta-chain/node/pull/2460) - Upgrade to go 1.22. This required us to temporarily remove the QUIC backend from [go-libp2p](https://github.com/libp2p/go-libp2p). If you are a zetaclient operator and have configured quic peers, you need to switch to tcp peers.


### PR DESCRIPTION
# Description

Update the changelogs file as we create the `release/v19` branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new version section in the changelog for improved clarity.
  
- **Breaking Changes**
	- Upgraded to Go 1.22, resulting in the temporary removal of the QUIC backend, requiring zetaclient operators to transition to TCP peers to maintain functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->