### PR TITLE
fix(ci): correct slack conditional comparison

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -179,7 +179,7 @@ jobs:
     steps:
       - name: Send slack message with results
         uses: actions/github-script@v7
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && needs.e2e.result == 'failed') }}
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'push' && needs.e2e.result == 'failure') }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_CI_ALERTS }}
         with:


### PR DESCRIPTION
It's `failure` not `failed`: https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the notification system for workflow failures, ensuring more accurate alerts based on specific failure states.
- **Bug Fixes**
	- Corrected the condition for sending Slack notifications to better reflect the job's actual failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->