### PR TITLE
fix(ci): Update golang cross compile to 1.22.4 (#2635)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ start-upgrade-import-mainnet-test: zetanode-upgrade
 ###############################################################################
 
 PACKAGE_NAME          := github.com/zeta-chain/node
-GOLANG_CROSS_VERSION  ?= v1.20.7
+GOLANG_CROSS_VERSION  ?= v1.22.4
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \
@@ -334,7 +334,7 @@ release-dry-run:
 		-v ${GOPATH}/pkg:/go/pkg \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip-validate --skip-publish --snapshot
+		--clean --skip=validate --skip=publish --snapshot
 
 release:
 	@if [ ! -f ".release-env" ]; then \
@@ -350,7 +350,7 @@ release:
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --clean --skip-validate
+		release --clean --skip=validate
 
 ###############################################################################
 ###                     Local Mainnet Development                           ###


### PR DESCRIPTION
# Description

* Update golang cross compile to 1.22.4

* update deprecated --skip-validate --skip-release flags

(cherry picked from commit 5dd6fd66354a6b43d036b8c3c07f5580b0c6a9ae)

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

Tested by @CharlieMc0 locally

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions
