### PR TITLE
fix(ci): remove job concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,6 @@ jobs:
   build-and-test:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    concurrency:
-      group: "build-and-test"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This statement will cancel the job if *any* other `build-and-test` job is running on any PR/push event. We already have a workflow level `concurrency` statement so I think this is pointless anyway.

Results in problems like this:

<img width="850" alt="image" src="https://github.com/user-attachments/assets/c0221789-1b00-427e-b41e-e6f24b6c3e95">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow configuration to allow multiple instances of the build-and-test job to run simultaneously, potentially improving resource utilization during builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->