### PR TITLE
fix: register all interfaces in encoding config

### DIFF
--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,17 +1,47 @@
 package app
 
 import (
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	evmenc "github.com/zeta-chain/ethermint/encoding"
 	ethermint "github.com/zeta-chain/ethermint/types"
+	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
+
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	emissionstypes "github.com/zeta-chain/node/x/emissions/types"
+	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
+	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
 // MakeEncodingConfig creates an EncodingConfig for testing
 func MakeEncodingConfig() ethermint.EncodingConfig {
-	//encodingConfig := params.MakeEncodingConfig()
 	encodingConfig := evmenc.MakeConfig(ModuleBasics)
-	//std.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	//std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	//ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	//ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	registry := encodingConfig.InterfaceRegistry
+
+	cryptocodec.RegisterInterfaces(registry)
+	authtypes.RegisterInterfaces(registry)
+	authz.RegisterInterfaces(registry)
+	banktypes.RegisterInterfaces(registry)
+	stakingtypes.RegisterInterfaces(registry)
+	slashingtypes.RegisterInterfaces(registry)
+	upgradetypes.RegisterInterfaces(registry)
+	distrtypes.RegisterInterfaces(registry)
+	evidencetypes.RegisterInterfaces(registry)
+	crisistypes.RegisterInterfaces(registry)
+	evmtypes.RegisterInterfaces(registry)
+	ethermint.RegisterInterfaces(registry)
+	crosschaintypes.RegisterInterfaces(registry)
+	emissionstypes.RegisterInterfaces(registry)
+	fungibletypes.RegisterInterfaces(registry)
+	observertypes.RegisterInterfaces(registry)
+
 	return encodingConfig
 }

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -15,9 +15,11 @@ import (
 	ethermint "github.com/zeta-chain/ethermint/types"
 	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
 
+	authoritytypes "github.com/zeta-chain/node/x/authority/types"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	emissionstypes "github.com/zeta-chain/node/x/emissions/types"
 	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
+	lightclienttypes "github.com/zeta-chain/node/x/lightclient/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
@@ -38,10 +40,12 @@ func MakeEncodingConfig() ethermint.EncodingConfig {
 	crisistypes.RegisterInterfaces(registry)
 	evmtypes.RegisterInterfaces(registry)
 	ethermint.RegisterInterfaces(registry)
+	authoritytypes.RegisterInterfaces(registry)
 	crosschaintypes.RegisterInterfaces(registry)
 	emissionstypes.RegisterInterfaces(registry)
 	fungibletypes.RegisterInterfaces(registry)
 	observertypes.RegisterInterfaces(registry)
+	lightclienttypes.RegisterInterfaces(registry)
 
 	return encodingConfig
 }


### PR DESCRIPTION
Fix https://github.com/zeta-chain/node/issues/2827

We have these `RegisterInterfaces()` calls copy pasted everywhere. Someone should probably clean theses up, but it would be nice to get state exports unblocked in the short term.

Will need to backport to `release/v19` and cut a 19.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced encoding configuration by registering multiple interfaces, improving module interoperability and clarity.
  
- **Bug Fixes**
	- Resolved issues related to interface registration that could affect functionality across various modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->