### PR TITLE
fix: disable the check on gasPrice >= priorityFee

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v20.0.1
+
+### Fixes
+
+* [2949](https://github.com/zeta-chain/node/pull/2949) - disable the check on gasPrice vs. priorityFee
+
 ## v20.0.0
 
 ### Features

--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -42,12 +42,12 @@ func (g Gas) validate() error {
 		return errors.New("max fee per unit is nil")
 	case g.PriorityFee == nil:
 		return errors.New("priority fee per unit is nil")
-	case g.Price.Cmp(g.PriorityFee) == -1:
-		return fmt.Errorf(
-			"max fee per unit (%d) is less than priority fee per unit (%d)",
-			g.Price.Int64(),
-			g.PriorityFee.Int64(),
-		)
+	// case g.Price.Cmp(g.PriorityFee) == -1:
+	// 	return fmt.Errorf(
+	// 		"max fee per unit (%d) is less than priority fee per unit (%d)",
+	// 		g.Price.Int64(),
+	// 		g.PriorityFee.Int64(),
+	// 	)
 	default:
 		return nil
 	}
@@ -91,8 +91,8 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 	switch {
 	case err != nil:
 		return Gas{}, errors.Wrap(err, "unable to parse priorityFee")
-	case gasPrice.Cmp(priorityFee) == -1:
-		return Gas{}, fmt.Errorf("gasPrice (%d) is less than priorityFee (%d)", gasPrice.Int64(), priorityFee.Int64())
+		// case gasPrice.Cmp(priorityFee) == -1:
+		// 	return Gas{}, fmt.Errorf("gasPrice (%d) is less than priorityFee (%d)", gasPrice.Int64(), priorityFee.Int64())
 	}
 
 	return Gas{

--- a/zetaclient/chains/evm/signer/gas_test.go
+++ b/zetaclient/chains/evm/signer/gas_test.go
@@ -97,11 +97,11 @@ func TestGasFromCCTX(t *testing.T) {
 			cctx:          makeCCTX(123_000, gwei(4).String(), "-1"),
 			errorContains: "unable to parse priorityFee: big.Int is negative",
 		},
-		{
-			name:          "gasPrice is less than priorityFee",
-			cctx:          makeCCTX(123_000, gwei(4).String(), gwei(5).String()),
-			errorContains: "gasPrice (4000000000) is less than priorityFee (5000000000)",
-		},
+		// {
+		// 	name:          "gasPrice is less than priorityFee",
+		// 	cctx:          makeCCTX(123_000, gwei(4).String(), gwei(5).String()),
+		// 	errorContains: "gasPrice (4000000000) is less than priorityFee (5000000000)",
+		// },
 		{
 			name:          "gasPrice is invalid",
 			cctx:          makeCCTX(123_000, "hello", gwei(5).String()),


### PR DESCRIPTION
# Description

Disable the error return on `gasPrice.Cmp(priorityFee) == -1` to unblock Polygon outbound `5963`
cctx: https://zetachain.blockpi.network/lcd/v1/public/zeta-chain/crosschain/cctx/137/5963

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
