### PR TITLE
fix(e2e): ensure zetaclientd restarts on upgrade

### DIFF
--- a/cmd/zetaclientd-supervisor/lib.go
+++ b/cmd/zetaclientd-supervisor/lib.go
@@ -67,7 +67,6 @@ type zetaclientdSupervisor struct {
 	upgradesDir        string
 	upgradePlanName    string
 	enableAutoDownload bool
-	restartChan        chan os.Signal
 }
 
 func newZetaclientdSupervisor(
@@ -83,15 +82,12 @@ func newZetaclientdSupervisor(
 	if err != nil {
 		return nil, fmt.Errorf("grpc dial: %w", err)
 	}
-	// these signals will result in the supervisor process only restarting zetaclientd
-	restartChan := make(chan os.Signal, 1)
 	return &zetaclientdSupervisor{
 		zetacoredConn:      conn,
 		logger:             logger,
 		reloadSignals:      make(chan bool, 1),
 		upgradesDir:        defaultUpgradesDir,
 		enableAutoDownload: enableAutoDownload,
-		restartChan:        restartChan,
 	}, nil
 }
 

--- a/cmd/zetaclientd-supervisor/main.go
+++ b/cmd/zetaclientd-supervisor/main.go
@@ -50,8 +50,6 @@ func main() {
 		os.Exit(1)
 	}
 	supervisor.Start(ctx)
-	// listen for SIGHUP to trigger a restart of zetaclientd
-	signal.Notify(supervisor.restartChan, syscall.SIGHUP)
 
 	shouldRestart := true
 	for shouldRestart {
@@ -89,8 +87,6 @@ func main() {
 				select {
 				case <-ctx.Done():
 					return nil
-				case sig := <-supervisor.restartChan:
-					logger.Info().Msgf("got signal %d, sending SIGINT to zetaclientd", sig)
 				case sig := <-shutdownChan:
 					logger.Info().Msgf("got signal %d, shutting down", sig)
 					shouldRestart = false

--- a/cmd/zetaclientd-supervisor/main.go
+++ b/cmd/zetaclientd-supervisor/main.go
@@ -81,6 +81,7 @@ func main() {
 		})
 		eg.Go(func() error {
 			supervisor.WaitForReloadSignal(ctx)
+			cancel()
 			return nil
 		})
 		eg.Go(func() error {


### PR DESCRIPTION
#2538 broke the upgrade tests by removing the `cancel()` from after `supervisor.WaitForReloadSignal(ctx)`. I'm also removing the `restartChan` as that was leftover after #2538.

`errorgroup` only cancels the context if a goroutine returns an error.

Update: upgrade test failures seem to be due to another issue, probably related to #2610 / https://github.com/zeta-chain/node/pull/2615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved process supervision by simplifying signal handling logic, focusing on graceful terminations instead of restarts.

- **Bug Fixes**
	- Resolved potential issues with unnecessary complexity in the supervisor's restart mechanism.

- **Refactor**
	- Streamlined the `zetaclientdSupervisor` structure for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->