### PR TITLE
fix: add license

### DIFF
--- a/precompiles/prototype/IPrototype.sol
+++ b/precompiles/prototype/IPrototype.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
 /// @dev The IPrototype contract's address.

--- a/precompiles/staking/IStaking.sol
+++ b/precompiles/staking/IStaking.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
 /// @dev The IStaking contract's address.


### PR DESCRIPTION
# Description

Provide licensing in precompiles, it's a good practice in Solidity development. Also, fixes the warning shown by IDE extensions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added SPDX license identifier comments to `IPrototype.sol` and `IStaking.sol` to clarify licensing terms.
  
These changes enhance compliance with licensing standards without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->