### PR TITLE
test(`e2e`): improve E2E reliability for tests on live network

### DIFF
--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -155,7 +155,8 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 
 // parseCmdArgsToE2ETestRunConfig parses command-line arguments into a slice of E2ETestRunConfig structs.
 func parseCmdArgsToE2ETestRunConfig(args []string) ([]runner.E2ETestRunConfig, error) {
-	var tests []runner.E2ETestRunConfig
+	tests := make([]runner.E2ETestRunConfig, 0, len(args))
+
 	for _, arg := range args {
 		parts := strings.SplitN(arg, ":", 2)
 		testName := parts[0]

--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -155,20 +155,21 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 
 // parseCmdArgsToE2ETestRunConfig parses command-line arguments into a slice of E2ETestRunConfig structs.
 func parseCmdArgsToE2ETestRunConfig(args []string) ([]runner.E2ETestRunConfig, error) {
-	tests := []runner.E2ETestRunConfig{}
+	var tests []runner.E2ETestRunConfig
 	for _, arg := range args {
 		parts := strings.SplitN(arg, ":", 2)
-		if len(parts) != 2 {
-			return nil, errors.New("command arguments should be in format: testName:testArgs")
-		}
-		if parts[0] == "" {
+		testName := parts[0]
+		if testName == "" {
 			return nil, errors.New("missing testName")
 		}
-		testName := parts[0]
-		testArgs := []string{}
-		if parts[1] != "" {
-			testArgs = strings.Split(parts[1], ",")
+
+		var testArgs []string
+		if len(parts) > 1 {
+			if parts[1] != "" {
+				testArgs = strings.Split(parts[1], ",")
+			}
 		}
+
 		tests = append(tests, runner.E2ETestRunConfig{
 			Name: testName,
 			Args: testArgs,

--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -1,10 +1,10 @@
 package e2etests
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"math/big"
-	"math/rand"
 	"strconv"
-	"time"
 
 	"cosmossdk.io/math"
 	"github.com/btcsuite/btcd/btcjson"
@@ -19,13 +19,15 @@ import (
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/chains"
 	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
-	"github.com/zeta-chain/node/testutil/sample"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-func randomText() string {
-	// #nosec G404 test purpose - weak randomness is not an issue here
-	return sample.StringRandom(rand.New(rand.NewSource(time.Now().UnixNano())), 50)
+func randomText(r *runner.E2ERunner) string {
+	bytes := make([]byte, 50)
+	_, err := rand.Read(bytes)
+	require.NoError(r, err)
+
+	return hex.EncodeToString(bytes)
 }
 
 func withdrawBTCZRC20(r *runner.E2ERunner, to btcutil.Address, amount *big.Int) *btcjson.TxRawResult {

--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -2,7 +2,9 @@ package e2etests
 
 import (
 	"math/big"
+	"math/rand"
 	"strconv"
+	"time"
 
 	"cosmossdk.io/math"
 	"github.com/btcsuite/btcd/btcjson"
@@ -17,8 +19,14 @@ import (
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/chains"
 	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
+	"github.com/zeta-chain/node/testutil/sample"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
+
+func randomText() string {
+	// #nosec G404 test purpose - weak randomness is not an issue here
+	return sample.StringRandom(rand.New(rand.NewSource(time.Now().UnixNano())), 50)
+}
 
 func withdrawBTCZRC20(r *runner.E2ERunner, to btcutil.Address, amount *big.Int) *btcjson.TxRawResult {
 	tx, err := r.BTCZRC20.Approve(

--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -22,7 +22,8 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-func randomText(r *runner.E2ERunner) string {
+// randomPayload generates a random payload to be used in gateway calls for testing purposes
+func randomPayload(r *runner.E2ERunner) string {
 	bytes := make([]byte, 50)
 	_, err := rand.Read(bytes)
 	require.NoError(r, err)

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call.go
@@ -20,7 +20,7 @@ func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call.go
@@ -2,8 +2,6 @@ package e2etests
 
 import (
 	"math/big"
-	"math/rand"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
@@ -11,7 +9,6 @@ import (
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
-	"github.com/zeta-chain/node/testutil/sample"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
@@ -23,14 +20,12 @@ func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	oldBalance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
-
-	sample.StringRandom(rand.New(rand.NewSource(time.Now().UnixNano())), 50)
 
 	// perform the deposit
 	tx := r.V2ERC20DepositAndCall(

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
@@ -20,7 +20,7 @@ func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
@@ -12,8 +12,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageDepositOnRevertERC20 = "this is a test ERC20 deposit and call on revert"
-
 func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -22,13 +20,15 @@ func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageDepositOnRevertERC20, amount)
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	// perform the deposit
 	tx := r.V2ERC20DepositAndCall(r.TestDAppV2ZEVMAddr, amount, []byte("revert"), gatewayevm.RevertOptions{
 		RevertAddress:    r.TestDAppV2EVMAddr,
 		CallOnRevert:     true,
-		RevertMessage:    []byte(payloadMessageDepositOnRevertERC20),
+		RevertMessage:    []byte(payload),
 		OnRevertGasLimit: big.NewInt(200000),
 	})
 
@@ -38,12 +38,12 @@ func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageDepositOnRevertERC20, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageDepositOnRevertERC20),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, r.EVMAuth.From, senderForMsg)

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
@@ -20,7 +20,7 @@ func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_arbitrary_call.go
@@ -17,7 +17,7 @@ func TestV2ERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCall")
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_arbitrary_call.go
@@ -11,15 +11,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageWithdrawERC20 = "this is a test ERC20 withdraw and call payload"
-
 func TestV2ERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCall")
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageWithdrawERC20, amount)
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -28,7 +28,7 @@ func TestV2ERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ERC20WithdrawAndArbitraryCall(
 		r.TestDAppV2EVMAddr,
 		amount,
-		r.EncodeERC20Call(r.ERC20Addr, amount, payloadMessageWithdrawERC20),
+		r.EncodeERC20Call(r.ERC20Addr, amount, payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -37,5 +37,5 @@ func TestV2ERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageWithdrawERC20, amount)
+	r.AssertTestDAppEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_arbitrary_call.go
@@ -17,7 +17,7 @@ func TestV2ERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCall")
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
@@ -12,8 +12,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageWithdrawAuthenticatedCallERC20 = "this is a test ERC20 withdraw and authenticated call payload"
-
 func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, _ []string) {
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000
@@ -25,7 +23,9 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, _ []string) {
 	// without decoding the payload and amount handling for erc20, purpose of test is to verify correct sender and payload are used
 	amount := big.NewInt(10000)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageWithdrawAuthenticatedCallERC20, amount)
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -34,7 +34,7 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, _ []string) {
 	tx := r.V2ERC20WithdrawAndCall(
 		r.TestDAppV2EVMAddr,
 		amount,
-		[]byte(payloadMessageWithdrawAuthenticatedCallERC20),
+		[]byte(payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -43,12 +43,12 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, _ []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageWithdrawAuthenticatedCallERC20, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageWithdrawAuthenticatedCallERC20),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, r.ZEVMAuth.From, senderForMsg)

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
@@ -23,7 +23,7 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, _ []string) {
 	// without decoding the payload and amount handling for erc20, purpose of test is to verify correct sender and payload are used
 	amount := big.NewInt(10000)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
@@ -23,7 +23,7 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, _ []string) {
 	// without decoding the payload and amount handling for erc20, purpose of test is to verify correct sender and payload are used
 	amount := big.NewInt(10000)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
@@ -12,15 +12,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageWithdrawOnRevertERC20 = "this is a test ERC20 withdraw and call on revert"
-
 func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCallRevertWithCall")
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageWithdrawOnRevertERC20, amount)
+	payload := randomText()
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -33,7 +33,7 @@ func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string
 		gatewayzevm.RevertOptions{
 			RevertAddress:    r.TestDAppV2ZEVMAddr,
 			CallOnRevert:     true,
-			RevertMessage:    []byte(payloadMessageWithdrawOnRevertERC20),
+			RevertMessage:    []byte(payload),
 			OnRevertGasLimit: big.NewInt(0),
 		},
 	)
@@ -43,12 +43,12 @@ func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppZEVMCalled(true, payloadMessageWithdrawOnRevertERC20, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageWithdrawOnRevertERC20),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, r.ZEVMAuth.From, senderForMsg)

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
@@ -18,7 +18,7 @@ func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCallRevertWithCall")
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
@@ -18,7 +18,7 @@ func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCallRevertWithCall")
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call.go
@@ -18,7 +18,7 @@ func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHDepositAndCall")
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call.go
@@ -18,7 +18,7 @@ func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHDepositAndCall")
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call.go
@@ -12,15 +12,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageDepositETH = "this is a test ETH deposit and call payload"
-
 func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHDepositAndCall")
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageDepositETH, amount)
+	payload := randomText()
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	oldBalance, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -29,7 +29,7 @@ func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ETHDepositAndCall(
 		r.TestDAppV2ZEVMAddr,
 		amount,
-		[]byte(payloadMessageDepositETH),
+		[]byte(payload),
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -39,7 +39,7 @@ func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payloadMessageDepositETH, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, amount)
 
 	// check the balance was updated
 	newBalance, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)

--- a/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
@@ -20,7 +20,7 @@ func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
@@ -20,7 +20,7 @@ func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
@@ -12,8 +12,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageDepositOnRevertETH = "this is a test ETH deposit and call on revert"
-
 func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -22,13 +20,15 @@ func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageDepositOnRevertETH, amount)
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	// perform the deposit
 	tx := r.V2ETHDepositAndCall(r.TestDAppV2ZEVMAddr, amount, []byte("revert"), gatewayevm.RevertOptions{
 		RevertAddress:    r.TestDAppV2EVMAddr,
 		CallOnRevert:     true,
-		RevertMessage:    []byte(payloadMessageDepositOnRevertETH),
+		RevertMessage:    []byte(payload),
 		OnRevertGasLimit: big.NewInt(200000),
 	})
 
@@ -38,12 +38,12 @@ func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageDepositOnRevertETH, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageDepositOnRevertETH),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, r.EVMAuth.From, senderForMsg)

--- a/e2e/e2etests/test_v2_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_arbitrary_call.go
@@ -17,7 +17,7 @@ func TestV2ETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_arbitrary_call.go
@@ -11,15 +11,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageWithdrawETH = "this is a test ETH withdraw and call payload"
-
 func TestV2ETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageWithdrawETH, amount)
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -27,7 +27,7 @@ func TestV2ETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ETHWithdrawAndArbitraryCall(
 		r.TestDAppV2EVMAddr,
 		amount,
-		r.EncodeGasCall(payloadMessageWithdrawETH),
+		r.EncodeGasCall(payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -36,5 +36,5 @@ func TestV2ETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageWithdrawETH, amount)
+	r.AssertTestDAppEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_v2_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_arbitrary_call.go
@@ -17,7 +17,7 @@ func TestV2ETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call.go
@@ -24,7 +24,7 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call.go
@@ -12,8 +12,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageAuthenticatedWithdrawETH = "this is a test ETH withdraw and authenticated call payload"
-
 func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -26,7 +24,9 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageAuthenticatedWithdrawETH, amount)
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -34,7 +34,7 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ETHWithdrawAndCall(
 		r.TestDAppV2EVMAddr,
 		amount,
-		[]byte(payloadMessageAuthenticatedWithdrawETH),
+		[]byte(payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -43,12 +43,12 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageAuthenticatedWithdrawETH, amount)
+	r.AssertTestDAppEVMCalled(true, payload, amount)
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageAuthenticatedWithdrawETH),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, r.ZEVMAuth.From, senderForMsg)

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call.go
@@ -24,7 +24,7 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
@@ -18,7 +18,7 @@ func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCallRevertWithCall")
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
@@ -18,7 +18,7 @@ func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCallRevertWithCall")
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, amount)
 

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
@@ -12,15 +12,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageWithdrawOnRevertETH = "this is a test ETH withdraw and call on revert"
-
 func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCallRevertWithCall")
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageWithdrawOnRevertETH, amount)
+	payload := randomText()
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -32,7 +32,7 @@ func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 		gatewayzevm.RevertOptions{
 			RevertAddress:    r.TestDAppV2ZEVMAddr,
 			CallOnRevert:     true,
-			RevertMessage:    []byte(payloadMessageWithdrawOnRevertETH),
+			RevertMessage:    []byte(payload),
 			OnRevertGasLimit: big.NewInt(0),
 		},
 	)
@@ -42,12 +42,12 @@ func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppZEVMCalled(true, payloadMessageWithdrawOnRevertETH, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageWithdrawOnRevertETH),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, r.ZEVMAuth.From, senderForMsg)

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_through_contract.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_through_contract.go
@@ -12,8 +12,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageAuthenticatedWithdrawETHThroughContract = "this is a test ETH withdraw and authenticated call payload through contract"
-
 func TestV2ETHWithdrawAndCallThroughContract(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -40,10 +38,12 @@ func TestV2ETHWithdrawAndCallThroughContract(r *runner.E2ERunner, args []string)
 	require.NoError(r, err)
 	utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 
+	payload := randomText()
+
 	// perform the authenticated call
 	tx = r.V2ETHWithdrawAndCallThroughContract(gatewayCaller, r.TestDAppV2EVMAddr,
 		amount,
-		[]byte(payloadMessageAuthenticatedWithdrawETHThroughContract),
+		[]byte(payload),
 		gatewayzevmcaller.RevertOptions{OnRevertGasLimit: big.NewInt(0)})
 
 	utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
@@ -51,12 +51,12 @@ func TestV2ETHWithdrawAndCallThroughContract(r *runner.E2ERunner, args []string)
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageAuthenticatedWithdrawETHThroughContract, amount)
+	r.AssertTestDAppEVMCalled(true, payload, amount)
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageAuthenticatedWithdrawETHThroughContract),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, gatewayCallerAddr, senderForMsg)

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_through_contract.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_through_contract.go
@@ -38,7 +38,7 @@ func TestV2ETHWithdrawAndCallThroughContract(r *runner.E2ERunner, args []string)
 	require.NoError(r, err)
 	utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	// perform the authenticated call
 	tx = r.V2ETHWithdrawAndCallThroughContract(gatewayCaller, r.TestDAppV2EVMAddr,

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_through_contract.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_through_contract.go
@@ -38,7 +38,7 @@ func TestV2ETHWithdrawAndCallThroughContract(r *runner.E2ERunner, args []string)
 	require.NoError(r, err)
 	utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	// perform the authenticated call
 	tx = r.V2ETHWithdrawAndCallThroughContract(gatewayCaller, r.TestDAppV2EVMAddr,

--- a/e2e/e2etests/test_v2_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_v2_evm_to_zevm_call.go
@@ -14,7 +14,7 @@ import (
 func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_v2_evm_to_zevm_call.go
@@ -14,7 +14,7 @@ import (
 func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_v2_evm_to_zevm_call.go
@@ -11,17 +11,17 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageZEVMCall = "this is a test ZEVM call payload"
-
 func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageZEVMCall, big.NewInt(0))
+	payload := randomText()
+
+	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
 
 	// perform the withdraw
 	tx := r.V2EVMToZEMVCall(
 		r.TestDAppV2ZEVMAddr,
-		[]byte(payloadMessageZEVMCall),
+		[]byte(payload),
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -31,5 +31,5 @@ func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payloadMessageZEVMCall, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_zevm_to_evm_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_arbitrary_call.go
@@ -14,7 +14,7 @@ import (
 func TestV2ZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_zevm_to_evm_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_arbitrary_call.go
@@ -14,7 +14,7 @@ import (
 func TestV2ZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_zevm_to_evm_arbitrary_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_arbitrary_call.go
@@ -11,12 +11,12 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageEVMCall = "this is a test EVM call payload"
-
 func TestV2ZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageEVMCall, big.NewInt(0))
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 
 	// Necessary approval for fee payment
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -24,7 +24,7 @@ func TestV2ZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	// perform the call
 	tx := r.V2ZEVMToEMVArbitraryCall(
 		r.TestDAppV2EVMAddr,
-		r.EncodeSimpleCall(payloadMessageEVMCall),
+		r.EncodeSimpleCall(payload),
 		gatewayzevm.RevertOptions{
 			OnRevertGasLimit: big.NewInt(0),
 		},
@@ -36,5 +36,5 @@ func TestV2ZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageEVMCall, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call.go
@@ -12,12 +12,12 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageEVMAuthenticatedCall = "this is a test EVM authenticated call payload"
-
 func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageEVMAuthenticatedCall, big.NewInt(0))
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 
 	// necessary approval for fee payment
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -25,7 +25,7 @@ func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	// perform the authenticated call
 	tx := r.V2ZEVMToEMVCall(
 		r.TestDAppV2EVMAddr,
-		[]byte(payloadMessageEVMAuthenticatedCall),
+		[]byte(payload),
 		gatewayzevm.RevertOptions{
 			OnRevertGasLimit: big.NewInt(0),
 		},
@@ -37,10 +37,10 @@ func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageEVMAuthenticatedCall, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
-	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(&bind.CallOpts{}, []byte(payloadMessageEVMAuthenticatedCall))
+	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(&bind.CallOpts{}, []byte(payload))
 	require.NoError(r, err)
 	require.Equal(r, r.ZEVMAuth.From, senderForMsg)
 }

--- a/e2e/e2etests/test_v2_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call.go
@@ -15,7 +15,7 @@ import (
 func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call.go
@@ -15,7 +15,7 @@ import (
 func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_zevm_to_evm_call_through_contract.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call_through_contract.go
@@ -15,7 +15,7 @@ import (
 func TestV2ZEVMToEVMCallThroughContract(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText()
+	payload := randomText(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_zevm_to_evm_call_through_contract.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call_through_contract.go
@@ -15,7 +15,7 @@ import (
 func TestV2ZEVMToEVMCallThroughContract(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomText(r)
+	payload := randomPayload(r)
 
 	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_v2_zevm_to_evm_call_through_contract.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call_through_contract.go
@@ -12,12 +12,12 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-const payloadMessageEVMAuthenticatedCallThroughContract = "this is a test EVM authenticated call payload through contract"
-
 func TestV2ZEVMToEVMCallThroughContract(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageEVMAuthenticatedCallThroughContract, big.NewInt(0))
+	payload := randomText()
+
+	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 
 	// deploy caller contract and send it gas zrc20 to pay gas fee
 	gatewayCallerAddr, tx, gatewayCaller, err := gatewayzevmcaller.DeployGatewayZEVMCaller(
@@ -37,7 +37,7 @@ func TestV2ZEVMToEVMCallThroughContract(r *runner.E2ERunner, args []string) {
 	tx = r.V2ZEVMToEMVCallThroughContract(
 		gatewayCaller,
 		r.TestDAppV2EVMAddr,
-		[]byte(payloadMessageEVMAuthenticatedCallThroughContract),
+		[]byte(payload),
 		gatewayzevmcaller.RevertOptions{
 			OnRevertGasLimit: big.NewInt(0),
 		},
@@ -47,12 +47,12 @@ func TestV2ZEVMToEVMCallThroughContract(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "call")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageEVMAuthenticatedCallThroughContract, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2EVM.SenderWithMessage(
 		&bind.CallOpts{},
-		[]byte(payloadMessageEVMAuthenticatedCallThroughContract),
+		[]byte(payload),
 	)
 	require.NoError(r, err)
 	require.Equal(r, gatewayCallerAddr, senderForMsg)

--- a/e2e/runner/v2_zevm.go
+++ b/e2e/runner/v2_zevm.go
@@ -11,7 +11,7 @@ import (
 	gatewayzevmcaller "github.com/zeta-chain/node/pkg/contracts/gatewayzevmcaller"
 )
 
-var gasLimit = big.NewInt(1000000)
+var gasLimit = big.NewInt(150000)
 
 // V2ETHWithdraw calls Withdraw of Gateway with gas token on ZEVM
 func (r *E2ERunner) V2ETHWithdraw(
@@ -31,7 +31,7 @@ func (r *E2ERunner) V2ETHWithdraw(
 	return tx
 }
 
-// V2ETHWithdrawAndCall calls WithdrawAndCall of Gateway with gas token on ZEVM using arbitrary call
+// V2ETHWithdrawAndArbitraryCall calls WithdrawAndCall of Gateway with gas token on ZEVM using arbitrary call
 func (r *E2ERunner) V2ETHWithdrawAndArbitraryCall(
 	receiver ethcommon.Address,
 	amount *big.Int,

--- a/e2e/runner/v2_zevm.go
+++ b/e2e/runner/v2_zevm.go
@@ -11,7 +11,7 @@ import (
 	gatewayzevmcaller "github.com/zeta-chain/node/pkg/contracts/gatewayzevmcaller"
 )
 
-var gasLimit = big.NewInt(200000)
+var gasLimit = big.NewInt(250000)
 
 // V2ETHWithdraw calls Withdraw of Gateway with gas token on ZEVM
 func (r *E2ERunner) V2ETHWithdraw(

--- a/e2e/runner/v2_zevm.go
+++ b/e2e/runner/v2_zevm.go
@@ -11,7 +11,7 @@ import (
 	gatewayzevmcaller "github.com/zeta-chain/node/pkg/contracts/gatewayzevmcaller"
 )
 
-var gasLimit = big.NewInt(150000)
+var gasLimit = big.NewInt(200000)
 
 // V2ETHWithdraw calls Withdraw of Gateway with gas token on ZEVM
 func (r *E2ERunner) V2ETHWithdraw(


### PR DESCRIPTION
# Description

- Reduce gas limit used for withdrawAndCall
- Use random string for the testDapp

Current test that interacts with TestDappV2 during withdrawAndCall tests specify 1M as gas limit.
This makes the cost of tx very expensive on live networks. This PR reduces this number to a smaller value sufficient to run the tests.

The random string for payload allow having tests that have no shared context between each other and therefore run those independently


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated gas limit settings for improved performance.
  - Renamed method for clarity, enhancing user understanding of its functionality.

- **Bug Fixes**
  - Adjusted method logic to ensure continued functionality with new gas limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->