### PR TITLE
fix: do not submit pending hash to tracker to avoid invalid hash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v18.0.0
+## v18.0.1
 
 ### Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* []() - avoid submitting invalid hashes
+* [2706](https://github.com/zeta-chain/node/pull/2706) - avoid submitting pending outbound hashes
 
 ## v18.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## v18.0.0
 
+### Fixes
+
+* []() - avoid submitting invalid hashes
+
+## v18.0.0
+
 * [2470](https://github.com/zeta-chain/node/pull/2470) - add Polygon, Base and Base Sepolia in static chain info
 
 ## v17.0.1

--- a/go.sum
+++ b/go.sum
@@ -1855,7 +1855,6 @@ github.com/ipfs/go-datastore v0.6.0/go.mod h1:rt5M3nNbSO/8q1t4LNkLyUwRs8HupMeN/8
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
-github.com/ipfs/go-ipfs-util v0.0.2/go.mod h1:CbPtkWJzjLdEcezDns2XYaehFVNXG9zrdrtMecczcsQ=
 github.com/ipfs/go-log v1.0.5 h1:2dOuUCB1Z7uoczMWgAyDck5JLb72zHzrMnGnCNNbvY8=
 github.com/ipfs/go-log v1.0.5/go.mod h1:j0b8ZoR+7+R99LD9jZ6+AJsrzkPbSXbZfGakb5JPtIo=
 github.com/ipfs/go-log/v2 v2.1.3/go.mod h1:/8d0SH3Su5Ooc31QlL1WysJhvyOTDCjcCZ9Axpmri6g=
@@ -2772,7 +2771,6 @@ github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34c
 github.com/sourcegraph/go-diff v0.5.3/go.mod h1:v9JDtjCE4HHHCZGId75rg8gkKKa98RVjBcBGsVmMmak=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
-github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -3056,10 +3054,6 @@ github.com/zeta-chain/go-tss v0.1.1-0.20240208222330-f3be0d4a0d98 h1:GCSRgszQbAR
 github.com/zeta-chain/go-tss v0.1.1-0.20240208222330-f3be0d4a0d98/go.mod h1:+lJfk/qqt+oxXeVuJV+PzpUoxftUfoTRf2eF3qlbyFI=
 github.com/zeta-chain/keystone/keys v0.0.0-20231105174229-903bc9405da2 h1:gd2uE0X+ZbdFJ8DubxNqLbOVlCB12EgWdzSNRAR82tM=
 github.com/zeta-chain/keystone/keys v0.0.0-20231105174229-903bc9405da2/go.mod h1:x7Bkwbzt2W2lQfjOirnff0Dj+tykdbTG1FMJPVPZsvE=
-github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240415192848-ad076a028d30 h1:V1Kl0xLsdL2l9ThMEx/NLqRvr8zTAAyq2IoM+nhPMhE=
-github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240415192848-ad076a028d30/go.mod h1:v79f+eY6PMpmLv188FAubst4XV2Mm8mUmx1OgmdFG3c=
-github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240417132824-4be6fd4cb877 h1:Lp1HUBFI4M1vJg5exJ4zasIEAtD/iPef/OYW4eM9pXw=
-github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240417132824-4be6fd4cb877/go.mod h1:v79f+eY6PMpmLv188FAubst4XV2Mm8mUmx1OgmdFG3c=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240418181724-c222fd3ae1f5 h1:ljM7xka3WZvth9k1uYxrG3/FKQQTkR96FZlIjUKOoYw=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240418181724-c222fd3ae1f5/go.mod h1:v79f+eY6PMpmLv188FAubst4XV2Mm8mUmx1OgmdFG3c=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=

--- a/zetaclient/evm/evm_client.go
+++ b/zetaclient/evm/evm_client.go
@@ -374,7 +374,7 @@ func (ob *ChainClient) WatchOutTx() {
 					ob.logger.OutTx.Error().Msgf("WatchOutTx: confirmed multiple (%d) outTx for chain %d nonce %d", txCount, ob.chain.ChainId, nonceInt)
 				} else {
 					if len(tracker.HashList) == crosschainkeeper.MaxOutTxTrackerHashes {
-						ob.logger.OutTx.Error().Msgf("WatchOutTx: outbound tracker is full of invalid hashes for chain %d nonce %d", ob.chain.ChainId, nonceInt)
+						ob.logger.OutTx.Error().Msgf("WatchOutTx: outbound tracker is full of hashes for chain %d nonce %d", ob.chain.ChainId, nonceInt)
 					}
 				}
 			}

--- a/zetaclient/evm/evm_client.go
+++ b/zetaclient/evm/evm_client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/pkg/coin"
 	"github.com/zeta-chain/zetacore/pkg/proofs"
+	crosschainkeeper "github.com/zeta-chain/zetacore/x/crosschain/keeper"
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 	appcontext "github.com/zeta-chain/zetacore/zetaclient/app_context"
 	clientcommon "github.com/zeta-chain/zetacore/zetaclient/common"
@@ -371,6 +372,10 @@ func (ob *ChainClient) WatchOutTx() {
 					ob.SetTxNReceipt(nonceInt, outtxReceipt, outtx)
 				} else if txCount > 1 { // should not happen. We can't tell which txHash is true. It might happen (e.g. glitchy/hacked endpoint)
 					ob.logger.OutTx.Error().Msgf("WatchOutTx: confirmed multiple (%d) outTx for chain %d nonce %d", txCount, ob.chain.ChainId, nonceInt)
+				} else {
+					if len(tracker.HashList) == crosschainkeeper.MaxOutTxTrackerHashes {
+						ob.logger.OutTx.Error().Msgf("WatchOutTx: outbound tracker is full of invalid hashes for chain %d nonce %d", ob.chain.ChainId, nonceInt)
+					}
 				}
 			}
 			ticker.UpdateInterval(ob.GetChainParams().OutTxTicker, ob.logger.OutTx)

--- a/zetaclient/evm/evm_signer.go
+++ b/zetaclient/evm/evm_signer.go
@@ -521,15 +521,15 @@ func (signer *Signer) reportToOutTxTracker(zetaBridge interfaces.ZetaCoreBridger
 		blockNumber := uint64(0)
 		tStart := time.Now()
 		for {
-			// give up after 10 minutes of monitoring
+			// take a rest between each check
 			time.Sleep(10 * time.Second)
 
+			// give up (forget about the tx) after 20 minutes of monitoring, the reasons are:
+			// 1. the gas stability pool should have kicked in and replaced the tx by then.
+			// 2. even if there is a chance that the tx is included later, more likely it's going to be a false tx hash (either replaced or dropped).
+			// 3. we prefer missed tx hash over potentially invalid tx hash.
 			if time.Since(tStart) > OutTxInclusionTimeout {
-				// if tx is still pending after timeout, report to outTxTracker anyway as we cannot monitor forever
-				if isPending {
-					report = true // probably will be included later
-				}
-				logger.Info().Msgf("reportToOutTxTracker: timeout waiting tx inclusion for chain %d nonce %d outTxHash %s report %v", chainID, nonce, outTxHash, report)
+				logger.Info().Msgf("reportToOutTxTracker: timeout waiting tx inclusion for chain %d nonce %d outTxHash %s", chainID, nonce, outTxHash)
 				break
 			}
 			// try getting the tx


### PR DESCRIPTION
# Description

Cherry picked minimum fix from [the PR](https://github.com/zeta-chain/node/pull/2628):

- [x] on 20-min timeout, do not submit pending outbound tx hash to tracker to avoid invalid hash.
- [x] print log if outbound tracker is detected full of hashes.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
