### PR TITLE
fix(ci): update nightly evm performance nodejs version

### DIFF
--- a/.github/workflows/ci-nightly-performance-testing.yaml
+++ b/.github/workflows/ci-nightly-performance-testing.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: "INSTALL:NODEJS"
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: "START:LOCAL:NET:WITH:STATE"
         run: |
@@ -102,7 +102,7 @@ jobs:
           artillery report report.json --output artillery_report.html
 
       - name: "UPLOAD:REPORT"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: artillery-report


### PR DESCRIPTION
The nightly evm performance test started failing with `ReferenceError: ReadableStream is not defined`. This is apparently because the nodejs version is too old. Upgrade to node.js 20.

Also upgrade actions/upload-artifact to remove the node.js 16 deprecation warning.

These tests are still not particularly useful as they do not test reading real transactions.

Actions run: https://github.com/zeta-chain/node/actions/runs/10374376739/job/28721636174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Upgraded Node.js version from 16 to 20, enhancing performance and compatibility.
	- Updated artifact upload action to the latest version, potentially introducing new functionalities and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->