### PR TITLE
ci: Added goreleaser check

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check_branch:
+  check-branch:
     if: ${{ (startsWith(github.ref, 'refs/heads/release/v') || startsWith(github.ref, 'refs/heads/hotfix/v')) }}
     runs-on: ubuntu-22.04
     steps:
@@ -31,9 +31,18 @@ jobs:
         run: |
           echo "${{ github.ref }}"
 
+  check-goreleaser:
+    needs:
+      - check-branch
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Branch
+        run: |
+          make release-dry-run
+          
   check-changelog:
     needs:
-      - check_branch
+      - check-branch
     runs-on: ubuntu-22.04
     steps:
 
@@ -75,7 +84,7 @@ jobs:
 
   check-upgrade-handler-updated:
     needs:
-      - check_branch
+      - check-branch
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -114,7 +123,7 @@ jobs:
     needs:
       - check-changelog
       - check-upgrade-handler-updated
-      - check_branch
+      - check-branch
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     environment: release


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added a dry run of goreleaser as part of the release workflow. Not having a test of goreleaser caused issued with the v19 release because it had not been properly updated. https://github.com/zeta-chain/node/actions/runs/10252637202

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job in the release workflow that performs a dry run of the release process, enhancing the reliability of future releases.
  
- **Improvements**
	- Standardized naming conventions for workflow jobs to improve clarity and consistency throughout the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->