### PR TITLE
chore: set lower tally params for localnet

### DIFF
--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -292,8 +292,13 @@ then
     echo "Importing data"
     zetacored parse-genesis-file /root/genesis_data/exported-genesis.json
   fi
-#  Update governance voting period to 100s , to ignore the voting period imported from mainnet.
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="100s"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+
+# Update governance voting parameters for localnet
+# this allows for quick upgrades and using more than two nodes
+  jq '.app_state["gov"]["params"]["voting_period"]="100s" |
+    .app_state["gov"]["params"]["quorum"]="0.1" |
+    .app_state["gov"]["params"]["threshold"]="0.1"' \
+  $HOME/.zetacored/config/genesis.json > tmp.json && mv tmp.json $HOME/.zetacored/config/genesis.json
 
 # 4. Collect all the gentx files in zetacore0 and create the final genesis.json
   zetacored collect-gentxs


### PR DESCRIPTION
# Description

This will allow for running upgrade tests with more than two nodes. I want to do this in developnet (performance tests + automated upgrades).

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/6655ef62-4fe0-497b-bad2-25c684c32aac">


References:
- https://docs.cosmos.network/main/build/modules/gov#quorum
- https://buf.build/cosmos/cosmos-sdk/file/v0.47.0-rc3:cosmos/gov/v1/genesis.proto

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced governance configuration for localnet with updated voting parameters: `quorum` and `threshold`.
	- Streamlined governance parameter updates in the genesis file for improved efficiency.

- **Documentation**
	- Updated comments for better clarity on genesis creation and SSH key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->