### PR TITLE
fix: ensure NODE_VERSION and NODE_COMMIT are set for upgrade builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,15 +296,24 @@ start-v2-test: zetanode
 ###############################################################################
 
 # build from source only if requested
+# NODE_VERSION and NODE_COMMIT must be set as old-runtime depends on lastest-runtime
 ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from source"
-	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source --build-arg OLD_VERSION='release/v20' .
+	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
+		--build-arg OLD_VERSION='release/v20' \
+		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg NODE_COMMIT=$(NODE_COMMIT)
+		.
 .PHONY: zetanode-upgrade
 else
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from binaries"
-	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime --build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v20.0.2' .
+	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v20.0.2' \
+	--build-arg NODE_VERSION=$(NODE_VERSION) \
+	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
+	.
 .PHONY: zetanode-upgrade
 endif
 


### PR DESCRIPTION
# Description

The `old-runtime` target in the docker build in the`zetanode-upgrade` make target depends on `latest-runtime` docker target so we need to also set the NODE_VERSION and NODE_COMMIT to ensure that there is not a pointless rebuild:

<details>

```
#27 [latest-build 6/6] RUN --mount=type=cache,target="/root/.cache/go-build"     NODE_VERSION=${NODE_VERSION}     NODE_COMMIT=${NODE_COMMIT}     make install install-zetae2e
#27 0.168 fatal: not a git repository (or any of the parent directories): .git
#27 0.169 fatal: not a git repository (or any of the parent directories): .git
#27 0.170 warning: Not a git repository. Use --no-index to compare two paths outside a working tree
#27 0.170 usage: git diff --no-index [<options>] <path> <path>
#27 0.170 
#27 0.170 Diff output format options
#27 0.170     -p, --patch           generate patch
#27 0.170     -s, --no-patch        suppress diff output
#27 0.170     -u                    generate patch
#27 0.170     -U, --unified[=<n>]   generate diffs with <n> lines context
#27 0.170     -W, --function-context
#27 0.170                           generate diffs with <n> lines context
#27 0.170     --raw                 generate the diff in raw format
#27 0.170     --patch-with-raw      synonym for '-p --raw'
#27 0.170     --patch-with-stat     synonym for '-p --stat'
#27 0.170     --numstat             machine friendly --stat
#27 0.170     --shortstat           output only the last line of --stat
#27 0.170     -X, --dirstat[=<param1,param2>...]
#27 0.170                           output the distribution of relative amount of changes for each sub-directory
#27 0.170     --cumulative          synonym for --dirstat=cumulative
#27 0.170     --dirstat-by-file[=<param1,param2>...]
#27 0.170                           synonym for --dirstat=files,param1,param2...
#27 0.170     --check               warn if changes introduce conflict markers or whitespace errors
#27 0.170     --summary             condensed summary such as creations, renames and mode changes
#27 0.170     --name-only           show only names of changed files
#27 0.170     --name-status         show only names and status of changed files
#27 0.170     --stat[=<width>[,<name-width>[,<count>]]]
#27 0.170                           generate diffstat
#27 0.170     --stat-width <width>  generate diffstat with a given width
#27 0.170     --stat-name-width <width>
#27 0.170                           generate diffstat with a given name width
#27 0.170     --stat-graph-width <width>
#27 0.170                           generate diffstat with a given graph width
#27 0.170     --stat-count <count>  generate diffstat with limited lines
#27 0.170     --compact-summary     generate compact summary in diffstat
#27 0.170     --binary              output a binary diff that can be applied
#27 0.170     --full-index          show full pre- and post-image object names on the "index" lines
#27 0.170     --color[=<when>]      show colored diff
#27 0.170     --ws-error-highlight <kind>
#27 0.170                           highlight whitespace errors in the 'context', 'old' or 'new' lines in the diff
#27 0.170     -z                    do not munge pathnames and use NULs as output field terminators in --raw or --numstat
#27 0.170     --abbrev[=<n>]        use <n> digits to display object names
#27 0.170     --src-prefix <prefix>
#27 0.170                           show the given source prefix instead of "a/"
#27 0.170     --dst-prefix <prefix>
#27 0.170                           show the given destination prefix instead of "b/"
#27 0.170     --line-prefix <prefix>
#27 0.170                           prepend an additional prefix to every line of output
#27 0.170     --no-prefix           do not show any source or destination prefix
#27 0.170     --inter-hunk-context <n>
#27 0.170                           show context between diff hunks up to the specified number of lines
#27 0.170     --output-indicator-new <char>
#27 0.170                           specify the character to indicate a new line instead of '+'
#27 0.170     --output-indicator-old <char>
#27 0.170                           specify the character to indicate an old line instead of '-'
#27 0.170     --output-indicator-context <char>
#27 0.170                           specify the character to indicate a context instead of ' '
#27 0.170 
#27 0.170 Diff rename options
#27 0.170     -B, --break-rewrites[=<n>[/<m>]]
#27 0.170                           break complete rewrite changes into pairs of delete and create
#27 0.170     -M, --find-renames[=<n>]
#27 0.170                           detect renames
#27 0.170     -D, --irreversible-delete
#27 0.170                           omit the preimage for deletes
#27 0.170     -C, --find-copies[=<n>]
#27 0.170                           detect copies
#27 0.170     --find-copies-harder  use unmodified files as source to find copies
#27 0.170     --no-renames          disable rename detection
#27 0.170     --rename-empty        use empty blobs as rename source
#27 0.170     --follow              continue listing the history of a file beyond renames
#27 0.170     -l <n>                prevent rename/copy detection if the number of rename/copy targets exceeds given limit
#27 0.170 
#27 0.170 Diff algorithm options
#27 0.170     --minimal             produce the smallest possible diff
#27 0.170     -w, --ignore-all-space
#27 0.170                           ignore whitespace when comparing lines
#27 0.170     -b, --ignore-space-change
#27 0.170                           ignore changes in amount of whitespace
#27 0.170     --ignore-space-at-eol
#27 0.170                           ignore changes in whitespace at EOL
#27 0.170     --ignore-cr-at-eol    ignore carrier-return at the end of line
#27 0.170     --ignore-blank-lines  ignore changes whose lines are all blank
#27 0.170     -I, --ignore-matching-lines <regex>
#27 0.170                           ignore changes whose all lines match <regex>
#27 0.170     --indent-heuristic    heuristic to shift diff hunk boundaries for easy reading
#27 0.170     --patience            generate diff using the "patience diff" algorithm
#27 0.170     --histogram           generate diff using the "histogram diff" algorithm
#27 0.170     --diff-algorithm <algorithm>
#27 0.170                           choose a diff algorithm
#27 0.170     --anchored <text>     generate diff using the "anchored diff" algorithm
#27 0.170     --word-diff[=<mode>]  show word diff, using <mode> to delimit changed words
#27 0.170     --word-diff-regex <regex>
#27 0.170                           use <regex> to decide what a word is
#27 0.170     --color-words[=<regex>]
#27 0.170                           equivalent to --word-diff=color --word-diff-regex=<regex>
#27 0.170     --color-moved[=<mode>]
#27 0.170                           moved lines of code are colored differently
#27 0.170     --color-moved-ws <mode>
#27 0.170                           how white spaces are ignored in --color-moved
#27 0.170 
#27 0.170 Other diff options
#27 0.170     --relative[=<prefix>]
#27 0.170                           when run from subdir, exclude changes outside and show relative paths
#27 0.170     -a, --text            treat all files as text
#27 0.170     -R                    swap two inputs, reverse the diff
#27 0.170     --exit-code           exit with 1 if there were differences, 0 otherwise
#27 0.171     --quiet               disable all output of the program
#27 0.171     --ext-diff            allow an external diff helper to be executed
#27 0.171     --textconv            run external text conversion filters when comparing binary files
#27 0.171     --ignore-submodules[=<when>]
#27 0.171                           ignore changes to submodules in the diff generation
#27 0.171     --submodule[=<format>]
#27 0.171                           specify how differences in submodules are shown
#27 0.171     --ita-invisible-in-index
#27 0.171                           hide 'git add -N' entries from the index
#27 0.171     --ita-visible-in-index
#27 0.171                           treat 'git add -N' entries as real in the index
#27 0.171     -S <string>           look for differences that change the number of occurrences of the specified string
#27 0.171     -G <regex>            look for differences that change the number of occurrences of the specified regex
#27 0.171     --pickaxe-all         show all changes in the changeset with -S or -G
#27 0.171     --pickaxe-regex       treat <string> in -S as extended POSIX regular expression
#27 0.171     -O <file>             control the order in which files appear in the output
#27 0.171     --rotate-to <path>    show the change in the specified path first
#27 0.171     --skip-to <path>      skip the output to the specified path
#27 0.171     --find-object <object-id>
#27 0.171                           look for differences that change the number of occurrences of the specified object
#27 0.171     --diff-filter [(A|C|D|M|R|T|U|X|B)...[*]]
#27 0.171                           select files by diff type
#27 0.171     --output <file>       output to a specific file
#27 0.171 
#27 0.172 fatal: not a git repository (or any of the parent directories): .git
#27 0.175 --> Installing zetacored, zetaclientd, and zetaclientd-supervisor
#27 22.13 --> Installing zetae2e
#27 DONE 31.2s
#28 [old-runtime 2/3] COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
```

</details>

Upgrade tests failures are unrelated: https://github.com/zeta-chain/node/issues/2982

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
