### PR TITLE
chore: improve localnet build performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ yarn.lock
 .github/
 .gitignore
 dist/**
+.git
 
 # dockerfiles are not needed inside the docker build
 Dockerfile

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -22,8 +22,10 @@ COPY --exclude=*.sh --exclude=*.md --exclude=*.yml . .
 ARG NODE_VERSION
 ARG NODE_COMMIT
 
-RUN --mount=type=cache,target="/root/.cache/go-build" make install
-RUN --mount=type=cache,target="/root/.cache/go-build" make install-zetae2e
+RUN --mount=type=cache,target="/root/.cache/go-build" \
+    NODE_VERSION=${NODE_VERSION} \
+    NODE_COMMIT=${NODE_COMMIT} \
+    make install install-zetae2e
 
 FROM ghcr.io/zeta-chain/golang:1.22.5-bookworm AS cosmovisor-build
 RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.6.0

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -19,6 +19,8 @@ COPY go.sum .
 RUN go mod download
 COPY version.sh .
 COPY --exclude=*.sh --exclude=*.md --exclude=*.yml . .
+ARG NODE_VERSION
+ARG NODE_COMMIT
 
 RUN --mount=type=cache,target="/root/.cache/go-build" make install
 RUN --mount=type=cache,target="/root/.cache/go-build" make install-zetae2e

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build
 
 PACKAGE_NAME := github.com/zeta-chain/node
-VERSION := $(shell ./version.sh)
-COMMIT := $(shell [ -z "${COMMIT_ID}" ] && git log -1 --format='%H' || echo ${COMMIT_ID} )
+NODE_VERSION := $(shell ./version.sh)
+NODE_COMMIT := $(shell [ -z "${NODE_COMMIT}" ] && git log -1 --format='%H' || echo ${NODE_COMMIT} )
 BUILDTIME := $(shell date -u +"%Y%m%d.%H%M%S" )
 DOCKER ?= docker
 # allow setting of NODE_COMPOSE_ARGS to pass additional args to docker compose
@@ -17,11 +17,11 @@ GOPATH ?= '$(HOME)/go'
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=zetacore \
 	-X github.com/cosmos/cosmos-sdk/version.ServerName=zetacored \
 	-X github.com/cosmos/cosmos-sdk/version.ClientName=zetaclientd \
-	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
-	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+	-X github.com/cosmos/cosmos-sdk/version.Version=$(NODE_VERSION) \
+	-X github.com/cosmos/cosmos-sdk/version.Commit=$(NODE_COMMIT) \
 	-X github.com/zeta-chain/node/pkg/constant.Name=zetacored \
-	-X github.com/zeta-chain/node/pkg/constant.Version=$(VERSION) \
-	-X github.com/zeta-chain/node/pkg/constant.CommitHash=$(COMMIT) \
+	-X github.com/zeta-chain/node/pkg/constant.Version=$(NODE_VERSION) \
+	-X github.com/zeta-chain/node/pkg/constant.CommitHash=$(NODE_COMMIT) \
 	-X github.com/zeta-chain/node/pkg/constant.BuildTime=$(BUILDTIME) \
 	-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb
 
@@ -233,7 +233,7 @@ stop-localnet:
 
 zetanode:
 	@echo "Building zetanode"
-	$(DOCKER) build -t zetanode --target latest-runtime -f ./Dockerfile-localnet .
+	$(DOCKER) build -t zetanode --build-arg NODE_VERSION=$(NODE_VERSION) --build-arg NODE_COMMIT=$(NODE_COMMIT) --target latest-runtime -f ./Dockerfile-localnet .
 	$(DOCKER) build -t orchestrator -f contrib/localnet/orchestrator/Dockerfile.fastbuild .
 .PHONY: zetanode
 

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# if NODE_VERSION is set, just return it immediately
+# this allows you to do docker builds without the git directory
+if [[ -n $NODE_VERSION ]]; then
+    echo $NODE_VERSION
+    exit
+fi
+
 # --exact-match will ensure the tag is only returned if our commit is a tag
 version=$(git describe --exact-match --tags 2>/dev/null)
 if [[ $? -eq 0 ]]; then
@@ -9,14 +16,14 @@ if [[ $? -eq 0 ]]; then
     exit
 fi
 
-# use current timestamp for dirty builds
+# develop build and use commit timestamp for version
+commit_timestamp=$(git show --no-patch --format=%at)
+short_commit=$(git rev-parse --short HEAD)
+
+# append -dirty for dirty builds
 if ! git diff --no-ext-diff --quiet --exit-code ; then
-    current_timestamp=$(date +"%s")
-    echo "0.0.${current_timestamp}-dirty"
+    echo "0.0.${commit_timestamp}-${short_commit}-dirty"
     exit
 fi
 
-# otherwise assume we are on a develop build and use commit timestamp for version
-commit_timestamp=$(git show --no-patch --format=%at)
-
-echo "0.0.${commit_timestamp}-develop"
+echo "0.0.${commit_timestamp}-${short_commit}"


### PR DESCRIPTION
# Description

- Don't use a timestamp if dirty build. Doing this forced unconditional rebuilds every run.
- Don't copy the git directory into the build. This requires that we also provide a way to push the version info into the build.

With this change you should be able to run `make start-e2e-test` and if nothing has changed `zetanode` should not be rebuilt.

I could also be convinced that the localnet build should always just be static. Like `v22.0.0-next` or something like that.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced versioning logic in the `version.sh` script, providing more detailed version information including short commit hashes.
  
- **Improvements**
	- Docker build process optimized with new arguments for version control.
	- Streamlined handling of legacy versions in Dockerfile.

- **Bug Fixes**
	- Adjusted output format for versioning in `version.sh` to include commit details for both dirty and non-dirty builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->