### PR TITLE
fix(zetacore): add default cctx list pagination size

### DIFF
--- a/x/crosschain/keeper/grpc_query_cctx.go
+++ b/x/crosschain/keeper/grpc_query_cctx.go
@@ -20,6 +20,8 @@ const (
 
 	// MaxLookbackNonce is the maximum number of nonces to look back to find missed pending cctxs
 	MaxLookbackNonce = 1000
+
+	defaultPageSize = 100
 )
 
 func (k Keeper) ZetaAccounting(
@@ -45,6 +47,10 @@ func (k Keeper) CctxAll(c context.Context, req *types.QueryAllCctxRequest) (*typ
 
 	store := ctx.KVStore(k.storeKey)
 	sendStore := prefix.NewStore(store, types.KeyPrefix(types.CCTXKey))
+
+	if req.Pagination.Limit == 0 {
+		req.Pagination.Limit = defaultPageSize
+	}
 
 	pageRes, err := query.Paginate(sendStore, req.Pagination, func(_ []byte, value []byte) error {
 		var send types.CrossChainTx

--- a/x/crosschain/keeper/grpc_query_cctx.go
+++ b/x/crosschain/keeper/grpc_query_cctx.go
@@ -21,7 +21,7 @@ const (
 	// MaxLookbackNonce is the maximum number of nonces to look back to find missed pending cctxs
 	MaxLookbackNonce = 1000
 
-	defaultPageSize = 100
+	DefaultPageSize = 100
 )
 
 func (k Keeper) ZetaAccounting(
@@ -48,8 +48,11 @@ func (k Keeper) CctxAll(c context.Context, req *types.QueryAllCctxRequest) (*typ
 	store := ctx.KVStore(k.storeKey)
 	sendStore := prefix.NewStore(store, types.KeyPrefix(types.CCTXKey))
 
+	if req.Pagination == nil {
+		req.Pagination = &query.PageRequest{}
+	}
 	if req.Pagination.Limit == 0 {
-		req.Pagination.Limit = defaultPageSize
+		req.Pagination.Limit = DefaultPageSize
 	}
 
 	pageRes, err := query.Paginate(sendStore, req.Pagination, func(_ []byte, value []byte) error {


### PR DESCRIPTION
This endpoint returns *all* CCTXs. It takes about 15 minutes to respond on mainnet and degrades RPC providers. Add a default page size to ensure the response is fast by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default pagination limit of 100 for cross-chain transaction queries, enhancing usability.
  
- **Bug Fixes**
	- Improved handling of requests without pagination parameters, ensuring no errors are returned.

- **Tests**
	- Added comprehensive tests for the `CctxAll` method to validate functionality under different pagination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->