### PR TITLE
chore(changelog.md): fix v19 breaking change statement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 * [2460](https://github.com/zeta-chain/node/pull/2460) - Upgrade to go 1.22. This required us to temporarily remove the QUIC backend from [go-libp2p](https://github.com/libp2p/go-libp2p). If you are a zetaclient operator and have configured quic peers, you need to switch to tcp peers.
+* [List of the other breaking changes can be found in this document](docs/releases/v19_breaking_changes.md)
 
 ### Features
 


### PR DESCRIPTION
# Description

Add back link containing details changes for v19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated changelog to highlight breaking changes with Go version 1.22 upgrade.
	- Removed QUIC backend from the `go-libp2p` library, advising users to switch to TCP peers.
	- Added a new entry directing users to a document detailing other breaking changes for better transition support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->