### PR TITLE
test: skip precompiles test for tss migration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,7 +34,8 @@
 * [2726](https://github.com/zeta-chain/node/pull/2726) - add e2e tests for deposit and call, deposit and revert
 * [2703](https://github.com/zeta-chain/node/pull/2703) - add e2e tests for stateful precompiled contracts
 * [2763](https://github.com/zeta-chain/node/pull/2763) - add V2 contracts migration test
-* [2830] (https://github.com/zeta-chain/node/pull/2830) - extend staking precompile tests
+* [2830](https://github.com/zeta-chain/node/pull/2830) - extend staking precompile tests
+* [2867](https://github.com/zeta-chain/node/pull/2867) - skip precompiles test for tss migration
 
 ### Fixes
 

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -181,7 +181,7 @@ if [ "$LOCALNET_MODE" == "tss-migrate" ]; then
   echo "waiting 10 seconds for node to restart"
     sleep 10
 
-  zetae2e local --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof
+  zetae2e local --skip-setup --config deployed.yml --skip-bitcoin-setup --light --skip-header-proof --skip-precompiles
   ZETAE2E_EXIT_CODE=$?
   if [ $ZETAE2E_EXIT_CODE -eq 0 ]; then
     echo "E2E passed after migration"


### PR DESCRIPTION
# Description

This pr adds logic to skip the precompiles test after migration

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `zetae2e local` command to include an option to skip precompilation steps, improving execution efficiency for users in `tss-migrate` mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->