### PR TITLE
fix(ci): correct e2e nightly syntax

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -113,7 +113,7 @@ jobs:
               core.setOutput('ADMIN_TESTS', true);
               core.setOutput('PERFORMANCE_TESTS', true);
               core.setOutput('STATEFUL_DATA_TESTS', true);
-              core.setOutput('TSS_MIGRATION_TESTS', labels.includes('TSS_MIGRATION_TESTS'));
+              core.setOutput('TSS_MIGRATION_TESTS', true);
               core.setOutput('SOLANA_TESTS', true);
             } else if (context.eventName === 'workflow_dispatch') {
               core.setOutput('DEFAULT_TESTS', context.payload.inputs['default-test']);


### PR DESCRIPTION
I broke the nightly e2e run in #2687 because I copy pasted the PR line without removing the conditional. This results in `ReferenceError: labels is not defined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the output settings for TSS migration tests in the GitHub Actions workflow, ensuring consistent enablement during job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->