### PR TITLE
chore(zetaclient): remove btc references in Solana client

### DIFF
--- a/zetaclient/chains/solana/observer/inbound.go
+++ b/zetaclient/chains/solana/observer/inbound.go
@@ -68,7 +68,7 @@ func (ob *Observer) WatchInbound(ctx context.Context) error {
 	}
 }
 
-// ObserveInbound observes the Bitcoin chain for inbounds and post votes to zetacore.
+// ObserveInbound observes the Solana chain for inbounds and post votes to zetacore.
 func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	chainID := ob.Chain().ChainId
 	pageLimit := solanarpc.DefaultPageLimit

--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -23,7 +23,7 @@ import (
 
 var _ interfaces.ChainSigner = (*Signer)(nil)
 
-// Signer deals with signing BTC transactions and implements the ChainSigner interface
+// Signer deals with signing Solana transactions and implements the ChainSigner interface
 type Signer struct {
 	*base.Signer
 
@@ -41,7 +41,7 @@ type Signer struct {
 	pda solana.PublicKey
 }
 
-// NewSigner creates a new Bitcoin signer
+// NewSigner creates a new Solana signer
 func NewSigner(
 	chain chains.Chain,
 	chainParams observertypes.ChainParams,


### PR DESCRIPTION
# Description

Fix some comments for Solana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation Updates**
  - Clarified the purpose of the `ObserveInbound` method to specify its focus on the Solana chain.
  - Updated comments for the `Signer` type and `NewSigner` function to reflect their functionality for signing Solana transactions instead of Bitcoin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->