### PR TITLE
fix(`observer`): remove error return on staking hooks

### DIFF
--- a/x/observer/keeper/hooks.go
+++ b/x/observer/keeper/hooks.go
@@ -15,7 +15,7 @@ type Hooks struct {
 func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) error {
 	err := h.k.CleanObservers(ctx, valAddr)
 	if err != nil {
-		return err
+		ctx.Logger().Error("Error cleaning observer set", "error", err)
 	}
 	return nil
 }
@@ -23,7 +23,7 @@ func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, _ sdk.ConsAddress, valAddr
 func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) error {
 	err := h.k.CheckAndCleanObserver(ctx, valAddr)
 	if err != nil {
-		return err
+		ctx.Logger().Error("Error cleaning observer set", "error", err)
 	}
 	return nil
 }
@@ -31,7 +31,7 @@ func (h Hooks) AfterValidatorBeginUnbonding(ctx sdk.Context, _ sdk.ConsAddress, 
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	err := h.k.CheckAndCleanObserverDelegator(ctx, valAddr, delAddr)
 	if err != nil {
-		return err
+		ctx.Logger().Error("Error cleaning observer set", "error", err)
 	}
 	return nil
 }
@@ -39,7 +39,7 @@ func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, 
 func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) error {
 	err := h.k.CleanSlashedValidator(ctx, valAddr, fraction)
 	if err != nil {
-		return err
+		ctx.Logger().Error("Error cleaning observer set", "error", err)
 	}
 	return nil
 }

--- a/x/observer/keeper/hooks_test.go
+++ b/x/observer/keeper/hooks_test.go
@@ -139,15 +139,20 @@ func TestKeeper_AfterDelegationModified(t *testing.T) {
 }
 
 func TestKeeper_BeforeValidatorSlashed(t *testing.T) {
-	t.Run("should error if validator not found", func(t *testing.T) {
+	t.Run("should not error if validator not found", func(t *testing.T) {
 		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 
 		r := rand.New(rand.NewSource(9))
 		validator := sample.Validator(t, r)
+		os := sample.ObserverSet(10)
+		k.SetObserverSet(ctx, os)
 
 		hooks := k.Hooks()
 		err := hooks.BeforeValidatorSlashed(ctx, validator.GetOperator(), sdk.NewDec(1))
-		require.Error(t, err)
+		require.NoError(t, err)
+		storedOs, found := k.GetObserverSet(ctx)
+		require.True(t, found)
+		require.Equal(t, os, storedOs)
 	})
 
 	t.Run("should not error if observer set not found", func(t *testing.T) {

--- a/x/observer/keeper/voting.go
+++ b/x/observer/keeper/voting.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -134,12 +135,12 @@ func (k Keeper) CheckObserverSelfDelegation(ctx sdk.Context, accAddress string) 
 	}
 	validator, found := k.stakingKeeper.GetValidator(ctx, valAddress)
 	if !found {
-		return types.ErrNotValidator
+		return errors.Wrapf(types.ErrNotValidator, "validator : %s", valAddress)
 	}
 
 	delegation, found := k.stakingKeeper.GetDelegation(ctx, selfdelAddr, valAddress)
 	if !found {
-		return types.ErrSelfDelegation
+		return errors.Wrapf(types.ErrSelfDelegation, "self delegation : %s , valAddres : %s", selfdelAddr, valAddress)
 	}
 
 	minDelegation, err := types.GetMinObserverDelegationDec()

--- a/x/observer/keeper/voting.go
+++ b/x/observer/keeper/voting.go
@@ -2,10 +2,10 @@ package keeper
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/x/observer/types"


### PR DESCRIPTION
# Description

Staking hook fix was missing on develop

https://github.com/zeta-chain/node/commit/102b872d1294480880d407e72265a8c9349d24b2#diff-f6d8e75e5cf1f39354b3a150db855a69895dbf5e6da8d24c89213a17256440dcR143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in key methods to log errors instead of returning them directly, enhancing visibility into issues.
	- Updated test cases to reflect new expected behaviors when validators are absent, ensuring robust handling of edge cases.

- **New Features**
	- Enhanced error messages in the `CheckObserverSelfDelegation` method for better context and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->