### PR TITLE
fix(zetacore): add default cctx list pagination size (#2871)

### DIFF
--- a/x/crosschain/keeper/grpc_query_cctx.go
+++ b/x/crosschain/keeper/grpc_query_cctx.go
@@ -20,6 +20,8 @@ const (
 
 	// MaxLookbackNonce is the maximum number of nonces to look back to find missed pending cctxs
 	MaxLookbackNonce = 1000
+
+	DefaultPageSize = 100
 )
 
 func (k Keeper) ZetaAccounting(
@@ -45,6 +47,13 @@ func (k Keeper) CctxAll(c context.Context, req *types.QueryAllCctxRequest) (*typ
 
 	store := ctx.KVStore(k.storeKey)
 	sendStore := prefix.NewStore(store, types.KeyPrefix(types.CCTXKey))
+
+	if req.Pagination == nil {
+		req.Pagination = &query.PageRequest{}
+	}
+	if req.Pagination.Limit == 0 {
+		req.Pagination.Limit = DefaultPageSize
+	}
 
 	pageRes, err := query.Paginate(sendStore, req.Pagination, func(_ []byte, value []byte) error {
 		var send types.CrossChainTx

--- a/x/crosschain/keeper/grpc_query_cctx_test.go
+++ b/x/crosschain/keeper/grpc_query_cctx_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 
 	keepertest "github.com/zeta-chain/zetacore/testutil/keeper"
@@ -283,5 +284,42 @@ func TestKeeper_CctxByNonce(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, cctx, res.CrossChainTx)
+	})
+}
+
+func TestKeeper_CctxAll(t *testing.T) {
+	t.Run("empty request", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		_, err := k.CctxAll(ctx, &types.QueryAllCctxRequest{})
+		require.NoError(t, err)
+	})
+
+	t.Run("default page size", func(t *testing.T) {
+		k, ctx, _, zk := keepertest.CrosschainKeeper(t)
+		chainID := getValidEthChainID()
+		tss := sample.Tss()
+		zk.ObserverKeeper.SetTSS(ctx, tss)
+		_ = createCctxWithNonceRange(t, ctx, *k, 1000, 2000, chainID, tss, zk)
+
+		res, err := k.CctxAll(ctx, &types.QueryAllCctxRequest{})
+		require.NoError(t, err)
+		require.Len(t, res.CrossChainTx, keeper.DefaultPageSize)
+	})
+
+	t.Run("page size provided", func(t *testing.T) {
+		k, ctx, _, zk := keepertest.CrosschainKeeper(t)
+		chainID := getValidEthChainID()
+		tss := sample.Tss()
+		zk.ObserverKeeper.SetTSS(ctx, tss)
+		_ = createCctxWithNonceRange(t, ctx, *k, 1000, 2000, chainID, tss, zk)
+		testPageSize := 200
+
+		res, err := k.CctxAll(ctx, &types.QueryAllCctxRequest{
+			Pagination: &query.PageRequest{
+				Limit: uint64(testPageSize),
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, res.CrossChainTx, testPageSize)
 	})
 }


### PR DESCRIPTION
Backport https://github.com/zeta-chain/node/pull/2871 for another optional hotfix release to resolve RPC provider issues.