### PR TITLE
ci: remove v2 migration test from scheduled CI and release workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,6 @@ jobs:
               core.setOutput('SOLANA_TESTS', true);
               core.setOutput('TON_TESTS', true);
               core.setOutput('V2_TESTS', true); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
-              core.setOutput('V2_MIGRATION_TESTS', true); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
             } else if (context.eventName === 'schedule') {
               core.setOutput('DEFAULT_TESTS', true);
               core.setOutput('UPGRADE_TESTS', true);
@@ -102,7 +101,6 @@ jobs:
               core.setOutput('SOLANA_TESTS', true);
               core.setOutput('TON_TESTS', true);
               core.setOutput('V2_TESTS', true); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
-              core.setOutput('V2_MIGRATION_TESTS', true); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
             } else if (context.eventName === 'workflow_dispatch') {
               const makeTargets = context.payload.inputs['make-targets'].split(',');
               core.setOutput('DEFAULT_TESTS', makeTargets.includes('default-test'));


### PR DESCRIPTION
# Description

The test is not functional when running from develop as it uses v2 contracts pre-deployed by default
 
Just keep it in manual workflow for now for exceptional case (we have to make a new hotfix on v20)

Will be completely removed once v2 migration completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated test execution logic to streamline conditions for running specific tests based on GitHub event types. 
	- Removed certain outputs for `push` and `schedule` events, focusing on `workflow_dispatch` events for `V2_MIGRATION_TESTS`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->