### PR TITLE
fix: move interval assignment out of cctx loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 * [2674](https://github.com/zeta-chain/node/pull/2674) - allow operators to vote on ballots associated with discarded keygen without affecting the status of the current keygen.
 * [2672](https://github.com/zeta-chain/node/pull/2672) - check observer set for duplicates when adding a new observer or updating an existing one
 * [2787](https://github.com/zeta-chain/node/pull/2787) - ask for 3 accounts (signer, pda, system_program) on solana gateway deposit
+* [2842](https://github.com/zeta-chain/node/pull/2842) - fix: move interval assignment out of cctx loop in EVM outbound tx scheduler
 
 ## v19.0.0
 

--- a/zetaclient/orchestrator/orchestrator.go
+++ b/zetaclient/orchestrator/orchestrator.go
@@ -452,6 +452,8 @@ func (oc *Orchestrator) ScheduleCctxEVM(
 	outboundScheduleLookback := uint64(float64(outboundScheduleLookahead) * evmOutboundLookbackFactor)
 	// #nosec G115 positive
 	outboundScheduleInterval := uint64(observer.GetChainParams().OutboundScheduleInterval)
+	criticalInterval := uint64(10)                      // for critical pending outbound we reduce re-try interval
+	nonCriticalInterval := outboundScheduleInterval * 2 // for non-critical pending outbound we increase re-try interval
 
 	for idx, cctx := range cctxList {
 		params := cctx.GetCurrentOutboundParam()
@@ -486,8 +488,6 @@ func (oc *Orchestrator) ScheduleCctxEVM(
 		// determining critical outbound; if it satisfies following criteria
 		// 1. it's the first pending outbound for this chain
 		// 2. the following 5 nonces have been in tracker
-		criticalInterval := uint64(10)                      // for critical pending outbound we reduce re-try interval
-		nonCriticalInterval := outboundScheduleInterval * 2 // for non-critical pending outbound we increase re-try interval
 		if nonce%criticalInterval == zetaHeight%criticalInterval {
 			count := 0
 			for i := nonce + 1; i <= nonce+10; i++ {


### PR DESCRIPTION
# Description
The `criticalInterval` and `nonCriticalInterval` should not mutate inside the cctx loop in the
EVM outbound scheduler. 

As it was before they could mutate because outboundScheduleInterval could change.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of outbound transactions with defined retry intervals for critical and non-critical transactions.
	- Enhanced clarity and maintainability of transaction scheduling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->