### PR TITLE
fix: skip calling 'GetBlockHeaderEnabledChains()' to bypass API error

### DIFF
--- a/zetaclient/zetacore/client.go
+++ b/zetaclient/zetacore/client.go
@@ -428,11 +428,14 @@ func (c *Client) UpdateAppContext(
 		return fmt.Errorf("failed to get crosschain flags: %w", err)
 	}
 
-	blockHeaderEnabledChains, err := c.GetBlockHeaderEnabledChains(ctx)
-	if err != nil {
-		c.logger.Info().Msg("Unable to fetch block header enabled chains from zetacore")
-		return err
-	}
+	// hotfix-v19.0.1: hardcode blockHeaderEnabledChains to empty because the zetacore API somehow won't work
+	blockHeaderEnabledChains := []lightclienttypes.HeaderSupportedChain{}
+
+	// blockHeaderEnabledChains, err := c.GetBlockHeaderEnabledChains(ctx)
+	// if err != nil {
+	// 	c.logger.Info().Msg("Unable to fetch block header enabled chains from zetacore")
+	// 	return err
+	// }
 
 	appContext.Update(
 		keyGen,


### PR DESCRIPTION
# Description

API `GetBlockHeaderEnabledChains` is not working in `v19.0.0`. Bypass the query so that `zetaclientd` can start well.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
