### PR TITLE
fix(e2e): skip tracker check in upgrade tests

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -41,6 +41,7 @@ const (
 	flagTestTSSMigration  = "test-tss-migration"
 	flagSkipBitcoinSetup  = "skip-bitcoin-setup"
 	flagSkipHeaderProof   = "skip-header-proof"
+	flagSkipTrackerCheck  = "skip-tracker-check"
 )
 
 var (
@@ -73,6 +74,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().Bool(flagSkipBitcoinSetup, false, "set to true to skip bitcoin wallet setup")
 	cmd.Flags().Bool(flagSkipHeaderProof, false, "set to true to skip header proof tests")
 	cmd.Flags().Bool(flagTestTSSMigration, false, "set to true to include a migration test at the end")
+	cmd.Flags().Bool(flagSkipTrackerCheck, false, "set to true to skip tracker check at the end of the tests")
 
 	return cmd
 }
@@ -94,6 +96,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		skipSetup         = must(cmd.Flags().GetBool(flagSkipSetup))
 		skipBitcoinSetup  = must(cmd.Flags().GetBool(flagSkipBitcoinSetup))
 		skipHeaderProof   = must(cmd.Flags().GetBool(flagSkipHeaderProof))
+		skipTrackerCheck  = must(cmd.Flags().GetBool(flagSkipTrackerCheck))
 		testTSSMigration  = must(cmd.Flags().GetBool(flagTestTSSMigration))
 	)
 
@@ -354,7 +357,9 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		runTSSMigrationTest(deployerRunner, logger, verbose, conf)
 	}
 	// Verify that there are no trackers left over after tests complete
-	deployerRunner.EnsureNoTrackers()
+	if !skipTrackerCheck {
+		deployerRunner.EnsureNoTrackers()
+	}
 	// print and validate report
 	networkReport, err := deployerRunner.GenerateNetworkReport()
 	if err != nil {

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -99,6 +99,7 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
 
   # set upgrade height to 225 by default
   UPGRADE_HEIGHT=${UPGRADE_HEIGHT:=225}
+  OLD_VERSION=$(get_zetacored_version)
 
   if [[ ! -f deployed.yml ]]; then
     zetae2e local $E2E_ARGS --setup-only --config config.yml --config-out deployed.yml --skip-header-proof
@@ -123,9 +124,6 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   fi
 
   echo "Waiting for upgrade height..."
-
-  OLD_VERSION=$(get_zetacored_version)
-
   CURRENT_HEIGHT=0
   WAIT_HEIGHT=$(( UPGRADE_HEIGHT - 1 ))
   # wait for upgrade height

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -100,9 +100,10 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   # set upgrade height to 225 by default
   UPGRADE_HEIGHT=${UPGRADE_HEIGHT:=225}
   OLD_VERSION=$(get_zetacored_version)
+  COMMON_ARGS="--skip-header-proof --skip-tracker-check"
 
   if [[ ! -f deployed.yml ]]; then
-    zetae2e local $E2E_ARGS --setup-only --config config.yml --config-out deployed.yml --skip-header-proof
+    zetae2e local $E2E_ARGS --setup-only --config config.yml --config-out deployed.yml ${COMMON_ARGS}
     if [ $? -ne 0 ]; then
       echo "e2e setup failed"
       exit 1
@@ -116,7 +117,7 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
     echo "running E2E command to setup the networks and populate the state..."
 
     # Use light flag to ensure tests can complete before the upgrade height
-    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --light --skip-header-proof
+    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --light ${COMMON_ARGS}
     if [ $? -ne 0 ]; then
       echo "first e2e failed"
       exit 1
@@ -155,9 +156,9 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   # When the upgrade height is greater than 100 for upgrade test, the Bitcoin tests have been run once, therefore the Bitcoin wallet is already set up
   # Use light flag to skip advanced tests
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
-    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --light --skip-header-proof
+    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --light ${COMMON_ARGS}
   else
-    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof
+    zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --skip-bitcoin-setup --light ${COMMON_ARGS}
   fi
 
   ZETAE2E_EXIT_CODE=$?


### PR DESCRIPTION
#2615 introduced new logic to delete old trackers and also check that trackers were deleted in the e2e tests. We need to skip that check if we are running the e2e tests against old versions or you will sometimes get something like this in the upgrade tests:

```
	Error Trace:	/go/delivery/zeta-node/e2e/runner/trackers.go:17
	            				/go/delivery/zeta-node/cmd/zetae2e/local/local.go:357
	            				/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987
	            				/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115
	            				/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
	            				/go/delivery/zeta-node/cmd/zetae2e/main.go:16
	            				/usr/local/go/src/runtime/proc.go:271
	            				/usr/local/go/src/runtime/asm_amd64.s:1695
	Error:      	Should be empty, but was [{1337-13 1337 13 [tx_hash:"0x492dc29af7867400b5d8605d8a80a67ed44d2c84b9c71efc3d24b6e9bacd960b" tx_signer:"zeta1qsf0j04f4ufv6yduhka4207m65haqhjrzqdn82" ]} {1337-9 1337 9 [tx_hash:"0x623fed626a1adabbba32f937c5abfbc54c6fb777be07bf7621c566c4c5344326" tx_signer:"zeta1qsf0j04f4ufv6yduhka4207m65haqhjrzqdn82" ]}]
	Messages:   	there should be no trackers at the end of the test
```

Blocked by #2686 

Add a `--skip-tracker-check` arg which allows us to skip this check during the upgrade tests.

Also set `OLD_VERSION` before running the e2e tests to tolerate the upgrade height being missed:

```
setup      | ⏳ e2e tests passed,checking tx priority
setup      | ✅ e2e tests completed in 8m18.708096198s
setup      |  ---📈 Network Report ---
setup      | Block Height:           266
setup      | CCTX Processed:         35
setup      | Emissions Pool Balance: 19997921ZETA
Waiting for upgrade height...
current height is 266, waiting for 224
waiting 10 seconds for node to restart...
upgrade result: 0.0.1723492097-dirty -> 0.0.1723492097-dirty
version did not change after upgrade height, maybe the upgrade did not run?
```

In this scenario, the e2e tests populate the state successfully but was slower than expected. So long as some state is populated, I think this scenario is fine. My best guess is that occasionally an actions run will be scheduled on a machine with a weaker CPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new service client to enhance transaction management capabilities.
	- Improved functionality of several testing functions with version checks for better robustness.
- **Enhancements**
	- Expanded capabilities of key functions to utilize the new service client.
	- Updated structures to support additional functionalities in the testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->