### PR TITLE
ci: use large runner for release build

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,11 +32,11 @@ jobs:
           echo "${{ github.ref }}"
 
   check-goreleaser:
-    needs:
-      - check-branch
-    runs-on: ubuntu-22.04
+    if: ${{ github.event.inputs.skip_checks != 'true' }}
+    runs-on: ${{ vars.RELEASE_RUNNER }}
     steps:
-      - name: Branch
+      - uses: actions/checkout@v4
+      - name: Release build dry-run
         run: |
           make release-dry-run
           
@@ -124,7 +124,8 @@ jobs:
       - check-changelog
       - check-upgrade-handler-updated
       - check-branch
-    runs-on: ubuntu-22.04
+      - check-goreleaser
+    runs-on: ${{ vars.RELEASE_RUNNER }}
     timeout-minutes: 60
     environment: release
     steps:


### PR DESCRIPTION
The release build has been randomly failing because it runs out of disk space:

```
/usr/local/go/pkg/tool/linux_amd64/link: /usr/local/go/pkg/tool/linux_amd64/link: combining dwarf failed: write $WORK/b001/exe/a.out~: no space left on device
```

Use a configurable runner in the release workflow to allow running on larger runners if needed without having to update the workflow. It currently is configured to run on large github actions runners. You can check what runner built on via the build logs. The release attestation will indicate if the binaries were built on a github managed runner.

Also always run the release dry run before the release to ensure we can acutally build the release before cutting the tag. This should reduce the amount of pointless retagging we have to do.

Actions release check run: https://github.com/zeta-chain/node/actions/runs/10425868668/job/28877657855


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability of the release workflow, allowing users to skip checks based on their input.
	- Improved flexibility of the runner environment used for executing jobs.

- **Bug Fixes**
	- Adjusted job dependencies to ensure proper execution order, prioritizing essential checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->