### PR TITLE
fix(emissions): add nil checks for reward distributions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -224,7 +224,7 @@ var (
 		fungibletypes.ModuleName:                        {authtypes.Minter, authtypes.Burner},
 		emissionstypes.ModuleName:                       nil,
 		emissionstypes.UndistributedObserverRewardsPool: nil,
-		emissionstypes.UndistributedTssRewardsPool:      nil,
+		emissionstypes.UndistributedTSSRewardsPool:      nil,
 	}
 
 	// module accounts that are NOT allowed to receive tokens

--- a/testutil/keeper/keeper.go
+++ b/testutil/keeper/keeper.go
@@ -136,7 +136,7 @@ var moduleAccountPerms = map[string][]string{
 	fungibletypes.ModuleName:                        {authtypes.Minter, authtypes.Burner},
 	emissionstypes.ModuleName:                       {authtypes.Minter},
 	emissionstypes.UndistributedObserverRewardsPool: nil,
-	emissionstypes.UndistributedTssRewardsPool:      nil,
+	emissionstypes.UndistributedTSSRewardsPool:      nil,
 	ibctransfertypes.ModuleName:                     {authtypes.Minter, authtypes.Burner},
 	ibccrosschaintypes.ModuleName:                   nil,
 }

--- a/x/emissions/abci_test.go
+++ b/x/emissions/abci_test.go
@@ -1,7 +1,6 @@
 package emissions_test
 
 import (
-	emissionskeeper "github.com/zeta-chain/node/x/emissions/keeper"
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
@@ -14,9 +13,10 @@ import (
 	"github.com/zeta-chain/node/pkg/sdkconfig"
 	keepertest "github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
-	emissionsModule "github.com/zeta-chain/node/x/emissions"
+	"github.com/zeta-chain/node/x/emissions"
+	emissionskeeper "github.com/zeta-chain/node/x/emissions/keeper"
 	emissionstypes "github.com/zeta-chain/node/x/emissions/types"
-	observerTypes "github.com/zeta-chain/node/x/observer/types"
+	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
 func TestBeginBlocker(t *testing.T) {
@@ -36,14 +36,14 @@ func TestBeginBlocker(t *testing.T) {
 			zk.ObserverKeeper.SetBallot(ctx, &ballot)
 			ballotIdentifiers = append(ballotIdentifiers, ballot.BallotIdentifier)
 		}
-		zk.ObserverKeeper.SetBallotList(ctx, &observerTypes.BallotListForHeight{
+		zk.ObserverKeeper.SetBallotList(ctx, &observertypes.BallotListForHeight{
 			Height:           0,
 			BallotsIndexList: ballotIdentifiers,
 		})
 
 		//Act
 		for i := 0; i < 100; i++ {
-			emissionsModule.BeginBlocker(ctx, *k)
+			emissions.BeginBlocker(ctx, *k)
 			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
 		}
 
@@ -65,12 +65,12 @@ func TestBeginBlocker(t *testing.T) {
 			zk.ObserverKeeper.SetBallot(ctx, &ballot)
 			ballotIdentifiers = append(ballotIdentifiers, ballot.BallotIdentifier)
 		}
-		zk.ObserverKeeper.SetBallotList(ctx, &observerTypes.BallotListForHeight{
+		zk.ObserverKeeper.SetBallotList(ctx, &observertypes.BallotListForHeight{
 			Height:           0,
 			BallotsIndexList: ballotIdentifiers,
 		})
 		for i := 0; i < 100; i++ {
-			emissionsModule.BeginBlocker(ctx, *k)
+			emissions.BeginBlocker(ctx, *k)
 			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
 		}
 		for _, observer := range observerSet.ObserverList {
@@ -83,7 +83,7 @@ func TestBeginBlocker(t *testing.T) {
 		k, ctx, sk, _ := keepertest.EmissionsKeeper(t)
 		feeCollectorAddress := sk.AuthKeeper.GetModuleAccount(ctx, types.FeeCollectorName).GetAddress()
 		for i := 0; i < 100; i++ {
-			emissionsModule.BeginBlocker(ctx, *k)
+			emissions.BeginBlocker(ctx, *k)
 			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
 		}
 		require.True(t, sk.BankKeeper.GetBalance(ctx, feeCollectorAddress, config.BaseDenom).Amount.IsZero())
@@ -106,7 +106,7 @@ func TestBeginBlocker(t *testing.T) {
 
 		for i := 0; i < 100; i++ {
 			// produce a block
-			emissionsModule.BeginBlocker(ctx, *k)
+			emissions.BeginBlocker(ctx, *k)
 			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
 		}
 		require.True(t, sk.BankKeeper.GetBalance(ctx, feeCollectorAddress, config.BaseDenom).Amount.IsZero())
@@ -139,7 +139,7 @@ func TestBeginBlocker(t *testing.T) {
 		bankMock.On("SendCoinsFromModuleToModule",
 			mock.Anything, emissionstypes.ModuleName, k.GetFeeCollector(), mock.Anything).
 			Return(emissionstypes.ErrUnableToWithdrawEmissions).Once()
-		emissionsModule.BeginBlocker(ctx, *k)
+		emissions.BeginBlocker(ctx, *k)
 
 		bankMock.AssertNumberOfCalls(t, "SendCoinsFromModuleToModule", 1)
 	})
@@ -166,7 +166,7 @@ func TestBeginBlocker(t *testing.T) {
 		bankMock.On("SendCoinsFromModuleToModule",
 			mock.Anything, emissionstypes.ModuleName, emissionstypes.UndistributedObserverRewardsPool, mock.Anything).
 			Return(emissionstypes.ErrUnableToWithdrawEmissions).Once()
-		emissionsModule.BeginBlocker(ctx, *k)
+		emissions.BeginBlocker(ctx, *k)
 
 		bankMock.AssertNumberOfCalls(t, "SendCoinsFromModuleToModule", 2)
 	})
@@ -199,7 +199,7 @@ func TestBeginBlocker(t *testing.T) {
 		bankMock.On("SendCoinsFromModuleToModule",
 			mock.Anything, emissionstypes.ModuleName, emissionstypes.UndistributedTSSRewardsPool, mock.Anything).
 			Return(emissionstypes.ErrUnableToWithdrawEmissions).Once()
-		emissionsModule.BeginBlocker(ctx, *k)
+		emissions.BeginBlocker(ctx, *k)
 
 		bankMock.AssertNumberOfCalls(t, "SendCoinsFromModuleToModule", 3)
 	})
@@ -217,7 +217,7 @@ func TestBeginBlocker(t *testing.T) {
 			zk.ObserverKeeper.SetBallot(ctx, &ballot)
 			ballotIdentifiers = append(ballotIdentifiers, ballot.BallotIdentifier)
 		}
-		zk.ObserverKeeper.SetBallotList(ctx, &observerTypes.BallotListForHeight{
+		zk.ObserverKeeper.SetBallotList(ctx, &observertypes.BallotListForHeight{
 			Height:           0,
 			BallotsIndexList: ballotIdentifiers,
 		})
@@ -252,7 +252,7 @@ func TestBeginBlocker(t *testing.T) {
 		for i := 0; i < numberOfTestBlocks; i++ {
 			emissionPoolBeforeBlockDistribution := sk.BankKeeper.GetBalance(ctx, emissionPool, config.BaseDenom).Amount
 			// produce a block
-			emissionsModule.BeginBlocker(ctx, *k)
+			emissions.BeginBlocker(ctx, *k)
 
 			// require distribution amount
 			emissionPoolBalanceAfterBlockDistribution := sk.BankKeeper.GetBalance(
@@ -318,22 +318,22 @@ func TestDistributeObserverRewards(t *testing.T) {
 
 	tt := []struct {
 		name                      string
-		votes                     [][]observerTypes.VoteType
+		votes                     [][]observertypes.VoteType
 		observerStartingEmissions sdkmath.Int
 		totalRewardsForBlock      sdkmath.Int
 		expectedRewards           map[string]int64
-		ballotStatus              observerTypes.BallotStatus
+		ballotStatus              observertypes.BallotStatus
 		slashAmount               sdkmath.Int
 		rewardsPerBlock           sdkmath.LegacyDec
 	}{
 		{
 			name: "all observers rewarded correctly",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(100),
@@ -345,18 +345,18 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 125,
 				observerSet.ObserverList[3]: 125,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_SuccessObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_SuccessObservation,
 			slashAmount:     sdkmath.NewInt(25),
 			rewardsPerBlock: emissionstypes.BlockReward,
 		},
 		{
 			name: "one observer slashed",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_FailureObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_FailureObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(100),
@@ -368,18 +368,18 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 125,
 				observerSet.ObserverList[3]: 125,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_SuccessObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_SuccessObservation,
 			slashAmount:     sdkmath.NewInt(25),
 			rewardsPerBlock: emissionstypes.BlockReward,
 		},
 		{
 			name: "all observer slashed",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(100),
@@ -391,18 +391,18 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 75,
 				observerSet.ObserverList[3]: 75,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_FailureObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_FailureObservation,
 			slashAmount:     sdkmath.NewInt(25),
 			rewardsPerBlock: emissionstypes.BlockReward,
 		},
 		{
 			name: "slashed to zero if slash amount is greater than available emissions",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(100),
@@ -414,24 +414,24 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 0,
 				observerSet.ObserverList[3]: 0,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_FailureObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_FailureObservation,
 			slashAmount:     sdkmath.NewInt(2500),
 			rewardsPerBlock: emissionstypes.BlockReward,
 		},
 		{
 			name: "withdraw able emissions unchanged if rewards and slashes are equal",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 				{
-					observerTypes.VoteType_FailureObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_FailureObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(100),
@@ -443,18 +443,18 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 120,
 				observerSet.ObserverList[3]: 120,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_SuccessObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_SuccessObservation,
 			slashAmount:     sdkmath.NewInt(25),
 			rewardsPerBlock: emissionstypes.BlockReward,
 		},
 		{
 			name: "no rewards if block reward is nil",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(0),
@@ -466,18 +466,18 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 0,
 				observerSet.ObserverList[3]: 0,
 			},
-			ballotStatus: observerTypes.BallotStatus_BallotFinalized_SuccessObservation,
+			ballotStatus: observertypes.BallotStatus_BallotFinalized_SuccessObservation,
 			slashAmount:  sdkmath.NewInt(25),
 			//rewardsPerBlock: nil,
 		},
 		{
 			name: "no rewards if block reward is negative",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(0),
@@ -489,18 +489,18 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 0,
 				observerSet.ObserverList[3]: 0,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_SuccessObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_SuccessObservation,
 			slashAmount:     sdkmath.NewInt(25),
 			rewardsPerBlock: sdk.NewDec(1).NegMut(),
 		},
 		{
 			name: "no rewards if block reward is zero",
-			votes: [][]observerTypes.VoteType{
+			votes: [][]observertypes.VoteType{
 				{
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
-					observerTypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
+					observertypes.VoteType_SuccessObservation,
 				},
 			},
 			observerStartingEmissions: sdkmath.NewInt(0),
@@ -512,7 +512,7 @@ func TestDistributeObserverRewards(t *testing.T) {
 				observerSet.ObserverList[2]: 0,
 				observerSet.ObserverList[3]: 0,
 			},
-			ballotStatus:    observerTypes.BallotStatus_BallotFinalized_SuccessObservation,
+			ballotStatus:    observertypes.BallotStatus_BallotFinalized_SuccessObservation,
 			slashAmount:     sdkmath.NewInt(25),
 			rewardsPerBlock: sdk.ZeroDec(),
 		},
@@ -548,7 +548,7 @@ func TestDistributeObserverRewards(t *testing.T) {
 			// Set the ballot list
 			ballotIdentifiers := []string{}
 			for i, votes := range tc.votes {
-				ballot := observerTypes.Ballot{
+				ballot := observertypes.Ballot{
 					BallotIdentifier: "ballot" + string(rune(i)),
 					BallotStatus:     tc.ballotStatus,
 					VoterList:        observerSet.ObserverList,
@@ -557,14 +557,14 @@ func TestDistributeObserverRewards(t *testing.T) {
 				zk.ObserverKeeper.SetBallot(ctx, &ballot)
 				ballotIdentifiers = append(ballotIdentifiers, ballot.BallotIdentifier)
 			}
-			zk.ObserverKeeper.SetBallotList(ctx, &observerTypes.BallotListForHeight{
+			zk.ObserverKeeper.SetBallotList(ctx, &observertypes.BallotListForHeight{
 				Height:           0,
 				BallotsIndexList: ballotIdentifiers,
 			})
 			ctx = ctx.WithBlockHeight(100)
 
 			// Distribute the rewards and check if the rewards are distributed correctly
-			err = emissionsModule.DistributeObserverRewards(ctx, tc.totalRewardsForBlock, *k, params)
+			err = emissions.DistributeObserverRewards(ctx, tc.totalRewardsForBlock, *k, params)
 			require.NoError(t, err)
 
 			for i, observer := range observerSet.ObserverList {

--- a/x/emissions/keeper/params_test.go
+++ b/x/emissions/keeper/params_test.go
@@ -38,7 +38,7 @@ func TestKeeper_GetParams(t *testing.T) {
 				BallotMaturityBlocks:        int64(emissionstypes.BallotMaturityBlocks),
 				BlockRewardAmount:           emissionstypes.BlockReward,
 			},
-			constainsErr: "slash amount cannot be less than 0",
+			constainsErr: "slash amount must not be negative",
 		},
 		{
 			name: "validator emission percentage too high",
@@ -122,7 +122,7 @@ func TestKeeper_GetParams(t *testing.T) {
 				BallotMaturityBlocks:        -100,
 				BlockRewardAmount:           emissionstypes.BlockReward,
 			},
-			constainsErr: "ballot maturity types must be gte 0",
+			constainsErr: "ballot maturity types must not be negative",
 		},
 		{
 			name: "block reward amount too low",
@@ -134,7 +134,7 @@ func TestKeeper_GetParams(t *testing.T) {
 				BallotMaturityBlocks:        int64(emissionstypes.BallotMaturityBlocks),
 				BlockRewardAmount:           sdkmath.LegacyMustNewDecFromStr("-10.00"),
 			},
-			constainsErr: "block reward amount cannot be less than 0",
+			constainsErr: "block reward amount must not be negative",
 		},
 	}
 	for _, tt := range tests {

--- a/x/emissions/module.go
+++ b/x/emissions/module.go
@@ -150,7 +150,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 	InitGenesis(ctx, am.keeper, genState)
 
 	am.keeper.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName)
-	am.keeper.GetAuthKeeper().GetModuleAccount(ctx, types.UndistributedTssRewardsPool)
+	am.keeper.GetAuthKeeper().GetModuleAccount(ctx, types.UndistributedTSSRewardsPool)
 	am.keeper.GetAuthKeeper().GetModuleAccount(ctx, types.UndistributedObserverRewardsPool)
 
 	return []abci.ValidatorUpdate{}

--- a/x/emissions/types/keys.go
+++ b/x/emissions/types/keys.go
@@ -10,7 +10,7 @@ const (
 	// ModuleName defines the module name
 	ModuleName                       = "emissions"
 	UndistributedObserverRewardsPool = ModuleName + "Observers"
-	UndistributedTssRewardsPool      = ModuleName + "Tss"
+	UndistributedTSSRewardsPool      = ModuleName + "Tss"
 
 	// StoreKey defines the primary module store key
 	StoreKey = ModuleName
@@ -42,7 +42,7 @@ const (
 var (
 	EmissionsModuleAddress                  = authtypes.NewModuleAddress(ModuleName)
 	UndistributedObserverRewardsPoolAddress = authtypes.NewModuleAddress(UndistributedObserverRewardsPool)
-	UndistributedTssRewardsPoolAddress      = authtypes.NewModuleAddress(UndistributedTssRewardsPool)
+	UndistributedTssRewardsPoolAddress      = authtypes.NewModuleAddress(UndistributedTSSRewardsPool)
 	// BlockReward is an initial block reward amount when emissions module was initialized.
 	// The current value can be obtained from by querying the params
 	BlockReward = sdk.MustNewDecFromStr("9620949074074074074.074070733466756687")

--- a/x/emissions/types/message_update_params_test.go
+++ b/x/emissions/types/message_update_params_test.go
@@ -29,7 +29,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 			Params:    params,
 		}
 		err := msg.ValidateBasic()
-		require.ErrorContains(t, err, "block reward amount cannot be less than 0")
+		require.ErrorContains(t, err, "block reward amount must not be negative")
 	})
 
 	t.Run("valid", func(t *testing.T) {

--- a/x/emissions/types/params.go
+++ b/x/emissions/types/params.go
@@ -63,7 +63,7 @@ func validateValidatorEmissionPercentage(i interface{}) error {
 	if dec.GT(sdk.OneDec()) {
 		return fmt.Errorf("validator emission percentage cannot be more than 100 percent")
 	}
-	if dec.LT(sdk.ZeroDec()) {
+	if dec.IsNegative() {
 		return fmt.Errorf("validator emission percentage cannot be less than 0 percent")
 	}
 	return nil
@@ -78,7 +78,7 @@ func validateObserverEmissionPercentage(i interface{}) error {
 	if dec.GT(sdk.OneDec()) {
 		return fmt.Errorf("observer emission percentage cannot be more than 100 percent")
 	}
-	if dec.LT(sdk.ZeroDec()) {
+	if dec.IsNegative() {
 		return fmt.Errorf("observer emission percentage cannot be less than 0 percent")
 	}
 	return nil
@@ -93,7 +93,7 @@ func validateTssEmissionPercentage(i interface{}) error {
 	if dec.GT(sdk.OneDec()) {
 		return fmt.Errorf("tss emission percentage cannot be more than 100 percent")
 	}
-	if dec.LT(sdk.ZeroDec()) {
+	if dec.IsNegative() {
 		return fmt.Errorf("tss emission percentage cannot be less than 0 percent")
 	}
 	return nil
@@ -104,8 +104,11 @@ func validateObserverSlashAmount(i interface{}) error {
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
-	if v.LT(sdk.ZeroInt()) {
-		return fmt.Errorf("slash amount cannot be less than 0")
+	if v.IsNil() {
+		return fmt.Errorf("observer slash amount cannot be nil")
+	}
+	if v.IsNegative() {
+		return fmt.Errorf("slash amount must not be negative")
 	}
 	return nil
 }
@@ -117,7 +120,7 @@ func validateBallotMaturityBlocks(i interface{}) error {
 	}
 
 	if v < 0 {
-		return fmt.Errorf("ballot maturity types must be gte 0")
+		return fmt.Errorf("ballot maturity types must not be negative")
 	}
 
 	return nil
@@ -128,8 +131,11 @@ func validateBlockRewardsAmount(i interface{}) error {
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
-	if v.LT(sdkmath.LegacyZeroDec()) {
-		return fmt.Errorf("block reward amount cannot be less than 0")
+	if v.IsNil() {
+		return fmt.Errorf("block reward amount cannot be nil")
+	}
+	if v.IsNegative() {
+		return fmt.Errorf("block reward amount must not be negative")
 	}
 	return nil
 }

--- a/x/emissions/types/params_test.go
+++ b/x/emissions/types/params_test.go
@@ -56,6 +56,7 @@ func TestValidateObserverSlashAmount(t *testing.T) {
 	require.Error(t, validateObserverSlashAmount(10))
 	require.Error(t, validateObserverSlashAmount("10"))
 	require.Error(t, validateObserverSlashAmount(sdkmath.NewInt(-10))) // Less than 0
+	require.Error(t, validateObserverSlashAmount(nil))
 	require.NoError(t, validateObserverSlashAmount(sdkmath.NewInt(10)))
 }
 
@@ -69,6 +70,7 @@ func TestValidateBlockRewardAmount(t *testing.T) {
 	require.Error(t, validateBlockRewardsAmount("0.50"))
 	require.Error(t, validateBlockRewardsAmount("-0.50"))
 	require.Error(t, validateBlockRewardsAmount(sdkmath.LegacyMustNewDecFromStr("-0.50")))
+	require.Error(t, validateBlockRewardsAmount(nil))
 	require.NoError(t, validateBlockRewardsAmount(sdkmath.LegacyMustNewDecFromStr("0.50")))
 	require.NoError(t, validateBlockRewardsAmount(sdkmath.LegacyZeroDec()))
 	require.NoError(t, validateBlockRewardsAmount(BlockReward))
@@ -113,7 +115,7 @@ func TestValidate(t *testing.T) {
 	t.Run("should error for negative block reward amount", func(t *testing.T) {
 		params := NewParams()
 		params.BlockRewardAmount = sdkmath.LegacyMustNewDecFromStr("-1.30")
-		require.ErrorContains(t, params.Validate(), "block reward amount cannot be less than 0")
+		require.ErrorContains(t, params.Validate(), "block reward amount must not be negative")
 	})
 }
 func TestParamsString(t *testing.T) {


### PR DESCRIPTION
# Description

- Add nil check for the reward per block params, panic here would halt the chain
- Add nil checks in the params validation, originally it panicked at this stage as well
- Skip reward distribution logic if reward per block is 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new helper function for improved logging during reward distribution.
  
- **Bug Fixes**
	- Enhanced error handling and validation for reward distribution and parameter checks.
  
- **Documentation**
	- Updated test cases and error messages for better clarity and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->