### PR TITLE
fix: prevent division by 0 in ScheduleCctxEVM

### DIFF
--- a/zetaclient/orchestrator/orchestrator.go
+++ b/zetaclient/orchestrator/orchestrator.go
@@ -505,12 +505,8 @@ func (oc *Orchestrator) ScheduleCctxEVM(
 			// TODO: clean up this log when issue is resolved
 			// logging observer chain params to help with debugging if issue happens again
 			oc.logger.Error().
-				Err(err).
-				Msgf("ScheduleCctxEVM: outboundScheduleInterval set to 0 for chain %d using observer for chain %d", chainID, observer.GetChainParams().ChainId)
-
-			oc.logger.Info().
 				Interface("observer.chain_params", observer.GetChainParams()).
-				Msgf("chain params for chainID %d", chainID)
+				Msgf("ScheduleCctxEVM: outboundScheduleInterval set to 0 for chain %d", chainID)
 			return
 		}
 


### PR DESCRIPTION
# Description

Return if outboundScheduleInterval is 0. Add error log to print chain id and observer chain id, to help with debugging if issue happens again.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
