### PR TITLE
test(e2e): update testdapp contract in deploy test

### DIFF
--- a/e2e/e2etests/test_deploy_contract.go
+++ b/e2e/e2etests/test_deploy_contract.go
@@ -6,9 +6,9 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zeta-chain/node/e2e/contracts/testdapp"
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/pkg/contracts/testdappv2"
 )
 
 // deployFunc is a function that deploys a contract
@@ -42,11 +42,9 @@ func TestDeployContract(r *runner.E2ERunner, args []string) {
 
 // deployZEVMTestDApp deploys the TestDApp contract on ZetaChain
 func deployZEVMTestDApp(r *runner.E2ERunner) (ethcommon.Address, error) {
-	addr, tx, _, err := testdapp.DeployTestDApp(
+	addr, tx, _, err := testdappv2.DeployTestDAppV2(
 		r.ZEVMAuth,
 		r.ZEVMClient,
-		r.ConnectorZEVMAddr,
-		r.WZetaAddr,
 	)
 	if err != nil {
 		return addr, err
@@ -63,11 +61,9 @@ func deployZEVMTestDApp(r *runner.E2ERunner) (ethcommon.Address, error) {
 
 // deployEVMTestDApp deploys the TestDApp contract on Ethereum
 func deployEVMTestDApp(r *runner.E2ERunner) (ethcommon.Address, error) {
-	addr, tx, _, err := testdapp.DeployTestDApp(
+	addr, tx, _, err := testdappv2.DeployTestDAppV2(
 		r.EVMAuth,
 		r.EVMClient,
-		r.ConnectorEthAddr,
-		r.ZetaEthAddr,
 	)
 	if err != nil {
 		return addr, err


### PR DESCRIPTION
# Description

TestDAppV2 has replaced TestDapp, replaces the contract in the deploy test as the later will no longer be deployed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded contract deployment functionality with the introduction of `testdappv2`.
	- Streamlined deployment process for ZetaChain and Ethereum contracts by simplifying parameters.
  
These changes enhance the efficiency and clarity of the contract deployment process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->