### PR TITLE
fix: use relative path for openapi handler

### DIFF
--- a/docs/openapi/openapi.go
+++ b/docs/openapi/openapi.go
@@ -26,6 +26,6 @@ func RegisterOpenAPIService(router *mux.Router) {
 func openAPIHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write(html)
+		_, _ = w.Write(html)
 	}
 }

--- a/docs/openapi/openapi.go
+++ b/docs/openapi/openapi.go
@@ -2,22 +2,21 @@ package openapi
 
 import (
 	"embed"
-	"html/template"
 	"net/http"
 
 	"github.com/gorilla/mux"
 )
 
 const (
-	apiFile      = "openapi.swagger.yaml"
-	templateFile = "template.tpl"
+	apiFile  = "openapi.swagger.yaml"
+	htmlFile = "openapi.html"
 )
 
 //go:embed openapi.swagger.yaml
 var staticFS embed.FS
 
-//go:embed template.tpl
-var templateFS embed.FS
+//go:embed openapi.html
+var html []byte
 
 func RegisterOpenAPIService(router *mux.Router) {
 	router.Handle("/"+apiFile, http.FileServer(http.FS(staticFS)))
@@ -25,19 +24,8 @@ func RegisterOpenAPIService(router *mux.Router) {
 }
 
 func openAPIHandler() http.HandlerFunc {
-	tmpl, err := template.ParseFS(templateFS, templateFile)
-	if err != nil {
-		panic(err)
-	}
-
 	return func(w http.ResponseWriter, _ *http.Request) {
-		err := tmpl.Execute(w, struct {
-			URL string
-		}{
-			"/" + apiFile,
-		})
-		if err != nil {
-			http.Error(w, "Failed to render template", http.StatusInternalServerError)
-		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(html)
 	}
 }

--- a/docs/openapi/openapi.html
+++ b/docs/openapi/openapi.html
@@ -20,7 +20,7 @@
     <script>
       window.onload = function() {
           window.ui = SwaggerUIBundle({
-              url: {{ .URL }},
+              url: "./openapi.swagger.yaml",
               dom_id: "#swagger-ui",
               deepLinking: true,
               layout: "BaseLayout",


### PR DESCRIPTION
All the public RPCs swagger UIs are broken because they try to load `/openapi.swagger.yaml` instead of `./openapi.swagger.yaml`.

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/600d80f4-3540-4da3-b6e2-b7e3e8f0e762">

 Use the a relative URL instead.


https://github.com/user-attachments/assets/f5d66fd3-c06d-4680-944d-aabb6738ab6a

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/ef524a7e-d88c-4f0f-a5df-761fa01e0f33">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a static HTML response for the OpenAPI service, enhancing performance and reducing complexity.
	- Updated Swagger UI configuration to use a static URL for the OpenAPI specification.

- **Bug Fixes**
	- Removed unnecessary template rendering, streamlining response generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->