### PR TITLE
ci: update e2e parameters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,6 +112,7 @@ jobs:
               core.setOutput('ADMIN_TESTS', true);
               core.setOutput('PERFORMANCE_TESTS', true);
               core.setOutput('STATEFUL_DATA_TESTS', true);
+              core.setOutput('TSS_MIGRATION_TESTS', labels.includes('TSS_MIGRATION_TESTS'));
               core.setOutput('SOLANA_TESTS', true);
             } else if (context.eventName === 'workflow_dispatch') {
               core.setOutput('DEFAULT_TESTS', context.payload.inputs['default-test']);
@@ -197,6 +198,7 @@ jobs:
               const cleanName = job.name.split("/")[0];
               return `${icon} ${cleanName}`;
             });
+            e2eResults.sort();
 
             const overallResultStr = '${{ needs.e2e.result }}';
             const overallResultPassing = overallResultStr === 'success' || overallResultStr === 'skipped';

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,6 +94,7 @@ jobs:
               core.setOutput('SOLANA_TESTS', labels.includes('SOLANA_TESTS'));
             } else if (context.eventName === 'merge_group') {
               core.setOutput('DEFAULT_TESTS', true);
+              core.setOutput('UPGRADE_LIGHT_TESTS', true);
             } else if (context.eventName === 'push' && context.ref === 'refs/heads/develop') {
               core.setOutput('DEFAULT_TESTS', true);
             } else if (context.eventName === 'push' && context.ref.startsWith('refs/heads/release/')) {


### PR DESCRIPTION
- Enable tss migration tests for nightly run
- Enable light upgrade tests for mergequeue
- Sort the results so the slack message is easier to read

Blocked by https://github.com/zeta-chain/node/pull/2686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced testing workflow to include new output variables for upgrade light tests and TSS migration tests based on specific triggers.
- **Improvements**
	- Organized end-to-end test results for better clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->