### PR TITLE
refactor: configure solana chain during e2e setup

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -226,7 +226,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		deployerRunner.ERC20CustodyAddr = deployerRunner.ERC20CustodyV2Addr
 
 		if testSolana {
-			deployerRunner.SetSolanaContracts(conf.AdditionalAccounts.UserSolana.SolanaPrivateKey.String())
+			deployerRunner.SetupSolana(conf.AdditionalAccounts.UserSolana.SolanaPrivateKey.String())
 		}
 		noError(deployerRunner.FundEmissionsPool())
 

--- a/e2e/e2etests/test_solana_withdraw.go
+++ b/e2e/e2etests/test_solana_withdraw.go
@@ -13,19 +13,22 @@ import (
 func TestSolanaWithdraw(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
+	withdrawAmount := parseBigInt(r, args[0])
+
 	// get ERC20 SOL balance before withdraw
 	balanceBefore, err := r.SOLZRC20.BalanceOf(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
 	r.Logger.Info("runner balance of SOL before withdraw: %d", balanceBefore)
 
+	require.Equal(r, 1, balanceBefore.Cmp(withdrawAmount), "Insufficient balance for withdrawal")
+
 	// parse withdraw amount (in lamports), approve amount is 1 SOL
 	approvedAmount := new(big.Int).SetUint64(solana.LAMPORTS_PER_SOL)
-	withdrawAmount := parseBigInt(r, args[0])
 	require.Equal(
 		r,
 		-1,
 		withdrawAmount.Cmp(approvedAmount),
-		"Withdrawal amount must be less than the approved amount (1e9).",
+		"Withdrawal amount must be less than the approved amount (1e9)",
 	)
 
 	// load deployer private key

--- a/e2e/runner/setup_solana.go
+++ b/e2e/runner/setup_solana.go
@@ -1,14 +1,20 @@
 package runner
 
 import (
+	"time"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/near/borsh-go"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/constant"
 	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
+	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
 // SetupSolanaAccount imports the deployer's private key
@@ -20,8 +26,8 @@ func (r *E2ERunner) SetupSolanaAccount() {
 	r.Logger.Info("SolanaDeployerAddress: %s", r.SolanaDeployerAddress)
 }
 
-// SetSolanaContracts set Solana contracts
-func (r *E2ERunner) SetSolanaContracts(deployerPrivateKey string) {
+// SetupSolana sets Solana contracts and params
+func (r *E2ERunner) SetupSolana(deployerPrivateKey string) {
 	r.Logger.Print("⚙️ initializing gateway program on Solana")
 
 	// set Solana contracts
@@ -78,4 +84,64 @@ func (r *E2ERunner) SetSolanaContracts(deployerPrivateKey string) {
 	balance, err := r.SolanaClient.GetBalance(r.Ctx, pdaComputed, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 	r.Logger.Info("initial PDA balance: %d lamports", balance.Value)
+
+	err = r.ensureSolanaChainParams()
+	require.NoError(r, err)
+}
+
+func (r *E2ERunner) ensureSolanaChainParams() error {
+	if r.ZetaTxServer == nil {
+		return errors.New("ZetaTxServer is not initialized")
+	}
+
+	creator := r.ZetaTxServer.MustGetAccountAddressFromName(utils.OperationalPolicyName)
+
+	chainID := chains.SolanaLocalnet.ChainId
+
+	chainParams := &observertypes.ChainParams{
+		ChainId:                     chainID,
+		ConfirmationCount:           32,
+		ZetaTokenContractAddress:    constant.EVMZeroAddress,
+		ConnectorContractAddress:    constant.EVMZeroAddress,
+		Erc20CustodyContractAddress: constant.EVMZeroAddress,
+		GasPriceTicker:              5,
+		WatchUtxoTicker:             0,
+		InboundTicker:               2,
+		OutboundTicker:              2,
+		OutboundScheduleInterval:    2,
+		OutboundScheduleLookahead:   5,
+		BallotThreshold:             observertypes.DefaultBallotThreshold,
+		MinObserverDelegation:       observertypes.DefaultMinObserverDelegation,
+		IsSupported:                 true,
+		GatewayAddress:              solanacontracts.SolanaGatewayProgramID,
+	}
+
+	updateMsg := observertypes.NewMsgUpdateChainParams(creator, chainParams)
+
+	if _, err := r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, updateMsg); err != nil {
+		return errors.Wrap(err, "unable to broadcast solana chain params tx")
+	}
+
+	resetMsg := observertypes.NewMsgResetChainNonces(creator, chainID, 0, 0)
+	if _, err := r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, resetMsg); err != nil {
+		return errors.Wrap(err, "unable to broadcast solana chain nonce reset tx")
+	}
+
+	r.Logger.Print("⚙️ voted for adding solana chain params (localnet). Waiting for confirmation")
+
+	query := &observertypes.QueryGetChainParamsForChainRequest{ChainId: chainID}
+
+	const duration = 2 * time.Second
+
+	for i := 0; i < 10; i++ {
+		_, err := r.ObserverClient.GetChainParamsForChain(r.Ctx, query)
+		if err == nil {
+			r.Logger.Print("⚙️ solana chain params are set")
+			return nil
+		}
+
+		time.Sleep(duration)
+	}
+
+	return errors.New("unable to set Solana chain params")
 }

--- a/e2e/runner/solana.go
+++ b/e2e/runner/solana.go
@@ -153,7 +153,7 @@ func (r *E2ERunner) WithdrawSOLZRC20(
 	tx, err := r.SOLZRC20.Approve(r.ZEVMAuth, r.SOLZRC20Addr, approveAmount)
 	require.NoError(r, err)
 	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
-	utils.RequireTxSuccessful(r, receipt)
+	utils.RequireTxSuccessful(r, receipt, "approve")
 
 	// withdraw
 	tx, err = r.SOLZRC20.Withdraw(r.ZEVMAuth, []byte(to.String()), amount)
@@ -162,7 +162,7 @@ func (r *E2ERunner) WithdrawSOLZRC20(
 
 	// wait for tx receipt
 	receipt = utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
-	utils.RequireTxSuccessful(r, receipt)
+	utils.RequireTxSuccessful(r, receipt, "withdraw")
 	r.Logger.Info("Receipt txhash %s status %d", receipt.TxHash, receipt.Status)
 
 	// wait for the cctx to be mined

--- a/x/observer/genesis.go
+++ b/x/observer/genesis.go
@@ -26,15 +26,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 		btcChainParams.IsSupported = true
 		goerliChainParams := types.GetDefaultGoerliLocalnetChainParams()
 		goerliChainParams.IsSupported = true
-		solanaChainParams := types.GetDefaultSolanaLocalnetChainParams()
-		solanaChainParams.IsSupported = true
 		zetaPrivnetChainParams := types.GetDefaultZetaPrivnetChainParams()
 		zetaPrivnetChainParams.IsSupported = true
 		k.SetChainParamsList(ctx, types.ChainParamsList{
 			ChainParams: []*types.ChainParams{
 				btcChainParams,
 				goerliChainParams,
-				solanaChainParams,
 				zetaPrivnetChainParams,
 			},
 		})

--- a/x/observer/genesis_test.go
+++ b/x/observer/genesis_test.go
@@ -68,15 +68,12 @@ func TestGenesis(t *testing.T) {
 		btcChainParams.IsSupported = true
 		goerliChainParams := types.GetDefaultGoerliLocalnetChainParams()
 		goerliChainParams.IsSupported = true
-		solanaChainParams := types.GetDefaultSolanaLocalnetChainParams()
-		solanaChainParams.IsSupported = true
 		zetaPrivnetChainParams := types.GetDefaultZetaPrivnetChainParams()
 		zetaPrivnetChainParams.IsSupported = true
 		localnetChainParams := types.ChainParamsList{
 			ChainParams: []*types.ChainParams{
 				btcChainParams,
 				goerliChainParams,
-				solanaChainParams,
 				zetaPrivnetChainParams,
 			},
 		}
@@ -107,15 +104,12 @@ func TestGenesis(t *testing.T) {
 		btcChainParams.IsSupported = true
 		goerliChainParams := types.GetDefaultGoerliLocalnetChainParams()
 		goerliChainParams.IsSupported = true
-		solanaChainParams := types.GetDefaultSolanaLocalnetChainParams()
-		solanaChainParams.IsSupported = true
 		zetaPrivnetChainParams := types.GetDefaultZetaPrivnetChainParams()
 		zetaPrivnetChainParams.IsSupported = true
 		localnetChainParams := types.ChainParamsList{
 			ChainParams: []*types.ChainParams{
 				btcChainParams,
 				goerliChainParams,
-				solanaChainParams,
 				zetaPrivnetChainParams,
 			},
 		}

--- a/x/observer/types/chain_params.go
+++ b/x/observer/types/chain_params.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/constant"
-	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
 )
 
 var (
@@ -148,7 +147,6 @@ func GetDefaultChainParams() ChainParamsList {
 			GetDefaultMumbaiTestnetChainParams(),
 			GetDefaultBtcTestnetChainParams(),
 			GetDefaultBtcRegtestChainParams(),
-			GetDefaultSolanaLocalnetChainParams(),
 			GetDefaultGoerliLocalnetChainParams(),
 		},
 	}
@@ -297,25 +295,6 @@ func GetDefaultBtcRegtestChainParams() *ChainParams {
 		BallotThreshold:             DefaultBallotThreshold,
 		MinObserverDelegation:       DefaultMinObserverDelegation,
 		IsSupported:                 false,
-	}
-}
-func GetDefaultSolanaLocalnetChainParams() *ChainParams {
-	return &ChainParams{
-		ChainId:                     chains.SolanaLocalnet.ChainId,
-		ConfirmationCount:           32,
-		ZetaTokenContractAddress:    constant.EVMZeroAddress,
-		ConnectorContractAddress:    constant.EVMZeroAddress,
-		Erc20CustodyContractAddress: constant.EVMZeroAddress,
-		GasPriceTicker:              5,
-		WatchUtxoTicker:             0,
-		InboundTicker:               2,
-		OutboundTicker:              2,
-		OutboundScheduleInterval:    2,
-		OutboundScheduleLookahead:   5,
-		BallotThreshold:             DefaultBallotThreshold,
-		MinObserverDelegation:       DefaultMinObserverDelegation,
-		IsSupported:                 false,
-		GatewayAddress:              solanacontracts.SolanaGatewayProgramID,
 	}
 }
 func GetDefaultGoerliLocalnetChainParams() *ChainParams {

--- a/zetaclient/context/app_test.go
+++ b/zetaclient/context/app_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"golang.org/x/exp/maps"
@@ -37,6 +38,8 @@ func TestAppContext(t *testing.T) {
 
 	btcParams := types.GetDefaultBtcMainnetChainParams()
 	btcParams.IsSupported = true
+
+	solParams := sample.ChainParamsSupported(chains.SolanaLocalnet.ChainId)
 
 	fancyL2 := chains.Chain{
 		ChainId:     123,
@@ -77,6 +80,7 @@ func TestAppContext(t *testing.T) {
 		chainParams := map[int64]*types.ChainParams{
 			chains.Ethereum.ChainId:       ethParams,
 			chains.BitcoinMainnet.ChainId: btcParams,
+			chains.SolanaLocalnet.ChainId: solParams,
 			fancyL2.ChainId:               fancyL2Params,
 		}
 
@@ -113,7 +117,7 @@ func TestAppContext(t *testing.T) {
 		assert.Equal(t, fancyL2Params, fancyL2Chain.Params())
 
 		// Check chain IDs
-		expectedIDs := []int64{ethParams.ChainId, btcParams.ChainId, fancyL2.ChainId}
+		expectedIDs := []int64{ethParams.ChainId, btcParams.ChainId, solParams.ChainId, fancyL2.ChainId}
 		assert.ElementsMatch(t, expectedIDs, appContext.ListChainIDs())
 
 		// Check config

--- a/zetaclient/context/app_test.go
+++ b/zetaclient/context/app_test.go
@@ -38,9 +38,6 @@ func TestAppContext(t *testing.T) {
 	btcParams := types.GetDefaultBtcMainnetChainParams()
 	btcParams.IsSupported = true
 
-	solParams := types.GetDefaultSolanaLocalnetChainParams()
-	solParams.IsSupported = true
-
 	fancyL2 := chains.Chain{
 		ChainId:     123,
 		Network:     0,
@@ -80,7 +77,6 @@ func TestAppContext(t *testing.T) {
 		chainParams := map[int64]*types.ChainParams{
 			chains.Ethereum.ChainId:       ethParams,
 			chains.BitcoinMainnet.ChainId: btcParams,
-			chains.SolanaLocalnet.ChainId: solParams,
 			fancyL2.ChainId:               fancyL2Params,
 		}
 
@@ -117,7 +113,7 @@ func TestAppContext(t *testing.T) {
 		assert.Equal(t, fancyL2Params, fancyL2Chain.Params())
 
 		// Check chain IDs
-		expectedIDs := []int64{ethParams.ChainId, btcParams.ChainId, solParams.ChainId, fancyL2.ChainId}
+		expectedIDs := []int64{ethParams.ChainId, btcParams.ChainId, fancyL2.ChainId}
 		assert.ElementsMatch(t, expectedIDs, appContext.ListChainIDs())
 
 		// Check config


### PR DESCRIPTION
# Description

Configure solana during e2e setup rather than at genesis to avoid these zetaclient error messages during standard e2e run:

```
2024-10-10T17:25:42Z ERR PostGasPrice error for chain 902 error="GetSlot error: rpc call getSlot() on http://solana:8899: Post \"http://solana:8899\": dial tcp: lookup solana on 127.0.0.11:53: no such host" chain=902 chain_network=solana module=gasprice
2024-10-10T17:25:42Z ERR WatchInbound: observeInbound error error="error GetFirstSignatureForAddress for chain 902 address 94U5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d: error GetSignaturesForAddressWithOpts for address 94U5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d: rpc call getSignaturesForAddress() on http://solana:8899: Post \"http://solana:8899\": dial tcp: lookup solana on 127.0.0.11:53: no such host" chain=902 chain_network=solana module=inbound
```

This matches how TON is setup but we also reset the chain nonces like https://github.com/zeta-chain/gov-ops/pull/424

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated method for setting up Solana contracts, enhancing initialization logic.
	- Added functionality to ensure Solana chain parameters during setup.

- **Bug Fixes**
	- Improved clarity in transaction status checks for Solana withdrawals.

- **Chores**
	- Removed Solana chain parameters from initialization and testing files to streamline local testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->