### PR TITLE
test: initialize liquidity cap for newly deployed erc20 in WhiteListERC20 e2e test

### DIFF
--- a/e2e/e2etests/test_whitelist_erc20.go
+++ b/e2e/e2etests/test_whitelist_erc20.go
@@ -50,6 +50,9 @@ func TestWhitelistERC20(r *runner.E2ERunner, _ []string) {
 	erc20zrc20Addr, err := txserver.FetchAttributeFromTxResponse(res, "zrc20_address")
 	require.NoError(r, err)
 
+	err = r.ZetaTxServer.InitializeLiquidityCap(erc20zrc20Addr)
+	require.NoError(r, err)
+
 	// ensure CCTX created
 	resCCTX, err := r.CctxClient.Cctx(r.Ctx, &crosschaintypes.QueryGetCctxRequest{Index: whitelistCCTXIndex})
 	require.NoError(r, err)

--- a/e2e/txserver/zeta_tx_server.go
+++ b/e2e/txserver/zeta_tx_server.go
@@ -459,7 +459,7 @@ func (zts ZetaTxServer) DeployZRC20s(
 	if err != nil {
 		return "", err
 	}
-	if err := zts.initializeLiquidityCap(zrc20); err != nil {
+	if err := zts.InitializeLiquidityCap(zrc20); err != nil {
 		return "", err
 	}
 
@@ -481,7 +481,7 @@ func (zts ZetaTxServer) DeployZRC20s(
 	if err != nil {
 		return "", err
 	}
-	if err := zts.initializeLiquidityCap(zrc20); err != nil {
+	if err := zts.InitializeLiquidityCap(zrc20); err != nil {
 		return "", err
 	}
 
@@ -503,7 +503,7 @@ func (zts ZetaTxServer) DeployZRC20s(
 	if err != nil {
 		return "", err
 	}
-	if err := zts.initializeLiquidityCap(zrc20); err != nil {
+	if err := zts.InitializeLiquidityCap(zrc20); err != nil {
 		return "", err
 	}
 
@@ -527,7 +527,7 @@ func (zts ZetaTxServer) DeployZRC20s(
 	if err != nil {
 		return "", err
 	}
-	if err := zts.initializeLiquidityCap(erc20zrc20Addr); err != nil {
+	if err := zts.InitializeLiquidityCap(erc20zrc20Addr); err != nil {
 		return "", err
 	}
 
@@ -579,8 +579,8 @@ func (zts *ZetaTxServer) SetAuthorityClient(authorityClient authoritytypes.Query
 	zts.authorityClient = authorityClient
 }
 
-// initializeLiquidityCap initializes the liquidity cap for the given coin with a large value
-func (zts ZetaTxServer) initializeLiquidityCap(zrc20 string) error {
+// InitializeLiquidityCap initializes the liquidity cap for the given coin with a large value
+func (zts ZetaTxServer) InitializeLiquidityCap(zrc20 string) error {
 	liquidityCap := sdktypes.NewUint(1e18).MulUint64(1e12)
 
 	msg := fungibletypes.NewMsgUpdateZRC20LiquidityCap(


### PR DESCRIPTION
# Description

Closes : https://github.com/zeta-chain/node/issues/2888

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced test functionality by ensuring proper initialization of the liquidity cap for ERC20 tokens.
  
- **Refactor**
	- Renamed method for initializing liquidity cap to improve readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->