### PR TITLE
ci: use ghcr docker images to avoid rate limiting

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.7-labs
-FROM golang:1.22.5-bookworm AS base-build
+# syntax=ghcr.io/zeta-chain/docker-dockerfile:1.7-labs
+FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS base-build
 
 ENV GOPATH /go
 ENV GOOS=linux
@@ -22,10 +22,10 @@ COPY --exclude=*.sh --exclude=*.md --exclude=*.yml . .
 RUN --mount=type=cache,target="/root/.cache/go-build" make install
 RUN --mount=type=cache,target="/root/.cache/go-build" make install-zetae2e
 
-FROM golang:1.22.5-bookworm AS cosmovisor-build
+FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS cosmovisor-build
 RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
 
-FROM golang:1.22.5-bookworm AS base-runtime
+FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS base-runtime
 
 RUN apt update && \
     apt install -yq jq yq curl tmux python3 openssh-server iputils-ping iproute2 bind9-host && \

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -9,6 +9,8 @@
 # - An orchestrator to manage interaction with the localnet (orchestrator)
 # - An upgrade host to serve binaries for the upgrade tests (upgrade-host). Only enabled when profile is set to upgrade.
 # - An upgrade orchestrator to send the upgrade governance proposal (upgrade-orchestrator). Only enabled when profile is set to upgrade.
+#
+# If you are using third party images in CI, you should copy them into ghcr via https://github.com/zeta-chain/copy-docker-images
 
 networks:
   mynetwork:
@@ -181,7 +183,7 @@ services:
       - preparams:/root/preparams
 
   eth:
-    image: ethereum/client-go:v1.10.26
+    image: ghcr.io/zeta-chain/ethereum-client-go:v1.10.26
     container_name: eth
     hostname: eth
     ports:
@@ -207,7 +209,7 @@ services:
         ipv4_address: 172.20.0.102
 
   bitcoin:
-    image: ruimarinho/bitcoin-core:22 # version 23 is not working with btcd 0.22.0 due to change in createwallet rpc
+    image: ghcr.io/zeta-chain/ruimarinho-bitcoin-core:22 # version 23 is not working with btcd 0.22.0 due to change in createwallet rpc
     container_name: bitcoin
     hostname: bitcoin
     networks:

--- a/contrib/localnet/orchestrator/Dockerfile.fastbuild
+++ b/contrib/localnet/orchestrator/Dockerfile.fastbuild
@@ -1,6 +1,6 @@
 FROM zetanode:latest as zeta
-FROM ethereum/client-go:v1.10.26 as geth
-FROM  golang:1.20.14-bookworm as orchestrator
+FROM ghcr.io/zeta-chain/ethereum-client-go:v1.10.26 as geth
+FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm as orchestrator
 
 RUN apt update && \
     apt install -yq jq yq curl tmux python3 openssh-server iputils-ping iproute2 && \


### PR DESCRIPTION
Occasionally CI will fail to pull an image because of docker hub rate limiting (we get 200 pulls per 6 hours).

https://github.com/zeta-chain/copy-docker-images copies relevant images into ghcr.io. Use those images in our CI Dockerfile and docker-compose files.

This must be done on github actions as only the CI token may push to ghcr.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the base images for various Dockerfiles to utilize GitHub Container Registry, enhancing the sourcing of critical services.
	- Improved clarity in the `docker-compose.yml` with new image references for Ethereum and Bitcoin services.

- **Documentation**
	- Added guidance within the `docker-compose.yml` for using third-party images in CI.

These changes improve the reliability and infrastructure of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->