### PR TITLE
ci: ensure variables are set for cache build

### DIFF
--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -69,6 +69,14 @@ jobs:
             }
           skip-extraction: ${{ steps.restore-go-cache.outputs.cache-hit || github.event_name != 'push' }}
 
+      # this ensures that the version is consistent between cache build and make build
+      - name: Set version for cache
+        run: |
+          NODE_VERSION=$(./version.sh)
+          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
+          NODE_COMMIT=$(git log -1 --format='%H')
+          echo "NODE_COMMIT=$NODE_COMMIT" >> $GITHUB_ENV
+
       # build zetanode with cache options
       - name: Build zetanode for cache
         uses: docker/build-push-action@v6
@@ -83,6 +91,9 @@ jobs:
           cache-from: ${{ env.CACHE_FROM_CONFIG }}
           cache-to: ${{ github.event_name == 'push' && env.CACHE_TO_CONFIG || '' }}
           target: latest-runtime
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            NODE_COMMIT=${{ env.NODE_COMMIT }}
 
       - name: Enable monitoring
         if: inputs.enable-monitoring


### PR DESCRIPTION
#2928 introduced these logs in E2E CI:

```
#19 [latest-build 6/6] RUN --mount=type=cache,target="/root/.cache/go-build"     NODE_VERSION=${NODE_VERSION}     NODE_COMMIT=${NODE_COMMIT}     make install install-zetae2e
#19 0.187 fatal: not a git repository (or any of the parent directories): .git
#19 0.188 fatal: not a git repository (or any of the parent directories): .git
#19 0.189 warning: Not a git repository. Use --no-index to compare two paths outside a working tree
#19 0.189 usage: git diff --no-index [<options>] <path> <path>
#19 0.189 
#19 0.189 Diff output format options
#19 0.189     -p, --patch           generate patch
#19 0.189     -s, --no-patch        suppress diff output
#19 0.189     -u                    generate patch
#19 0.189     -U, --unified[=<n>]   generate diffs with <n> lines context
#19 0.189     -W, --function-context
#19 0.189                           generate diffs with <n> lines context
#19 0.189     --raw                 generate the diff in raw format
#19 0.189     --patch-with-raw      synonym for '-p --raw'
#19 0.189     --patch-with-stat     synonym for '-p --stat'
#19 0.189     --numstat             machine friendly --stat
#19 0.190     --shortstat           output only the last line of --stat
<snip>
```

This is because the cache build also needs to have the version set. But considering it passed all CI it might make sense to just keep the version static in e2e so that build cache performance is improved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new environment variables `NODE_VERSION` and `NODE_COMMIT` to enhance the caching mechanism during Docker builds.

- **Improvements**
	- Updated the build process to ensure consistency between cache builds and make builds by utilizing the new environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->