### PR TITLE
feat(E2E): add body for smart contract V2 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,11 @@ start-solana-test: zetanode solana
 	export E2E_ARGS="--skip-regular --test-solana" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile solana -f docker-compose.yml up -d
 
+start-v2-test: zetanode
+	@echo "--> Starting e2e smart contracts v2 test"
+	export E2E_ARGS="--test-v2" && \
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) -f docker-compose.yml up -d
+
 ###############################################################################
 ###                         Upgrade Tests              						###
 ###############################################################################

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -41,6 +41,7 @@ const (
 	flagTestTSSMigration  = "test-tss-migration"
 	flagSkipBitcoinSetup  = "skip-bitcoin-setup"
 	flagSkipHeaderProof   = "skip-header-proof"
+	flagTestV2            = "test-v2"
 )
 
 var (
@@ -73,6 +74,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().Bool(flagSkipBitcoinSetup, false, "set to true to skip bitcoin wallet setup")
 	cmd.Flags().Bool(flagSkipHeaderProof, false, "set to true to skip header proof tests")
 	cmd.Flags().Bool(flagTestTSSMigration, false, "set to true to include a migration test at the end")
+	cmd.Flags().Bool(flagTestV2, false, "set to true to run tests for v2 contracts")
 
 	return cmd
 }
@@ -95,6 +97,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		skipBitcoinSetup  = must(cmd.Flags().GetBool(flagSkipBitcoinSetup))
 		skipHeaderProof   = must(cmd.Flags().GetBool(flagSkipHeaderProof))
 		testTSSMigration  = must(cmd.Flags().GetBool(flagTestTSSMigration))
+		testV2            = must(cmd.Flags().GetBool(flagTestV2))
 	)
 
 	logger := runner.NewLogger(verbose, color.FgWhite, "setup")
@@ -324,6 +327,9 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	}
 	if testSolana {
 		eg.Go(solanaTestRoutine(conf, deployerRunner, verbose, e2etests.TestSolanaDepositName))
+	}
+	if testV2 {
+		eg.Go(v2TestRoutine(conf, deployerRunner, verbose))
 	}
 
 	// while tests are executed, monitor blocks in parallel to check if system txs are on top and they have biggest priority

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -329,7 +329,18 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		eg.Go(solanaTestRoutine(conf, deployerRunner, verbose, e2etests.TestSolanaDepositName))
 	}
 	if testV2 {
-		eg.Go(v2TestRoutine(conf, deployerRunner, verbose))
+		eg.Go(v2TestRoutine(conf, deployerRunner, verbose,
+			e2etests.TestV2ETHDepositName,
+			e2etests.TestV2ETHDepositAndCallName,
+			e2etests.TestV2ETHWithdrawName,
+			e2etests.TestV2ETHWithdrawAndCallName,
+			e2etests.TestV2ERC20DepositName,
+			e2etests.TestV2ERC20DepositAndCallName,
+			e2etests.TestV2ERC20WithdrawName,
+			e2etests.TestV2ERC20WithdrawAndCallName,
+			e2etests.TestV2ZEVMToEVMCallName,
+			e2etests.TestV2EVMToZEVMCallName,
+		))
 	}
 
 	// while tests are executed, monitor blocks in parallel to check if system txs are on top and they have biggest priority

--- a/cmd/zetae2e/local/v2.go
+++ b/cmd/zetae2e/local/v2.go
@@ -1,0 +1,69 @@
+package local
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/zeta-chain/zetacore/e2e/config"
+	"github.com/zeta-chain/zetacore/e2e/e2etests"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"time"
+)
+
+// erc20TestRoutine runs v2 related e2e tests
+// TODO: this routine will be broken down in the future and will replace most current tests
+// we keep a single routine for v2 for simplicity
+// https://github.com/zeta-chain/node/issues/2554
+func v2TestRoutine(
+	conf config.Config,
+	deployerRunner *runner.E2ERunner,
+	verbose bool,
+	testNames ...string,
+) func() error {
+	return func() (err error) {
+		account := conf.AdditionalAccounts.UserERC20
+		// initialize runner for erc20 test
+		v2Runner, err := initTestRunner(
+			"v2",
+			conf,
+			deployerRunner,
+			account,
+			runner.NewLogger(verbose, color.FgHiYellow, "v2"),
+			runner.WithZetaTxServer(deployerRunner.ZetaTxServer),
+		)
+		if err != nil {
+			return err
+		}
+
+		v2Runner.Logger.Print("🏃 starting v2 tests")
+		startTime := time.Now()
+
+		// funding the account
+		txERC20Send := deployerRunner.SendERC20OnEvm(account.EVMAddress(), 10)
+		v2Runner.WaitForTxReceiptOnEvm(txERC20Send)
+
+		// depositing the necessary tokens on ZetaChain
+		// TODO: update with v2 deposits
+		// https://github.com/zeta-chain/node/issues/2554
+		txEtherDeposit := v2Runner.DepositEther(false)
+		txERC20Deposit := v2Runner.DepositERC20()
+		v2Runner.WaitForMinedCCTX(txEtherDeposit)
+		v2Runner.WaitForMinedCCTX(txERC20Deposit)
+
+		// run erc20 test
+		testsToRun, err := v2Runner.GetE2ETestsToRunByName(
+			e2etests.AllE2ETests,
+			testNames...,
+		)
+		if err != nil {
+			return fmt.Errorf("v2 tests failed: %v", err)
+		}
+
+		if err := v2Runner.RunE2ETests(testsToRun); err != nil {
+			return fmt.Errorf("v2 tests failed: %v", err)
+		}
+
+		v2Runner.Logger.Print("🍾 v2 tests completed in %s", time.Since(startTime).String())
+
+		return err
+	}
+}

--- a/cmd/zetae2e/local/v2.go
+++ b/cmd/zetae2e/local/v2.go
@@ -2,11 +2,13 @@ package local
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/fatih/color"
+
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/e2etests"
 	"github.com/zeta-chain/zetacore/e2e/runner"
-	"time"
 )
 
 // erc20TestRoutine runs v2 related e2e tests

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -112,16 +112,16 @@ const (
 	/*
 	 V2 smart contract tests
 	*/
-	TestV2EthDeposit        = "v2_eth_deposit"
-	TestV2EthDepositAndCall = "v2_eth_deposit_and_call"
-	TestV2EthWithdraw       = "v2_eth_withdraw"
-	TestV2EthWithdrawCall   = "v2_eth_withdraw_and_call"
-	TestV2ERC20Deposit      = "v2_erc20_deposit"
-	TestV2ERC20DepositCall  = "v2_erc20_deposit_and_call"
-	TestV2ERC20Withdraw     = "v2_erc20_withdraw"
-	TestV2ERC20WithdrawCall = "v2_erc20_withdraw_and_call"
-	TestV2ZEVMToEVMCall     = "v2_zevm_to_evm_call"
-	TestV2EVMToZEVMCall     = "v2_evm_to_zevm_call"
+	TestV2ETHDepositName           = "v2_eth_deposit"
+	TestV2ETHDepositAndCallName    = "v2_eth_deposit_and_call"
+	TestV2ETHWithdrawName          = "v2_eth_withdraw"
+	TestV2ETHWithdrawAndCallName   = "v2_eth_withdraw_and_call"
+	TestV2ERC20DepositName         = "v2_erc20_deposit"
+	TestV2ERC20DepositAndCallName  = "v2_erc20_deposit_and_call"
+	TestV2ERC20WithdrawName        = "v2_erc20_withdraw"
+	TestV2ERC20WithdrawAndCallName = "v2_erc20_withdraw_and_call"
+	TestV2ZEVMToEVMCallName        = "v2_zevm_to_evm_call"
+	TestV2EVMToZEVMCallName        = "v2_evm_to_zevm_call"
 
 	/*
 	 Special tests
@@ -569,6 +569,85 @@ var AllE2ETests = []runner.E2ETest{
 		"test critical admin transactions",
 		[]runner.ArgDefinition{},
 		TestCriticalAdminTransactions,
+	),
+	/*
+	 V2 smart contract tests
+	*/
+	runner.NewE2ETest(
+		TestV2ETHDepositName,
+		"deposit Ether into ZEVM using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount in wei", DefaultValue: "10000000000000000"},
+		},
+		TestV2ERC20Deposit,
+	),
+	runner.NewE2ETest(
+		TestV2ETHDepositAndCallName,
+		"deposit Ether into ZEVM and call a contract using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount in wei", DefaultValue: "10000000000000000"},
+		},
+		TestV2ETHDepositAndCall,
+	),
+	runner.NewE2ETest(
+		TestV2ETHWithdrawName,
+		"withdraw Ether from ZEVM using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount in wei", DefaultValue: "100000"},
+		},
+		TestV2ETHWithdraw,
+	),
+	runner.NewE2ETest(
+		TestV2ETHWithdrawAndCallName,
+		"withdraw Ether from ZEVM and call a contract using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount in wei", DefaultValue: "100000"},
+		},
+		TestV2ETHWithdrawAndCall,
+	),
+	runner.NewE2ETest(
+		TestV2ERC20DepositName,
+		"deposit ERC20 into ZEVM using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount", DefaultValue: "100000"},
+		},
+		TestV2ERC20Deposit,
+	),
+	runner.NewE2ETest(
+		TestV2ERC20DepositAndCallName,
+		"deposit ERC20 into ZEVM and call a contract using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount", DefaultValue: "100000"},
+		},
+		TestV2ERC20DepositAndCall,
+	),
+	runner.NewE2ETest(
+		TestV2ERC20WithdrawName,
+		"withdraw ERC20 from ZEVM using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount", DefaultValue: "1000"},
+		},
+		TestV2ERC20Withdraw,
+	),
+	runner.NewE2ETest(
+		TestV2ERC20WithdrawAndCallName,
+		"withdraw ERC20 from ZEVM and call a contract using V2 contract",
+		[]runner.ArgDefinition{
+			{Description: "amount", DefaultValue: "1000"},
+		},
+		TestV2ERC20WithdrawAndCall,
+	),
+	runner.NewE2ETest(
+		TestV2ZEVMToEVMCallName,
+		"zevm -> evm call using V2 contract",
+		[]runner.ArgDefinition{},
+		TestV2ZEVMToEVMCall,
+	),
+	runner.NewE2ETest(
+		TestV2EVMToZEVMCallName,
+		"evm -> zevm call using V2 contract",
+		[]runner.ArgDefinition{},
+		TestV2EVMToZEVMCall,
 	),
 	/*
 	 Special tests

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -110,6 +110,20 @@ const (
 	TestMigrateTSSName = "migrate_TSS"
 
 	/*
+	 V2 smart contract tests
+	*/
+	TestV2EthDeposit        = "v2_eth_deposit"
+	TestV2EthDepositAndCall = "v2_eth_deposit_and_call"
+	TestV2EthWithdraw       = "v2_eth_withdraw"
+	TestV2EthWithdrawCall   = "v2_eth_withdraw_and_call"
+	TestV2ERC20Deposit      = "v2_erc20_deposit"
+	TestV2ERC20DepositCall  = "v2_erc20_deposit_and_call"
+	TestV2ERC20Withdraw     = "v2_erc20_withdraw"
+	TestV2ERC20WithdrawCall = "v2_erc20_withdraw_and_call"
+	TestV2ZEVMToEVMCall     = "v2_zevm_to_evm_call"
+	TestV2EVMToZEVMCall     = "v2_evm_to_zevm_call"
+
+	/*
 	 Special tests
 	 Not used to test functionalities but do various interactions with the netwoks
 	*/

--- a/e2e/e2etests/test_v2_erc20_deposit.go
+++ b/e2e/e2etests/test_v2_erc20_deposit.go
@@ -1,0 +1,22 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ERC20Deposit(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ERC20Deposit")
+
+	// perform the deposit
+	tx := r.V2ERC20Deposit(r.EVMAddress(), amount)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+}

--- a/e2e/e2etests/test_v2_erc20_deposit.go
+++ b/e2e/e2etests/test_v2_erc20_deposit.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ERC20Deposit(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call.go
@@ -1,0 +1,25 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ERC20DepositAndCall")
+
+	// TODO: set payload
+	payload := []byte("")
+
+	// perform the deposit
+	tx := r.V2ERC20DepositAndCall(r.EVMAddress(), amount, payload)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+}

--- a/e2e/e2etests/test_v2_erc20_withdraw.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ERC20Withdraw(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_erc20_withdraw.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw.go
@@ -1,0 +1,22 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ERC20Withdraw(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ERC20Withdraw")
+
+	// perform the withdraw
+	tx := r.V2ERC20Withdraw(r.EVMAddress(), amount)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+}

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
@@ -1,0 +1,25 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCall")
+
+	// TODO: set payload
+	payload := []byte("")
+
+	// perform the withdraw
+	tx := r.V2ERC20WithdrawAndCall(r.EVMAddress(), amount, payload)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+}

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_eth_deposit.go
+++ b/e2e/e2etests/test_v2_eth_deposit.go
@@ -1,0 +1,22 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ETHDeposit(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ETHDeposit")
+
+	// perform the deposit
+	tx := r.V2ETHDeposit(r.EVMAddress(), amount)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+}

--- a/e2e/e2etests/test_v2_eth_deposit.go
+++ b/e2e/e2etests/test_v2_eth_deposit.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ETHDeposit(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call.go
@@ -1,0 +1,25 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ETHDepositAndCall")
+
+	// TODO: set payload
+	payload := []byte("")
+
+	// perform the deposit
+	tx := r.V2ETHDepositAndCall(r.EVMAddress(), amount, payload)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+}

--- a/e2e/e2etests/test_v2_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_eth_withdraw.go
+++ b/e2e/e2etests/test_v2_eth_withdraw.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ETHWithdraw(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_eth_withdraw.go
+++ b/e2e/e2etests/test_v2_eth_withdraw.go
@@ -1,0 +1,22 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ETHWithdraw(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdraw")
+
+	// perform the withdraw
+	tx := r.V2ETHWithdraw(r.EVMAddress(), amount)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+}

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call.go
@@ -1,0 +1,25 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"math/big"
+)
+
+func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount, ok := big.NewInt(0).SetString(args[0], 10)
+	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
+
+	// TODO: set payload
+	payload := []byte("")
+
+	// perform the withdraw
+	tx := r.V2ETHWithdrawAndCall(r.EVMAddress(), amount, payload)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+}

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call.go
@@ -1,10 +1,12 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
-	"math/big"
 )
 
 func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {

--- a/e2e/e2etests/test_v2_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_v2_evm_to_zevm_call.go
@@ -1,0 +1,21 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+)
+
+func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 0)
+
+	// TODO: set payload
+	payload := []byte("")
+
+	// perform the withdraw
+	tx := r.V2EVMToZEMVCall(r.EVMAddress(), payload)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "call")
+}

--- a/e2e/e2etests/test_v2_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_v2_evm_to_zevm_call.go
@@ -2,6 +2,7 @@ package e2etests
 
 import (
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
 )

--- a/e2e/e2etests/test_v2_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call.go
@@ -2,6 +2,7 @@ package e2etests
 
 import (
 	"github.com/stretchr/testify/require"
+
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
 )

--- a/e2e/e2etests/test_v2_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call.go
@@ -1,0 +1,21 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+)
+
+func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 0)
+
+	// TODO: set payload
+	payload := []byte("")
+
+	// perform the withdraw
+	tx := r.V2ZEVMToEMVCall(r.EVMAddress(), payload)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "call")
+}

--- a/e2e/runner/v2_evm.go
+++ b/e2e/runner/v2_evm.go
@@ -1,0 +1,62 @@
+package runner
+
+import (
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"math/big"
+)
+
+// V2ETHDeposit calls Deposit of Gateway with gas token on EVM
+func (r *E2ERunner) V2ETHDeposit(receiver ethcommon.Address, amount *big.Int) *ethtypes.Transaction {
+	// set the value of the transaction
+	previousValue := r.EVMAuth.Value
+	defer func() {
+		r.EVMAuth.Value = previousValue
+	}()
+	r.EVMAuth.Value = amount
+
+	tx, err := r.GatewayEVM.Deposit(r.EVMAuth, receiver)
+	require.NoError(r, err)
+
+	return tx
+}
+
+// V2ETHDepositAndCall calls DepositAndCall of Gateway with gas token on EVM
+func (r *E2ERunner) V2ETHDepositAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+	// set the value of the transaction
+	previousValue := r.EVMAuth.Value
+	defer func() {
+		r.EVMAuth.Value = previousValue
+	}()
+	r.EVMAuth.Value = amount
+
+	tx, err := r.GatewayEVM.DepositAndCall(r.EVMAuth, receiver, payload)
+	require.NoError(r, err)
+
+	return tx
+}
+
+// V2ERC20Deposit calls Deposit of Gateway with erc20 token on EVM
+func (r *E2ERunner) V2ERC20Deposit(receiver ethcommon.Address, amount *big.Int) *ethtypes.Transaction {
+	tx, err := r.GatewayEVM.Deposit0(r.EVMAuth, receiver, amount, r.ERC20Addr)
+	require.NoError(r, err)
+
+	return tx
+}
+
+// V2ERC20DepositAndCall calls DepositAndCall of Gateway with erc20 token on EVM
+func (r *E2ERunner) V2ERC20DepositAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+	tx, err := r.GatewayEVM.DepositAndCall0(r.EVMAuth, receiver, amount, r.ERC20Addr, payload)
+	require.NoError(r, err)
+
+	return tx
+}
+
+// V2EVMToZEMVCall calls Call of Gateway on EVM
+func (r *E2ERunner) V2EVMToZEMVCall(receiver ethcommon.Address, payload []byte) *ethtypes.Transaction {
+	tx, err := r.GatewayEVM.Call(r.EVMAuth, receiver, payload)
+	require.NoError(r, err)
+
+	return tx
+}

--- a/e2e/runner/v2_evm.go
+++ b/e2e/runner/v2_evm.go
@@ -1,10 +1,11 @@
 package runner
 
 import (
+	"math/big"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
-	"math/big"
 )
 
 // V2ETHDeposit calls Deposit of Gateway with gas token on EVM
@@ -23,7 +24,11 @@ func (r *E2ERunner) V2ETHDeposit(receiver ethcommon.Address, amount *big.Int) *e
 }
 
 // V2ETHDepositAndCall calls DepositAndCall of Gateway with gas token on EVM
-func (r *E2ERunner) V2ETHDepositAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+func (r *E2ERunner) V2ETHDepositAndCall(
+	receiver ethcommon.Address,
+	amount *big.Int,
+	payload []byte,
+) *ethtypes.Transaction {
 	// set the value of the transaction
 	previousValue := r.EVMAuth.Value
 	defer func() {
@@ -46,7 +51,11 @@ func (r *E2ERunner) V2ERC20Deposit(receiver ethcommon.Address, amount *big.Int) 
 }
 
 // V2ERC20DepositAndCall calls DepositAndCall of Gateway with erc20 token on EVM
-func (r *E2ERunner) V2ERC20DepositAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+func (r *E2ERunner) V2ERC20DepositAndCall(
+	receiver ethcommon.Address,
+	amount *big.Int,
+	payload []byte,
+) *ethtypes.Transaction {
 	tx, err := r.GatewayEVM.DepositAndCall0(r.EVMAuth, receiver, amount, r.ERC20Addr, payload)
 	require.NoError(r, err)
 

--- a/e2e/runner/v2_zevm.go
+++ b/e2e/runner/v2_zevm.go
@@ -1,0 +1,53 @@
+package runner
+
+import (
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"math/big"
+)
+
+// V2ETHWithdraw calls Withdraw of Gateway with gas token on ZEVM
+func (r *E2ERunner) V2ETHWithdraw(receiver ethcommon.Address, amount *big.Int) *ethtypes.Transaction {
+	tx, err := r.GatewayZEVM.Withdraw(r.EVMAuth, receiver.Bytes(), amount, r.ETHZRC20Addr)
+	require.NoError(r, err)
+
+	return tx
+
+}
+
+// V2ETHWithdrawAndCall calls WithdrawAndCall of Gateway with gas token on ZEVM
+func (r *E2ERunner) V2ETHWithdrawAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+	tx, err := r.GatewayZEVM.WithdrawAndCall0(r.EVMAuth, receiver.Bytes(), amount, r.ETHZRC20Addr, payload)
+	require.NoError(r, err)
+
+	return tx
+
+}
+
+// V2ERC20Withdraw calls Withdraw of Gateway with erc20 token on ZEVM
+func (r *E2ERunner) V2ERC20Withdraw(receiver ethcommon.Address, amount *big.Int) *ethtypes.Transaction {
+	tx, err := r.GatewayZEVM.Withdraw(r.EVMAuth, receiver.Bytes(), amount, r.ERC20Addr)
+	require.NoError(r, err)
+
+	return tx
+
+}
+
+// V2ERC20WithdrawAndCall calls WithdrawAndCall of Gateway with erc20 token on ZEVM
+func (r *E2ERunner) V2ERC20WithdrawAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+	tx, err := r.GatewayZEVM.WithdrawAndCall0(r.EVMAuth, receiver.Bytes(), amount, r.ERC20Addr, payload)
+	require.NoError(r, err)
+
+	return tx
+
+}
+
+// V2ZEVMToEMVCall calls Call of Gateway on ZEVM
+func (r *E2ERunner) V2ZEVMToEMVCall(receiver ethcommon.Address, payload []byte) *ethtypes.Transaction {
+	tx, err := r.GatewayZEVM.Call(r.EVMAuth, receiver.Bytes(), payload)
+	require.NoError(r, err)
+
+	return tx
+
+}

--- a/e2e/runner/v2_zevm.go
+++ b/e2e/runner/v2_zevm.go
@@ -1,10 +1,11 @@
 package runner
 
 import (
+	"math/big"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
-	"math/big"
 )
 
 // V2ETHWithdraw calls Withdraw of Gateway with gas token on ZEVM
@@ -13,16 +14,18 @@ func (r *E2ERunner) V2ETHWithdraw(receiver ethcommon.Address, amount *big.Int) *
 	require.NoError(r, err)
 
 	return tx
-
 }
 
 // V2ETHWithdrawAndCall calls WithdrawAndCall of Gateway with gas token on ZEVM
-func (r *E2ERunner) V2ETHWithdrawAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+func (r *E2ERunner) V2ETHWithdrawAndCall(
+	receiver ethcommon.Address,
+	amount *big.Int,
+	payload []byte,
+) *ethtypes.Transaction {
 	tx, err := r.GatewayZEVM.WithdrawAndCall0(r.EVMAuth, receiver.Bytes(), amount, r.ETHZRC20Addr, payload)
 	require.NoError(r, err)
 
 	return tx
-
 }
 
 // V2ERC20Withdraw calls Withdraw of Gateway with erc20 token on ZEVM
@@ -31,16 +34,18 @@ func (r *E2ERunner) V2ERC20Withdraw(receiver ethcommon.Address, amount *big.Int)
 	require.NoError(r, err)
 
 	return tx
-
 }
 
 // V2ERC20WithdrawAndCall calls WithdrawAndCall of Gateway with erc20 token on ZEVM
-func (r *E2ERunner) V2ERC20WithdrawAndCall(receiver ethcommon.Address, amount *big.Int, payload []byte) *ethtypes.Transaction {
+func (r *E2ERunner) V2ERC20WithdrawAndCall(
+	receiver ethcommon.Address,
+	amount *big.Int,
+	payload []byte,
+) *ethtypes.Transaction {
 	tx, err := r.GatewayZEVM.WithdrawAndCall0(r.EVMAuth, receiver.Bytes(), amount, r.ERC20Addr, payload)
 	require.NoError(r, err)
 
 	return tx
-
 }
 
 // V2ZEVMToEMVCall calls Call of Gateway on ZEVM
@@ -49,5 +54,4 @@ func (r *E2ERunner) V2ZEVMToEMVCall(receiver ethcommon.Address, payload []byte) 
 	require.NoError(r, err)
 
 	return tx
-
 }


### PR DESCRIPTION
# Description

Add the body for the v2 smart contract E2E tests to the contract-v2 feature branch.

```
	/*
	 V2 smart contract tests
	*/
	TestV2ETHDepositName           = "v2_eth_deposit"
	TestV2ETHDepositAndCallName    = "v2_eth_deposit_and_call"
	TestV2ETHWithdrawName          = "v2_eth_withdraw"
	TestV2ETHWithdrawAndCallName   = "v2_eth_withdraw_and_call"
	TestV2ERC20DepositName         = "v2_erc20_deposit"
	TestV2ERC20DepositAndCallName  = "v2_erc20_deposit_and_call"
	TestV2ERC20WithdrawName        = "v2_erc20_withdraw"
	TestV2ERC20WithdrawAndCallName = "v2_erc20_withdraw_and_call"
	TestV2ZEVMToEVMCallName        = "v2_zevm_to_evm_call"
	TestV2EVMToZEVMCallName        = "v2_evm_to_zevm_call"
```

Add makefile command:
```
make start-v2-test
```

This will allow to test the features live. Right now the tests will fail as the processing is not implemented in the protocol.
