### PR TITLE
fix: add validation for authorization list in genesisState.Validate() for authority module 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@
 
 * [2615](https://github.com/zeta-chain/node/pull/2615) - Refactor cleanup of outbound trackers
 
+### Fixes
+
+* [2654](https://github.com/zeta-chain/node/pull/2654) - add validation for authorization list in when validating genesis state for authorization module
+
 ## v19.0.0
 
 ### Breaking Changes

--- a/x/authority/migrations/v2/migrate.go
+++ b/x/authority/migrations/v2/migrate.go
@@ -15,6 +15,7 @@ func MigrateStore(
 	ctx sdk.Context,
 	keeper authorityKeeper,
 ) error {
+	// It is okay to not validate here, as the authorization list is fixed and will not change
 	keeper.SetAuthorizationList(ctx, types.DefaultAuthorizationsList())
 	return nil
 }

--- a/x/authority/types/genesis.go
+++ b/x/authority/types/genesis.go
@@ -14,6 +14,11 @@ func (gs GenesisState) Validate() error {
 	if err := gs.Policies.Validate(); err != nil {
 		return err
 	}
-
-	return gs.ChainInfo.Validate()
+	if err := gs.AuthorizationList.Validate(); err != nil {
+		return err
+	}
+	if err := gs.ChainInfo.Validate(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/x/authority/types/genesis_test.go
+++ b/x/authority/types/genesis_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,8 +27,9 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			name: "valid genesis",
 			gs: &types.GenesisState{
-				Policies:  sample.Policies(),
-				ChainInfo: sample.ChainInfo(42),
+				Policies:          sample.Policies(),
+				ChainInfo:         sample.ChainInfo(42),
+				AuthorizationList: sample.AuthorizationList("testMessage"),
 			},
 			errContains: "",
 		},
@@ -42,12 +44,13 @@ func TestGenesisState_Validate(t *testing.T) {
 						},
 					},
 				},
-				ChainInfo: sample.ChainInfo(42),
+				ChainInfo:         sample.ChainInfo(42),
+				AuthorizationList: sample.AuthorizationList("testMessage"),
 			},
 			errContains: "invalid address",
 		},
 		{
-			name: "invalid if policies is invalid",
+			name: "invalid if chainInfo is invalid",
 			gs: &types.GenesisState{
 				Policies: sample.Policies(),
 				ChainInfo: types.ChainInfo{
@@ -63,8 +66,33 @@ func TestGenesisState_Validate(t *testing.T) {
 						},
 					},
 				},
+				AuthorizationList: sample.AuthorizationList("testMessage"),
 			},
 			errContains: "chain ID must be positive",
+		},
+		{
+			name: "invalid if authorization list is invalid",
+			gs: &types.GenesisState{
+				Policies:  sample.Policies(),
+				ChainInfo: sample.ChainInfo(42),
+				AuthorizationList: types.AuthorizationList{
+					Authorizations: []types.Authorization{
+						{
+							MsgUrl:           fmt.Sprintf("/zetachain/%d%s", 0, "testMessage"),
+							AuthorizedPolicy: types.PolicyType_groupEmergency,
+						},
+						{
+							MsgUrl:           fmt.Sprintf("/zetachain/%d%s", 0, "testMessage"),
+							AuthorizedPolicy: types.PolicyType_groupAdmin,
+						},
+						{
+							MsgUrl:           fmt.Sprintf("/zetachain/%d%s", 0, "testMessage"),
+							AuthorizedPolicy: types.PolicyType_groupOperational,
+						},
+					},
+				},
+			},
+			errContains: "duplicate message url",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Closes : https://github.com/zeta-chain/node/issues/2653
# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced validation for the authorization module, improving security and integrity checks during the genesis state validation.
	- Added an `AuthorizationList` to the `GenesisState`, allowing for better tracking of authorization-related logic.
  
- **Bug Fixes**
	- Improved validation logic to ensure both `AuthorizationList` and `ChainInfo` are validated sequentially, enhancing the robustness of the validation process.

- **Tests**
	- Expanded test coverage for the `GenesisState` validation logic, including scenarios for the `AuthorizationList`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->