### PR TITLE
feat(e2e): add support for dynamically resolving erc20 addresses

### DIFF
--- a/cmd/zetae2e/config/clients.go
+++ b/cmd/zetae2e/config/clients.go
@@ -73,7 +73,7 @@ func getClientsFromConfig(ctx context.Context, conf config.Config, account confi
 	if err != nil {
 		return E2EClients{}, fmt.Errorf("failed to get evm client: %w", err)
 	}
-	zetaChainClients, err := getZetaClients(
+	zetaChainClients, err := GetZetaClients(
 		conf.RPCs.ZetaCoreGRPC,
 	)
 	if err != nil {
@@ -152,8 +152,8 @@ func getEVMClient(
 	return evmClient, evmAuth, nil
 }
 
-// getZetaClients get zeta clients
-func getZetaClients(rpc string) (
+// GetZetaClients get zeta clients
+func GetZetaClients(rpc string) (
 	zetaChainClients,
 	error,
 ) {

--- a/cmd/zetae2e/config/clients.go
+++ b/cmd/zetae2e/config/clients.go
@@ -43,8 +43,8 @@ type E2EClients struct {
 	ZevmAuth   *bind.TransactOpts
 }
 
-// zetaChainClients contains all the RPC clients and gRPC clients for ZetaChain
-type zetaChainClients struct {
+// ZetaChainClients contains all the RPC clients and gRPC clients for ZetaChain
+type ZetaChainClients struct {
 	AuthorityClient authoritytypes.QueryClient
 	CctxClient      crosschaintypes.QueryClient
 	FungibleClient  fungibletypes.QueryClient
@@ -154,12 +154,12 @@ func getEVMClient(
 
 // GetZetaClients get zeta clients
 func GetZetaClients(rpc string) (
-	zetaChainClients,
+	ZetaChainClients,
 	error,
 ) {
 	grpcConn, err := grpc.Dial(rpc, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return zetaChainClients{}, err
+		return ZetaChainClients{}, err
 	}
 
 	authorityClient := authoritytypes.NewQueryClient(grpcConn)
@@ -170,7 +170,7 @@ func GetZetaClients(rpc string) (
 	observerClient := observertypes.NewQueryClient(grpcConn)
 	lightclientClient := lightclienttypes.NewQueryClient(grpcConn)
 
-	return zetaChainClients{
+	return ZetaChainClients{
 		AuthorityClient: authorityClient,
 		CctxClient:      cctxClient,
 		FungibleClient:  fungibleClient,

--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -16,10 +16,14 @@ import (
 	"github.com/zeta-chain/zetacore/e2e/config"
 	"github.com/zeta-chain/zetacore/e2e/e2etests"
 	"github.com/zeta-chain/zetacore/e2e/runner"
+	fungibletypes "github.com/zeta-chain/zetacore/x/fungible/types"
+	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 )
 
 const flagVerbose = "verbose"
 const flagConfig = "config"
+const flagERC20ChainName = "erc20-chain-name"
+const flagERC20Symbol = "erc20-symbol"
 
 // NewRunCmd returns the run command
 // which runs the E2E from a config file describing the tests, networks, and accounts
@@ -40,6 +44,9 @@ For example: zetae2e run deposit:1000 withdraw: --config config.yml`,
 		fmt.Println("Error marking flag as required")
 		os.Exit(1)
 	}
+
+	cmd.Flags().String(flagERC20ChainName, "", "chain_name from /zeta-chain/observer/supportedChains")
+	cmd.Flags().String(flagERC20Symbol, "", "symbol from /zeta-chain/fungible/foreign_coins")
 
 	// Retain the verbose flag
 	cmd.Flags().Bool(flagVerbose, false, "set to true to enable verbose logging")
@@ -66,6 +73,16 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 
 	// initialize logger
 	logger := runner.NewLogger(verbose, color.FgHiCyan, "e2e")
+
+	// update config with dynamic ERC20
+	erc20ChainName, _ := cmd.Flags().GetString(flagERC20ChainName)
+	erc20Symbol, _ := cmd.Flags().GetString(flagERC20Symbol)
+	if erc20ChainName != "" && erc20Symbol != "" {
+		err := updateConfigWithDynamicERC20(cmd.Context(), &conf, erc20ChainName, erc20Symbol)
+		if err != nil {
+			return err
+		}
+	}
 
 	// set config
 	app.SetConfig()
@@ -99,11 +116,6 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 	testRunner.CctxTimeout = 60 * time.Minute
 	testRunner.ReceiptTimeout = 60 * time.Minute
 
-	balancesBefore, err := testRunner.GetAccountBalances(true)
-	if err != nil {
-		return err
-	}
-
 	// parse test names and arguments from cmd args and run them
 	userTestsConfigs, err := parseCmdArgsToE2ETestRunConfig(args)
 	if err != nil {
@@ -119,15 +131,9 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	balancesAfter, err := testRunner.GetAccountBalances(true)
-	if err != nil {
-		return err
-	}
-
 	// Print tests completion info
 	logger.Print("tests finished successfully in %s", time.Since(testStartTime).String())
 	testRunner.Logger.SetColor(color.FgHiRed)
-	testRunner.PrintTotalDiff(runner.GetAccountBalancesDiff(balancesBefore, balancesAfter))
 	testRunner.Logger.SetColor(color.FgHiGreen)
 	testRunner.PrintTestReports(reports)
 
@@ -156,4 +162,46 @@ func parseCmdArgsToE2ETestRunConfig(args []string) ([]runner.E2ETestRunConfig, e
 		})
 	}
 	return tests, nil
+}
+
+// updateConfigWithDynamicERC20 loads ERC20 addresses via gRPC given CLI flags
+func updateConfigWithDynamicERC20(ctx context.Context, conf *config.Config, erc20ChainName, erc20Symbol string) error {
+	clients, err := zetae2econfig.GetZetaClients(conf.RPCs.ZetaCoreGRPC)
+	if err != nil {
+		return fmt.Errorf("get zeta clients: %w", err)
+	}
+
+	supportedChainsRes, err := clients.ObserverClient.SupportedChains(ctx, &observertypes.QuerySupportedChains{})
+	if err != nil {
+		return fmt.Errorf("get chain params: %w", err)
+	}
+
+	chainID := int64(0)
+	for _, chain := range supportedChainsRes.Chains {
+		if chain.Name == erc20ChainName {
+			chainID = chain.ChainId
+			break
+		}
+	}
+	if chainID == 0 {
+		return fmt.Errorf("chain %s not found", erc20ChainName)
+	}
+
+	foreignCoinsRes, err := clients.FungibleClient.ForeignCoinsAll(ctx, &fungibletypes.QueryAllForeignCoinsRequest{})
+	if err != nil {
+		return fmt.Errorf("get foreign coins: %w", err)
+	}
+
+	for _, coin := range foreignCoinsRes.ForeignCoins {
+		if coin.ForeignChainId != chainID {
+			continue
+		}
+		// sometimes symbol is USDT, sometimes it's like USDT.SEPOLIA
+		if strings.Contains(coin.Symbol, erc20Symbol) {
+			conf.Contracts.EVM.ERC20 = config.DoubleQuotedString(coin.Asset)
+			conf.Contracts.ZEVM.ERC20ZRC20Addr = config.DoubleQuotedString(coin.Zrc20ContractAddress)
+			return nil
+		}
+	}
+	return fmt.Errorf("erc20 %s not found on %s", erc20Symbol, erc20ChainName)
 }

--- a/e2e/runner/report.go
+++ b/e2e/runner/report.go
@@ -59,7 +59,7 @@ func (r *E2ERunner) PrintTestReports(tr TestReports) {
 	if err != nil {
 		r.Logger.Print("Error rendering test report: %s", err)
 	}
-	r.Logger.PrintNoPrefix(table, "")
+	r.Logger.PrintNoPrefix(table)
 }
 
 // NetworkReport is a struct that contains the report for the network used after running e2e tests


### PR DESCRIPTION
Allow setting erc20 info via cli parameters. When provided, we will resolve the addresses via RPC call. This is a bit tricky/fragile because the naming of our foreign coins are not consistent across different networks. 

Also tolerate nil contract address in balance checks and remove duplicate balance check (it's already done by the test report).

Related to https://github.com/zeta-chain/infrastructure/issues/1498

```
➜  zetae2e git:(zetae2e-erc20-dynamic) ✗ ./zetae2e run -c config/local.yml --erc20-chain-name goerli_localnet --erc20-symbol USDT erc20_deposit:200000
e2e        | starting tests
e2e        | ⚙️ setting up TSS address
e2e        | [ERROR]get SOL balance: zrc20 contract is nil
e2e        | ⏳running - deposit ERC20 into ZEVM
e2e        | ✅ completed in 20.095935555s - deposit ERC20 into ZEVM
e2e        | [ERROR]get SOL balance: zrc20 contract is nil
e2e        | tests finished successfully in 25.123415485s
e2e        |  ---📈 E2E Test Report ---
Name             Success    Time             Spent
erc20_deposit    ✅          25.118187973s    ETH:1055496

➜  zetae2e git:(zetae2e-erc20-dynamic) ✗ ./zetae2e run -c config/local.yml --erc20-chain-name goerli_localnet --erc20-symbol asdf erc20_deposit:200000
Error: erc20 asdf not found on goerli_localnet
Usage:
  zetae2e run [testname1]:[arg1],[arg2] [testname2]:[arg1],[arg2]... [flags]

Flags:
  -c, --config string             path to the configuration file
      --erc20-chain-name string   chain_name from /zeta-chain/observer/chain_params structure
      --erc20-symbol string       erc20_name from /zeta-chain/fungible/foreign_coins structure
  -h, --help                      help for run
      --verbose                   set to true to enable verbose logging

erc20 asdf not found on goerli_localnet
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new command-line flags for specifying ERC20 chain name and symbol during E2E tests.
	- Introduced dynamic configuration capabilities for E2E tests based on user input.

- **Bug Fixes**
	- Enhanced error handling for retrieving balances from ZRC20 contracts, improving robustness.

- **Refactor**
	- Simplified logging in the test report functionality by removing unnecessary arguments.

- **Chores**
	- Improved naming conventions for exported types and functions to enhance code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->