### PR TITLE
chore: use btcsuite/btcd/btcec/v2 in x/crosschain/types

### DIFF
--- a/x/crosschain/types/tx_body_verification.go
+++ b/x/crosschain/types/tx_body_verification.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	eth "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
@@ -136,7 +136,7 @@ func verifyOutboundBodyBTC(msg MsgAddOutboundTracker, txBytes []byte, tssBtc str
 		if len(vin.Witness) != 2 { // outTx is SegWit transaction for now
 			return fmt.Errorf("not a SegWit transaction")
 		}
-		pubKey, err := btcec.ParsePubKey(vin.Witness[1], btcec.S256())
+		pubKey, err := btcec.ParsePubKey(vin.Witness[1])
 		if err != nil {
 			return fmt.Errorf("failed to parse public key")
 		}


### PR DESCRIPTION
Part of #2798, Related to #2750 

Should resolve:

```
go: zetacored-rpc imports
	github.com/zeta-chain/node/pkg/rpc imports
	github.com/zeta-chain/node/x/crosschain/types imports
	github.com/btcsuite/btcd/btcec: module github.com/btcsuite/btcd@latest found (v0.24.2), but does not contain package github.com/btcsuite/btcd/btcec
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the cryptographic library for enhanced transaction verification.
	- Improved public key parsing logic, potentially increasing the reliability of SegWit transaction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->