### PR TITLE
chore: set v21 upgrade version

### DIFF
--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -7,9 +7,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
-
-	"github.com/zeta-chain/node/pkg/constant"
 )
+
+const releaseVersion = "v21"
 
 func SetupHandlers(app *App) {
 	allUpgrades := upgradeTracker{
@@ -51,9 +51,9 @@ func SetupHandlers(app *App) {
 	}
 
 	app.UpgradeKeeper.SetUpgradeHandler(
-		constant.Version,
+		releaseVersion,
 		func(ctx sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			app.Logger().Info("Running upgrade handler for " + constant.Version)
+			app.Logger().Info("Running upgrade handler for " + releaseVersion)
 
 			var err error
 			for _, upgradeHandler := range upgradeHandlerFns {
@@ -71,7 +71,7 @@ func SetupHandlers(app *App) {
 	if err != nil {
 		panic(err)
 	}
-	if upgradeInfo.Name == constant.Version && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == releaseVersion && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// Use upgrade store loader for the initial loading of all stores when app starts,
 		// it checks if version == upgradeHeight and applies store upgrades before loading the stores,
 		// so that new stores start with the correct version (the current height of chain),

--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -39,7 +39,7 @@ fi
 # get new zetacored version
 curl -L -o /tmp/zetacored.new "${ZETACORED_URL}"
 chmod +x /tmp/zetacored.new
-UPGRADE_NAME=$(/tmp/zetacored.new version)
+UPGRADE_NAME="v21"
 
 # if explicit upgrade height not provided, use dumb estimator
 if [[ -z $UPGRADE_HEIGHT ]]; then


### PR DESCRIPTION
# Description

Set explicit upgrade handler version for v21 like we did in v20

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
