### PR TITLE
fix(zetaclient): tolerate priorityFee > gasFee

### DIFF
--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -93,11 +93,11 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 		return Gas{}, errors.Wrap(err, "unable to parse priorityFee")
 	case gasPrice.Cmp(priorityFee) == -1:
 		logger.Warn().
-			Uint64("cctx.initial_priority_fee", priorityFee.Uint64()).
-			Uint64("cctx.forced_priority_fee", gasPrice.Uint64()).
+			Str("cctx.initial_priority_fee", priorityFee.String()).
+			Str("cctx.forced_priority_fee", gasPrice.String()).
 			Msg("gasPrice is less than priorityFee, setting priorityFee = gasPrice")
 
-		priorityFee = gasPrice
+		priorityFee = big.NewInt(0).Set(gasPrice)
 	}
 
 	return Gas{

--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -98,7 +98,7 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 			Msg("gasPrice is less than priorityFee, setting priorityFee = gasPrice")
 
 		// this should in theory never happen, but this reported bug might be a cause: https://github.com/zeta-chain/node/issues/2954
-		// in this case we lower the priorityFee to the gasFeecCap to ensure the transaction is valid
+		// in this case we lower the priorityFee to the gasPrice to ensure the transaction is valid
 		// the only potential issue is the transaction might not cover the baseFee
 		// the gas stability pool mechanism help to mitigate this issue
 		priorityFee = big.NewInt(0).Set(gasPrice)

--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -92,7 +92,12 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 	case err != nil:
 		return Gas{}, errors.Wrap(err, "unable to parse priorityFee")
 	case gasPrice.Cmp(priorityFee) == -1:
-		return Gas{}, fmt.Errorf("gasPrice (%d) is less than priorityFee (%d)", gasPrice.Int64(), priorityFee.Int64())
+		logger.Warn().
+			Uint64("cctx.initial_priority_fee", priorityFee.Uint64()).
+			Uint64("cctx.forced_priority_fee", gasPrice.Uint64()).
+			Msg("gasPrice is less than priorityFee, setting priorityFee = gasPrice")
+
+		priorityFee = gasPrice
 	}
 
 	return Gas{

--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -97,6 +97,10 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 			Str("cctx.forced_priority_fee", gasPrice.String()).
 			Msg("gasPrice is less than priorityFee, setting priorityFee = gasPrice")
 
+		// this should in theory never happen, but this reported bug might be a cause: https://github.com/zeta-chain/node/issues/2954
+		// in this case we lower the priorityFee to the gasFeecCap to ensure the transaction is valid
+		// the only potential issue is the transaction might not cover the baseFee
+		// the gas stability pool mechanism help to mitigate this issue
 		priorityFee = big.NewInt(0).Set(gasPrice)
 	}
 

--- a/zetaclient/chains/evm/signer/gas_test.go
+++ b/zetaclient/chains/evm/signer/gas_test.go
@@ -98,9 +98,16 @@ func TestGasFromCCTX(t *testing.T) {
 			errorContains: "unable to parse priorityFee: big.Int is negative",
 		},
 		{
-			name:          "gasPrice is less than priorityFee",
-			cctx:          makeCCTX(123_000, gwei(4).String(), gwei(5).String()),
-			errorContains: "gasPrice (4000000000) is less than priorityFee (5000000000)",
+			name: "gasPrice is less than priorityFee",
+			cctx: makeCCTX(123_000, gwei(4).String(), gwei(5).String()),
+			assert: func(t *testing.T, g Gas) {
+				assert.False(t, g.isLegacy())
+				assertGasEquals(t, Gas{
+					Limit:       123_000,
+					Price:       gwei(4),
+					PriorityFee: gwei(4),
+				}, g)
+			},
 		},
 		{
 			name:          "gasPrice is invalid",


### PR DESCRIPTION
# Description

Cherry pick changes from https://github.com/zeta-chain/node/pull/2950 and add one additional comment

Closes: https://github.com/zeta-chain/node/issues/2951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gas pricing logic to log warnings instead of returning errors when `gasPrice` is less than `priorityFee`.
	- Adjusted handling of gas values in EIP-1559 transactions for improved user experience.

- **Bug Fixes**
	- Updated test cases to reflect new gas pricing behavior, ensuring accurate validation of gas parameters.

- **Style**
	- Minor formatting adjustments in test cases for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->