### PR TITLE
fix(ci): use FullCommit and align version logic

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,6 @@ env:
   - CC_windows_amd64=x86_64-w64-mingw32-gcc
   - CXX_windows_amd64=x86_64-w64-mingw32-g++
   - VERSION={{ .Version }}
-  - COMMIT={{ .Commit }}
   - BUILDTIME={{ .Date }}
   # - CC_windows_arm64= NOT_CREATING_WINDOWS_ARM64_BINARIES
   # - CXX_windows_arm64= NOT_CREATING_WINDOWS_ARM64_BINARIES
@@ -54,10 +53,10 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.ServerName=zetacored
       - -X github.com/cosmos/cosmos-sdk/version.ClientName=zetaclientd
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
-      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Env.COMMIT }}
+      - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .FullCommit }}
       - -X github.com/zeta-chain/zetacore/pkg/constant.Name=zetacored
       - -X github.com/zeta-chain/zetacore/pkg/constant.Version={{ .Version }}
-      - -X github.com/zeta-chain/zetacore/pkg/constant.CommitHash={{ .Env.COMMIT }}
+      - -X github.com/zeta-chain/zetacore/pkg/constant.CommitHash={{ .FullCommit }}
       - -X github.com/zeta-chain/zetacore/pkg/constant.BuildTime={{ .Env.BUILDTIME }}
       - -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb
 
@@ -100,7 +99,7 @@ release:
   # Available only for GitHub and Gitea.
   draft: false
 
-  target_commitish: "{{ .Commit }}"
+  target_commitish: "{{ .FullCommit }}"
 
   # If set, will create a release discussion in the category specified.
   #

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -20,11 +20,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"golang.org/x/exp/slices"
 
-	"github.com/zeta-chain/zetacore/pkg/constant"
 	authoritytypes "github.com/zeta-chain/zetacore/x/authority/types"
 	emissionstypes "github.com/zeta-chain/zetacore/x/emissions/types"
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
+
+const releaseVersion = "v19"
 
 func SetupHandlers(app *App) {
 	// Set param key table for params module migration
@@ -135,9 +136,9 @@ func SetupHandlers(app *App) {
 	}
 
 	app.UpgradeKeeper.SetUpgradeHandler(
-		constant.Version,
+		releaseVersion,
 		func(ctx sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			app.Logger().Info("Running upgrade handler for " + constant.Version)
+			app.Logger().Info("Running upgrade handler for " + releaseVersion)
 
 			var err error
 			for _, upgradeHandler := range upgradeHandlerFns {
@@ -155,7 +156,7 @@ func SetupHandlers(app *App) {
 	if err != nil {
 		panic(err)
 	}
-	if upgradeInfo.Name == constant.Version && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == releaseVersion && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// Use upgrade store loader for the initial loading of all stores when app starts,
 		// it checks if version == upgradeHeight and applies store upgrades before loading the stores,
 		// so that new stores start with the correct version (the current height of chain),

--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -36,10 +36,7 @@ if [[ $(hostname) != "zetacore0" ]]; then
   sed -i 's|tcp://localhost:26657|tcp://zetacore0:26657|g' ~/.zetacored/config/client.toml
 fi
 
-# get new zetacored version
-curl -L -o /tmp/zetacored.new "${ZETACORED_URL}"
-chmod +x /tmp/zetacored.new
-UPGRADE_NAME=$(/tmp/zetacored.new version)
+UPGRADE_NAME="v19"
 
 # if explicit upgrade height not provided, use dumb estimator
 if [[ -z $UPGRADE_HEIGHT ]]; then

--- a/version.sh
+++ b/version.sh
@@ -3,18 +3,20 @@
 # --exact-match will ensure the tag is only returned if our commit is a tag
 version=$(git describe --exact-match --tags 2>/dev/null)
 if [[ $? -eq 0 ]]; then
-    echo $version
+    # do not return v prefix on the version
+    # to match the goreleaser logic
+    echo ${version#v}
     exit
 fi
 
 # use current timestamp for dirty builds
 if ! git diff --no-ext-diff --quiet --exit-code ; then
     current_timestamp=$(date +"%s")
-    echo "v0.0.${current_timestamp}-dirty"
+    echo "0.0.${current_timestamp}-dirty"
     exit
 fi
 
 # otherwise assume we are on a develop build and use commit timestamp for version
 commit_timestamp=$(git show --no-patch --format=%at)
 
-echo "v0.0.${commit_timestamp}-develop"
+echo "0.0.${commit_timestamp}-develop"


### PR DESCRIPTION
Backport https://github.com/zeta-chain/node/pull/2646

Also explicitly set upgrade handler version to `v19` to stay consistent with previous upgrades 