### PR TITLE
fix(`pkg/chains`): check if VM is EVM for `IsEVMChain` check

### DIFF
--- a/pkg/chains/chain.go
+++ b/pkg/chains/chain.go
@@ -86,7 +86,7 @@ func (chain Chain) EncodeAddress(b []byte) (string, error) {
 }
 
 func (chain Chain) IsEVMChain() bool {
-	return chain.Consensus == Consensus_ethereum
+	return chain.Vm == Vm_evm
 }
 
 func (chain Chain) IsBitcoinChain() bool {
@@ -109,11 +109,15 @@ func DecodeAddressFromChainID(chainID int64, addr string, additionalChains []Cha
 	}
 }
 
-// IsEVMChain returns true if the chain is an EVM chain or uses the ethereum consensus mechanism for block finality
+// IsEVMChain returns true if the chain is an EVM chain
 // additionalChains is a list of additional chains to search from
 // in practice, it is used in the protocol to dynamically support new chains without doing an upgrade
 func IsEVMChain(chainID int64, additionalChains []Chain) bool {
-	return ChainIDInChainList(chainID, ChainListByConsensus(Consensus_ethereum, additionalChains))
+	chain, found := GetChainFromChainID(chainID, additionalChains)
+	if !found {
+		return false
+	}
+	return chain.IsEVMChain()
 }
 
 // IsBitcoinChain returns true if the chain is a Bitcoin-based chain or uses the bitcoin consensus mechanism for block finality

--- a/pkg/chains/chain_test.go
+++ b/pkg/chains/chain_test.go
@@ -222,7 +222,7 @@ func TestChain_IsEVMChain(t *testing.T) {
 		{"Goerli Testnet", chains.Goerli, true},
 		{"Sepolia Testnet", chains.Sepolia, true},
 		{"Non-EVM", chains.BitcoinMainnet, false},
-		{"Zeta Mainnet", chains.ZetaChainMainnet, false},
+		{"Zeta Mainnet", chains.ZetaChainMainnet, true},
 	}
 
 	for _, tt := range tests {
@@ -331,7 +331,7 @@ func TestIsEVMChain(t *testing.T) {
 		{"Goerli Testnet", chains.Goerli.ChainId, true},
 		{"Sepolia Testnet", chains.Sepolia.ChainId, true},
 		{"Non-EVM", chains.BitcoinMainnet.ChainId, false},
-		{"Zeta Mainnet", chains.ZetaChainMainnet.ChainId, false},
+		{"Zeta Mainnet", chains.ZetaChainMainnet.ChainId, true},
 	}
 
 	for _, tt := range tests {

--- a/x/crosschain/keeper/refund_test.go
+++ b/x/crosschain/keeper/refund_test.go
@@ -216,11 +216,12 @@ func TestKeeper_RefundAmountOnZetaChainZeta(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 		k.GetAuthKeeper().GetModuleAccount(ctx, fungibletypes.ModuleName)
 		sender := sample.EthAddress()
+		chainID := getValidBtcChainID()
 
 		err := k.RefundAmountOnZetaChainZeta(ctx, types.CrossChainTx{
 			InboundParams: &types.InboundParams{
 				CoinType:      coin.CoinType_Gas,
-				SenderChainId: 101,
+				SenderChainId: chainID,
 				Sender:        sender.String(),
 				TxOrigin:      sender.String(),
 				Amount:        math.NewUint(20),


### PR DESCRIPTION
# Description

`IsEVMChain` used to check if the chain consensus is Ethereum, which is invalid, the components using `IsEVMChain` don't perform logic that relies on consensus used by Ethereum.

Example: Base doesn't use Ethereum consensus as a L2 but comply with logic using isEVMChain.

This PR change the check.

All EVM chains so far had the value `ConsensusEthereum` except Base where we made a patch in the chain info. Therefore changing this check in theory doesn't bring any change in the workflow

Close: https://github.com/zeta-chain/node/issues/2752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced identification of EVM chains by broadening criteria from consensus mechanism to virtual machine type.
	- Improved error handling in the `IsEVMChain` function for better reliability.

- **Bug Fixes**
	- Updated test cases to correctly classify "Zeta Mainnet" as an EVM chain.

- **Tests**
	- Modified tests to use dynamic values for `SenderChainId` in cross-chain transactions, improving accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->