### PR TITLE
ci: run on PRs to all base branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,6 @@ on:
       - release/*
   merge_group:
   pull_request:
-    branches:
-      - "*"
-    types:
-      - synchronize
-      - opened
-      - reopened
 
 concurrency: 
   group: pr-testing-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,8 +6,6 @@ on:
       - develop
       - release/*
   pull_request:
-    branches:
-      - "*"
   merge_group:
   schedule:
     # run at 6AM UTC Daily

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -8,9 +8,6 @@ on:
       - "*"
   merge_group:
   pull_request:
-    types:
-      - opened
-      - synchronize
 
 concurrency:
   group: linters-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
The `*` expression is [apparently not working](https://github.com/zeta-chain/node/pull/2605). Remove types too since default is already opened, reopened, synchronized 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined pull request workflow by limiting event triggers, optimizing execution efficiency.
	- Enhanced responsiveness of the SAST linters to all pull request events, improving CI/CD pipeline performance.
- **Bug Fixes**
	- Adjusted workflow triggers to prevent unnecessary builds, ensuring smoother development processes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->