### PR TITLE
fix(e2e): tolerate revert message in both error and status message

### DIFF
--- a/e2e/e2etests/test_eth_deposit_call.go
+++ b/e2e/e2etests/test_eth_deposit_call.go
@@ -88,5 +88,10 @@ func TestEtherDepositAndCall(r *runner.E2ERunner, args []string) {
 	r.Logger.Info("Cross-chain call to reverter reverted")
 
 	// Check the error carries the revert executed.
-	require.Contains(r, cctx.CctxStatus.ErrorMessage, "revert executed")
+	// tolerate the error in both the ErrorMessage field and the StatusMessage field
+	if cctx.CctxStatus.ErrorMessage != "" {
+		require.Contains(r, cctx.CctxStatus.ErrorMessage, "revert executed")
+	} else {
+		require.Contains(r, cctx.CctxStatus.StatusMessage, utils.ErrHashRevertFoo)
+	}
 }

--- a/e2e/e2etests/test_solana_deposit_refund.go
+++ b/e2e/e2etests/test_solana_deposit_refund.go
@@ -32,5 +32,10 @@ func TestSolanaDepositAndCallRefund(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// Check the error carries the revert executed.
-	require.Contains(r, cctx.CctxStatus.ErrorMessage, "revert executed")
+	// tolerate the error in both the ErrorMessage field and the StatusMessage field
+	if cctx.CctxStatus.ErrorMessage != "" {
+		require.Contains(r, cctx.CctxStatus.ErrorMessage, "revert executed")
+	} else {
+		require.Contains(r, cctx.CctxStatus.StatusMessage, utils.ErrHashRevertFoo)
+	}
 }


### PR DESCRIPTION
# Description

Fix the upgrade tests.

Closes https://github.com/zeta-chain/node/issues/2982

E2E is failing with:
```
setup      | ❌ zeta tests failed: Post "http://zetacore0:8545": dial tcp 172.20.0.11:8545: connect: connection refused
setup      | ❌ e2e tests failed after 6m25.624286441s
```

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for cross-chain calls and Solana deposit transactions to accommodate a wider range of error messages.
  
- **Tests**
	- Improved robustness of error checking in Ether and Solana deposit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->