### PR TITLE
fix: remove redundant error in parsing synthetic txs

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -339,6 +339,7 @@ func (b *Backend) parseSyntheticTxFromBlockResults(
 		return nil, nil
 	}
 	if additional == nil || res == nil {
+		b.logger.Debug("synthetic ethereum tx not found in msgs: block %d, index %d", block.Height, i)
 		return nil, nil
 	}
 	return b.parseSyntethicTxFromAdditionalFields(additional), additional

--- a/rpc/types/events.go
+++ b/rpc/types/events.go
@@ -271,7 +271,7 @@ func ParseTxBlockResult(
 	}
 
 	if len(txs.Txs) == 0 {
-		return nil, nil, fmt.Errorf("ethereum tx not found in msgs: block %d, index %d", height, txIndex)
+		return nil, nil, nil
 	}
 	parsedTx := txs.Txs[0]
 	if parsedTx.Type == CosmosEVMTxType {


### PR DESCRIPTION
# Description

If synthetic tx is not found in the block that should not be an error, it is not expected that every block contains them.

This can be logged in debug mode just in case.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved debugging information for synthetic Ethereum transaction parsing, enhancing visibility for developers.

- **Bug Fixes**
	- Simplified error handling in transaction parsing, allowing for smoother operation when no transactions are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->