### PR TITLE
fix(e2e): update chain params if deployer account changes

### DIFF
--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -224,8 +224,6 @@ then
   admin_policy=$(yq -r '.policy_accounts.admin_policy_account.bech32_address' /root/config.yml)
   operational_policy=$(yq -r '.policy_accounts.operational_policy_account.bech32_address' /root/config.yml)
 
-
-  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
   zetacored add-genesis-account "$emergency_policy" 100000000000000000000000000azeta
   zetacored add-genesis-account "$admin_policy" 100000000000000000000000000azeta
   zetacored add-genesis-account "$operational_policy" 100000000000000000000000000azeta
@@ -252,16 +250,7 @@ then
   zetacored add-genesis-account "$address" 100000000000000000000000000azeta
 # ethers tester
   address=$(yq -r '.additional_accounts.user_ether.bech32_address' /root/config.yml)
-  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
-# emergency policy account
-  address=$(yq -r '.policy_accounts.emergency_policy_account.bech32_address' /root/config.yml)
-  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
-#  admin policy account
-  address=$(yq -r '.policy_accounts.admin_policy_account.bech32_address' /root/config.yml)
-  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
-#  operational policy account
-  address=$(yq -r '.policy_accounts.operational_policy_account.bech32_address' /root/config.yml)
-  zetacored add-genesis-account "$address" 100000000000000000000000000azeta
+  zetacored add-genesis-account "$address" 100000000000000000000000000azeta 
 # migration tester
   address=$(yq -r '.additional_accounts.user_migration.bech32_address' /root/config.yml)
   zetacored add-genesis-account "$address" 100000000000000000000000000azeta

--- a/e2e/runner/setup_evm.go
+++ b/e2e/runner/setup_evm.go
@@ -179,26 +179,11 @@ func (r *E2ERunner) SetupEVM(contractsDeployed bool, whitelistERC20 bool) {
 		},
 	)
 	require.NoError(r, err, "failed to get chain params for chain %d", chains.GoerliLocalnet.ChainId)
+
 	chainParams := currentChainParamsRes.ChainParams
-	needsUpdate := false
-
-	if chainParams.Erc20CustodyContractAddress != r.ERC20CustodyAddr.Hex() {
-		chainParams.Erc20CustodyContractAddress = r.ERC20CustodyAddr.Hex()
-		needsUpdate = true
-	}
-	if chainParams.ConnectorContractAddress != r.ConnectorEthAddr.Hex() {
-		chainParams.ConnectorContractAddress = r.ConnectorEthAddr.Hex()
-		needsUpdate = true
-	}
-	if chainParams.ZetaTokenContractAddress != r.ZetaEthAddr.Hex() {
-		chainParams.ZetaTokenContractAddress = r.ZetaEthAddr.Hex()
-		needsUpdate = true
-	}
-
-	if !needsUpdate {
-		r.Logger.Info("Chain params are up to date")
-		return
-	}
+	chainParams.Erc20CustodyContractAddress = r.ERC20CustodyAddr.Hex()
+	chainParams.ConnectorContractAddress = r.ConnectorEthAddr.Hex()
+	chainParams.ZetaTokenContractAddress = r.ZetaEthAddr.Hex()
 
 	_, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, observertypes.NewMsgUpdateChainParams(
 		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),

--- a/e2e/runner/setup_evm.go
+++ b/e2e/runner/setup_evm.go
@@ -15,7 +15,9 @@ import (
 	"github.com/zeta-chain/zetacore/e2e/contracts/erc20"
 	"github.com/zeta-chain/zetacore/e2e/contracts/testdapp"
 	"github.com/zeta-chain/zetacore/e2e/utils"
+	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/pkg/constant"
+	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
 const (
@@ -167,4 +169,42 @@ func (r *E2ERunner) SetupEVM(contractsDeployed bool, whitelistERC20 bool) {
 	// We use this config to be consistent with the old implementation
 	// https://github.com/zeta-chain/node-private/issues/41
 	require.NoError(r, config.WriteConfig(ContractsConfigFile, conf))
+
+	// chain params will need to be updated if they do not match the default params
+	// this be required if the deployer account changes
+	currentChainParamsRes, err := r.ObserverClient.GetChainParamsForChain(
+		r.Ctx,
+		&observertypes.QueryGetChainParamsForChainRequest{
+			ChainId: chains.GoerliLocalnet.ChainId,
+		},
+	)
+	require.NoError(r, err, "failed to get chain params for chain %d", chains.GoerliLocalnet.ChainId)
+	chainParams := currentChainParamsRes.ChainParams
+	needsUpdate := false
+
+	if chainParams.Erc20CustodyContractAddress != r.ERC20CustodyAddr.Hex() {
+		chainParams.Erc20CustodyContractAddress = r.ERC20CustodyAddr.Hex()
+		needsUpdate = true
+	}
+	if chainParams.ConnectorContractAddress != r.ConnectorEthAddr.Hex() {
+		chainParams.ConnectorContractAddress = r.ConnectorEthAddr.Hex()
+		needsUpdate = true
+	}
+	if chainParams.ZetaTokenContractAddress != r.ZetaEthAddr.Hex() {
+		chainParams.ZetaTokenContractAddress = r.ZetaEthAddr.Hex()
+		needsUpdate = true
+	}
+
+	if !needsUpdate {
+		r.Logger.Info("Chain params are up to date")
+		return
+	}
+
+	_, err = r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, observertypes.NewMsgUpdateChainParams(
+		r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName),
+		chainParams,
+	))
+
+	require.NoError(r, err, "failed to update chain params")
+	r.Logger.Print("🔄 updated chain params")
 }


### PR DESCRIPTION
# Description

While I was working on #2238, I missed that I needed to update the EVM contract addresses in ChainParams. The `GetDefaultGoerliLocalnetChainParams()` only work if using the current localnet.yml deployer account.

It seems a zetaclient restart is required if this happens though. See https://github.com/zeta-chain/node/issues/2005

Also fix double `zetacored add-genesis-account` call for policy operations accounts.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined account initialization process for blockchain operations, focusing solely on user accounts.
	- Enhanced EVM setup process with dynamic updates to chain parameters based on the deployment context, improving adaptability and robustness.

- **Bug Fixes**
	- Improved error handling for fetching and updating chain parameters during EVM setup to ensure more reliable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->