### PR TITLE
ci: Set Docker Workflow to use Go 1.22

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+      - run: go version
+
       - name: Set Version from the release title.
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -60,6 +65,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+      - run: go version
 
       - name: Set Version from the release title.
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.2'
-      - run: go version
-
       - name: Set Version from the release title.
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -65,11 +60,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.2'
-      - run: go version
 
       - name: Set Version from the release title.
         if: github.event_name == 'workflow_dispatch'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS builder
+FROM golang:1.22-alpine3.18 AS builder
 
 ENV GOPATH /go
 ENV GOOS=linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.20-alpine3.18 AS builder
+FROM golang:1.22.2-alpine3.18 AS builder
 
 ENV GOPATH /go
 ENV GOOS=linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.22.2-alpine3.18 AS builder
+FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS builder
 
 ENV GOPATH /go
 ENV GOOS=linux


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The workflow to push images to docker is not working and needs to be set to use Go 1.22. 
https://github.com/zeta-chain/node/actions/runs/10408541357


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflow to support Go programming environment with version 1.22.2.
	- Added a verification step to check the installed Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->