### PR TITLE
chore: upgrade protocol contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/zeta-chain/ethermint v0.0.0-20241010181243-044e22bdb7e7
 	github.com/zeta-chain/keystone/keys v0.0.0-20240826165841-3874f358c138
-	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c
+	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241028082130-577403818960
 	gitlab.com/thorchain/tss/go-tss v1.6.5
 	go.nhat.io/grpcmock v0.25.0
 	golang.org/x/crypto v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -4208,8 +4208,8 @@ github.com/zeta-chain/go-tss v0.0.0-20240916173049-89fee4b0ae7f h1:XqUvw9a3EnDa2
 github.com/zeta-chain/go-tss v0.0.0-20240916173049-89fee4b0ae7f/go.mod h1:B1FDE6kHs8hozKSX1/iXgCdvlFbS6+FeAupoBHDK0Cc=
 github.com/zeta-chain/keystone/keys v0.0.0-20240826165841-3874f358c138 h1:vck/FcIIpFOvpBUm0NO17jbEtmSz/W/a5Y4jRuSJl6I=
 github.com/zeta-chain/keystone/keys v0.0.0-20240826165841-3874f358c138/go.mod h1:U494OsZTWsU75hqoriZgMdSsgSGP1mUL1jX+wN/Aez8=
-github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c h1:ZoFxMMZtivRLquXVq1sEVlT45UnTPMO1MSXtc88nDv4=
-github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
+github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241028082130-577403818960 h1:uLcbGIyQzhFkbxcnRyc4RUjRHMfR/rrztFG7jvR3EUs=
+github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241028082130-577403818960/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901 h1:9whtN5fjYHfk4yXIuAsYP2EHxImwDWDVUOnZJ2pfL3w=
 github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901/go.mod h1:d2iTC62s9JwKiCMPhcDDXbIZmuzAyJ4lwso0H5QyRbk=
 github.com/zondax/hid v0.9.1/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=


### PR DESCRIPTION
# Description

Update protocol contracts dependency to latest version.

Original idea of the issue was to create a tag in https://github.com/zeta-chain/protocol-contracts to use as reference in dependency

However, Go requires using release semantic, and if we use the released used in the repo (v11.0.0) will be used for node v21, we need to update all import to specify `protocol-contracts/v11`, which doesn't make much sense for this case imo.

We can:
- use v11..0.0 tag and update all imports in the codebase
- use v11..0.0 and use a replace statement in go.mod to remove v11 and keep current imports (not very clean IMO)
- continue using a commit hash, current solution here

Feedback welcome