### PR TITLE
fix: skip calling 'GetBlockHeaderEnabledChains()' to bypass API error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v19.0.1
+
+### Fixes
+
+* [2704](https://github.com/zeta-chain/node/pull/2704) - skip calling `GetBlockHeaderEnabledChains()` to bypass API error
+
 ## v19.0.0
 
 ### Breaking Changes

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -177,7 +177,7 @@ else
   echo "running e2e setup..."
 
   if [[ ! -f deployed.yml ]]; then
-    zetae2e local $E2E_ARGS --config config.yml --setup-only --config-out deployed.yml
+    zetae2e local $E2E_ARGS --config config.yml --setup-only --config-out deployed.yml --skip-header-proof
     if [ $? -ne 0 ]; then
       echo "e2e setup failed"
       exit 1
@@ -192,7 +192,7 @@ else
 
   echo "running e2e tests with arguments: $E2E_ARGS"
 
-  zetae2e local $E2E_ARGS --skip-setup --config deployed.yml
+  zetae2e local $E2E_ARGS --skip-setup --config deployed.yml --skip-header-proof
   ZETAE2E_EXIT_CODE=$?
 
   # if e2e passed, exit with 0, otherwise exit with 1

--- a/zetaclient/zetacore/client.go
+++ b/zetaclient/zetacore/client.go
@@ -428,11 +428,14 @@ func (c *Client) UpdateAppContext(
 		return fmt.Errorf("failed to get crosschain flags: %w", err)
 	}
 
-	blockHeaderEnabledChains, err := c.GetBlockHeaderEnabledChains(ctx)
-	if err != nil {
-		c.logger.Info().Msg("Unable to fetch block header enabled chains from zetacore")
-		return err
-	}
+	// hotfix-v19.0.1: hardcode blockHeaderEnabledChains to empty because the zetacore API somehow won't work
+	blockHeaderEnabledChains := []lightclienttypes.HeaderSupportedChain{}
+
+	// blockHeaderEnabledChains, err := c.GetBlockHeaderEnabledChains(ctx)
+	// if err != nil {
+	// 	c.logger.Info().Msg("Unable to fetch block header enabled chains from zetacore")
+	// 	return err
+	// }
 
 	appContext.Update(
 		keyGen,

--- a/zetaclient/zetacore/tx_test.go
+++ b/zetaclient/zetacore/tx_test.go
@@ -329,20 +329,21 @@ func TestZetacore_UpdateAppContext(t *testing.T) {
 					GasPriceIncreaseFlags: nil,
 				}})
 
-			method = "/zetachain.zetacore.lightclient.Query/HeaderEnabledChains"
-			s.ExpectUnary(method).
-				UnlimitedTimes().
-				WithPayload(lightclienttypes.QueryHeaderEnabledChainsRequest{}).
-				Return(lightclienttypes.QueryHeaderEnabledChainsResponse{HeaderEnabledChains: []lightclienttypes.HeaderSupportedChain{
-					{
-						ChainId: chains.Ethereum.ChainId,
-						Enabled: true,
-					},
-					{
-						ChainId: chains.BitcoinMainnet.ChainId,
-						Enabled: false,
-					},
-				}})
+			// hotfix-v19.0.1: hardcode blockHeaderEnabledChains to empty
+			// method = "/zetachain.zetacore.lightclient.Query/HeaderEnabledChains"
+			// s.ExpectUnary(method).
+			// 	UnlimitedTimes().
+			// 	WithPayload(lightclienttypes.QueryHeaderEnabledChainsRequest{}).
+			// 	Return(lightclienttypes.QueryHeaderEnabledChainsResponse{HeaderEnabledChains: []lightclienttypes.HeaderSupportedChain{
+			// 		{
+			// 			ChainId: chains.Ethereum.ChainId,
+			// 			Enabled: true,
+			// 		},
+			// 		{
+			// 			ChainId: chains.BitcoinMainnet.ChainId,
+			// 			Enabled: false,
+			// 		},
+			// 	}})
 
 			method = "/zetachain.zetacore.authority.Query/ChainInfo"
 			s.ExpectUnary(method).


### PR DESCRIPTION
# Description

API `GetBlockHeaderEnabledChains` is not working in `v19.0.0`. Bypass the query so that `zetaclientd` can start well.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
