### PR TITLE
chore: update e2e local config

### DIFF
--- a/cmd/zetae2e/config/clients.go
+++ b/cmd/zetae2e/config/clients.go
@@ -58,12 +58,12 @@ func getClientsFromConfig(ctx context.Context, conf config.Config, account confi
 	E2EClients,
 	error,
 ) {
-	if conf.RPCs.Solana == "" {
-		return E2EClients{}, fmt.Errorf("solana rpc is empty")
-	}
-	solanaClient := rpc.New(conf.RPCs.Solana)
-	if solanaClient == nil {
-		return E2EClients{}, fmt.Errorf("failed to get solana client")
+	var solanaClient *rpc.Client
+	if conf.RPCs.Solana != "" {
+		solanaClient = rpc.New(conf.RPCs.Solana)
+		if solanaClient == nil {
+			return E2EClients{}, fmt.Errorf("failed to get solana client")
+		}
 	}
 	btcRPCClient, err := getBtcClient(conf.RPCs.Bitcoin)
 	if err != nil {

--- a/cmd/zetae2e/config/clients.go
+++ b/cmd/zetae2e/config/clients.go
@@ -60,8 +60,7 @@ func getClientsFromConfig(ctx context.Context, conf config.Config, account confi
 ) {
 	var solanaClient *rpc.Client
 	if conf.RPCs.Solana != "" {
-		solanaClient = rpc.New(conf.RPCs.Solana)
-		if solanaClient == nil {
+		if solanaClient = rpc.New(conf.RPCs.Solana); solanaClient == nil {
 			return E2EClients{}, fmt.Errorf("failed to get solana client")
 		}
 	}

--- a/cmd/zetae2e/config/local.yml
+++ b/cmd/zetae2e/config/local.yml
@@ -4,17 +4,18 @@ default_account:
   evm_address: "0xE5C5367B8224807Ac2207d350E60e1b6F27a7ecC"
   private_key: "d87baf7bf6dc560a252596678c12e41f7d1682837f05b29d411bc3f78ae2c263"
 rpcs:
-  zevm: "http://0.0.0.0:9545"
-  evm: "http://0.0.0.0:8545"
+  zevm: "http://localhost:9545"
+  evm: "http://localhost:8545"
   bitcoin:
-    host: "0.0.0.0:18443"
+    host: "localhost:18443"
     user: "smoketest"
     pass: "123"
     http_post_mode: true
     disable_tls: true
     params: regnet
-  zetacore_grpc: "0.0.0.0:9090"
-  zetacore_rpc: "http://0.0.0.0:26657"
+  zetacore_grpc: "localhost:9090"
+  zetacore_rpc: "http://localhost:26657"
+  solana: "http://solana:8899"
 contracts:
   zevm:
     system_contract: "0x91d18e54DAf4F677cB28167158d6dd21F6aB3921"

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -317,6 +317,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		eg.Go(miscTestRoutine(conf, deployerRunner, verbose, e2etests.TestMyTestName))
 	}
 	if testSolana {
+		if deployerRunner.SolanaClient == nil {
+			logger.Print("❌ solana client is nil, maybe solana rpc is not set")
+			os.Exit(1)
+		}
 		eg.Go(solanaTestRoutine(conf, deployerRunner, verbose, e2etests.TestSolanaDepositName))
 	}
 


### PR DESCRIPTION
Make solana rpc config optional and use localhost instead of `0.0.0.0`.

Closes https://github.com/zeta-chain/node/issues/2565 and https://github.com/zeta-chain/node/issues/2566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced handling for Solana RPC configurations to improve functionality when the RPC is not provided.
	- Added a new Solana service configuration to enhance overall functionality.

- **Bug Fixes**
	- Implemented validation to prevent execution of tests if the Solana client is not properly initialized, improving error handling during testing.

- **Chores**
	- Updated local configuration to specify `localhost` instead of `0.0.0.0` for improved clarity and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->