### PR TITLE
chore: fix docker build warnings

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -1,7 +1,8 @@
-# syntax=ghcr.io/zeta-chain/docker-dockerfile:1.7-labs
+# syntax=ghcr.io/zeta-chain/docker-dockerfile:1.9-labs
+# check=error=true
 FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS base-build
 
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOOS=linux
 ENV CGO_ENABLED=1
 ENV GOCACHE=/root/.cache/go-build
@@ -41,7 +42,7 @@ RUN mkdir -p /root/.zetacored/cosmovisor/genesis/bin && \
     ln -s /usr/local/bin/zetaclientd /root/.zetaclientd/upgrades/genesis/zetacored && \
     ln -s /root/.zetaclientd/upgrades/genesis /root/.zetaclientd/upgrades/current
 
-ENV PATH /root/.zetacored/cosmovisor/current/bin/:/root/.zetaclientd/upgrades/current/:${PATH}
+ENV PATH=/root/.zetacored/cosmovisor/current/bin/:/root/.zetaclientd/upgrades/current/:${PATH}
 
 COPY contrib/localnet/scripts /root
 COPY contrib/localnet/ssh_config /etc/ssh/ssh_config.d/localnet.conf
@@ -62,7 +63,7 @@ COPY --from=latest-build /go/bin/zetacored /go/bin/zetaclientd /go/bin/zetaclien
 
 # Optional old version build (from source). This old build is used as the genesis version in the upgrade tests. 
 # Use --target latest-runtime to skip.
-FROM base-build as old-build-source
+FROM base-build AS old-build-source
 
 ARG OLD_VERSION
 RUN git clone https://github.com/zeta-chain/node.git

--- a/contrib/localnet/orchestrator/Dockerfile.fastbuild
+++ b/contrib/localnet/orchestrator/Dockerfile.fastbuild
@@ -1,6 +1,8 @@
-FROM zetanode:latest as zeta
-FROM ghcr.io/zeta-chain/ethereum-client-go:v1.10.26 as geth
-FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm as orchestrator
+# syntax=ghcr.io/zeta-chain/docker-dockerfile:1.9-labs
+# check=error=true
+FROM zetanode:latest AS zeta
+FROM ghcr.io/zeta-chain/ethereum-client-go:v1.10.26 AS geth
+FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS orchestrator
 
 RUN apt update && \
     apt install -yq jq yq curl tmux python3 openssh-server iputils-ping iproute2 && \


### PR DESCRIPTION
Docker introduced a linter in newest syntax versions. If syntax is unspecified, you will start to see this when you upgrade docker:

```
 3 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 ```
 
 Upgrade our syntax version and set it on all localnet dockerfiles so that we get consistent lint results. Also prevent builds from passing if there are any lint errors:
 
 ```
 ➜  node git:(docker-warnings) ✗ make zetanode
Building zetanode
docker build -t zetanode --target latest-runtime -f ./Dockerfile-localnet .
[+] Building 1.3s (4/4) FINISHED                                                                                                                                                                                                                               docker:default
 => [internal] load build definition from Dockerfile-localnet                                                                                                                                                                                                            0.0s
 => => transferring dockerfile: 3.37kB                                                                                                                                                                                                                                   0.0s
 => resolve image config for docker-image://ghcr.io/zeta-chain/docker-dockerfile:1.9-labs                                                                                                                                                                                0.2s
 => CACHED docker-image://ghcr.io/zeta-chain/docker-dockerfile:1.9-labs@sha256:64585ac36e6af50f0078728783f6a874c6f5f63bd31ec94195ca44b69ed1e7f8                                                                                                                          0.0s
 => [internal] load metadata for ghcr.io/zeta-chain/golang:1.22.5-bookworm                                                                                                                                                                                               0.6s
Dockerfile-localnet:1
--------------------
   1 | >>> # syntax=ghcr.io/zeta-chain/docker-dockerfile:1.9-labs
   2 |     # check=error=true
   3 |     FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS base-build
--------------------
ERROR: failed to solve: lint violation found for rules: LegacyKeyValueFormat, FromAsCasing
make: *** [Makefile:227: zetanode] Error 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Dockerfile for localnet and orchestrator to utilize the latest Docker syntax version, which may enhance build capabilities.
  
- **Improvements**
	- Enhanced clarity and consistency in environment variable declarations.
	- Added error checking for improved build reliability. 

These changes aim to streamline the build process and improve maintainability for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->