### PR TITLE
refactor(precompile): do not execute write functions on staticcall

### DIFF
--- a/precompiles/bank/bank.go
+++ b/precompiles/bank/bank.go
@@ -136,8 +136,8 @@ func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) ([]byt
 	// Deposit and Withdraw methods are both not allowed in read-only mode.
 	case DepositMethodName, WithdrawMethodName:
 		if readOnly {
-			return nil, ptypes.ErrUnexpected{
-				Got: "method not allowed in read-only mode: " + method.Name,
+			return nil, ptypes.ErrWriteMethod{
+				Method: method.Name,
 			}
 		}
 

--- a/precompiles/bank/method_test.go
+++ b/precompiles/bank/method_test.go
@@ -46,8 +46,8 @@ func Test_Methods(t *testing.T) {
 		success, err := ts.bankContract.Run(ts.mockEVM, ts.mockVMContract, true)
 		require.ErrorIs(
 			t,
-			ptypes.ErrUnexpected{
-				Got: "method not allowed in read-only mode: deposit",
+			ptypes.ErrWriteMethod{
+				Method: "deposit",
 			},
 			err)
 		require.Empty(t, success)
@@ -73,8 +73,8 @@ func Test_Methods(t *testing.T) {
 		success, err := ts.bankContract.Run(ts.mockEVM, ts.mockVMContract, true)
 		require.ErrorIs(
 			t,
-			ptypes.ErrUnexpected{
-				Got: "method not allowed in read-only mode: withdraw",
+			ptypes.ErrWriteMethod{
+				Method: "withdraw",
 			},
 			err)
 		require.Empty(t, success)

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -380,7 +380,7 @@ func (c *Contract) MoveStake(
 
 // Run is the entrypoint of the precompiled contract, it switches over the input method,
 // and execute them accordingly.
-func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, _ bool) ([]byte, error) {
+func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) ([]byte, error) {
 	method, err := ABI.MethodById(contract.Input[:4])
 	if err != nil {
 		return nil, err
@@ -415,6 +415,12 @@ func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, _ bool) ([]byte, erro
 		}
 		return res, nil
 	case StakeMethodName:
+		if readOnly {
+			return nil, ptypes.ErrWriteMethod{
+				Method: method.Name,
+			}
+		}
+
 		var res []byte
 		execErr := stateDB.ExecuteNativeAction(contract.Address(), nil, func(ctx sdk.Context) error {
 			res, err = c.Stake(ctx, evm, contract, method, args)
@@ -425,6 +431,12 @@ func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, _ bool) ([]byte, erro
 		}
 		return res, nil
 	case UnstakeMethodName:
+		if readOnly {
+			return nil, ptypes.ErrWriteMethod{
+				Method: method.Name,
+			}
+		}
+
 		var res []byte
 		execErr := stateDB.ExecuteNativeAction(contract.Address(), nil, func(ctx sdk.Context) error {
 			res, err = c.Unstake(ctx, evm, contract, method, args)
@@ -435,6 +447,12 @@ func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, _ bool) ([]byte, erro
 		}
 		return res, nil
 	case MoveStakeMethodName:
+		if readOnly {
+			return nil, ptypes.ErrWriteMethod{
+				Method: method.Name,
+			}
+		}
+
 		var res []byte
 		execErr := stateDB.ExecuteNativeAction(contract.Address(), nil, func(ctx sdk.Context) error {
 			res, err = c.MoveStake(ctx, evm, contract, method, args)

--- a/precompiles/types/errors.go
+++ b/precompiles/types/errors.go
@@ -94,6 +94,14 @@ func (e ErrInvalidMethod) Error() string {
 	return fmt.Sprintf("invalid method: %s", e.Method)
 }
 
+type ErrWriteMethod struct {
+	Method string
+}
+
+func (e ErrWriteMethod) Error() string {
+	return fmt.Sprintf("method not allowed in read-only mode: %s", e.Method)
+}
+
 type ErrUnexpected struct {
 	When string
 	Got  string

--- a/precompiles/types/errors_test.go
+++ b/precompiles/types/errors_test.go
@@ -13,9 +13,7 @@ func Test_ErrInvalidAddr(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid address foo, reason: bar"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidAddr{"foo", "bar"}, e)
 }
 
@@ -26,9 +24,7 @@ func Test_ErrInvalidNumberOfArgs(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid number of arguments; expected 2; got: 1"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidNumberOfArgs{1, 2}, e)
 }
 
@@ -38,9 +34,7 @@ func Test_ErrInvalidArgument(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid argument: foo"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidArgument{"foo"}, e)
 }
 
@@ -50,9 +44,7 @@ func Test_ErrInvalidMethod(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid method: foo"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidMethod{"foo"}, e)
 }
 
@@ -65,9 +57,7 @@ func Test_ErrInvalidCoin(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid coin: denom: foo, is negative: true, is nil: false, is empty: false"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidCoin{"foo", true, false, false}, e)
 }
 
@@ -77,9 +67,7 @@ func Test_ErrInvalidAmount(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid token amount: foo"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidAmount{"foo"}, e)
 }
 
@@ -90,9 +78,7 @@ func Test_ErrUnexpected(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "unexpected error in foo: bar"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrUnexpected{"foo", "bar"}, e)
 }
 
@@ -103,9 +89,7 @@ func Test_ErrInsufficientBalance(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "insufficient balance: requested foo, current bar"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInsufficientBalance{"foo", "bar"}, e)
 }
 
@@ -116,9 +100,7 @@ func Test_ErrInvalidToken(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "invalid token foo: bar"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrInvalidToken{"foo", "bar"}, e)
 }
 
@@ -128,8 +110,6 @@ func Test_ErrWriteMethod(t *testing.T) {
 	}
 	got := e.Error()
 	expect := "method not allowed in read-only mode: foo"
-	if got != expect {
-		t.Errorf("Expected %v, got %v", expect, got)
-	}
+	require.Equal(t, expect, got)
 	require.ErrorIs(t, ErrWriteMethod{"foo"}, e)
 }

--- a/precompiles/types/errors_test.go
+++ b/precompiles/types/errors_test.go
@@ -121,3 +121,15 @@ func Test_ErrInvalidToken(t *testing.T) {
 	}
 	require.ErrorIs(t, ErrInvalidToken{"foo", "bar"}, e)
 }
+
+func Test_ErrWriteMethod(t *testing.T) {
+	e := ErrWriteMethod{
+		Method: "foo",
+	}
+	got := e.Error()
+	expect := "method not allowed in read-only mode: foo"
+	if got != expect {
+		t.Errorf("Expected %v, got %v", expect, got)
+	}
+	require.ErrorIs(t, ErrWriteMethod{"foo"}, e)
+}


### PR DESCRIPTION
# Description

Minor refactor, not associated to any issue or changelog. This is part of the preparation work before introducing the distribute functions.

The EVM marks `staticcall` as a readOnly low-level call, with this PR we avoid running write methods through static calls.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [X] Go unit tests
- [X] Go integration tests
- [X] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a read-only mode for staking operations, providing enhanced control over method execution.
  
- **Bug Fixes**
	- Improved error messaging for operations attempted in read-only mode, offering clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->