### PR TITLE
fix: SetGatewayAddress might set invalid gateway address

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 * [2925](https://github.com/zeta-chain/node/pull/2925) - add recover to init chainer to diplay informative message when starting a node from block 1
 * [2909](https://github.com/zeta-chain/node/pull/2909) - add legacy messages back to codec for querier backward compatibility
 * [3018](https://github.com/zeta-chain/node/pull/3018) - support `DepositAndCall` and `WithdrawAndCall` with empty payload
+* [3030](https://github.com/zeta-chain/node/pull/3030) - Avoid storing invalid Solana gateway address in the `SetGatewayAddress`
 
 ## v20.0.0
 

--- a/tests/simulation/sim/sim_state.go
+++ b/tests/simulation/sim/sim_state.go
@@ -248,7 +248,7 @@ func AppStateFromGenesisFileFn(
 	cdc codec.JSONCodec,
 	genesisFile string,
 ) (tmtypes.GenesisDoc, []simtypes.Account, error) {
-	bytes, err := os.ReadFile(genesisFile)
+	bytes, err := os.ReadFile(genesisFile) // #nosec G304 -- genesisFile value is controlled
 	if err != nil {
 		panic(err)
 	}

--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -192,7 +192,8 @@ func (signer *Signer) SetGatewayAddress(address string) {
 	// parse gateway ID and PDA
 	gatewayID, pda, err := contracts.ParseGatewayIDAndPda(address)
 	if err != nil {
-		signer.Logger().Std.Error().Err(err).Msgf("cannot parse gateway address %s", address)
+		signer.Logger().Std.Error().Err(err).Msgf("cannot parse gateway address: %s", address)
+		return
 	}
 
 	// update gateway ID and PDA

--- a/zetaclient/chains/solana/signer/signer_test.go
+++ b/zetaclient/chains/solana/signer/signer_test.go
@@ -102,6 +102,48 @@ func Test_NewSigner(t *testing.T) {
 	}
 }
 
+func Test_SetGatewayAddress(t *testing.T) {
+	// test parameters
+	chain := chains.SolanaDevnet
+	chainParams := sample.ChainParams(chain.ChainId)
+	chainParams.GatewayAddress = testutils.GatewayAddresses[chain.ChainId]
+
+	// helper functor to create signer
+	signerCreator := func() *signer.Signer {
+		s, err := signer.NewSigner(chain, *chainParams, nil, nil, nil, nil, base.DefaultLogger())
+		require.NoError(t, err)
+		return s
+	}
+
+	// test cases
+	tests := []struct {
+		name       string
+		signer     *signer.Signer
+		newAddress string
+		expected   string
+	}{
+		{
+			name:       "should set new gateway address",
+			signer:     signerCreator(),
+			newAddress: "9Z5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d",
+			expected:   "9Z5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d",
+		},
+		{
+			name:       "should not set invalid gateway address",
+			signer:     signerCreator(),
+			newAddress: "invalid",
+			expected:   chainParams.GatewayAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.signer.SetGatewayAddress(tt.newAddress)
+			require.Equal(t, tt.expected, tt.signer.GetGatewayAddress())
+		})
+	}
+}
+
 func Test_SetRelayerBalanceMetrics(t *testing.T) {
 	// test parameters
 	chain := chains.SolanaDevnet


### PR DESCRIPTION
# Description

Fixed the issue in method `SetGatewayAddress` and add unit test.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Support for stateful precompiled contracts.
	- Common importable RPC package added.
	- Enhancements to staking and Bitcoin functionalities.
	- Integration of authenticated calls for smart contracts.
	- Support for multiple Bitcoin chains and non-EVM standard inbound memo package.

- **Bug Fixes**
	- Improved error handling for gateway address parsing.
	- Resolved issues with operator voting on discarded keygen ballots.
	- Enhanced outbound tracker to prevent blocking confirmations.

- **Tests**
	- Added new test for setting gateway address.
	- Enhanced existing tests for relayer balance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->