### PR TITLE
fix(ci): use FullCommit and align version.sh logic

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,6 @@ env:
   - CC_windows_amd64=x86_64-w64-mingw32-gcc
   - CXX_windows_amd64=x86_64-w64-mingw32-g++
   - VERSION={{ .Version }}
-  - COMMIT={{ .Commit }}
   - BUILDTIME={{ .Date }}
   # - CC_windows_arm64= NOT_CREATING_WINDOWS_ARM64_BINARIES
   # - CXX_windows_arm64= NOT_CREATING_WINDOWS_ARM64_BINARIES
@@ -54,10 +53,10 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.ServerName=zetacored
       - -X github.com/cosmos/cosmos-sdk/version.ClientName=zetaclientd
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Env.COMMIT }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .FullCommit }}
       - -X github.com/zeta-chain/zetacore/pkg/constant.Name=zetacored
       - -X github.com/zeta-chain/zetacore/pkg/constant.Version={{ .Version }}
-      - -X github.com/zeta-chain/zetacore/pkg/constant.CommitHash={{ .Env.COMMIT }}
+      - -X github.com/zeta-chain/zetacore/pkg/constant.CommitHash={{ .FullCommit }}
       - -X github.com/zeta-chain/zetacore/pkg/constant.BuildTime={{ .Env.BUILDTIME }}
       - -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb
 
@@ -100,7 +99,7 @@ release:
   # Available only for GitHub and Gitea.
   draft: false
 
-  target_commitish: "{{ .Commit }}"
+  target_commitish: "{{ .FullCommit }}"
 
   # If set, will create a release discussion in the category specified.
   #

--- a/version.sh
+++ b/version.sh
@@ -3,18 +3,20 @@
 # --exact-match will ensure the tag is only returned if our commit is a tag
 version=$(git describe --exact-match --tags 2>/dev/null)
 if [[ $? -eq 0 ]]; then
-    echo $version
+    # do not return v prefix on the version
+    # to match the goreleaser logic
+    echo ${version#v}
     exit
 fi
 
 # use current timestamp for dirty builds
 if ! git diff --no-ext-diff --quiet --exit-code ; then
     current_timestamp=$(date +"%s")
-    echo "v0.0.${current_timestamp}-dirty"
+    echo "0.0.${current_timestamp}-dirty"
     exit
 fi
 
 # otherwise assume we are on a develop build and use commit timestamp for version
 commit_timestamp=$(git show --no-patch --format=%at)
 
-echo "v0.0.${commit_timestamp}-develop"
+echo "0.0.${commit_timestamp}-develop"


### PR DESCRIPTION
# Description

The Commit variable isn't set correctly on the v19.0.0 release:

```
$ strings zetacored-linux-arm64 | grep constant.Version=19.0.0
build	-ldflags="-X github.com/cosmos/cosmos-sdk/version.Name=zetacore -X github.com/cosmos/cosmos-sdk/version.ServerName=zetacored -X github.com/cosmos/cosmos-sdk/version.ClientName=zetaclientd -X github.com/cosmos/cosmos-sdk/version.Version=19.0.0 -X github.com/cosmos/cosmos-sdk/version.Commit= -X github.com/zeta-chain/zetacore/pkg/constant.Name=zetacored -X github.com/zeta-chain/zetacore/pkg/constant.Version=19.0.0 -X github.com/zeta-chain/zetacore/pkg/constant.CommitHash= -X github.com/zeta-chain/zetacore/pkg/constant.BuildTime=2024-08-06T16:54:11Z -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb"
```

Use [`.FullCommit`](https://goreleaser.com/customization/templates/#common-fields) instead. I'm not exactly sure why the `.Env` wasn't working.

Also strip the v from the version in `version.sh` to align with the goreleaser version logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced commit identifier handling for improved traceability and versioning accuracy during builds and releases.
	- Removed 'v' prefix from version strings in output, aligning with goreleaser expectations.
  
These changes ensure more precise versioning and better integration with build tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->