### PR TITLE
fix(zetaclient): use on-chain chain struct

### DIFF
--- a/zetaclient/chains/evm/observer/observer.go
+++ b/zetaclient/chains/evm/observer/observer.go
@@ -21,11 +21,11 @@ import (
 	"github.com/zeta-chain/protocol-contracts/v2/pkg/gatewayevm.sol"
 
 	"github.com/zeta-chain/node/pkg/bg"
+	"github.com/zeta-chain/node/pkg/chains"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/evm"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
-	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/metrics"
 )
@@ -61,8 +61,9 @@ type priorityFeeConfig struct {
 // NewObserver returns a new EVM chain observer
 func NewObserver(
 	ctx context.Context,
-	evmCfg config.EVMConfig,
+	chain chains.Chain,
 	evmClient interfaces.EVMRPCClient,
+	evmJSONRPC interfaces.EVMJSONRPCClient,
 	chainParams observertypes.ChainParams,
 	zetacoreClient interfaces.ZetacoreClient,
 	tss interfaces.TSSSigner,
@@ -72,7 +73,7 @@ func NewObserver(
 ) (*Observer, error) {
 	// create base observer
 	baseObserver, err := base.NewObserver(
-		evmCfg.Chain,
+		chain,
 		chainParams,
 		zetacoreClient,
 		tss,
@@ -90,7 +91,7 @@ func NewObserver(
 	ob := &Observer{
 		Observer:                      *baseObserver,
 		evmClient:                     evmClient,
-		evmJSONRPC:                    ethrpc.NewEthRPC(evmCfg.Endpoint),
+		evmJSONRPC:                    evmJSONRPC,
 		outboundConfirmedReceipts:     make(map[string]*ethtypes.Receipt),
 		outboundConfirmedTransactions: make(map[string]*ethtypes.Transaction),
 		priorityFeeConfig:             priorityFeeConfig{},

--- a/zetaclient/chains/evm/signer/signer_test.go
+++ b/zetaclient/chains/evm/signer/signer_test.go
@@ -69,14 +69,11 @@ func getNewEvmChainObserver(t *testing.T, tss interfaces.TSSSigner) (*observer.O
 	if tss == nil {
 		tss = mocks.NewTSSMainnet()
 	}
-	cfg := config.New(false)
 
 	// prepare mock arguments to create observer
-	evmcfg := config.EVMConfig{Chain: chains.BscMainnet, Endpoint: "http://localhost:8545"}
 	evmClient := mocks.NewMockEvmClient().WithBlockNumber(1000)
-	params := mocks.MockChainParams(evmcfg.Chain.ChainId, 10)
-	cfg.EVMChainConfigs[chains.BscMainnet.ChainId] = evmcfg
-	//appContext := context.New(cfg, zerolog.Nop())
+	evmJSONRPCClient := mocks.NewMockJSONRPCClient()
+	params := mocks.MockChainParams(chains.BscMainnet.ChainId, 10)
 	logger := base.Logger{}
 	ts := &metrics.TelemetryServer{}
 
@@ -85,8 +82,9 @@ func getNewEvmChainObserver(t *testing.T, tss interfaces.TSSSigner) (*observer.O
 
 	return observer.NewObserver(
 		ctx,
-		evmcfg,
+		chains.BscMainnet,
 		evmClient,
+		evmJSONRPCClient,
 		params,
 		mocks.NewZetacoreClient(t),
 		tss,

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
+	ethrpc2 "github.com/onrik/ethrpc"
 	"github.com/pkg/errors"
 
 	"github.com/zeta-chain/node/zetaclient/chains/base"
@@ -298,11 +299,14 @@ func syncObserverMap(
 				continue
 			}
 
+			evmJSONRPCClient := ethrpc2.NewEthRPC(cfg.Endpoint, ethrpc2.WithHttpClient(httpClient))
+
 			// create EVM chain observer
 			observer, err := evmobserver.NewObserver(
 				ctx,
-				cfg,
+				*rawChain,
 				evmClient,
+				evmJSONRPCClient,
 				*params,
 				client,
 				tss,


### PR DESCRIPTION
Use the on-chain `chain.Chain{}` rather than the local on disk config. This ensure that all attributes in `chain.Chain{}` are consistent across `zetaclientd` deployments rather than relying on operators to configure things manually.

Also inject the `evmJSONRPC` client as parameter rather than constructing it in `NewObserver` to match the style of all the other observers.

We should probably also update the config structure to not use the `chain.Chain{}` type so people don't accidentally use this type in unexpected places.

Closes https://github.com/zeta-chain/node/issues/2829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced observer initialization with a more flexible configuration approach.
	- Introduced a new mock JSON RPC client for improved testing capabilities.

- **Bug Fixes**
	- Streamlined test setup by removing unnecessary configuration steps for EVM observers.

- **Documentation**
	- Updated documentation to reflect changes in observer parameters and configuration.

- **Tests**
	- Improved test cases to align with the new observer initialization logic, ensuring accurate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->