### PR TITLE
chore: log panic line in ticker error

### DIFF
--- a/pkg/ticker/ticker.go
+++ b/pkg/ticker/ticker.go
@@ -29,6 +29,8 @@ package ticker
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -78,7 +80,14 @@ func SecondsFromUint64(d uint64) time.Duration {
 func (t *Ticker) Run(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic during ticker run: %v", r)
+			stack := string(debug.Stack())
+			lines := strings.Split(stack, "\n")
+			line := ""
+			// 8th line should be the actual line, see the unit tests
+			if len(lines) > 8 {
+				line = strings.TrimSpace(lines[8])
+			}
+			err = fmt.Errorf("panic during ticker run: %v at %s", r, line)
 		}
 	}()
 

--- a/pkg/ticker/ticker_test.go
+++ b/pkg/ticker/ticker_test.go
@@ -147,6 +147,33 @@ func TestTicker(t *testing.T) {
 
 		// ASSERT
 		assert.ErrorContains(t, err, "panic during ticker run: oops")
+		// assert that we get error with the correct line number
+		assert.ErrorContains(t, err, "ticker_test.go:142")
+	})
+
+	t.Run("Nil panic", func(t *testing.T) {
+		// ARRANGE
+		// Given a context
+		ctx := context.Background()
+
+		// And a ticker
+		ticker := New(durSmall, func(_ context.Context, _ *Ticker) error {
+			var a func()
+			a()
+			return nil
+		})
+
+		// ACT
+		err := ticker.Run(ctx)
+
+		// ASSERT
+		assert.ErrorContains(
+			t,
+			err,
+			"panic during ticker run: runtime error: invalid memory address or nil pointer dereference",
+		)
+		// assert that we get error with the correct line number
+		assert.ErrorContains(t, err, "ticker_test.go:162")
 	})
 
 	t.Run("Run as a single call", func(t *testing.T) {


### PR DESCRIPTION
We're seeing a panic on mainnet which causes an inbound processing halt.

```
{"level":"error","chain":56,"module":"inbound","error":"panic during ticker run: runtime error: invalid memory address or nil pointer dereference","worker.name":"WatchInbound","time":"2024-09-14T01:34:02Z","message":"Background task failed"}
```

Add ensure the we log the full path to any panics for debugging. Test coverage proves that we select the correct line for the message. We already built and deployed a binary manually on mainnet which gives us a useful result:

```
{"level":"error","chain":56,"module":"inbound","error":"panic during ticker run: runtime error: invalid memory address or nil pointer dereference at /go/src/github.com/zeta-chain/node/zetaclient/chains/evm/observer/observer.go:340 +0x34","worker.name":"WatchInbound","time":"2024-09-14T01:33:40Z","message":"Background task failed"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling to capture and report stack traces during panic scenarios in the ticker functionality.
  
- **Tests**
	- Introduced a new test case to validate panic handling, ensuring accurate error reporting for nil pointer dereferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->