### PR TITLE
fix(zetaclient): use name in pending tx metric

### DIFF
--- a/zetaclient/context/chain.go
+++ b/zetaclient/context/chain.go
@@ -132,6 +132,10 @@ func (c Chain) ID() int64 {
 	return c.chainInfo.ChainId
 }
 
+func (c Chain) Name() string {
+	return c.chainInfo.Name
+}
+
 func (c Chain) Params() *observer.ChainParams {
 	return c.observerParams
 }

--- a/zetaclient/orchestrator/orchestrator.go
+++ b/zetaclient/orchestrator/orchestrator.go
@@ -375,7 +375,7 @@ func (oc *Orchestrator) runScheduler(ctx context.Context) error {
 						cctxList := cctxMap[chainID]
 
 						metrics.PendingTxsPerChain.
-							WithLabelValues(fmt.Sprintf("chain_%d", chainID)).
+							WithLabelValues(chain.Name()).
 							Set(float64(len(cctxList)))
 
 						if len(cctxList) == 0 {


### PR DESCRIPTION
https://github.com/zeta-chain/node/pull/2568 started putting integer chain IDs in the `zetaclient_pending_txs_total` metric. We want string IDs so dashboards and alerts are readable at a glance. This also is not consistent with our other metrics like `zetaclient_rpc_getBlockByNumber_count`

Current (`develop`) state:

```
# HELP zetaclient_pending_txs_total Number of pending transactions per chain
# TYPE zetaclient_pending_txs_total gauge
zetaclient_pending_txs_total{chain="chain_1337"} 500
zetaclient_pending_txs_total{chain="chain_18444"} 0
zetaclient_pending_txs_total{chain="chain_902"} 0
# HELP zetaclient_rpc_getBlockByNumber_count Count of getLogs per chain
# TYPE zetaclient_rpc_getBlockByNumber_count counter
zetaclient_rpc_getBlockByNumber_count{chain="goerli_localnet"} 15135
# HELP zetaclient_rpc_getFilterLogs_count Count of getLogs per chain
# TYPE zetaclient_rpc_getFilterLogs_count counter
zetaclient_rpc_getFilterLogs_count{chain="goerli_localnet"} 30270
```

New (desired) state:

```
# HELP zetaclient_pending_txs_total Number of pending transactions per chain
# TYPE zetaclient_pending_txs_total gauge
zetaclient_pending_txs_total{chain="btc_regtest"} 0
zetaclient_pending_txs_total{chain="goerli_localnet"} 3
zetaclient_pending_txs_total{chain="solana_localnet"} 0
# HELP zetaclient_rpc_getBlockByNumber_count Count of getLogs per chain
# TYPE zetaclient_rpc_getBlockByNumber_count counter
zetaclient_rpc_getBlockByNumber_count{chain="goerli_localnet"} 131
# HELP zetaclient_rpc_getFilterLogs_count Count of getLogs per chain
# TYPE zetaclient_rpc_getFilterLogs_count counter
zetaclient_rpc_getFilterLogs_count{chain="goerli_localnet"} 260
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve the name of the chain, improving usability.
	- Updated metrics reporting to use the chain's name for clarity.

- **Bug Fixes**
	- Enhanced metric labeling for better semantic understanding by using chain names instead of IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->