### PR TITLE
Update golang cross compile to 1.22.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ start-upgrade-import-mainnet-test: zetanode-upgrade
 ###############################################################################
 
 PACKAGE_NAME          := github.com/zeta-chain/node
-GOLANG_CROSS_VERSION  ?= v1.20.7
+GOLANG_CROSS_VERSION  ?= v1.22.4
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \


### PR DESCRIPTION
# Description

Build process uses golang v1.20, but v1.22 is needed.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
