### PR TITLE
ci: add rpcimportable test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: PR Testing
+name: ci
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: pr-testing-${{ github.head_ref || github.run_id }}
+  group: ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:
@@ -93,3 +93,35 @@ jobs:
         if: always()
         shell: bash
         run: rm -rf *
+  rpcimportable:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: go get node
+        working-directory: contrib/rpcimportable
+        run: go get github.com/zeta-chain/node@${{github.event.pull_request.head.sha || github.sha}}
+        env: 
+          GOPROXY: direct
+      - name: go mod tidy
+        working-directory: contrib/rpcimportable
+        run: go mod tidy
+      - name: go test
+        working-directory: contrib/rpcimportable
+        run: go test ./...
+  ci-ok:
+    runs-on: ubuntu-22.04
+    needs:
+      - build-and-test
+      - rpcimportable
+    if: always()
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One of the jobs failed or was cancelled"
+          exit 1
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
       - name: go mod tidy
         working-directory: contrib/rpcimportable
         run: go mod tidy
+      - name: show go.mod
+        working-directory: contrib/rpcimportable
+        run: cat go.mod
       - name: go test
         working-directory: contrib/rpcimportable
         run: go test ./...

--- a/contrib/rpcimportable/go.mod
+++ b/contrib/rpcimportable/go.mod
@@ -5,6 +5,8 @@ go 1.22.5
 // this go.mod should be empty when committed
 // the go.sum should not be committed
 
+// this replacement is unavoidable until we upgrade cosmos sdk >=v0.50
+// but we should not tolerate any other replacements
 replace (
     github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 )

--- a/contrib/rpcimportable/go.mod
+++ b/contrib/rpcimportable/go.mod
@@ -2,11 +2,12 @@ module github.com/zeta-chain/node/contrib/rpcimportable
 
 go 1.22.5
 
-require github.com/zeta-chain/node v0.0.0-20240903163921-74f1ab59c658 // indirect
+// this go.mod should be empty when committed
+// the go.sum should not be committed
 
 replace (
     github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 )
 
-// uncomment this for local testing/development
+// uncomment this for local development/testing/debugging
 // replace github.com/zeta-chain/node => ../..

--- a/contrib/rpcimportable/go.mod
+++ b/contrib/rpcimportable/go.mod
@@ -1,0 +1,12 @@
+module github.com/zeta-chain/node/contrib/rpcimportable
+
+go 1.22.5
+
+require github.com/zeta-chain/node v0.0.0-20240903163921-74f1ab59c658 // indirect
+
+replace (
+    github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+)
+
+// uncomment this for local testing/development
+// replace github.com/zeta-chain/node => ../..

--- a/contrib/rpcimportable/go.sum
+++ b/contrib/rpcimportable/go.sum
@@ -1,3 +1,0 @@
-github.com/zeta-chain/node v0.0.0-20240903163921-74f1ab59c658 h1:+KzsEBBWfxAMqMjwOcivdpSHPncDSMU3yw7oIG5YJAw=
-github.com/zeta-chain/node v0.0.0-20240903163921-74f1ab59c658/go.mod h1:XJj15D2+sgtX3wqx1O85A0bKUI3srKyZwkxdcfgoK6I=
-github.com/zeta-chain/node v1.2.1/go.mod h1:z72YVX6jPPst8K06l0LTKORJXN7XB1RKUiliU52Cwk0=

--- a/contrib/rpcimportable/go.sum
+++ b/contrib/rpcimportable/go.sum
@@ -1,0 +1,3 @@
+github.com/zeta-chain/node v0.0.0-20240903163921-74f1ab59c658 h1:+KzsEBBWfxAMqMjwOcivdpSHPncDSMU3yw7oIG5YJAw=
+github.com/zeta-chain/node v0.0.0-20240903163921-74f1ab59c658/go.mod h1:XJj15D2+sgtX3wqx1O85A0bKUI3srKyZwkxdcfgoK6I=
+github.com/zeta-chain/node v1.2.1/go.mod h1:z72YVX6jPPst8K06l0LTKORJXN7XB1RKUiliU52Cwk0=

--- a/contrib/rpcimportable/rpcimportable_test.go
+++ b/contrib/rpcimportable/rpcimportable_test.go
@@ -1,0 +1,11 @@
+package rpcimportable
+
+import (
+	"testing"
+
+	"github.com/zeta-chain/node/pkg/rpc"
+)
+
+func TestRPCImportable(t *testing.T) {
+	_ = rpc.Clients{}
+}

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zeta-chain/ethermint v0.0.0-20240924180551-9c12024cdc36
+	github.com/zeta-chain/ethermint v0.0.0-20240927155358-f34e2a4a86f1
 	github.com/zeta-chain/keystone/keys v0.0.0-20240826165841-3874f358c138
 	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240924201108-3a274ce7bad0
 	gitlab.com/thorchain/tss/go-tss v1.6.5

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zeta-chain/ethermint v0.0.0-20240909234716-2fad916e7179
+	github.com/zeta-chain/ethermint v0.0.0-20240924180551-9c12024cdc36
 	github.com/zeta-chain/keystone/keys v0.0.0-20240826165841-3874f358c138
 	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240924201108-3a274ce7bad0
 	gitlab.com/thorchain/tss/go-tss v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -4172,8 +4172,8 @@ github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPS
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-github.com/zeta-chain/ethermint v0.0.0-20240909234716-2fad916e7179 h1:HykzQOeqBYFHPQCLrj7VAhoGOONtYJnt8IvyHNb9/d8=
-github.com/zeta-chain/ethermint v0.0.0-20240909234716-2fad916e7179/go.mod h1:NeQEwcKBpKAUxIsii2F+jfyOD94jN/3fzPMv/1kVF9M=
+github.com/zeta-chain/ethermint v0.0.0-20240924180551-9c12024cdc36 h1:QbXeSkgHDTKW90yQWO/23Mt/g0LWQt3WjJ7kKBkE+Xg=
+github.com/zeta-chain/ethermint v0.0.0-20240924180551-9c12024cdc36/go.mod h1:NeQEwcKBpKAUxIsii2F+jfyOD94jN/3fzPMv/1kVF9M=
 github.com/zeta-chain/go-ethereum v1.10.26-spc h1:NvY4rR9yw52wfxWt7YoFsWbaIwVMyOtTsWKqGAXk+sE=
 github.com/zeta-chain/go-ethereum v1.10.26-spc/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=

--- a/go.sum
+++ b/go.sum
@@ -4172,8 +4172,8 @@ github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPS
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-github.com/zeta-chain/ethermint v0.0.0-20240924180551-9c12024cdc36 h1:QbXeSkgHDTKW90yQWO/23Mt/g0LWQt3WjJ7kKBkE+Xg=
-github.com/zeta-chain/ethermint v0.0.0-20240924180551-9c12024cdc36/go.mod h1:NeQEwcKBpKAUxIsii2F+jfyOD94jN/3fzPMv/1kVF9M=
+github.com/zeta-chain/ethermint v0.0.0-20240927155358-f34e2a4a86f1 h1:o0Sh6Y2PKcG634hWqRWmWqBteSuoQUDxIR04OX9Llr8=
+github.com/zeta-chain/ethermint v0.0.0-20240927155358-f34e2a4a86f1/go.mod h1:NeQEwcKBpKAUxIsii2F+jfyOD94jN/3fzPMv/1kVF9M=
 github.com/zeta-chain/go-ethereum v1.10.26-spc h1:NvY4rR9yw52wfxWt7YoFsWbaIwVMyOtTsWKqGAXk+sE=
 github.com/zeta-chain/go-ethereum v1.10.26-spc/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=

--- a/pkg/rpc/clients_crosschain.go
+++ b/pkg/rpc/clients_crosschain.go
@@ -2,15 +2,12 @@ package rpc
 
 import (
 	"context"
-	"sort"
 
 	"cosmossdk.io/errors"
-	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc"
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 )
 
 // 32MB
@@ -156,39 +153,4 @@ func (c *Clients) GetInboundTrackersForChain(ctx context.Context, chainID int64)
 	}
 
 	return resp.InboundTracker, nil
-}
-
-// GetAllOutboundTrackerByChain returns all outbound trackers for a chain
-func (c *Clients) GetAllOutboundTrackerByChain(
-	ctx context.Context,
-	chainID int64,
-	order interfaces.Order,
-) ([]types.OutboundTracker, error) {
-	in := &types.QueryAllOutboundTrackerByChainRequest{
-		Chain: chainID,
-		Pagination: &query.PageRequest{
-			Key:        nil,
-			Offset:     0,
-			Limit:      2000,
-			CountTotal: false,
-			Reverse:    false,
-		},
-	}
-
-	resp, err := c.Crosschain.OutboundTrackerAllByChain(ctx, in)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get all outbound trackers")
-	}
-
-	if order == interfaces.Ascending {
-		sort.SliceStable(resp.OutboundTracker, func(i, j int) bool {
-			return resp.OutboundTracker[i].Nonce < resp.OutboundTracker[j].Nonce
-		})
-	} else if order == interfaces.Descending {
-		sort.SliceStable(resp.OutboundTracker, func(i, j int) bool {
-			return resp.OutboundTracker[i].Nonce > resp.OutboundTracker[j].Nonce
-		})
-	}
-
-	return resp.OutboundTracker, nil
 }

--- a/pkg/rpc/clients_test.go
+++ b/pkg/rpc/clients_test.go
@@ -12,7 +12,6 @@ import (
 	tmtypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/query"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	lightclienttypes "github.com/zeta-chain/node/x/lightclient/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
-	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 )
 
 const skipMethod = "skip"
@@ -686,44 +684,6 @@ func TestZetacore_GetOutboundTracker(t *testing.T) {
 	resp, err := client.GetOutboundTracker(ctx, chain, 456)
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput.OutboundTracker, *resp)
-}
-
-func TestZetacore_GetAllOutboundTrackerByChain(t *testing.T) {
-	ctx := context.Background()
-
-	chain := chains.BscMainnet
-	expectedOutput := crosschaintypes.QueryAllOutboundTrackerByChainResponse{
-		OutboundTracker: []crosschaintypes.OutboundTracker{
-			{
-				Index:    "tracker23456",
-				ChainId:  chain.ChainId,
-				Nonce:    123456,
-				HashList: nil,
-			},
-		},
-	}
-	input := crosschaintypes.QueryAllOutboundTrackerByChainRequest{
-		Chain: chain.ChainId,
-		Pagination: &query.PageRequest{
-			Key:        nil,
-			Offset:     0,
-			Limit:      2000,
-			CountTotal: false,
-			Reverse:    false,
-		},
-	}
-	method := "/zetachain.zetacore.crosschain.Query/OutboundTrackerAllByChain"
-	setupMockServer(t, crosschaintypes.RegisterQueryServer, method, input, expectedOutput)
-
-	client := setupZetacoreClients(t)
-
-	resp, err := client.GetAllOutboundTrackerByChain(ctx, chain.ChainId, interfaces.Ascending)
-	require.NoError(t, err)
-	require.Equal(t, expectedOutput.OutboundTracker, resp)
-
-	resp, err = client.GetAllOutboundTrackerByChain(ctx, chain.ChainId, interfaces.Descending)
-	require.NoError(t, err)
-	require.Equal(t, expectedOutput.OutboundTracker, resp)
 }
 
 func TestZetacore_GetPendingNoncesByChain(t *testing.T) {

--- a/pkg/sdkconfig/sdkconfig.go
+++ b/pkg/sdkconfig/sdkconfig.go
@@ -1,0 +1,36 @@
+package sdkconfig
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	AccountAddressPrefix = "zeta"
+)
+
+var (
+	AccountPubKeyPrefix    = AccountAddressPrefix + "pub"
+	ValidatorAddressPrefix = AccountAddressPrefix + "valoper"
+	ValidatorPubKeyPrefix  = AccountAddressPrefix + "valoperpub"
+	ConsNodeAddressPrefix  = AccountAddressPrefix + "valcons"
+	ConsNodePubKeyPrefix   = AccountAddressPrefix + "valconspub"
+)
+
+func SetDefault(seal bool) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
+	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
+	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)
+	if seal {
+		config.Seal()
+	}
+}
+
+func Set(config *sdk.Config, seal bool) {
+	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
+	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
+	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)
+	if seal {
+		config.Seal()
+	}
+}

--- a/testutil/keeper/config.go
+++ b/testutil/keeper/config.go
@@ -30,28 +30,6 @@ import (
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
-const (
-	AccountAddressPrefix = "zeta"
-)
-
-var (
-	AccountPubKeyPrefix    = AccountAddressPrefix + "pub"
-	ValidatorAddressPrefix = AccountAddressPrefix + "valoper"
-	ValidatorPubKeyPrefix  = AccountAddressPrefix + "valoperpub"
-	ConsNodeAddressPrefix  = AccountAddressPrefix + "valcons"
-	ConsNodePubKeyPrefix   = AccountAddressPrefix + "valconspub"
-)
-
-func SetConfig(seal bool) {
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
-	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
-	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)
-	if seal {
-		config.Seal()
-	}
-}
-
 func StoreKeys() (
 	map[string]*storetypes.KVStoreKey,
 	map[string]*storetypes.MemoryStoreKey,

--- a/testutil/keeper/emissions.go
+++ b/testutil/keeper/emissions.go
@@ -33,7 +33,7 @@ func EmissionKeeperWithMockOptions(
 	t testing.TB,
 	mockOptions EmissionMockOptions,
 ) (*keeper.Keeper, sdk.Context, SDKKeepers, ZetaKeepers) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
 

--- a/testutil/keeper/emissions.go
+++ b/testutil/keeper/emissions.go
@@ -12,6 +12,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	emissionsmocks "github.com/zeta-chain/node/testutil/keeper/mocks/emissions"
 	"github.com/zeta-chain/node/x/emissions/keeper"
 	"github.com/zeta-chain/node/x/emissions/types"
@@ -32,7 +33,7 @@ func EmissionKeeperWithMockOptions(
 	t testing.TB,
 	mockOptions EmissionMockOptions,
 ) (*keeper.Keeper, sdk.Context, SDKKeepers, ZetaKeepers) {
-	SetConfig(false)
+	sdkconfig.SetDefault(true)
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
 

--- a/x/authority/types/genesis_test.go
+++ b/x/authority/types/genesis_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/authority/types"
 )
 
 func TestGenesisState_Validate(t *testing.T) {
-	setConfig(t)
+	keeper.SetConfig(true)
 
 	tests := []struct {
 		name        string

--- a/x/authority/types/genesis_test.go
+++ b/x/authority/types/genesis_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGenesisState_Validate(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 
 	tests := []struct {
 		name        string

--- a/x/authority/types/genesis_test.go
+++ b/x/authority/types/genesis_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/authority/types"
 )
 
 func TestGenesisState_Validate(t *testing.T) {
-	keeper.SetConfig(true)
+	sdkconfig.SetDefault(true)
 
 	tests := []struct {
 		name        string

--- a/x/authority/types/policies_test.go
+++ b/x/authority/types/policies_test.go
@@ -3,28 +3,15 @@ package types_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/app"
+	"github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/authority/types"
 )
 
-// setConfig sets the global config to use zeta chain's bech32 prefixes
-func setConfig(t *testing.T) {
-	defer func(t *testing.T) {
-		if r := recover(); r != nil {
-			t.Log("config is already sealed", r)
-		}
-	}(t)
-	cfg := sdk.GetConfig()
-	cfg.SetBech32PrefixForAccount(app.Bech32PrefixAccAddr, app.Bech32PrefixAccPub)
-	cfg.Seal()
-}
-
 func TestPolicies_Validate(t *testing.T) {
-	setConfig(t)
+	keeper.SetConfig(true)
 	// use table driven tests to test the validation of policies
 	tests := []struct {
 		name        string

--- a/x/authority/types/policies_test.go
+++ b/x/authority/types/policies_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPolicies_Validate(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	// use table driven tests to test the validation of policies
 	tests := []struct {
 		name        string

--- a/x/authority/types/policies_test.go
+++ b/x/authority/types/policies_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/authority/types"
 )
 
 func TestPolicies_Validate(t *testing.T) {
-	keeper.SetConfig(true)
+	sdkconfig.SetDefault(true)
 	// use table driven tests to test the validation of policies
 	tests := []struct {
 		name        string

--- a/x/crosschain/keeper/cctx_test.go
+++ b/x/crosschain/keeper/cctx_test.go
@@ -6,17 +6,21 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	keepertest "github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/keeper"
 	"github.com/zeta-chain/node/x/crosschain/types"
+	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
 func createNCctxWithStatus(
@@ -289,4 +293,164 @@ func TestKeeper_RemoveCrossChainTx(t *testing.T) {
 	keeper.RemoveCrossChainTx(ctx, txs[0].Index)
 	txs = keeper.GetAllCrossChainTx(ctx)
 	require.Equal(t, 4, len(txs))
+}
+
+func TestCrossChainTx_AddOutbound(t *testing.T) {
+	t.Run("successfully get outbound tx", func(t *testing.T) {
+		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		cctx := sample.CrossChainTx(t, "test")
+		hash := sample.Hash().String()
+
+		err := cctx.AddOutbound(ctx, types.MsgVoteOutbound{
+			ValueReceived:                     cctx.GetCurrentOutboundParam().Amount,
+			ObservedOutboundHash:              hash,
+			ObservedOutboundBlockHeight:       10,
+			ObservedOutboundGasUsed:           100,
+			ObservedOutboundEffectiveGasPrice: sdkmath.NewInt(100),
+			ObservedOutboundEffectiveGasLimit: 20,
+		}, observertypes.BallotStatus_BallotFinalized_SuccessObservation)
+		require.NoError(t, err)
+		require.Equal(t, cctx.GetCurrentOutboundParam().Hash, hash)
+		require.Equal(t, cctx.GetCurrentOutboundParam().GasUsed, uint64(100))
+		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasPrice, sdkmath.NewInt(100))
+		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasLimit, uint64(20))
+		require.Equal(t, cctx.GetCurrentOutboundParam().ObservedExternalHeight, uint64(10))
+	})
+
+	t.Run("successfully get outbound tx for failed ballot without amount check", func(t *testing.T) {
+		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		cctx := sample.CrossChainTx(t, "test")
+		hash := sample.Hash().String()
+
+		err := cctx.AddOutbound(ctx, types.MsgVoteOutbound{
+			ObservedOutboundHash:              hash,
+			ObservedOutboundBlockHeight:       10,
+			ObservedOutboundGasUsed:           100,
+			ObservedOutboundEffectiveGasPrice: sdkmath.NewInt(100),
+			ObservedOutboundEffectiveGasLimit: 20,
+		}, observertypes.BallotStatus_BallotFinalized_FailureObservation)
+		require.NoError(t, err)
+		require.Equal(t, cctx.GetCurrentOutboundParam().Hash, hash)
+		require.Equal(t, cctx.GetCurrentOutboundParam().GasUsed, uint64(100))
+		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasPrice, sdkmath.NewInt(100))
+		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasLimit, uint64(20))
+		require.Equal(t, cctx.GetCurrentOutboundParam().ObservedExternalHeight, uint64(10))
+	})
+
+	t.Run("failed to get outbound tx if amount does not match value received", func(t *testing.T) {
+		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
+
+		cctx := sample.CrossChainTx(t, "test")
+		hash := sample.Hash().String()
+
+		err := cctx.AddOutbound(ctx, types.MsgVoteOutbound{
+			ValueReceived:                     sdkmath.NewUint(100),
+			ObservedOutboundHash:              hash,
+			ObservedOutboundBlockHeight:       10,
+			ObservedOutboundGasUsed:           100,
+			ObservedOutboundEffectiveGasPrice: sdkmath.NewInt(100),
+			ObservedOutboundEffectiveGasLimit: 20,
+		}, observertypes.BallotStatus_BallotFinalized_SuccessObservation)
+		require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
+	})
+}
+
+func Test_NewCCTX(t *testing.T) {
+	t.Run("should return a cctx with correct values", func(t *testing.T) {
+		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		senderChain := chains.Goerli
+		sender := sample.EthAddress()
+		receiverChain := chains.Goerli
+		receiver := sample.EthAddress()
+		creator := sample.AccAddress()
+		amount := sdkmath.NewUint(42)
+		message := "test"
+		inboundBlockHeight := uint64(420)
+		inboundHash := sample.Hash()
+		gasLimit := uint64(100)
+		asset := "test-asset"
+		eventIndex := uint64(1)
+		cointType := coin.CoinType_ERC20
+		tss := sample.Tss()
+		msg := types.MsgVoteInbound{
+			Creator:            creator,
+			Sender:             sender.String(),
+			SenderChainId:      senderChain.ChainId,
+			Receiver:           receiver.String(),
+			ReceiverChain:      receiverChain.ChainId,
+			Amount:             amount,
+			Message:            message,
+			InboundHash:        inboundHash.String(),
+			InboundBlockHeight: inboundBlockHeight,
+			CallOptions: &types.CallOptions{
+				GasLimit: gasLimit,
+			},
+			CoinType:                cointType,
+			TxOrigin:                sender.String(),
+			Asset:                   asset,
+			EventIndex:              eventIndex,
+			ProtocolContractVersion: types.ProtocolContractVersion_V2,
+		}
+		cctx, err := types.NewCCTX(ctx, msg, tss.TssPubkey)
+		require.NoError(t, err)
+		require.Equal(t, receiver.String(), cctx.GetCurrentOutboundParam().Receiver)
+		require.Equal(t, receiverChain.ChainId, cctx.GetCurrentOutboundParam().ReceiverChainId)
+		require.Equal(t, sender.String(), cctx.GetInboundParams().Sender)
+		require.Equal(t, senderChain.ChainId, cctx.GetInboundParams().SenderChainId)
+		require.Equal(t, amount, cctx.GetInboundParams().Amount)
+		require.Equal(t, message, cctx.RelayedMessage)
+		require.Equal(t, inboundHash.String(), cctx.GetInboundParams().ObservedHash)
+		require.Equal(t, inboundBlockHeight, cctx.GetInboundParams().ObservedExternalHeight)
+		require.Equal(t, gasLimit, cctx.GetCurrentOutboundParam().CallOptions.GasLimit)
+		require.Equal(t, asset, cctx.GetInboundParams().Asset)
+		require.Equal(t, cointType, cctx.InboundParams.CoinType)
+		require.Equal(t, uint64(0), cctx.GetCurrentOutboundParam().TssNonce)
+		require.Equal(t, sdkmath.ZeroUint(), cctx.GetCurrentOutboundParam().Amount)
+		require.Equal(t, types.CctxStatus_PendingInbound, cctx.CctxStatus.Status)
+		require.Equal(t, false, cctx.CctxStatus.IsAbortRefunded)
+		require.Equal(t, types.ProtocolContractVersion_V2, cctx.ProtocolContractVersion)
+	})
+
+	t.Run("should return an error if the cctx is invalid", func(t *testing.T) {
+		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		senderChain := chains.Goerli
+		sender := sample.EthAddress()
+		receiverChain := chains.Goerli
+		receiver := sample.EthAddress()
+		creator := sample.AccAddress()
+		amount := sdkmath.NewUint(42)
+		message := "test"
+		inboundBlockHeight := uint64(420)
+		inboundHash := sample.Hash()
+		gasLimit := uint64(100)
+		asset := "test-asset"
+		eventIndex := uint64(1)
+		cointType := coin.CoinType_ERC20
+		tss := sample.Tss()
+		msg := types.MsgVoteInbound{
+			Creator:            creator,
+			Sender:             "",
+			SenderChainId:      senderChain.ChainId,
+			Receiver:           receiver.String(),
+			ReceiverChain:      receiverChain.ChainId,
+			Amount:             amount,
+			Message:            message,
+			InboundHash:        inboundHash.String(),
+			InboundBlockHeight: inboundBlockHeight,
+			CallOptions: &types.CallOptions{
+				GasLimit: gasLimit,
+			},
+			CoinType:   cointType,
+			TxOrigin:   sender.String(),
+			Asset:      asset,
+			EventIndex: eventIndex,
+		}
+		_, err := types.NewCCTX(ctx, msg, tss.TssPubkey)
+		require.ErrorContains(t, err, "sender cannot be empty")
+	})
+
+	t.Run("zero value for protocol contract version gives V1", func(t *testing.T) {
+		cctx := types.CrossChainTx{}
+		require.Equal(t, types.ProtocolContractVersion_V1, cctx.ProtocolContractVersion)
+	})
 }

--- a/x/crosschain/types/cctx_test.go
+++ b/x/crosschain/types/cctx_test.go
@@ -4,16 +4,10 @@ import (
 	"math/rand"
 	"testing"
 
-	sdkmath "cosmossdk.io/math"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/pkg/coin"
-	keepertest "github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/types"
-	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
 func TestCrossChainTx_GetEVMRevertAddress(t *testing.T) {
@@ -61,106 +55,6 @@ func TestCrossChainTx_GetCCTXIndexBytes(t *testing.T) {
 	indexBytes, err := cctx.GetCCTXIndexBytes()
 	require.NoError(t, err)
 	require.Equal(t, cctx.Index, types.GetCctxIndexFromBytes(indexBytes))
-}
-
-func Test_NewCCTX(t *testing.T) {
-	t.Run("should return a cctx with correct values", func(t *testing.T) {
-		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
-		senderChain := chains.Goerli
-		sender := sample.EthAddress()
-		receiverChain := chains.Goerli
-		receiver := sample.EthAddress()
-		creator := sample.AccAddress()
-		amount := sdkmath.NewUint(42)
-		message := "test"
-		inboundBlockHeight := uint64(420)
-		inboundHash := sample.Hash()
-		gasLimit := uint64(100)
-		asset := "test-asset"
-		eventIndex := uint64(1)
-		cointType := coin.CoinType_ERC20
-		tss := sample.Tss()
-		msg := types.MsgVoteInbound{
-			Creator:            creator,
-			Sender:             sender.String(),
-			SenderChainId:      senderChain.ChainId,
-			Receiver:           receiver.String(),
-			ReceiverChain:      receiverChain.ChainId,
-			Amount:             amount,
-			Message:            message,
-			InboundHash:        inboundHash.String(),
-			InboundBlockHeight: inboundBlockHeight,
-			CallOptions: &types.CallOptions{
-				GasLimit: gasLimit,
-			},
-			CoinType:                cointType,
-			TxOrigin:                sender.String(),
-			Asset:                   asset,
-			EventIndex:              eventIndex,
-			ProtocolContractVersion: types.ProtocolContractVersion_V2,
-		}
-		cctx, err := types.NewCCTX(ctx, msg, tss.TssPubkey)
-		require.NoError(t, err)
-		require.Equal(t, receiver.String(), cctx.GetCurrentOutboundParam().Receiver)
-		require.Equal(t, receiverChain.ChainId, cctx.GetCurrentOutboundParam().ReceiverChainId)
-		require.Equal(t, sender.String(), cctx.GetInboundParams().Sender)
-		require.Equal(t, senderChain.ChainId, cctx.GetInboundParams().SenderChainId)
-		require.Equal(t, amount, cctx.GetInboundParams().Amount)
-		require.Equal(t, message, cctx.RelayedMessage)
-		require.Equal(t, inboundHash.String(), cctx.GetInboundParams().ObservedHash)
-		require.Equal(t, inboundBlockHeight, cctx.GetInboundParams().ObservedExternalHeight)
-		require.Equal(t, gasLimit, cctx.GetCurrentOutboundParam().CallOptions.GasLimit)
-		require.Equal(t, asset, cctx.GetInboundParams().Asset)
-		require.Equal(t, cointType, cctx.InboundParams.CoinType)
-		require.Equal(t, uint64(0), cctx.GetCurrentOutboundParam().TssNonce)
-		require.Equal(t, sdkmath.ZeroUint(), cctx.GetCurrentOutboundParam().Amount)
-		require.Equal(t, types.CctxStatus_PendingInbound, cctx.CctxStatus.Status)
-		require.Equal(t, false, cctx.CctxStatus.IsAbortRefunded)
-		require.Equal(t, types.ProtocolContractVersion_V2, cctx.ProtocolContractVersion)
-	})
-
-	t.Run("should return an error if the cctx is invalid", func(t *testing.T) {
-		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
-		senderChain := chains.Goerli
-		sender := sample.EthAddress()
-		receiverChain := chains.Goerli
-		receiver := sample.EthAddress()
-		creator := sample.AccAddress()
-		amount := sdkmath.NewUint(42)
-		message := "test"
-		inboundBlockHeight := uint64(420)
-		inboundHash := sample.Hash()
-		gasLimit := uint64(100)
-		asset := "test-asset"
-		eventIndex := uint64(1)
-		cointType := coin.CoinType_ERC20
-		tss := sample.Tss()
-		msg := types.MsgVoteInbound{
-			Creator:            creator,
-			Sender:             "",
-			SenderChainId:      senderChain.ChainId,
-			Receiver:           receiver.String(),
-			ReceiverChain:      receiverChain.ChainId,
-			Amount:             amount,
-			Message:            message,
-			InboundHash:        inboundHash.String(),
-			InboundBlockHeight: inboundBlockHeight,
-			CallOptions: &types.CallOptions{
-				GasLimit: gasLimit,
-			},
-			CoinType:   cointType,
-			TxOrigin:   sender.String(),
-			Asset:      asset,
-			EventIndex: eventIndex,
-		}
-		_, err := types.NewCCTX(ctx, msg, tss.TssPubkey)
-		require.ErrorContains(t, err, "sender cannot be empty")
-	})
-
-	t.Run("zero value for protocol contract version gives V1", func(t *testing.T) {
-		cctx := types.CrossChainTx{}
-		require.Equal(t, types.ProtocolContractVersion_V1, cctx.ProtocolContractVersion)
-	})
 }
 
 func TestCrossChainTx_Validate(t *testing.T) {
@@ -223,66 +117,6 @@ func TestCrossChainTx_OriginalDestinationChainID(t *testing.T) {
 
 	cctx.OutboundParams = []*types.OutboundParams{sample.OutboundParams(r), sample.OutboundParams(r)}
 	require.Equal(t, cctx.OutboundParams[0].ReceiverChainId, cctx.OriginalDestinationChainID())
-}
-
-func TestCrossChainTx_AddOutbound(t *testing.T) {
-	t.Run("successfully get outbound tx", func(t *testing.T) {
-		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
-		cctx := sample.CrossChainTx(t, "test")
-		hash := sample.Hash().String()
-
-		err := cctx.AddOutbound(ctx, types.MsgVoteOutbound{
-			ValueReceived:                     cctx.GetCurrentOutboundParam().Amount,
-			ObservedOutboundHash:              hash,
-			ObservedOutboundBlockHeight:       10,
-			ObservedOutboundGasUsed:           100,
-			ObservedOutboundEffectiveGasPrice: sdkmath.NewInt(100),
-			ObservedOutboundEffectiveGasLimit: 20,
-		}, observertypes.BallotStatus_BallotFinalized_SuccessObservation)
-		require.NoError(t, err)
-		require.Equal(t, cctx.GetCurrentOutboundParam().Hash, hash)
-		require.Equal(t, cctx.GetCurrentOutboundParam().GasUsed, uint64(100))
-		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasPrice, sdkmath.NewInt(100))
-		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasLimit, uint64(20))
-		require.Equal(t, cctx.GetCurrentOutboundParam().ObservedExternalHeight, uint64(10))
-	})
-
-	t.Run("successfully get outbound tx for failed ballot without amount check", func(t *testing.T) {
-		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
-		cctx := sample.CrossChainTx(t, "test")
-		hash := sample.Hash().String()
-
-		err := cctx.AddOutbound(ctx, types.MsgVoteOutbound{
-			ObservedOutboundHash:              hash,
-			ObservedOutboundBlockHeight:       10,
-			ObservedOutboundGasUsed:           100,
-			ObservedOutboundEffectiveGasPrice: sdkmath.NewInt(100),
-			ObservedOutboundEffectiveGasLimit: 20,
-		}, observertypes.BallotStatus_BallotFinalized_FailureObservation)
-		require.NoError(t, err)
-		require.Equal(t, cctx.GetCurrentOutboundParam().Hash, hash)
-		require.Equal(t, cctx.GetCurrentOutboundParam().GasUsed, uint64(100))
-		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasPrice, sdkmath.NewInt(100))
-		require.Equal(t, cctx.GetCurrentOutboundParam().EffectiveGasLimit, uint64(20))
-		require.Equal(t, cctx.GetCurrentOutboundParam().ObservedExternalHeight, uint64(10))
-	})
-
-	t.Run("failed to get outbound tx if amount does not match value received", func(t *testing.T) {
-		_, ctx, _, _ := keepertest.CrosschainKeeper(t)
-
-		cctx := sample.CrossChainTx(t, "test")
-		hash := sample.Hash().String()
-
-		err := cctx.AddOutbound(ctx, types.MsgVoteOutbound{
-			ValueReceived:                     sdkmath.NewUint(100),
-			ObservedOutboundHash:              hash,
-			ObservedOutboundBlockHeight:       10,
-			ObservedOutboundGasUsed:           100,
-			ObservedOutboundEffectiveGasPrice: sdkmath.NewInt(100),
-			ObservedOutboundEffectiveGasLimit: 20,
-		}, observertypes.BallotStatus_BallotFinalized_SuccessObservation)
-		require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
-	})
 }
 
 func Test_SetRevertOutboundValues(t *testing.T) {

--- a/x/crosschain/types/message_migrate_erc20_custody_funds_test.go
+++ b/x/crosschain/types/message_migrate_erc20_custody_funds_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestNewMsgMigrateERC20CustodyFunds_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	tests := []struct {
 		name  string
 		msg   *types.MsgMigrateERC20CustodyFunds

--- a/x/crosschain/types/message_migrate_erc20_custody_funds_test.go
+++ b/x/crosschain/types/message_migrate_erc20_custody_funds_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewMsgMigrateERC20CustodyFunds_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	tests := []struct {
 		name  string
 		msg   *types.MsgMigrateERC20CustodyFunds

--- a/x/crosschain/types/message_migrate_tss_funds_test.go
+++ b/x/crosschain/types/message_migrate_tss_funds_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewMsgMigrateTssFunds_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	tests := []struct {
 		name  string
 		msg   *types.MsgMigrateTssFunds

--- a/x/crosschain/types/message_migrate_tss_funds_test.go
+++ b/x/crosschain/types/message_migrate_tss_funds_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestNewMsgMigrateTssFunds_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	tests := []struct {
 		name  string
 		msg   *types.MsgMigrateTssFunds

--- a/x/crosschain/types/message_update_erc20_custody_pause_status_test.go
+++ b/x/crosschain/types/message_update_erc20_custody_pause_status_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestNewMsgUpdateERC20CustodyPauseStatus_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	tests := []struct {
 		name  string
 		msg   *types.MsgUpdateERC20CustodyPauseStatus

--- a/x/crosschain/types/message_update_erc20_custody_pause_status_test.go
+++ b/x/crosschain/types/message_update_erc20_custody_pause_status_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewMsgUpdateERC20CustodyPauseStatus_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	tests := []struct {
 		name  string
 		msg   *types.MsgUpdateERC20CustodyPauseStatus

--- a/x/crosschain/types/message_update_tss_address_test.go
+++ b/x/crosschain/types/message_update_tss_address_test.go
@@ -6,13 +6,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestMessageUpdateTssAddress_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	tests := []struct {
 		name  string
 		msg   *types.MsgUpdateTssAddress

--- a/x/crosschain/types/message_update_tss_address_test.go
+++ b/x/crosschain/types/message_update_tss_address_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMessageUpdateTssAddress_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	tests := []struct {
 		name  string
 		msg   *types.MsgUpdateTssAddress

--- a/x/crosschain/types/message_whitelist_erc20_test.go
+++ b/x/crosschain/types/message_whitelist_erc20_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMsgWhitelistERC20_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	tests := []struct {
 		name  string
 		msg   *types.MsgWhitelistERC20

--- a/x/crosschain/types/message_whitelist_erc20_test.go
+++ b/x/crosschain/types/message_whitelist_erc20_test.go
@@ -6,13 +6,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestMsgWhitelistERC20_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	tests := []struct {
 		name  string
 		msg   *types.MsgWhitelistERC20

--- a/x/emissions/abci_test.go
+++ b/x/emissions/abci_test.go
@@ -312,7 +312,7 @@ func TestBeginBlocker(t *testing.T) {
 }
 
 func TestDistributeObserverRewards(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	k, ctx, _, _ := keepertest.EmissionsKeeper(t)
 	observerSet := sample.ObserverSet(4)
 

--- a/x/emissions/abci_test.go
+++ b/x/emissions/abci_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/cmd/zetacored/config"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	keepertest "github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
 	emissionsModule "github.com/zeta-chain/node/x/emissions"
@@ -311,7 +312,7 @@ func TestBeginBlocker(t *testing.T) {
 }
 
 func TestDistributeObserverRewards(t *testing.T) {
-	keepertest.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	k, ctx, _, _ := keepertest.EmissionsKeeper(t)
 	observerSet := sample.ObserverSet(4)
 

--- a/x/observer/types/message_vote_blame_test.go
+++ b/x/observer/types/message_vote_blame_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewMsgVoteBlameMsg_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	tests := []struct {
 		name  string
 		msg   *types.MsgVoteBlame

--- a/x/observer/types/message_vote_blame_test.go
+++ b/x/observer/types/message_vote_blame_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/observer/types"
 )
 
 func TestNewMsgVoteBlameMsg_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	tests := []struct {
 		name  string
 		msg   *types.MsgVoteBlame

--- a/x/observer/types/message_vote_block_header_test.go
+++ b/x/observer/types/message_vote_block_header_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/proofs"
-	"github.com/zeta-chain/node/testutil/keeper"
+	"github.com/zeta-chain/node/pkg/sdkconfig"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/observer/types"
 )
 
 func TestMsgVoteBlockHeader_ValidateBasic(t *testing.T) {
-	keeper.SetConfig(false)
+	sdkconfig.SetDefault(true)
 	var header ethtypes.Header
 	file, err := os.Open("../../../testutil/testdata/eth_header_18495266.json")
 	require.NoError(t, err)

--- a/x/observer/types/message_vote_block_header_test.go
+++ b/x/observer/types/message_vote_block_header_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMsgVoteBlockHeader_ValidateBasic(t *testing.T) {
-	sdkconfig.SetDefault(true)
+	sdkconfig.SetDefault(false)
 	var header ethtypes.Header
 	file, err := os.Open("../../../testutil/testdata/eth_header_18495266.json")
 	require.NoError(t, err)

--- a/zetaclient/zetacore/client_crosschain.go
+++ b/zetaclient/zetacore/client_crosschain.go
@@ -1,0 +1,46 @@
+package zetacore
+
+import (
+	"context"
+	"sort"
+
+	"cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/zeta-chain/node/x/crosschain/types"
+	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
+)
+
+// GetAllOutboundTrackerByChain returns all outbound trackers for a chain
+func (c *Client) GetAllOutboundTrackerByChain(
+	ctx context.Context,
+	chainID int64,
+	order interfaces.Order,
+) ([]types.OutboundTracker, error) {
+	in := &types.QueryAllOutboundTrackerByChainRequest{
+		Chain: chainID,
+		Pagination: &query.PageRequest{
+			Key:        nil,
+			Offset:     0,
+			Limit:      2000,
+			CountTotal: false,
+			Reverse:    false,
+		},
+	}
+
+	resp, err := c.Crosschain.OutboundTrackerAllByChain(ctx, in)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get all outbound trackers")
+	}
+
+	if order == interfaces.Ascending {
+		sort.SliceStable(resp.OutboundTracker, func(i, j int) bool {
+			return resp.OutboundTracker[i].Nonce < resp.OutboundTracker[j].Nonce
+		})
+	} else if order == interfaces.Descending {
+		sort.SliceStable(resp.OutboundTracker, func(i, j int) bool {
+			return resp.OutboundTracker[i].Nonce > resp.OutboundTracker[j].Nonce
+		})
+	}
+
+	return resp.OutboundTracker, nil
+}

--- a/zetaclient/zetacore/client_crosschain.go
+++ b/zetaclient/zetacore/client_crosschain.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
+
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 )

--- a/zetaclient/zetacore/client_test.go
+++ b/zetaclient/zetacore/client_test.go
@@ -220,7 +220,7 @@ func TestZetacore_GetAllOutboundTrackerByChain(t *testing.T) {
 	method := "/zetachain.zetacore.crosschain.Query/OutboundTrackerAllByChain"
 	setupMockServer(t, crosschaintypes.RegisterQueryServer, method, input, expectedOutput)
 
-	client := setupZetacoreClient(t)
+	client := setupZetacoreClient(t, withDefaultObserverKeys())
 
 	resp, err := client.GetAllOutboundTrackerByChain(ctx, chain.ChainId, interfaces.Ascending)
 	require.NoError(t, err)


### PR DESCRIPTION
Add a CI check that the RPC package is importable. This check should eventually check the import tree to ensure that the required dependencies are minimal.

Will move required status check to `ci-ok` to make the required status checks easier too.

Also fix issues causing import:
- move `GetAllOutboundTrackerByChain` back to zetaclient as it imports zetaclient
- use github.com/btcsuite/btcd/btcutil in pkg/chains

Update: the btcd deps are just too complex. Blocked by https://github.com/zeta-chain/node/issues/2728. Update: unblocked now.

Closes #2798

Currently failing with:
```
go: github.com/zeta-chain/node/contrib/rpcimportable tested by
	github.com/zeta-chain/node/contrib/rpcimportable.test imports
	github.com/zeta-chain/node/pkg/rpc imports
	github.com/zeta-chain/node/pkg/chains imports
	github.com/btcsuite/btcutil imports
	github.com/btcsuite/btcd/btcec: module github.com/btcsuite/btcd@latest found (v0.24.2), but does not contain package github.com/btcsuite/btcd/btcec
go: github.com/zeta-chain/node/contrib/rpcimportable tested by
	github.com/zeta-chain/node/contrib/rpcimportable.test imports
	github.com/zeta-chain/node/pkg/rpc imports
	github.com/zeta-chain/node/x/authority/types tested by
	github.com/zeta-chain/node/x/authority/types.test imports
	github.com/zeta-chain/node/app imports
	github.com/zeta-chain/node/x/observer imports
	github.com/zeta-chain/node/x/observer/client/cli imports
	gitlab.com/thorchain/tss/go-tss/blame imports
	gitlab.com/thorchain/tss/go-tss/conversion imports
	gitlab.com/thorchain/tss/tss-lib/crypto imports
	github.com/decred/dcrd/dcrec/edwards/v2 imports
	github.com/agl/ed25519: module github.com/agl/ed25519@latest found (v0.0.0-20200225211852-fd4d107ace12), but does not contain package github.com/agl/ed25519
go: github.com/zeta-chain/node/contrib/rpcimportable tested by
	github.com/zeta-chain/node/contrib/rpcimportable.test imports
	github.com/zeta-chain/node/pkg/rpc imports
	github.com/zeta-chain/node/x/authority/types tested by
	github.com/zeta-chain/node/x/authority/types.test imports
	github.com/zeta-chain/node/app imports
	github.com/zeta-chain/node/x/observer imports
	github.com/zeta-chain/node/x/observer/client/cli imports
	gitlab.com/thorchain/tss/go-tss/blame imports
	gitlab.com/thorchain/tss/go-tss/conversion imports
	gitlab.com/thorchain/tss/tss-lib/crypto imports
	github.com/decred/dcrd/dcrec/edwards/v2 imports
	github.com/agl/ed25519/edwards25519: module github.com/agl/ed25519@latest found (v0.0.0-20200225211852-fd4d107ace12), but does not contain package github.com/agl/ed25519/edwards25519
```

https://go.dev/ref/mod#go-mod-tidy

> go mod tidy works by loading all of the packages in the [main module](https://go.dev/ref/mod#glos-main-module) and all of the packages they import, recursively. This includes packages imported by tests (including tests in other modules). go mod tidy acts as if all build tags are enabled, so it will consider platform-specific source files and files that require custom build tags, even if those source files wouldn’t normally be built. There is one exception: the ignore build tag is not enabled, so a file with the build constraint // +build ignore will not be considered. Note that go mod tidy will not consider packages in the main module in directories named testdata or with names that start with . or _ unless those packages are explicitly imported by other packages.

We should try ensure there is minimal internal logic in the types package as all that will be imported when a user tries to import the package.

Ok now we're hitting:
```
➜  rpcimportable git:(rpc-importable-test) go mod tidy
go: found github.com/zeta-chain/node/pkg/rpc in github.com/zeta-chain/node v0.0.0-00010101000000-000000000000
➜  rpcimportable git:(rpc-importable-test) ✗ go test -v .
# github.com/zeta-chain/ethermint/x/evm/types
/home/alex/go/pkg/mod/github.com/zeta-chain/ethermint@v0.0.0-20240909234716-2fad916e7179/x/evm/types/tracer.go:48:21: undefined: vm.DefaultActivePrecompiles
FAIL	github.com/zeta-chain/node/contrib/rpcimportable [build failed]
FAIL
```
We definitely cannot force external users to use our ethereum/client-go fork. I will try to move that logic to keeper.

https://github.com/zeta-chain/ethermint/pull/126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to retrieve outbound trackers by blockchain, allowing users to access and sort this data.
  
- **Bug Fixes**
  - Removed outdated methods and tests related to outbound tracker functionality to streamline operations.

- **Tests**
  - Added new tests for the outbound tracker retrieval function, enhancing test coverage and reliability.
  
- **Chores**
  - Updated configuration management across various tests to use a centralized configuration package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->