### PR TITLE
chore: allow full zetaclient config overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ contrib/localnet/addresses.txt
 
 # Config for e2e tests
 e2e_conf*
-contrib/localnet/scripts/extra-evm-chains.json
+contrib/localnet/scripts/zetaclient-config-overlay.json

--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -109,9 +109,9 @@ then
   fi
 fi
 
-# merge extra-evm-chains.json into zetaclient_config.json if specified
-if [[ -f /root/extra-evm-chains.json ]]; then
-  jq '.EVMChainConfigs *= input' /root/.zetacored/config/zetaclient_config.json /root/extra-evm-chains.json > /tmp/merged_config.json
+# merge zetaclient-config-overlay.json into zetaclient_config.json if specified
+if [[ -f /root/zetaclient-config-overlay.json ]]; then
+  jq -s '.[0] * .[1]' /root/.zetacored/config/zetaclient_config.json /root/zetaclient-config-overlay.json > /tmp/merged_config.json
   mv /tmp/merged_config.json /root/.zetacored/config/zetaclient_config.json
 fi
 


### PR DESCRIPTION
Allow setting any zetaclient config rather than just EVM chain configs in localnet. This will allow you to set BTC/solana/TON parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization process for the ZetaClient, ensuring configurations are properly set before startup.
	- Added support for a new configuration file, improving management of ZetaClient settings.

- **Bug Fixes**
	- Streamlined logic for importing relayer keys based on hostname to prevent errors.

- **Chores**
	- Updated `.gitignore` to reflect changes in project structure by adding and removing specific entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->