### PR TITLE
chore: always set explicit base compose file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER ?= docker
 # allow setting of NODE_COMPOSE_ARGS to pass additional args to docker compose
 # useful for setting profiles and/ort optional overlays
 # example: NODE_COMPOSE_ARGS="--profile monitoring -f docker-compose-persistent.yml"
-DOCKER_COMPOSE ?= $(DOCKER) compose $(NODE_COMPOSE_ARGS)
+DOCKER_COMPOSE ?= $(DOCKER) compose -f docker-compose.yml $(NODE_COMPOSE_ARGS)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 GOFLAGS := ""
 GOLANG_CROSS_VERSION ?= v1.22.4
@@ -221,11 +221,11 @@ start-localnet: zetanode start-localnet-skip-build
 start-localnet-skip-build:
 	@echo "--> Starting localnet"
 	export LOCALNET_MODE=setup-only && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
 
 # stop-localnet should include all profiles so other containers are also removed
 stop-localnet:
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile all -f docker-compose.yml down --remove-orphans
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile all down --remove-orphans
 
 ###############################################################################
 ###                         E2E tests               						###
@@ -253,22 +253,22 @@ start-e2e-test: zetanode
 start-e2e-admin-test: zetanode
 	@echo "--> Starting e2e admin test"
 	export E2E_ARGS="--skip-regular --test-admin" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile eth2 -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile eth2 up -d
 
 start-e2e-performance-test: zetanode
 	@echo "--> Starting e2e performance test"
 	export E2E_ARGS="--test-performance" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
 start-e2e-import-mainnet-test: zetanode
 	@echo "--> Starting e2e import-data test"
 	export ZETACORED_IMPORT_GENESIS_DATA=true && \
 	export ZETACORED_START_PERIOD=15m && \
-	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) -f docker-compose.yml up -d
+	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) up -d
 
 start-stress-test: zetanode
 	@echo "--> Starting stress test"
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
 start-tss-migration-test: zetanode
 	@echo "--> Starting tss migration test"
@@ -279,17 +279,17 @@ start-tss-migration-test: zetanode
 start-solana-test: zetanode solana
 	@echo "--> Starting solana test"
 	export E2E_ARGS="--skip-regular --test-solana" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile solana -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile solana up -d
 
 start-ton-test: zetanode
 	@echo "--> Starting TON test"
 	export E2E_ARGS="--skip-regular --test-ton" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile ton -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile ton up -d
 
 start-v2-test: zetanode
 	@echo "--> Starting e2e smart contracts v2 test"
 	export E2E_ARGS="--skip-regular --test-v2" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) -f docker-compose.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
 
 ###############################################################################
 ###                         Upgrade Tests              						###
@@ -321,20 +321,20 @@ start-upgrade-test: zetanode-upgrade
 	@echo "--> Starting upgrade test"
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=225 && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 start-upgrade-test-light: zetanode-upgrade
 	@echo "--> Starting light upgrade test (no ZetaChain state populating before upgrade)"
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=90 && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 start-upgrade-test-admin: zetanode-upgrade
 	@echo "--> Starting admin upgrade test"
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=90 && \
 	export E2E_ARGS="--skip-regular --test-admin" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 # this test upgrades from v18 and execute the v2 contracts migration process
 # this tests is part of upgrade test part because it should run the upgrade from v18 to fully replicate the upgrade process
@@ -343,7 +343,7 @@ start-upgrade-v2-migration-test: zetanode-upgrade
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=90 && \
 	export E2E_ARGS="--test-v2-migration" && \
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 
 start-upgrade-import-mainnet-test: zetanode-upgrade
@@ -352,7 +352,7 @@ start-upgrade-import-mainnet-test: zetanode-upgrade
 	export ZETACORED_IMPORT_GENESIS_DATA=true && \
 	export ZETACORED_START_PERIOD=15m && \
 	export UPGRADE_HEIGHT=225 && \
-	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose.yml -f docker-compose-upgrade.yml up -d
+	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 
 ###############################################################################

--- a/docs/development/LOCAL_TESTING.md
+++ b/docs/development/LOCAL_TESTING.md
@@ -41,7 +41,7 @@ This uses `docker compose` to start the localnet and run standard e2e tests insi
 More options directly to `docker compose` via the `NODE_COMPOSE_ARGS` variable. This allows setting additional profiles or configuring an overlay. Example:
 
 ```
-example: NODE_COMPOSE_ARGS="--profile monitoring -f docker-compose-persistent.yml"`
+export NODE_COMPOSE_ARGS="--profile monitoring -f docker-compose-persistent.yml"
 make start-e2e-test
 ```
 


### PR DESCRIPTION
# Description

```
export NODE_COMPOSE_ARGS="-f docker-compose-persistent.yml"
make start-e2e-test
```

was broken because we did not provide `-f docker-compose.yml` in `start-e2e-test`. Ensure it's always provided explicitly via the `DOCKER_COMPOSE` variable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the Docker Compose command usage for localnet services.
	- Added a section for testing governance proposals in the documentation.

- **Documentation**
	- Improved structure and clarity in the `LOCAL_TESTING.md` document.
	- Standardized formatting for command examples and expanded descriptions for better usability.
	- Included additional details on monitoring setup and interaction with ZetaChain and EVM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->