### PR TITLE
fix(`e2e`): wrong evm client used for `TestDAppV2ZEVM`

### DIFF
--- a/cmd/zetae2e/config/contracts.go
+++ b/cmd/zetae2e/config/contracts.go
@@ -277,7 +277,7 @@ func setContractsFromConfig(r *runner.E2ERunner, conf config.Config) error {
 		if err != nil {
 			return fmt.Errorf("invalid TestDAppV2Addr: %w", err)
 		}
-		r.TestDAppV2ZEVM, err = testdappv2.NewTestDAppV2(r.TestDAppV2ZEVMAddr, r.EVMClient)
+		r.TestDAppV2ZEVM, err = testdappv2.NewTestDAppV2(r.TestDAppV2ZEVMAddr, r.ZEVMClient)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

Replace EVMClient with ZEVMClient.

The bug prevents running DepositAndCall tests on live networks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the contract instantiation process for improved interaction with the ZEVM context.
  
- **Bug Fixes**
	- Corrected the client used for initializing the TestDAppV2 contract, enhancing its functionality within the ZEVM environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->