### PR TITLE
ci: use single input for e2e workflow_dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,46 +13,10 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
-      default-test:
-        type: boolean
-        required: false
-        default: false
-      upgrade-light-test:
-        type: boolean
-        required: false
-        default: false
-      upgrade-test:
-        type: boolean
-        required: false
-        default: false
-      admin-test:
-        type: boolean
-        required: false
-        default: false
-      upgrade-import-mainnet-test:
-        type: boolean
-        required: false
-        default: false
-      performance-test:
-        type: boolean
-        required: false
-        default: false
-      stateful-data-test:
-        type: boolean
-        required: false
-        default: false
-      tss-migration-test:
-        type: boolean
-        required: false
-        default: false
-      solana-test:
-        type: boolean
-        required: false
-        default: false
-      v2-test:
-        type: boolean
-        required: false
-        default: false
+      make-targets:
+        description: 'Comma separated list of make targets to run (without the start- prefix)'
+        required: true
+        default: ''
 
 concurrency: 
   group: e2e-${{ github.head_ref || github.sha }}
@@ -124,16 +88,17 @@ jobs:
               core.setOutput('SOLANA_TESTS', true);
               core.setOutput('V2_TESTS', true); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
             } else if (context.eventName === 'workflow_dispatch') {
-              core.setOutput('DEFAULT_TESTS', context.payload.inputs['default-test']);
-              core.setOutput('UPGRADE_TESTS', context.payload.inputs['upgrade-test']);
-              core.setOutput('UPGRADE_LIGHT_TESTS', context.payload.inputs['upgrade-light-test']);
-              core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', context.payload.inputs['upgrade-import-mainnet-test']);
-              core.setOutput('ADMIN_TESTS', context.payload.inputs['admin-test']);
-              core.setOutput('PERFORMANCE_TESTS', context.payload.inputs['performance-test']);
-              core.setOutput('STATEFUL_DATA_TESTS', context.payload.inputs['stateful-data-test']);
-              core.setOutput('TSS_MIGRATION_TESTS', context.payload.inputs['tss-migration-test']);
-              core.setOutput('SOLANA_TESTS', context.payload.inputs['solana-test']);
-              core.setOutput('V2_TESTS', context.payload.inputs['v2-test']); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
+              const makeTargets = context.payload.inputs['make-targets'].split(',');
+              core.setOutput('DEFAULT_TESTS', makeTargets.includes('default-test'));
+              core.setOutput('UPGRADE_TESTS', makeTargets.includes('upgrade-test'));
+              core.setOutput('UPGRADE_LIGHT_TESTS', makeTargets.includes('upgrade-test-light'));
+              core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', makeTargets.includes('upgrade-import-mainnet-test'));
+              core.setOutput('ADMIN_TESTS', makeTargets.includes('admin-test'));
+              core.setOutput('PERFORMANCE_TESTS', makeTargets.includes('performance-test'));
+              core.setOutput('STATEFUL_DATA_TESTS', makeTargets.includes('import-mainnet-test'));
+              core.setOutput('TSS_MIGRATION_TESTS', makeTargets.includes('tss-migration-test'));
+              core.setOutput('SOLANA_TESTS', makeTargets.includes('solana-test'));
+              core.setOutput('V2_TESTS', makeTargets.includes('v2-test')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
             }
 
   e2e:


### PR DESCRIPTION
With #2763 we now have 11 e2e test targets. This is greater than the maximum number of inputs (10). [Reference](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch)

Move to a single comma separated input.

Example run: https://github.com/zeta-chain/node/actions/runs/10583082282



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified test configuration by introducing a single input parameter, `make-targets`, allowing users to specify multiple tests in a comma-separated format.
- **Improvements**
	- Enhanced workflow flexibility and maintainability, reducing potential user errors in specifying test parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->