### PR TITLE
docs: remove the note for July release observer migration

### DIFF
--- a/docs/releases/v19_observer_migration.md
+++ b/docs/releases/v19_observer_migration.md
@@ -27,5 +27,3 @@ zetacored tx authz grant [grantee_address] generic --msg-type=/zetachain.zetacor
 zetacored tx authz grant [grantee_address] generic --msg-type=/zetachain.zetacore.crosschain.MsgAddOutboundTracker
 zetacored tx authz grant [grantee_address] generic --msg-type=/zetachain.zetacore.crosschain.MsgAddInboundTracker
 ```
-
-Note: These new authorizations must be added before the v17 upgrade. These can be added anytime and doesn't require to restart the Zetaclient


### PR DESCRIPTION
# Description

The note is not correct (can't be run before the upgrade), therefore remove it from the docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for `zetacored` authorization commands to simplify user guidance by removing outdated notes about upgrade requirements and authorization timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->