### PR TITLE
fix: move btc std memo tests to advanced tests

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -302,10 +302,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestBitcoinDepositName,
 			e2etests.TestBitcoinDepositAndCallName,
 			e2etests.TestBitcoinDepositAndCallRevertName,
-			e2etests.TestBitcoinStdMemoDepositName,
-			e2etests.TestBitcoinStdMemoDepositAndCallName,
-			e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
-			e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
 			e2etests.TestBitcoinWithdrawSegWitName,
 			e2etests.TestBitcoinWithdrawInvalidAddressName,
 			e2etests.TestZetaWithdrawBTCRevertName,
@@ -318,6 +314,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestBitcoinWithdrawP2SHName,
 			e2etests.TestBitcoinWithdrawP2WSHName,
 			e2etests.TestBitcoinWithdrawRestrictedName,
+			e2etests.TestBitcoinStdMemoDepositName,
+			e2etests.TestBitcoinStdMemoDepositAndCallName,
+			e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
+			e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
 		}
 		ethereumTests := []string{
 			e2etests.TestEtherWithdrawName,


### PR DESCRIPTION
# Description

Move bitcoin std tests to advanced so they are not run before upgrade

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Restructured test cases for Bitcoin memo deposits, improving organization and clarity in testing processes.
  
- **Documentation**
	- Updated comments for enhanced clarity on the purpose of code sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->