### PR TITLE
feat(zetaclient): add generic rpc metrics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Features
 
 * [2578](https://github.com/zeta-chain/node/pull/2578) - Add Gateway address in protocol contract list
+* [2597](https://github.com/zeta-chain/node/pull/2597) - Add generic rpc metrics to zetaclient
 
 ## v19.0.0
 

--- a/zetaclient/chains/evm/signer/signer.go
+++ b/zetaclient/chains/evm/signer/signer.go
@@ -869,7 +869,7 @@ func getEVMRPC(ctx context.Context, endpoint string) (interfaces.EVMRPCClient, e
 	}
 	httpClient, err := metrics.GetInstrumentedHTTPClient(endpoint)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "unable to get instrumented HTTP client")
 	}
 
 	rpcClient, err := ethrpc.DialHTTPWithClient(endpoint, httpClient)

--- a/zetaclient/metrics/metrics_test.go
+++ b/zetaclient/metrics/metrics_test.go
@@ -1,10 +1,15 @@
 package metrics
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	. "gopkg.in/check.v1"
 )
 
@@ -23,20 +28,52 @@ func (ms *MetricsSuite) SetUpSuite(c *C) {
 	ms.m = m
 }
 
+// assert that the curried metric actually uses the same underlying storage
+func (ms *MetricsSuite) TestCurryWith(c *C) {
+	rpcTotalsC := RPCCount.MustCurryWith(prometheus.Labels{"host": "test"})
+	rpcTotalsC.With(prometheus.Labels{"code": "400"}).Add(1.0)
+
+	rpcCtr := testutil.ToFloat64(RPCCount.With(prometheus.Labels{"host": "test", "code": "400"}))
+	c.Assert(rpcCtr, Equals, 1.0)
+
+	RPCCount.Reset()
+}
+
 func (ms *MetricsSuite) TestMetrics(c *C) {
 	GetFilterLogsPerChain.WithLabelValues("chain1").Inc()
 	GetFilterLogsPerChain.WithLabelValues("chain2").Inc()
 	GetFilterLogsPerChain.WithLabelValues("chain2").Inc()
 	time.Sleep(1 * time.Second)
-	res, err := http.Get("http://127.0.0.1:8886/metrics")
-	c.Assert(err, IsNil)
-	c.Assert(res.StatusCode, Equals, http.StatusOK)
-	defer res.Body.Close()
-	//out, err := ioutil.ReadAll(res.Body)
-	//fmt.Println(string(out))
 
-	res, err = http.Get("http://127.0.0.1:8886")
+	chain1Ctr := testutil.ToFloat64(GetFilterLogsPerChain.WithLabelValues("chain1"))
+	c.Assert(chain1Ctr, Equals, 1.0)
+
+	httpClient, err := GetInstrumentedHTTPClient("http://127.0.0.1:8886")
 	c.Assert(err, IsNil)
-	c.Assert(res.StatusCode, Equals, http.StatusOK)
+
+	res, err := httpClient.Get("http://127.0.0.1:8886")
+	c.Assert(err, IsNil)
 	defer res.Body.Close()
+	c.Assert(res.StatusCode, Equals, http.StatusOK)
+
+	res, err = httpClient.Get("http://127.0.0.1:8886/metrics")
+	c.Assert(err, IsNil)
+	defer res.Body.Close()
+	c.Assert(res.StatusCode, Equals, http.StatusOK)
+	body, err := io.ReadAll(res.Body)
+	c.Assert(err, IsNil)
+	metricsBody := string(body)
+	c.Assert(strings.Contains(metricsBody, fmt.Sprintf("%s_%s", ZetaClientNamespace, "rpc_count")), Equals, true)
+
+	// assert that rpc count is being incremented at all
+	rpcCount := testutil.ToFloat64(RPCCount)
+	c.Assert(rpcCount, Equals, 2.0)
+
+	// assert that rpc count is being incremented correctly
+	rpcCount = testutil.ToFloat64(RPCCount.With(prometheus.Labels{"host": "127.0.0.1:8886", "code": "200"}))
+	c.Assert(rpcCount, Equals, 2.0)
+
+	// assert that rpc count is not being incremented incorrectly
+	rpcCount = testutil.ToFloat64(RPCCount.With(prometheus.Labels{"host": "127.0.0.1:8886", "code": "502"}))
+	c.Assert(rpcCount, Equals, 0.0)
 }

--- a/zetaclient/metrics/metrics_test.go
+++ b/zetaclient/metrics/metrics_test.go
@@ -48,7 +48,7 @@ func (ms *MetricsSuite) TestMetrics(c *C) {
 	chain1Ctr := testutil.ToFloat64(GetFilterLogsPerChain.WithLabelValues("chain1"))
 	c.Assert(chain1Ctr, Equals, 1.0)
 
-	httpClient, err := GetInstrumentedHTTPClient("http://127.0.0.1:8886")
+	httpClient, err := GetInstrumentedHTTPClient("http://127.0.0.1:8886/myauthuuid")
 	c.Assert(err, IsNil)
 
 	res, err := httpClient.Get("http://127.0.0.1:8886")

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -5,10 +5,10 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/pkg/errors"
 
-	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/zeta-chain/zetacore/zetaclient/chains/base"
 	btcobserver "github.com/zeta-chain/zetacore/zetaclient/chains/bitcoin/observer"
 	"github.com/zeta-chain/zetacore/zetaclient/chains/bitcoin/rpc"


### PR DESCRIPTION
# Description

Add generic rpc metrics to zetaclient. BTC metrics are not possible because our BTC RPC client will not currently accept a custom `http.Client`. I will work on that upstream.

Closes https://github.com/zeta-chain/node/issues/2588
Closes https://github.com/zeta-chain/node/issues/1524

```
root@zetaclient0:/usr/local/bin# curl -s http://localhost:8886 | grep zetaclient_rpc
# HELP zetaclient_rpc_count A counter for number of total RPC requests
# TYPE zetaclient_rpc_count counter
zetaclient_rpc_count{code="200",host="eth:8545"} 243
zetaclient_rpc_count{code="200",host="solana:8899"} 48
# HELP zetaclient_rpc_duration_seconds A histogram of the RPC duration in seconds
# TYPE zetaclient_rpc_duration_seconds histogram
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.005"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.01"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.025"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.05"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.1"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.25"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="0.5"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="1"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="2.5"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="5"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="10"} 243
zetaclient_rpc_duration_seconds_bucket{host="eth:8545",le="+Inf"} 243
zetaclient_rpc_duration_seconds_sum{host="eth:8545"} 0.16580842899999995
zetaclient_rpc_duration_seconds_count{host="eth:8545"} 243
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.005"} 46
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.01"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.025"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.05"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.1"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.25"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="0.5"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="1"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="2.5"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="5"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="10"} 48
zetaclient_rpc_duration_seconds_bucket{host="solana:8899",le="+Inf"} 48
zetaclient_rpc_duration_seconds_sum{host="solana:8899"} 0.05135230499999999
zetaclient_rpc_duration_seconds_count{host="solana:8899"} 48
# HELP zetaclient_rpc_getBlockByNumber_count Count of getLogs per chain
# TYPE zetaclient_rpc_getBlockByNumber_count counter
zetaclient_rpc_getBlockByNumber_count{chain="goerli_localnet"} 53
# HELP zetaclient_rpc_getFilterLogs_count Count of getLogs per chain
# TYPE zetaclient_rpc_getFilterLogs_count counter
zetaclient_rpc_getFilterLogs_count{chain="goerli_localnet"} 104
# HELP zetaclient_rpc_in_progress Number of RPC requests in progress
# TYPE zetaclient_rpc_in_progress gauge
zetaclient_rpc_in_progress{host="eth:8545"} 0
zetaclient_rpc_in_progress{host="solana:8899"} 0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced monitoring capabilities with new Prometheus metrics for RPC requests, including `RPCInProgress`, `RPCCount`, and `RPCLatency`.
  - Added an instrumented HTTP client for improved RPC request monitoring.

- **Bug Fixes**
  - Improved error handling and logging for RPC client connections.

- **Tests**
  - Enhanced testing suite with new assertions for metric accuracy and reliability using the instrumented HTTP client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->