### PR TITLE
feat: derive Bitcoin TSS address by chain ID; added more Signet static info in 'chains' package

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * [2861](https://github.com/zeta-chain/node/pull/2861) - emit events from staking precompile
 * [2870](https://github.com/zeta-chain/node/pull/2870) - support for multiple Bitcoin chains in the zetaclient
 * [2883](https://github.com/zeta-chain/node/pull/2883) - add chain static information for btc signet testnet
+* [2907](https://github.com/zeta-chain/node/pull/2907) - derive Bitcoin tss address by chain id and added more Signet static info
 
 ### Refactor
 

--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -275,7 +275,8 @@ func start(_ *cobra.Command, _ []string) error {
 		btcChainIDs[i] = chain.ID()
 	}
 
-	// Make sure the TSS EVM/BTC addresses are well formed
+	// Make sure the TSS EVM/BTC addresses are well formed.
+	// Zetaclient should not start if TSS addresses cannot be properly derived.
 	tss.CurrentPubkey = currentTss.TssPubkey
 	err = tss.ValidateAddresses(btcChainIDs)
 	if err != nil {

--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cometbft/cometbft/crypto/secp256k1"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	maddr "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -230,21 +229,10 @@ func start(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	btcChains := appContext.FilterChains(zctx.Chain.IsBitcoin)
-	switch {
-	case len(btcChains) == 0:
-		return errors.New("no BTC chains found")
-	case len(btcChains) > 1:
-		// In the future we might support multiple UTXO chains;
-		// right now we only support BTC. Let's make sure there are no surprises.
-		return errors.New("more than one BTC chain found")
-	}
-
 	tss, err := mc.NewTSS(
 		ctx,
 		zetacoreClient,
 		tssHistoricalList,
-		btcChains[0].ID(),
 		hotkeyPass,
 		server,
 	)
@@ -280,16 +268,19 @@ func start(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Defensive check: Make sure the tss address is set to the current TSS address and not the newly generated one
+	// Filter supported BTC chain IDs
+	btcChains := appContext.FilterChains(zctx.Chain.IsBitcoin)
+	btcChainIDs := make([]int64, len(btcChains))
+	for i, chain := range btcChains {
+		btcChainIDs[i] = chain.ID()
+	}
+
+	// Make sure the TSS EVM/BTC addresses are well formed
 	tss.CurrentPubkey = currentTss.TssPubkey
-	if tss.EVMAddress() == (ethcommon.Address{}) || tss.BTCAddress() == "" {
-		startLogger.Error().Msg("TSS address is not set in zetacore")
-	} else {
-		startLogger.Info().
-			Str("tss.eth", tss.EVMAddress().String()).
-			Str("tss.btc", tss.BTCAddress()).
-			Str("tss.pub_key", tss.CurrentPubkey).
-			Msg("Current TSS")
+	err = tss.ValidateAddresses(btcChainIDs)
+	if err != nil {
+		startLogger.Error().Err(err).Msg("TSS address validation failed")
+		return err
 	}
 
 	if len(appContext.ListChainIDs()) == 0 {

--- a/e2e/e2etests/test_bitcoin_deposit_call.go
+++ b/e2e/e2etests/test_bitcoin_deposit_call.go
@@ -34,7 +34,7 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	// deploy an example contract in ZEVM
 	contractAddr, _, contract, err := testcontract.DeployExample(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
-	r.Logger.Print("Bitcoin: Example contract deployed at: %s", contractAddr.String())
+	r.Logger.Info("Bitcoin: Example contract deployed at: %s", contractAddr.String())
 
 	// ACT
 	// Send BTC to TSS address with a dummy memo

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -296,7 +297,7 @@ func (r *E2ERunner) GetBitcoinChainID() int64 {
 
 // IsLocalBitcoin returns true if the runner is running on a local bitcoin network
 func (r *E2ERunner) IsLocalBitcoin() bool {
-	return r.BitcoinParams.Name == chains.BitcoinRegnetParams.Name
+	return r.BitcoinParams.Name == chaincfg.RegressionNetParams.Name
 }
 
 // GenerateToAddressIfLocalBitcoin generates blocks to an address if the runner is interacting

--- a/pkg/chains/bitcoin.go
+++ b/pkg/chains/bitcoin.go
@@ -10,6 +10,7 @@ var (
 	BitcoinMainnetParams = &chaincfg.MainNetParams
 	BitcoinRegnetParams  = &chaincfg.RegressionNetParams
 	BitcoinTestnetParams = &chaincfg.TestNet3Params
+	BitcoinSignetParams  = &chaincfg.SigNetParams
 )
 
 // BitcoinNetParamsFromChainID returns the bitcoin net params to be used from the chain id
@@ -21,6 +22,8 @@ func BitcoinNetParamsFromChainID(chainID int64) (*chaincfg.Params, error) {
 		return BitcoinMainnetParams, nil
 	case BitcoinTestnet.ChainId:
 		return BitcoinTestnetParams, nil
+	case BitcoinSignetTestnet.ChainId:
+		return BitcoinSignetParams, nil
 	default:
 		return nil, fmt.Errorf("no Bitcoin net params for chain ID: %d", chainID)
 	}
@@ -35,6 +38,8 @@ func BitcoinChainIDFromNetworkName(name string) (int64, error) {
 		return BitcoinMainnet.ChainId, nil
 	case BitcoinTestnetParams.Name:
 		return BitcoinTestnet.ChainId, nil
+	case BitcoinSignetParams.Name:
+		return BitcoinSignetTestnet.ChainId, nil
 	default:
 		return 0, fmt.Errorf("invalid Bitcoin network name: %s", name)
 	}

--- a/pkg/chains/bitcoin.go
+++ b/pkg/chains/bitcoin.go
@@ -7,42 +7,37 @@ import (
 )
 
 var (
-	BitcoinMainnetParams = &chaincfg.MainNetParams
-	BitcoinRegnetParams  = &chaincfg.RegressionNetParams
-	BitcoinTestnetParams = &chaincfg.TestNet3Params
-	BitcoinSignetParams  = &chaincfg.SigNetParams
+	// chainIDToNetworkParams maps the Bitcoin chain ID to the network parameters
+	chainIDToNetworkParams = map[int64]*chaincfg.Params{
+		BitcoinRegtest.ChainId:       &chaincfg.RegressionNetParams,
+		BitcoinMainnet.ChainId:       &chaincfg.MainNetParams,
+		BitcoinTestnet.ChainId:       &chaincfg.TestNet3Params,
+		BitcoinSignetTestnet.ChainId: &chaincfg.SigNetParams,
+	}
+
+	// networkNameToChainID maps the Bitcoin network name to the chain ID
+	networkNameToChainID = map[string]int64{
+		chaincfg.RegressionNetParams.Name: BitcoinRegtest.ChainId,
+		chaincfg.MainNetParams.Name:       BitcoinMainnet.ChainId,
+		chaincfg.TestNet3Params.Name:      BitcoinTestnet.ChainId,
+		chaincfg.SigNetParams.Name:        BitcoinSignetTestnet.ChainId,
+	}
 )
 
 // BitcoinNetParamsFromChainID returns the bitcoin net params to be used from the chain id
 func BitcoinNetParamsFromChainID(chainID int64) (*chaincfg.Params, error) {
-	switch chainID {
-	case BitcoinRegtest.ChainId:
-		return BitcoinRegnetParams, nil
-	case BitcoinMainnet.ChainId:
-		return BitcoinMainnetParams, nil
-	case BitcoinTestnet.ChainId:
-		return BitcoinTestnetParams, nil
-	case BitcoinSignetTestnet.ChainId:
-		return BitcoinSignetParams, nil
-	default:
-		return nil, fmt.Errorf("no Bitcoin net params for chain ID: %d", chainID)
+	if params, found := chainIDToNetworkParams[chainID]; found {
+		return params, nil
 	}
+	return nil, fmt.Errorf("no Bitcoin network params for chain ID: %d", chainID)
 }
 
 // BitcoinChainIDFromNetworkName returns the chain id for the given bitcoin network name
 func BitcoinChainIDFromNetworkName(name string) (int64, error) {
-	switch name {
-	case BitcoinRegnetParams.Name:
-		return BitcoinRegtest.ChainId, nil
-	case BitcoinMainnetParams.Name:
-		return BitcoinMainnet.ChainId, nil
-	case BitcoinTestnetParams.Name:
-		return BitcoinTestnet.ChainId, nil
-	case BitcoinSignetParams.Name:
-		return BitcoinSignetTestnet.ChainId, nil
-	default:
-		return 0, fmt.Errorf("invalid Bitcoin network name: %s", name)
+	if chainID, found := networkNameToChainID[name]; found {
+		return chainID, nil
 	}
+	return 0, fmt.Errorf("invalid Bitcoin network name: %s", name)
 }
 
 // IsBitcoinRegnet returns true if the chain id is for the regnet

--- a/pkg/chains/bitcoin_test.go
+++ b/pkg/chains/bitcoin_test.go
@@ -17,6 +17,7 @@ func TestBitcoinNetParamsFromChainID(t *testing.T) {
 		{"Regnet", BitcoinRegtest.ChainId, BitcoinRegnetParams, false},
 		{"Mainnet", BitcoinMainnet.ChainId, BitcoinMainnetParams, false},
 		{"Testnet", BitcoinTestnet.ChainId, BitcoinTestnetParams, false},
+		{"Signet", BitcoinSignetTestnet.ChainId, BitcoinSignetParams, false},
 		{"Unknown", -1, nil, true},
 	}
 
@@ -43,6 +44,7 @@ func TestBitcoinChainIDFromNetParams(t *testing.T) {
 		{"Regnet", BitcoinRegnetParams.Name, BitcoinRegtest.ChainId, false},
 		{"Mainnet", BitcoinMainnetParams.Name, BitcoinMainnet.ChainId, false},
 		{"Testnet", BitcoinTestnetParams.Name, BitcoinTestnet.ChainId, false},
+		{"Signet", BitcoinSignetParams.Name, BitcoinSignetTestnet.ChainId, false},
 		{"Unknown", "Unknown", 0, true},
 	}
 

--- a/pkg/chains/bitcoin_test.go
+++ b/pkg/chains/bitcoin_test.go
@@ -14,10 +14,10 @@ func TestBitcoinNetParamsFromChainID(t *testing.T) {
 		expected *chaincfg.Params
 		wantErr  bool
 	}{
-		{"Regnet", BitcoinRegtest.ChainId, BitcoinRegnetParams, false},
-		{"Mainnet", BitcoinMainnet.ChainId, BitcoinMainnetParams, false},
-		{"Testnet", BitcoinTestnet.ChainId, BitcoinTestnetParams, false},
-		{"Signet", BitcoinSignetTestnet.ChainId, BitcoinSignetParams, false},
+		{"Regnet", BitcoinRegtest.ChainId, &chaincfg.RegressionNetParams, false},
+		{"Mainnet", BitcoinMainnet.ChainId, &chaincfg.MainNetParams, false},
+		{"Testnet", BitcoinTestnet.ChainId, &chaincfg.TestNet3Params, false},
+		{"Signet", BitcoinSignetTestnet.ChainId, &chaincfg.SigNetParams, false},
 		{"Unknown", -1, nil, true},
 	}
 
@@ -26,9 +26,10 @@ func TestBitcoinNetParamsFromChainID(t *testing.T) {
 			params, err := BitcoinNetParamsFromChainID(tt.chainID)
 			if tt.wantErr {
 				require.Error(t, err)
+				require.Nil(t, params)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, params)
+				require.EqualValues(t, tt.expected, params)
 			}
 		})
 	}
@@ -41,10 +42,10 @@ func TestBitcoinChainIDFromNetParams(t *testing.T) {
 		expectedChainID int64
 		wantErr         bool
 	}{
-		{"Regnet", BitcoinRegnetParams.Name, BitcoinRegtest.ChainId, false},
-		{"Mainnet", BitcoinMainnetParams.Name, BitcoinMainnet.ChainId, false},
-		{"Testnet", BitcoinTestnetParams.Name, BitcoinTestnet.ChainId, false},
-		{"Signet", BitcoinSignetParams.Name, BitcoinSignetTestnet.ChainId, false},
+		{"Regnet", chaincfg.RegressionNetParams.Name, BitcoinRegtest.ChainId, false},
+		{"Mainnet", chaincfg.MainNetParams.Name, BitcoinMainnet.ChainId, false},
+		{"Testnet", chaincfg.TestNet3Params.Name, BitcoinTestnet.ChainId, false},
+		{"Signet", chaincfg.SigNetParams.Name, BitcoinSignetTestnet.ChainId, false},
 		{"Unknown", "Unknown", 0, true},
 	}
 

--- a/x/crosschain/keeper/cctx_orchestrator_validate_inbound_test.go
+++ b/x/crosschain/keeper/cctx_orchestrator_validate_inbound_test.go
@@ -567,7 +567,7 @@ func TestKeeper_CheckMigration(t *testing.T) {
 		}
 
 		err := k.CheckIfTSSMigrationTransfer(ctx, &msg)
-		require.ErrorContains(t, err, "no Bitcoin net params for chain ID: 999")
+		require.ErrorContains(t, err, "no Bitcoin network params for chain ID: 999")
 	})
 
 	t.Run("fails if gateway is not observer ", func(t *testing.T) {

--- a/x/observer/keeper/grpc_query_tss.go
+++ b/x/observer/keeper/grpc_query_tss.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -54,7 +55,7 @@ func (k Keeper) GetTssAddress(
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	bitcoinParams := chains.BitcoinRegnetParams
+	bitcoinParams := &chaincfg.RegressionNetParams
 	if req.BitcoinChainId != 0 {
 		bitcoinParams, err = chains.BitcoinNetParamsFromChainID(req.BitcoinChainId)
 		if err != nil {
@@ -88,7 +89,7 @@ func (k Keeper) GetTssAddressByFinalizedHeight(
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	bitcoinParams := chains.BitcoinRegnetParams
+	bitcoinParams := &chaincfg.RegressionNetParams
 	if req.BitcoinChainId != 0 {
 		bitcoinParams, err = chains.BitcoinNetParamsFromChainID(req.BitcoinChainId)
 		if err != nil {

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -217,6 +217,18 @@ func (ob *Observer) WithTSS(tss interfaces.TSSSigner) *Observer {
 	return ob
 }
 
+// TSSAddress returns the TSS address for the chain.
+//
+// Note: all chains uses TSS EVM address except Bitcoin chain.
+func (ob *Observer) TSSAddress() string {
+	switch ob.chain.Consensus {
+	case chains.Consensus_bitcoin:
+		return ob.tss.BTCAddress(ob.Chain().ChainId).EncodeAddress()
+	default:
+		return ob.tss.EVMAddress().String()
+	}
+}
+
 // LastBlock get external last block height.
 func (ob *Observer) LastBlock() uint64 {
 	return atomic.LoadUint64(&ob.lastBlock)
@@ -286,11 +298,7 @@ func (ob *Observer) WithHeaderCache(cache *lru.Cache) *Observer {
 // OutboundID returns a unique identifier for the outbound transaction.
 // The identifier is now used as the key for maps that store outbound related data (e.g. transaction, receipt, etc).
 func (ob *Observer) OutboundID(nonce uint64) string {
-	// all chains uses EVM address as part of the key except bitcoin
-	tssAddress := ob.tss.EVMAddress().String()
-	if ob.chain.Consensus == chains.Consensus_bitcoin {
-		tssAddress = ob.tss.BTCAddress(ob.Chain().ChainId)
-	}
+	tssAddress := ob.TSSAddress()
 	return fmt.Sprintf("%d-%s-%d", ob.chain.ChainId, tssAddress, nonce)
 }
 

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -289,7 +289,7 @@ func (ob *Observer) OutboundID(nonce uint64) string {
 	// all chains uses EVM address as part of the key except bitcoin
 	tssAddress := ob.tss.EVMAddress().String()
 	if ob.chain.Consensus == chains.Consensus_bitcoin {
-		tssAddress = ob.tss.BTCAddress()
+		tssAddress = ob.tss.BTCAddress(ob.Chain().ChainId)
 	}
 	return fmt.Sprintf("%d-%s-%d", ob.chain.ChainId, tssAddress, nonce)
 }

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -217,13 +217,17 @@ func (ob *Observer) WithTSS(tss interfaces.TSSSigner) *Observer {
 	return ob
 }
 
-// TSSAddress returns the TSS address for the chain.
+// TSSAddressString returns the TSS address for the chain.
 //
 // Note: all chains uses TSS EVM address except Bitcoin chain.
-func (ob *Observer) TSSAddress() string {
+func (ob *Observer) TSSAddressString() string {
 	switch ob.chain.Consensus {
 	case chains.Consensus_bitcoin:
-		return ob.tss.BTCAddress(ob.Chain().ChainId).EncodeAddress()
+		address, err := ob.tss.BTCAddress(ob.Chain().ChainId)
+		if err != nil {
+			return ""
+		}
+		return address.EncodeAddress()
 	default:
 		return ob.tss.EVMAddress().String()
 	}
@@ -298,7 +302,7 @@ func (ob *Observer) WithHeaderCache(cache *lru.Cache) *Observer {
 // OutboundID returns a unique identifier for the outbound transaction.
 // The identifier is now used as the key for maps that store outbound related data (e.g. transaction, receipt, etc).
 func (ob *Observer) OutboundID(nonce uint64) string {
-	tssAddress := ob.TSSAddress()
+	tssAddress := ob.TSSAddressString()
 	return fmt.Sprintf("%d-%s-%d", ob.chain.ChainId, tssAddress, nonce)
 }
 

--- a/zetaclient/chains/base/observer_test.go
+++ b/zetaclient/chains/base/observer_test.go
@@ -350,7 +350,7 @@ func TestOutboundID(t *testing.T) {
 			// expected outbound id
 			exepctedID := fmt.Sprintf("%d-%s-%d", tt.chain.ChainId, tt.tss.EVMAddress(), tt.nonce)
 			if tt.chain.Consensus == chains.Consensus_bitcoin {
-				exepctedID = fmt.Sprintf("%d-%s-%d", tt.chain.ChainId, tt.tss.BTCAddress(), tt.nonce)
+				exepctedID = fmt.Sprintf("%d-%s-%d", tt.chain.ChainId, tt.tss.BTCAddress(tt.chain.ChainId), tt.nonce)
 			}
 			require.Equal(t, exepctedID, outboundID)
 		})

--- a/zetaclient/chains/base/observer_test.go
+++ b/zetaclient/chains/base/observer_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/cmd"
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/testutil/sample"
@@ -21,6 +23,7 @@ import (
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/metrics"
+	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 )
 
@@ -271,6 +274,45 @@ func TestObserverGetterAndSetter(t *testing.T) {
 	})
 }
 
+func TestTSSAddress(t *testing.T) {
+	testConfig := sdk.GetConfig()
+	testConfig.SetBech32PrefixForAccount(cmd.Bech32PrefixAccAddr, cmd.Bech32PrefixAccPub)
+
+	tests := []struct {
+		name         string
+		chain        chains.Chain
+		addrExpected string
+	}{
+		{
+			name:         "should return TSS BTC address for Bitcoin chain",
+			chain:        chains.BitcoinMainnet,
+			addrExpected: testutils.TSSAddressBTCMainnet,
+		},
+		{
+			name:         "should return TSS EVM address for EVM chain",
+			chain:        chains.Ethereum,
+			addrExpected: testutils.TSSAddressEVMMainnet,
+		},
+		{
+			name:         "should return TSS EVM address for other non-BTC chain",
+			chain:        chains.SolanaDevnet,
+			addrExpected: testutils.TSSAddressEVMMainnet,
+		},
+	}
+
+	// run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// create observer
+			ob := createObserver(t, tt.chain, defaultAlertLatency)
+
+			// get TSS address
+			addr := ob.TSSAddress()
+			require.Equal(t, tt.addrExpected, addr)
+		})
+	}
+}
+
 func TestIsBlockConfirmed(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -348,10 +390,7 @@ func TestOutboundID(t *testing.T) {
 			outboundID := ob.OutboundID(tt.nonce)
 
 			// expected outbound id
-			exepctedID := fmt.Sprintf("%d-%s-%d", tt.chain.ChainId, tt.tss.EVMAddress(), tt.nonce)
-			if tt.chain.Consensus == chains.Consensus_bitcoin {
-				exepctedID = fmt.Sprintf("%d-%s-%d", tt.chain.ChainId, tt.tss.BTCAddress(tt.chain.ChainId), tt.nonce)
-			}
+			exepctedID := fmt.Sprintf("%d-%s-%d", tt.chain.ChainId, ob.TSSAddress(), tt.nonce)
 			require.Equal(t, exepctedID, outboundID)
 		})
 	}

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -146,7 +146,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// add block header to zetacore
 	if len(res.Block.Tx) > 1 {
 		// filter incoming txs to TSS address
-		tssAddress := ob.TSSAddress()
+		tssAddress := ob.TSSAddressString()
 
 		// #nosec G115 always positive
 		events, err := FilterAndParseIncomingTx(

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -146,7 +146,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// add block header to zetacore
 	if len(res.Block.Tx) > 1 {
 		// filter incoming txs to TSS address
-		tssAddress := ob.TSS().BTCAddress()
+		tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
 
 		// #nosec G115 always positive
 		events, err := FilterAndParseIncomingTx(

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -146,7 +146,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// add block header to zetacore
 	if len(res.Block.Tx) > 1 {
 		// filter incoming txs to TSS address
-		tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
+		tssAddress := ob.TSSAddress()
 
 		// #nosec G115 always positive
 		events, err := FilterAndParseIncomingTx(

--- a/zetaclient/chains/bitcoin/observer/observer.go
+++ b/zetaclient/chains/bitcoin/observer/observer.go
@@ -369,12 +369,11 @@ func (ob *Observer) FetchUTXOs(ctx context.Context) error {
 	maxConfirmations := int(bh)
 
 	// List all unspent UTXOs (160ms)
-	tssAddr := ob.TSS().BTCAddress()
-	address, err := chains.DecodeBtcAddress(tssAddr, ob.Chain().ChainId)
-	if err != nil {
-		return fmt.Errorf("btc: error decoding wallet address (%s) : %s", tssAddr, err.Error())
+	tssAddr := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId)
+	if tssAddr != nil {
+		return fmt.Errorf("error getting bitcoin tss address")
 	}
-	utxos, err := ob.btcClient.ListUnspentMinMaxAddresses(0, maxConfirmations, []btcutil.Address{address})
+	utxos, err := ob.btcClient.ListUnspentMinMaxAddresses(0, maxConfirmations, []btcutil.Address{tssAddr})
 	if err != nil {
 		return err
 	}

--- a/zetaclient/chains/bitcoin/observer/observer.go
+++ b/zetaclient/chains/bitcoin/observer/observer.go
@@ -369,8 +369,8 @@ func (ob *Observer) FetchUTXOs(ctx context.Context) error {
 	maxConfirmations := int(bh)
 
 	// List all unspent UTXOs (160ms)
-	tssAddr := ob.TSS().BTCAddress(ob.Chain().ChainId)
-	if tssAddr == nil {
+	tssAddr, err := ob.TSS().BTCAddress(ob.Chain().ChainId)
+	if err != nil {
 		return fmt.Errorf("error getting bitcoin tss address")
 	}
 	utxos, err := ob.btcClient.ListUnspentMinMaxAddresses(0, maxConfirmations, []btcutil.Address{tssAddr})

--- a/zetaclient/chains/bitcoin/observer/observer.go
+++ b/zetaclient/chains/bitcoin/observer/observer.go
@@ -370,7 +370,7 @@ func (ob *Observer) FetchUTXOs(ctx context.Context) error {
 
 	// List all unspent UTXOs (160ms)
 	tssAddr := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId)
-	if tssAddr != nil {
+	if tssAddr == nil {
 		return fmt.Errorf("error getting bitcoin tss address")
 	}
 	utxos, err := ob.btcClient.ListUnspentMinMaxAddresses(0, maxConfirmations, []btcutil.Address{tssAddr})

--- a/zetaclient/chains/bitcoin/observer/observer.go
+++ b/zetaclient/chains/bitcoin/observer/observer.go
@@ -369,7 +369,7 @@ func (ob *Observer) FetchUTXOs(ctx context.Context) error {
 	maxConfirmations := int(bh)
 
 	// List all unspent UTXOs (160ms)
-	tssAddr := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId)
+	tssAddr := ob.TSS().BTCAddress(ob.Chain().ChainId)
 	if tssAddr == nil {
 		return fmt.Errorf("error getting bitcoin tss address")
 	}

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -414,7 +414,7 @@ func (ob *Observer) getOutboundIDByNonce(ctx context.Context, nonce uint64, test
 
 // findNonceMarkUTXO finds the nonce-mark UTXO in the list of UTXOs.
 func (ob *Observer) findNonceMarkUTXO(nonce uint64, txid string) (int, error) {
-	tssAddress := ob.TSSAddress()
+	tssAddress := ob.TSSAddressString()
 	amount := chains.NonceMarkAmount(nonce)
 	for i, utxo := range ob.utxos {
 		sats, err := bitcoin.GetSatoshis(utxo.Amount)
@@ -599,7 +599,7 @@ func (ob *Observer) checkTSSVout(params *crosschaintypes.OutboundParams, vouts [
 	}
 
 	nonce := params.TssNonce
-	tssAddress := ob.TSSAddress()
+	tssAddress := ob.TSSAddressString()
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverExpected := tssAddress
@@ -658,7 +658,7 @@ func (ob *Observer) checkTSSVoutCancelled(params *crosschaintypes.OutboundParams
 	}
 
 	nonce := params.TssNonce
-	tssAddress := ob.TSSAddress()
+	tssAddress := ob.TSSAddressString()
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverVout, amount, err := bitcoin.DecodeTSSVout(vout, tssAddress, ob.Chain())

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -414,7 +414,7 @@ func (ob *Observer) getOutboundIDByNonce(ctx context.Context, nonce uint64, test
 
 // findNonceMarkUTXO finds the nonce-mark UTXO in the list of UTXOs.
 func (ob *Observer) findNonceMarkUTXO(nonce uint64, txid string) (int, error) {
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId).EncodeAddress()
+	tssAddress := ob.TSSAddress()
 	amount := chains.NonceMarkAmount(nonce)
 	for i, utxo := range ob.utxos {
 		sats, err := bitcoin.GetSatoshis(utxo.Amount)
@@ -599,7 +599,7 @@ func (ob *Observer) checkTSSVout(params *crosschaintypes.OutboundParams, vouts [
 	}
 
 	nonce := params.TssNonce
-	tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
+	tssAddress := ob.TSSAddress()
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverExpected := tssAddress
@@ -658,7 +658,7 @@ func (ob *Observer) checkTSSVoutCancelled(params *crosschaintypes.OutboundParams
 	}
 
 	nonce := params.TssNonce
-	tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
+	tssAddress := ob.TSSAddress()
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverVout, amount, err := bitcoin.DecodeTSSVout(vout, tssAddress, ob.Chain())

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -414,7 +414,7 @@ func (ob *Observer) getOutboundIDByNonce(ctx context.Context, nonce uint64, test
 
 // findNonceMarkUTXO finds the nonce-mark UTXO in the list of UTXOs.
 func (ob *Observer) findNonceMarkUTXO(nonce uint64, txid string) (int, error) {
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash().EncodeAddress()
+	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId).EncodeAddress()
 	amount := chains.NonceMarkAmount(nonce)
 	for i, utxo := range ob.utxos {
 		sats, err := bitcoin.GetSatoshis(utxo.Amount)
@@ -599,7 +599,7 @@ func (ob *Observer) checkTSSVout(params *crosschaintypes.OutboundParams, vouts [
 	}
 
 	nonce := params.TssNonce
-	tssAddress := ob.TSS().BTCAddress()
+	tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverExpected := tssAddress
@@ -658,7 +658,7 @@ func (ob *Observer) checkTSSVoutCancelled(params *crosschaintypes.OutboundParams
 	}
 
 	nonce := params.TssNonce
-	tssAddress := ob.TSS().BTCAddress()
+	tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverVout, amount, err := bitcoin.DecodeTSSVout(vout, tssAddress, ob.Chain())

--- a/zetaclient/chains/bitcoin/observer/outbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/outbound_test.go
@@ -61,7 +61,7 @@ func createObserverWithPrivateKey(t *testing.T) *Observer {
 func createObserverWithUTXOs(t *testing.T) *Observer {
 	// Create Bitcoin observer
 	ob := createObserverWithPrivateKey(t)
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId).EncodeAddress()
+	tssAddress := ob.TSS().BTCAddress(chains.BitcoinTestnet.ChainId).EncodeAddress()
 
 	// Create 10 dummy UTXOs (22.44 BTC in total)
 	ob.utxos = make([]btcjson.ListUnspentResult, 0, 10)
@@ -78,7 +78,7 @@ func mineTxNSetNonceMark(ob *Observer, nonce uint64, txid string, preMarkIndex i
 	ob.includedTxResults[outboundID] = &btcjson.GetTransactionResult{TxID: txid}
 
 	// Set nonce mark
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId).EncodeAddress()
+	tssAddress := ob.TSS().BTCAddress(chains.BitcoinTestnet.ChainId).EncodeAddress()
 	nonceMark := btcjson.ListUnspentResult{
 		TxID:    txid,
 		Address: tssAddress,

--- a/zetaclient/chains/bitcoin/observer/outbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/outbound_test.go
@@ -61,7 +61,7 @@ func createObserverWithPrivateKey(t *testing.T) *Observer {
 func createObserverWithUTXOs(t *testing.T) *Observer {
 	// Create Bitcoin observer
 	ob := createObserverWithPrivateKey(t)
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash().EncodeAddress()
+	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId).EncodeAddress()
 
 	// Create 10 dummy UTXOs (22.44 BTC in total)
 	ob.utxos = make([]btcjson.ListUnspentResult, 0, 10)
@@ -78,7 +78,7 @@ func mineTxNSetNonceMark(ob *Observer, nonce uint64, txid string, preMarkIndex i
 	ob.includedTxResults[outboundID] = &btcjson.GetTransactionResult{TxID: txid}
 
 	// Set nonce mark
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash().EncodeAddress()
+	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId).EncodeAddress()
 	nonceMark := btcjson.ListUnspentResult{
 		TxID:    txid,
 		Address: tssAddress,

--- a/zetaclient/chains/bitcoin/observer/rpc_status.go
+++ b/zetaclient/chains/bitcoin/observer/rpc_status.go
@@ -29,7 +29,7 @@ func (ob *Observer) watchRPCStatus(_ context.Context) error {
 
 // checkRPCStatus checks the RPC status of the Bitcoin chain
 func (ob *Observer) checkRPCStatus() {
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash()
+	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId)
 	blockTime, err := rpc.CheckRPCStatus(ob.btcClient, tssAddress)
 	if err != nil {
 		ob.Logger().Chain.Error().Err(err).Msg("CheckRPCStatus failed")

--- a/zetaclient/chains/bitcoin/observer/rpc_status.go
+++ b/zetaclient/chains/bitcoin/observer/rpc_status.go
@@ -29,7 +29,7 @@ func (ob *Observer) watchRPCStatus(_ context.Context) error {
 
 // checkRPCStatus checks the RPC status of the Bitcoin chain
 func (ob *Observer) checkRPCStatus() {
-	tssAddress := ob.TSS().BTCAddressWitnessPubkeyHash(ob.Chain().ChainId)
+	tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
 	blockTime, err := rpc.CheckRPCStatus(ob.btcClient, tssAddress)
 	if err != nil {
 		ob.Logger().Chain.Error().Err(err).Msg("CheckRPCStatus failed")

--- a/zetaclient/chains/bitcoin/observer/rpc_status.go
+++ b/zetaclient/chains/bitcoin/observer/rpc_status.go
@@ -29,7 +29,12 @@ func (ob *Observer) watchRPCStatus(_ context.Context) error {
 
 // checkRPCStatus checks the RPC status of the Bitcoin chain
 func (ob *Observer) checkRPCStatus() {
-	tssAddress := ob.TSS().BTCAddress(ob.Chain().ChainId)
+	tssAddress, err := ob.TSS().BTCAddress(ob.Chain().ChainId)
+	if err != nil {
+		ob.Logger().Chain.Error().Err(err).Msg("unable to get TSS BTC address")
+		return
+	}
+
 	blockTime, err := rpc.CheckRPCStatus(ob.btcClient, tssAddress)
 	if err != nil {
 		ob.Logger().Chain.Error().Err(err).Msg("CheckRPCStatus failed")

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -154,7 +154,10 @@ func (signer *Signer) AddWithdrawTxOutputs(
 	}
 
 	// 1st output: the nonce-mark btc to TSS self
-	tssAddrP2WPKH := signer.TSS().BTCAddress(signer.Chain().ChainId)
+	tssAddrP2WPKH, err := signer.TSS().BTCAddress(signer.Chain().ChainId)
+	if err != nil {
+		return err
+	}
 	payToSelfScript, err := bitcoin.PayToAddrScript(tssAddrP2WPKH)
 	if err != nil {
 		return err

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -154,7 +154,7 @@ func (signer *Signer) AddWithdrawTxOutputs(
 	}
 
 	// 1st output: the nonce-mark btc to TSS self
-	tssAddrP2WPKH := signer.TSS().BTCAddressWitnessPubkeyHash()
+	tssAddrP2WPKH := signer.TSS().BTCAddressWitnessPubkeyHash(signer.Chain().ChainId)
 	payToSelfScript, err := bitcoin.PayToAddrScript(tssAddrP2WPKH)
 	if err != nil {
 		return err

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -154,7 +154,7 @@ func (signer *Signer) AddWithdrawTxOutputs(
 	}
 
 	// 1st output: the nonce-mark btc to TSS self
-	tssAddrP2WPKH := signer.TSS().BTCAddressWitnessPubkeyHash(signer.Chain().ChainId)
+	tssAddrP2WPKH := signer.TSS().BTCAddress(signer.Chain().ChainId)
 	payToSelfScript, err := bitcoin.PayToAddrScript(tssAddrP2WPKH)
 	if err != nil {
 		return err

--- a/zetaclient/chains/bitcoin/signer/signer_keysign_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_keysign_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
@@ -38,7 +39,7 @@ func (suite *BTCSignTestSuite) SetupTest() {
 	suite.testSigner = &mocks.TSS{ // fake TSS
 		PrivKey: privateKey.ToECDSA(),
 	}
-	addr := suite.testSigner.BTCAddressWitnessPubkeyHash()
+	addr := suite.testSigner.BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId)
 	suite.T().Logf("segwit addr: %s", addr)
 }
 

--- a/zetaclient/chains/bitcoin/signer/signer_keysign_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_keysign_test.go
@@ -39,7 +39,7 @@ func (suite *BTCSignTestSuite) SetupTest() {
 	suite.testSigner = &mocks.TSS{ // fake TSS
 		PrivKey: privateKey.ToECDSA(),
 	}
-	addr := suite.testSigner.BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId)
+	addr := suite.testSigner.BTCAddress(chains.BitcoinTestnet.ChainId)
 	suite.T().Logf("segwit addr: %s", addr)
 }
 

--- a/zetaclient/chains/bitcoin/signer/signer_keysign_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_keysign_test.go
@@ -39,7 +39,8 @@ func (suite *BTCSignTestSuite) SetupTest() {
 	suite.testSigner = &mocks.TSS{ // fake TSS
 		PrivKey: privateKey.ToECDSA(),
 	}
-	addr := suite.testSigner.BTCAddress(chains.BitcoinTestnet.ChainId)
+	addr, err := suite.testSigner.BTCAddress(chains.BitcoinTestnet.ChainId)
+	suite.Require().NoError(err)
 	suite.T().Logf("segwit addr: %s", addr)
 }
 

--- a/zetaclient/chains/bitcoin/signer/signer_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_test.go
@@ -238,7 +238,8 @@ func TestAddWithdrawTxOutputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// tss address and script
-	tssAddr := signer.TSS().BTCAddress(chains.BitcoinTestnet.ChainId)
+	tssAddr, err := signer.TSS().BTCAddress(chains.BitcoinTestnet.ChainId)
+	require.NoError(t, err)
 	tssScript, err := bitcoin.PayToAddrScript(tssAddr)
 	require.NoError(t, err)
 	fmt.Printf("tss address: %s", tssAddr.EncodeAddress())

--- a/zetaclient/chains/bitcoin/signer/signer_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_test.go
@@ -238,7 +238,7 @@ func TestAddWithdrawTxOutputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// tss address and script
-	tssAddr := signer.TSS().BTCAddressWitnessPubkeyHash()
+	tssAddr := signer.TSS().BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId)
 	tssScript, err := bitcoin.PayToAddrScript(tssAddr)
 	require.NoError(t, err)
 	fmt.Printf("tss address: %s", tssAddr.EncodeAddress())

--- a/zetaclient/chains/bitcoin/signer/signer_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_test.go
@@ -238,7 +238,7 @@ func TestAddWithdrawTxOutputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// tss address and script
-	tssAddr := signer.TSS().BTCAddressWitnessPubkeyHash(chains.BitcoinTestnet.ChainId)
+	tssAddr := signer.TSS().BTCAddress(chains.BitcoinTestnet.ChainId)
 	tssScript, err := bitcoin.PayToAddrScript(tssAddr)
 	require.NoError(t, err)
 	fmt.Printf("tss address: %s", tssAddr.EncodeAddress())

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -255,9 +255,7 @@ type TSSSigner interface {
 	SignBatch(ctx context.Context, digests [][]byte, height uint64, nonce uint64, chainID int64) ([][65]byte, error)
 
 	EVMAddress() ethcommon.Address
-
 	EVMAddressList() []ethcommon.Address
-	BTCAddress(chainID int64) string
-	BTCAddressWitnessPubkeyHash(chainID int64) *btcutil.AddressWitnessPubKeyHash
+	BTCAddress(chainID int64) *btcutil.AddressWitnessPubKeyHash
 	PubKeyCompressedBytes() []byte
 }

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -256,6 +256,6 @@ type TSSSigner interface {
 
 	EVMAddress() ethcommon.Address
 	EVMAddressList() []ethcommon.Address
-	BTCAddress(chainID int64) *btcutil.AddressWitnessPubKeyHash
+	BTCAddress(chainID int64) (*btcutil.AddressWitnessPubKeyHash, error)
 	PubKeyCompressedBytes() []byte
 }

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -257,7 +257,7 @@ type TSSSigner interface {
 	EVMAddress() ethcommon.Address
 
 	EVMAddressList() []ethcommon.Address
-	BTCAddress() string
-	BTCAddressWitnessPubkeyHash() *btcutil.AddressWitnessPubKeyHash
+	BTCAddress(chainID int64) string
+	BTCAddressWitnessPubkeyHash(chainID int64) *btcutil.AddressWitnessPubKeyHash
 	PubKeyCompressedBytes() []byte
 }

--- a/zetaclient/testutils/constant.go
+++ b/zetaclient/testutils/constant.go
@@ -17,6 +17,9 @@ const (
 	// TSSAddressBTCMainnet the BTC TSS address for test purposes
 	TSSAddressBTCMainnet = "bc1qm24wp577nk8aacckv8np465z3dvmu7ry45el6y"
 
+	// TSSPubkeyAthens3 is the TSS public key in Athens3
+	TSSPubkeyAthens3 = "zetapub1addwnpepq28c57cvcs0a2htsem5zxr6qnlvq9mzhmm76z3jncsnzz32rclangr2g35p"
+
 	// TSSAddressEVMAthens3 the EVM TSS address for test purposes
 	// Note: public key is zetapub1addwnpepq28c57cvcs0a2htsem5zxr6qnlvq9mzhmm76z3jncsnzz32rclangr2g35p
 	TSSAddressEVMAthens3 = "0x8531a5aB847ff5B22D855633C25ED1DA3255247e"

--- a/zetaclient/testutils/mocks/tss_signer.go
+++ b/zetaclient/testutils/mocks/tss_signer.go
@@ -112,7 +112,7 @@ func (s *TSS) EVMAddressList() []ethcommon.Address {
 	return []ethcommon.Address{s.EVMAddress()}
 }
 
-func (s *TSS) BTCAddress() string {
+func (s *TSS) BTCAddress(_ int64) string {
 	// force use btcAddress if set
 	if s.btcAddress != "" {
 		return s.btcAddress
@@ -125,7 +125,7 @@ func (s *TSS) BTCAddress() string {
 	return testnet3Addr.EncodeAddress()
 }
 
-func (s *TSS) BTCAddressWitnessPubkeyHash() *btcutil.AddressWitnessPubKeyHash {
+func (s *TSS) BTCAddressWitnessPubkeyHash(_ int64) *btcutil.AddressWitnessPubKeyHash {
 	// if privkey is set, use it to generate a segwit address
 	if s.PrivKey != nil {
 		pkBytes := crypto.FromECDSAPub(&s.PrivKey.PublicKey)
@@ -154,7 +154,7 @@ func (s *TSS) BTCAddressWitnessPubkeyHash() *btcutil.AddressWitnessPubKeyHash {
 		fmt.Printf("error getting btc chain params: %v", err)
 		return nil
 	}
-	tssAddress := s.BTCAddress()
+	tssAddress := s.BTCAddress(s.chain.ChainId)
 	addr, err := btcutil.DecodeAddress(tssAddress, net)
 	if err != nil {
 		return nil

--- a/zetaclient/tss/tss_signer.go
+++ b/zetaclient/tss/tss_signer.go
@@ -415,7 +415,10 @@ func (tss *TSS) SignBatch(
 
 // ValidateAddresses try deriving both the EVM and BTC addresses from the pubkey and make sure they are valid.
 func (tss *TSS) ValidateAddresses(btcChainIDs []int64) error {
-	tss.logger.Info().Msgf("tss.pubkey: %s", tss.CurrentPubkey)
+	logger := tss.logger.With().
+		Str("method", "ValidateAddresses").
+		Str("tss.pubkey", tss.CurrentPubkey).
+		Logger()
 
 	// validate TSS EVM address
 	evmAddress := tss.EVMAddress()
@@ -423,7 +426,7 @@ func (tss *TSS) ValidateAddresses(btcChainIDs []int64) error {
 	if evmAddress == blankAddress {
 		return fmt.Errorf("blank tss evm address: %s", evmAddress.String())
 	}
-	tss.logger.Info().Msgf("tss.eth: %s", tss.EVMAddress().String())
+	logger.Info().Msgf("tss.eth: %s", evmAddress.String())
 
 	// validate TSS BTC address for each btc chain
 	for _, chainID := range btcChainIDs {
@@ -431,7 +434,7 @@ func (tss *TSS) ValidateAddresses(btcChainIDs []int64) error {
 		if err != nil {
 			return fmt.Errorf("cannot derive btc address for chain %d from tss pubkey %s", chainID, tss.CurrentPubkey)
 		}
-		tss.logger.Info().Msgf("tss.btc [chain %d]: %s", chainID, address.EncodeAddress())
+		logger.Info().Msgf("tss.btc [chain %d]: %s", chainID, address.EncodeAddress())
 	}
 
 	return nil

--- a/zetaclient/tss/tss_signer.go
+++ b/zetaclient/tss/tss_signer.go
@@ -427,10 +427,10 @@ func (tss *TSS) ValidateAddresses(btcChainIDs []int64) error {
 
 	// validate TSS BTC address for each btc chain
 	for _, chainID := range btcChainIDs {
-		if tss.BTCAddressWitnessPubkeyHash(chainID) == nil {
+		if tss.BTCAddress(chainID) == nil {
 			return fmt.Errorf("cannot derive btc address for chain %d from tss pubkey %s", chainID, tss.CurrentPubkey)
 		}
-		log.Info().Msgf("tss.btc [chain %d]: %s", chainID, tss.BTCAddress(chainID))
+		log.Info().Msgf("tss.btc [chain %d]: %s", chainID, tss.BTCAddress(chainID).EncodeAddress())
 	}
 
 	return nil
@@ -460,17 +460,7 @@ func (tss *TSS) EVMAddressList() []ethcommon.Address {
 }
 
 // BTCAddress generates a bech32 p2wpkh address from pubkey
-func (tss *TSS) BTCAddress(chainID int64) string {
-	addr, err := GetTssAddrBTC(tss.CurrentPubkey, chainID)
-	if err != nil {
-		log.Error().Err(err).Msg("getKeyAddr error")
-		return ""
-	}
-	return addr
-}
-
-// BTCAddressWitnessPubkeyHash generates a bech32 p2wpkh address from pubkey
-func (tss *TSS) BTCAddressWitnessPubkeyHash(chainID int64) *btcutil.AddressWitnessPubKeyHash {
+func (tss *TSS) BTCAddress(chainID int64) *btcutil.AddressWitnessPubKeyHash {
 	addrWPKH, err := getKeyAddrBTCWitnessPubkeyHash(tss.CurrentPubkey, chainID)
 	if err != nil {
 		log.Error().Err(err).Msg("BTCAddressPubkeyHash error")
@@ -561,17 +551,6 @@ func (tss *TSS) LoadTssFilesFromDirectory(tssPath string) error {
 		log.Info().Msg("TSS Keyshare file NOT found")
 	}
 	return nil
-}
-
-// GetTssAddrBTC generates a bech32 p2wpkh address from pubkey
-func GetTssAddrBTC(tssPubkey string, bitcoinChainID int64) (string, error) {
-	addrWPKH, err := getKeyAddrBTCWitnessPubkeyHash(tssPubkey, bitcoinChainID)
-	if err != nil {
-		log.Fatal().Err(err)
-		return "", err
-	}
-
-	return addrWPKH.EncodeAddress(), nil
 }
 
 // GetTssAddrEVM generates an EVM address from pubkey

--- a/zetaclient/tss/tss_signer_test.go
+++ b/zetaclient/tss/tss_signer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zeta-chain/node/cmd"
 	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/pkg/cosmos"
 	"github.com/zeta-chain/node/pkg/crypto"
 	"github.com/zeta-chain/node/zetaclient/testutils"
@@ -110,7 +111,7 @@ func Test_EVMAddress(t *testing.T) {
 		{
 			name:            "should return empty TSS EVM address on invalid TSS pubkey",
 			tssPubkey:       "invalidpubkey",
-			expectedEVMAddr: "0x0000000000000000000000000000000000000000",
+			expectedEVMAddr: constant.EVMZeroAddress,
 		},
 	}
 
@@ -159,8 +160,9 @@ func Test_BTCAddress(t *testing.T) {
 			tss := TSS{
 				CurrentPubkey: tc.tssPubkey,
 			}
-			address := tss.BTCAddress(tc.btcChainID)
+			address, err := tss.BTCAddress(tc.btcChainID)
 			if tc.wantAddr != "" {
+				require.NoError(t, err)
 				require.Equal(t, tc.wantAddr, address.EncodeAddress())
 			} else {
 				require.Nil(t, address)

--- a/zetaclient/tss/tss_signer_test.go
+++ b/zetaclient/tss/tss_signer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/cmd"
@@ -208,6 +209,7 @@ func Test_ValidateAddresses(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tss := TSS{
+				logger:        log.Logger,
 				CurrentPubkey: tc.tssPubkey,
 			}
 			err := tss.ValidateAddresses(tc.btcChainIDs)


### PR DESCRIPTION
# Description

- [x] To support multiple Bitcoin chains, we need to derive TSS address differently by Bitcoin `chain id`.
- [x] Added a few missed Signet info to `chains` package.
- [x] Consolidate `BTCAddressWitnessPubkeyHash` and `BTCAddress` into one single method `BTCAddress(chainID int64)` for simplicity.

Closes: https://github.com/zeta-chain/node/issues/1397

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to derive Bitcoin TSS addresses based on chain ID.
	- Enhanced support for the Bitcoin Signet testnet.
	- Introduced a new constant for TSS public key for Athens3.

- **Bug Fixes**
	- Improved error handling during TSS address validation.

- **Tests**
	- Added new test cases for Bitcoin addresses and validation scenarios related to TSS public keys.

- **Documentation**
	- Updated changelog to reflect new functionalities and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->