### PR TITLE
ci: add option to enable monitoring stack

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,11 @@ on:
         description: 'Comma separated list of make targets to run (without the start- prefix)'
         required: true
         default: ''
+      enable-monitoring:
+        description: 'Enable the monitoring stack'
+        required: true
+        type: boolean
+        default: false
 
 concurrency: 
   group: e2e-${{ github.head_ref || github.sha }}
@@ -40,6 +45,7 @@ jobs:
       TON_TESTS: ${{ steps.matrix-conditionals.outputs.TON_TESTS }}
       V2_TESTS: ${{ steps.matrix-conditionals.outputs.V2_TESTS }}
       V2_MIGRATION_TESTS: ${{ steps.matrix-conditionals.outputs.V2_MIGRATION_TESTS }}
+      ENABLE_MONITORING: ${{ steps.matrix-conditionals.outputs.ENABLE_MONITORING }}
     steps:
       # use api rather than event context to avoid race conditions (label added after push)
       - id: matrix-conditionals
@@ -66,6 +72,7 @@ jobs:
               core.setOutput('TON_TESTS', labels.includes('TON_TESTS'));
               core.setOutput('V2_TESTS', labels.includes('V2_TESTS')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
               core.setOutput('V2_MIGRATION_TESTS', labels.includes('V2_MIGRATION_TESTS')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
+              core.setOutput('ENABLE_MONITORING', labels.includes('ENABLE_MONITORING'));
             } else if (context.eventName === 'merge_group') {
               core.setOutput('DEFAULT_TESTS', true);
               core.setOutput('UPGRADE_LIGHT_TESTS', true);
@@ -110,6 +117,7 @@ jobs:
               core.setOutput('TON_TESTS', makeTargets.includes('ton-test'));
               core.setOutput('V2_TESTS', makeTargets.includes('v2-test')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
               core.setOutput('V2_MIGRATION_TESTS', makeTargets.includes('v2-migration-test')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
+              core.setOutput('ENABLE_MONITORING', context.payload.inputs['enable-monitoring']);
             }
 
   e2e:
@@ -164,6 +172,7 @@ jobs:
       runs-on: ${{ matrix.runs-on}}
       run: ${{ matrix.run }}
       timeout-minutes: "${{ matrix.timeout-minutes || 25 }}"
+      enable-monitoring: ${{ needs.matrix-conditionals.outputs.ENABLE_MONITORING == 'true' }}
     secrets: inherit
   # this allows you to set a required status check
   e2e-ok:

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -21,7 +21,6 @@ on:
         default: 'ubuntu-20.04'
       enable-monitoring:
         description: 'Enable the monitoring stack for this run'
-        required: true
         type: boolean
         default: false
 

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: string
         default: 'ubuntu-20.04'
+      enable-monitoring:
+        description: 'Enable the monitoring stack for this run'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   e2e:
@@ -80,8 +85,18 @@ jobs:
           cache-to: ${{ github.event_name == 'push' && env.CACHE_TO_CONFIG || '' }}
           target: latest-runtime
 
+      - name: Enable monitoring
+        if: inputs.enable-monitoring
+        run: |
+          echo "NODE_COMPOSE_ARGS=${NODE_COMPOSE_ARGS:-} --profile monitoring --profile monitoring-cloudflared" >> $GITHUB_ENV
+      
       - name: Start Test
         run: make ${{ inputs.make-target }}
+
+      - name: Get grafana URL
+        if: inputs.enable-monitoring
+        run: |
+          docker logs grafana-cloudflared 2>&1 | grep -oP 'https?://\S+\.trycloudflare\.com'
 
       # use docker logs -f rather than docker attach to make sure we get the initial logs
       - name: Watch Test

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -345,8 +345,7 @@ services:
       mynetwork:
         ipv4_address: 172.20.0.31
     depends_on:
-      zetacore0:
-        condition: service_healthy
+      - zetacore0
 
   zetachain-exporter:
     image: zetachain/zetachain-exporter:v2.0.6

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -313,7 +313,7 @@ services:
       - ssh:/root/.ssh
 
   grafana:
-    image: grafana/grafana:11.2.0
+    image: ghcr.io/zeta-chain/grafana-grafana:11.2.0
     container_name: grafana
     hostname: grafana
     profiles:
@@ -333,7 +333,7 @@ services:
       - prometheus
 
   prometheus:
-    image: prom/prometheus:v2.53.1
+    image: ghcr.io/zeta-chain/prom-prometheus:v2.53.1
     container_name: prometheus
     hostname: prometheus
     profiles:
@@ -377,7 +377,7 @@ services:
 
   loki:
     container_name: loki
-    image: grafana/loki:3.1.0
+    image: ghcr.io/zeta-chain/grafana-loki:3.1.0
     hostname: loki
     profiles:
       - monitoring
@@ -389,7 +389,7 @@ services:
 
   promtail:
     container_name: promtail
-    image: grafana/promtail:2.9.9
+    image: ghcr.io/zeta-chain/grafana-promtail:2.9.9
     hostname: promtail
     profiles:
       - monitoring
@@ -401,6 +401,24 @@ services:
       - ./promtail/config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock
     command: -config.file=/etc/promtail/config.yaml
+
+  grafana-cloudflared:
+    container_name: grafana-cloudflared
+    image: ghcr.io/zeta-chain/cloudflare-cloudflared:2024.9.1
+    hostname: grafana-cloudflared
+    profiles:
+      - monitoring-cloudflared
+      - all
+    command:
+      - tunnel
+      - --no-autoupdate
+      - --url
+      - http://grafana:3000
+    networks:
+      mynetwork:
+        ipv4_address: 172.20.0.35
+    depends_on:
+      - grafana
 
 volumes:
   ssh:


### PR DESCRIPTION
# Description

Add option to enable monitoring stack in CI. Expose grafana URL via cloudflared. This allows you to easily browse the logs and metrics during a CI run.


https://github.com/user-attachments/assets/1c0c0daa-ae4c-4922-a16f-4f0cbdbd8d20


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `enable-monitoring` for GitHub Actions workflows, allowing dynamic control of monitoring features.
	- Added a new service `grafana-cloudflared` to enhance monitoring capabilities.

- **Updates**
	- Updated image sources for `grafana`, `prometheus`, `loki`, and `promtail` services to a new repository for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->