### PR TITLE
test(e2e): add gateway upgrade in upgrade test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,12 +299,12 @@ start-v2-test: zetanode
 ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from source"
-	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source --build-arg OLD_VERSION='release/v19' .
+	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source --build-arg OLD_VERSION='release/v20' .
 .PHONY: zetanode-upgrade
 else
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from binaries"
-	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime --build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v19.1.1' .
+	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime --build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v20.0.2' .
 .PHONY: zetanode-upgrade
 endif
 

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 * [2874](https://github.com/zeta-chain/node/pull/2874) - add support for multiple runs for precompile tests
 * [2895](https://github.com/zeta-chain/node/pull/2895) - add e2e test for bitcoin deposit and call
 * [2894](https://github.com/zeta-chain/node/pull/2894) - increase gas limit for TSS vote tx
+* [2932](https://github.com/zeta-chain/node/pull/2932) - add gateway upgrade as part of the upgrade test
 
 ### Fixes
 

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -219,6 +219,12 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 
 		deployerRunner.SetZEVMZRC20s()
 
+		// Update the chain params to use v2 contract for ERC20Custody
+		// TODO: this function should be removed and the chain params should be directly set to use v2 contract
+		// https://github.com/zeta-chain/node/issues/2627
+		deployerRunner.UpdateChainParamsV2Contracts()
+		deployerRunner.ERC20CustodyAddr = deployerRunner.ERC20CustodyV2Addr
+
 		if testSolana {
 			deployerRunner.SetSolanaContracts(conf.AdditionalAccounts.UserSolana.SolanaPrivateKey.String())
 		}
@@ -404,12 +410,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		}
 
 		eg.Go(tonTestRoutine(conf, deployerRunner, verbose, tonTests...))
-	}
-
-	if testV2 {
-		// update the ERC20 custody contract for v2 tests
-		// note: not run in testV2Migration because it is already run in the migration process
-		deployerRunner.UpdateChainParamsV2Contracts()
 	}
 
 	// upgrade gateways

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -46,6 +46,7 @@ const (
 	flagTestV2Migration   = "test-v2-migration"
 	flagSkipTrackerCheck  = "skip-tracker-check"
 	flagSkipPrecompiles   = "skip-precompiles"
+	flagUpgradeGateways   = "upgrade-gateways"
 )
 
 var (
@@ -83,6 +84,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().Bool(flagTestV2Migration, false, "set to true to run tests for v2 contracts migration test")
 	cmd.Flags().Bool(flagSkipTrackerCheck, false, "set to true to skip tracker check at the end of the tests")
 	cmd.Flags().Bool(flagSkipPrecompiles, false, "set to true to skip stateful precompiled contracts test")
+	cmd.Flags().Bool(flagUpgradeGateways, false, "set to true to upgrade gateways during setup for ZEVM and EVM")
 
 	return cmd
 }
@@ -112,6 +114,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		testV2            = must(cmd.Flags().GetBool(flagTestV2))
 		testV2Migration   = must(cmd.Flags().GetBool(flagTestV2Migration))
 		skipPrecompiles   = must(cmd.Flags().GetBool(flagSkipPrecompiles))
+		upgradeGateways   = must(cmd.Flags().GetBool(flagUpgradeGateways))
 	)
 
 	logger := runner.NewLogger(verbose, color.FgWhite, "setup")
@@ -408,6 +411,11 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		// update the ERC20 custody contract for v2 tests
 		// note: not run in testV2Migration because it is already run in the migration process
 		deployerRunner.UpdateChainParamsV2Contracts()
+	}
+
+	// upgrade gateways
+	if upgradeGateways {
+		deployerRunner.UpgradeGateways()
 	}
 
 	if testV2 || testV2Migration {

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -205,18 +205,17 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		logger.Print("⚙️ setting up networks")
 		startTime := time.Now()
 
+		// TODO: merge v1 and v2 together
+		// https://github.com/zeta-chain/node/issues/2627
+
 		deployerRunner.SetupEVM(contractsDeployed, true)
 
-		if testV2 {
-			deployerRunner.SetupEVMV2()
-		}
+		deployerRunner.SetupEVMV2()
 
 		deployerRunner.SetZEVMSystemContracts()
 
-		if testV2 {
-			// NOTE: v2 (gateway) setup called here because system contract needs to be set first, then gateway, then zrc20
-			deployerRunner.SetZEVMContractsV2()
-		}
+		// NOTE: v2 (gateway) setup called here because system contract needs to be set first, then gateway, then zrc20
+		deployerRunner.SetZEVMContractsV2()
 
 		deployerRunner.SetZEVMZRC20s()
 

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -258,9 +258,9 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   # When the upgrade height is greater than 100 for upgrade test, the Bitcoin tests have been run once, therefore the Bitcoin wallet is already set up
   # Use light flag to skip advanced tests
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
-    zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --light ${COMMON_ARGS}
+    zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --light --upgrade-gateways ${COMMON_ARGS}
   else
-    zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --skip-bitcoin-setup --light ${COMMON_ARGS}
+    zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --skip-bitcoin-setup --light --test-v2 --upgrade-gateways ${COMMON_ARGS}
   fi
 
   ZETAE2E_EXIT_CODE=$?

--- a/contrib/localnet/orchestrator/start-zetae2e.sh
+++ b/contrib/localnet/orchestrator/start-zetae2e.sh
@@ -258,7 +258,7 @@ if [ "$LOCALNET_MODE" == "upgrade" ]; then
   # When the upgrade height is greater than 100 for upgrade test, the Bitcoin tests have been run once, therefore the Bitcoin wallet is already set up
   # Use light flag to skip advanced tests
   if [ "$UPGRADE_HEIGHT" -lt 100 ]; then
-    zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --light --upgrade-gateways ${COMMON_ARGS}
+    zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --light --test-v2 --upgrade-gateways ${COMMON_ARGS}
   else
     zetae2e local $E2E_ARGS --skip-setup --config "$deployed_config_path" --skip-bitcoin-setup --light --test-v2 --upgrade-gateways ${COMMON_ARGS}
   fi

--- a/e2e/runner/v2_gateway.go
+++ b/e2e/runner/v2_gateway.go
@@ -1,0 +1,55 @@
+package runner
+
+import (
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/v2/pkg/gatewayevm.sol"
+	"github.com/zeta-chain/protocol-contracts/v2/pkg/gatewayzevm.sol"
+
+	"github.com/zeta-chain/node/e2e/utils"
+)
+
+// UpgradeGateways upgrades the GatewayEVM and GatewayZEVM contracts
+// It deploy new gateway contract implementation with the current imported artifacts and upgrade the gateway contract
+func (r *E2ERunner) UpgradeGateways() {
+	r.UpgradeGatewayZEVM()
+	r.UpgradeGatewayEVM()
+}
+
+// UpgradeGatewayZEVM upgrades the GatewayZEVM contract
+func (r *E2ERunner) UpgradeGatewayZEVM() {
+	ensureTxReceipt := func(tx *ethtypes.Transaction, failMessage string) {
+		receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+		r.requireTxSuccessful(receipt, failMessage+" tx hash: "+tx.Hash().Hex())
+	}
+
+	r.Logger.Info("Upgrading Gateway ZEVM contract")
+	// Deploy the new gateway contract implementation
+	newImplementationAddress, txDeploy, _, err := gatewayzevm.DeployGatewayZEVM(r.ZEVMAuth, r.ZEVMClient)
+	require.NoError(r, err)
+	ensureTxReceipt(txDeploy, "New GatewayZEVM implementation deployment failed")
+
+	// Upgrade
+	txUpgrade, err := r.GatewayZEVM.UpgradeToAndCall(r.ZEVMAuth, newImplementationAddress, []byte{})
+	require.NoError(r, err)
+	ensureTxReceipt(txUpgrade, "GatewayZEVM upgrade failed")
+}
+
+// UpgradeGatewayEVM upgrades the GatewayEVM contract
+func (r *E2ERunner) UpgradeGatewayEVM() {
+	ensureTxReceipt := func(tx *ethtypes.Transaction, failMessage string) {
+		receipt := utils.MustWaitForTxReceipt(r.Ctx, r.EVMClient, tx, r.Logger, r.ReceiptTimeout)
+		r.requireTxSuccessful(receipt, failMessage+" tx hash: "+tx.Hash().Hex())
+	}
+
+	r.Logger.Info("Upgrading Gateway EVM contract")
+	// Deploy the new gateway contract implementation
+	newImplementationAddress, txDeploy, _, err := gatewayevm.DeployGatewayEVM(r.EVMAuth, r.EVMClient)
+	require.NoError(r, err)
+	ensureTxReceipt(txDeploy, "New GatewayEVM implementation deployment failed")
+
+	// Upgrade
+	txUpgrade, err := r.GatewayEVM.UpgradeToAndCall(r.EVMAuth, newImplementationAddress, []byte{})
+	require.NoError(r, err)
+	ensureTxReceipt(txUpgrade, "GatewayEVM upgrade failed")
+}


### PR DESCRIPTION
# Description

- Update upgrade reference to use v20
- Add a function in the E2E upgrade test workflow to upgrade the gateways to the latest used version in the dependency.
- Small change to use ERC20Custody v2 contract by default in chain setup, this logic will be cleaned up in the future in https://github.com/zeta-chain/node/issues/2627 to remove all usage of the v1 contracts

**Checking the change**

If you comment out the following line https://github.com/zeta-chain/node/blob/30d60d144f1debff5078b661fb7b18f6b1005116/cmd/zetae2e/local/local.go#L417 and run upgrade test, it will fail because the gateway will use the wrong interface with ZetaClient

Closes: https://github.com/zeta-chain/node/issues/2921 https://github.com/zeta-chain/node/issues/2926

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for stateful precompiled contracts and enhancements to staking precompiled contracts.
	- Added command-line flag to upgrade gateways during ZEVM and EVM setup.
	- New functionality for upgrading Ethereum-based gateway contracts.

- **Bug Fixes**
	- Resolved issues with outbound transaction processing on EVM chains and TSS keygen voting process.

- **Documentation**
	- Updated changelog to reflect recent updates and improvements.

- **Tests**
	- Enhanced testing coverage with new end-to-end tests for stateful precompiled contracts and Bitcoin deposits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->