### PR TITLE
fix(ci): propagate timeout-minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -168,6 +168,7 @@ jobs:
       make-target: ${{ matrix.make-target }}
       runs-on: ${{ matrix.runs-on}}
       run: ${{ matrix.run }}
+      timeout-minutes: "${{ matrix.timeout-minutes || 25 }}"
     secrets: inherit
   # this allows you to set a required status check
   e2e-ok:


### PR DESCRIPTION
`timeout-minutes` was set in the matrix, but not actually injected into the job. This resulted in everything being run with the default 25 minute timeout. The mainnet imports need more time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced configuration for job execution time in the GitHub Actions workflow, allowing for customizable timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->