### PR TITLE
fix(zetaclient): tolerate priorityFee > gasFee

### DIFF
--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -93,11 +93,11 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 		return Gas{}, errors.Wrap(err, "unable to parse priorityFee")
 	case gasPrice.Cmp(priorityFee) == -1:
 		logger.Warn().
-			Uint64("cctx.initial_priority_fee", priorityFee.Uint64()).
-			Uint64("cctx.forced_priority_fee", gasPrice.Uint64()).
+			Str("cctx.initial_priority_fee", priorityFee.String()).
+			Str("cctx.forced_priority_fee", gasPrice.String()).
 			Msg("gasPrice is less than priorityFee, setting priorityFee = gasPrice")
 
-		priorityFee = gasPrice
+		priorityFee = big.NewInt(0).Set(gasPrice)
 	}
 
 	return Gas{

--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -92,7 +92,12 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 	case err != nil:
 		return Gas{}, errors.Wrap(err, "unable to parse priorityFee")
 	case gasPrice.Cmp(priorityFee) == -1:
-		return Gas{}, fmt.Errorf("gasPrice (%d) is less than priorityFee (%d)", gasPrice.Int64(), priorityFee.Int64())
+		logger.Warn().
+			Uint64("cctx.initial_priority_fee", priorityFee.Uint64()).
+			Uint64("cctx.forced_priority_fee", gasPrice.Uint64()).
+			Msg("gasPrice is less than priorityFee, setting priorityFee = gasPrice")
+
+		priorityFee = gasPrice
 	}
 
 	return Gas{

--- a/zetaclient/chains/evm/signer/gas_test.go
+++ b/zetaclient/chains/evm/signer/gas_test.go
@@ -98,9 +98,16 @@ func TestGasFromCCTX(t *testing.T) {
 			errorContains: "unable to parse priorityFee: big.Int is negative",
 		},
 		{
-			name:          "gasPrice is less than priorityFee",
-			cctx:          makeCCTX(123_000, gwei(4).String(), gwei(5).String()),
-			errorContains: "gasPrice (4000000000) is less than priorityFee (5000000000)",
+			name: "gasPrice is less than priorityFee",
+			cctx: makeCCTX(123_000, gwei(4).String(), gwei(5).String()),
+			assert: func(t *testing.T, g Gas) {
+				assert.False(t, g.isLegacy())
+				assertGasEquals(t, Gas{
+					Limit:       123_000,
+					Price:       gwei(4),
+					PriorityFee: gwei(4),
+				}, g)
+			},
 		},
 		{
 			name:          "gasPrice is invalid",


### PR DESCRIPTION
# Description
Force priorityFee=gasPrice if priorityFee > gasPrice (EIP-1559)

Fixes Polygon outbound `5963` cctx: https://zetachain.blockpi.network/lcd/v1/public/zeta-chain/crosschain/cctx/137/5963


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined input for end-to-end testing, allowing users to specify multiple test targets.
	- Added support for new user accounts in the local network configuration.
	- Implemented version 2 migration tests for enhanced testing capabilities.

- **Bug Fixes**
	- Improved clarity in release workflow descriptions and logging for better traceability.

- **Refactor**
	- Simplified condition checks and removed deprecated code in various workflows and handlers.

- **Documentation**
	- Updated changelog to reflect the release of version 20.0.0 with new features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->