### PR TITLE
fix(zetaclient): add block by number result nil check

### DIFF
--- a/zetaclient/chains/evm/observer/observer.go
+++ b/zetaclient/chains/evm/observer/observer.go
@@ -315,6 +315,9 @@ func (ob *Observer) BlockByNumber(blockNumber int) (*ethrpc.Block, error) {
 	if err != nil {
 		return nil, err
 	}
+	if block == nil {
+		return nil, fmt.Errorf("block not found: %d", blockNumber)
+	}
 	for i := range block.Transactions {
 		err := evm.ValidateEvmTransaction(&block.Transactions[i])
 		if err != nil {


### PR DESCRIPTION
We're getting this panic on mainnet which results in inbounds not being processed.

```
{"level":"error","chain":56,"module":"inbound","error":"panic during ticker run: runtime error: invalid memory address or nil pointer dereference at /go/src/github.com/zeta-chain/node/zetaclient/chains/evm/observer/observer.go:340 +0x34","worker.name":"WatchInbound","time":"2024-09-14T01:33:40Z","message":"Background task failed"}
```
on release/v19 it points to this function. It looks like it can return nil and no error. Add an explicit nil check to ensure the `block.Transactions` does not nil dereference.

Related to #2881 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the block retrieval process, providing clearer feedback when a requested block is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->