### PR TITLE
fix: bump go tss to remove dht

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -366,4 +366,4 @@ replace github.com/evmos/ethermint => github.com/zeta-chain/ethermint v0.0.0-202
 
 replace github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
 
-replace gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20240907163312-b576693642e0
+replace gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20241022120736-f4e1f77ec142

--- a/go.sum
+++ b/go.sum
@@ -1669,8 +1669,8 @@ github.com/zeta-chain/ethermint v0.0.0-20240910000510-6248efa8bc4f h1:de8f21SSof
 github.com/zeta-chain/ethermint v0.0.0-20240910000510-6248efa8bc4f/go.mod h1:s1zA6OpXv3Tb5I0M6M6j5fo/AssaZL/pgkc7G0W2kN8=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
-github.com/zeta-chain/go-tss v0.0.0-20240907163312-b576693642e0 h1:OMuw0XgFcX0RQ8+B3gtreV4H/JPglCSfG2PfVi7bONM=
-github.com/zeta-chain/go-tss v0.0.0-20240907163312-b576693642e0/go.mod h1:LN1IBRN8xQkKgdgLhl5BDGZyPm70QOTbVLejdS2FVpo=
+github.com/zeta-chain/go-tss v0.0.0-20241022120736-f4e1f77ec142 h1:IdYDcONvTd/Qhi9sZ/msMJgY53c5M/PuyrZ79kl+XxI=
+github.com/zeta-chain/go-tss v0.0.0-20241022120736-f4e1f77ec142/go.mod h1:LN1IBRN8xQkKgdgLhl5BDGZyPm70QOTbVLejdS2FVpo=
 github.com/zeta-chain/keystone/keys v0.0.0-20231105174229-903bc9405da2 h1:gd2uE0X+ZbdFJ8DubxNqLbOVlCB12EgWdzSNRAR82tM=
 github.com/zeta-chain/keystone/keys v0.0.0-20231105174229-903bc9405da2/go.mod h1:x7Bkwbzt2W2lQfjOirnff0Dj+tykdbTG1FMJPVPZsvE=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20240819143729-b8229cd7b410 h1:sBeVX63s/qmfT1KnIKj1Y2SK3PsFpAM/P49ODcD1CN8=


### PR DESCRIPTION
# Description

Uses this commit: https://github.com/zeta-chain/go-tss/commit/f4e1f77ec1425d8391cfd89a3932db50ad4ea229
Removing dht to disable discovery.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
