### PR TITLE
test(e2e): backport improve E2E reliability for tests on live network

### DIFF
--- a/cmd/zetae2e/config/contracts.go
+++ b/cmd/zetae2e/config/contracts.go
@@ -266,7 +266,7 @@ func setContractsFromConfig(r *runner.E2ERunner, conf config.Config) error {
 		if err != nil {
 			return fmt.Errorf("invalid TestDAppV2Addr: %w", err)
 		}
-		r.TestDAppV2ZEVM, err = testdappv2.NewTestDAppV2(r.TestDAppV2ZEVMAddr, r.EVMClient)
+		r.TestDAppV2ZEVM, err = testdappv2.NewTestDAppV2(r.TestDAppV2ZEVMAddr, r.ZEVMClient)
 		if err != nil {
 			return err
 		}

--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -1,6 +1,8 @@
 package e2etests
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"math/big"
 	"strconv"
 
@@ -15,6 +17,15 @@ import (
 	"github.com/zeta-chain/zetacore/pkg/chains"
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
+
+// randomPayload generates a random payload to be used in gateway calls for testing purposes
+func randomPayload(r *runner.E2ERunner) string {
+	bytes := make([]byte, 50)
+	_, err := rand.Read(bytes)
+	require.NoError(r, err)
+
+	return hex.EncodeToString(bytes)
+}
 
 func withdrawBTCZRC20(r *runner.E2ERunner, to btcutil.Address, amount *big.Int) *btcjson.TxRawResult {
 	tx, err := r.BTCZRC20.Approve(

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call.go
@@ -12,8 +12,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageDepositERC20 = "this is a test ERC20 deposit and call payload"
-
 func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -22,7 +20,9 @@ func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageDepositERC20, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	oldBalance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -31,7 +31,7 @@ func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ERC20DepositAndCall(
 		r.TestDAppV2ZEVMAddr,
 		amount,
-		[]byte(payloadMessageDepositERC20),
+		[]byte(payload),
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -41,7 +41,7 @@ func TestV2ERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payloadMessageDepositERC20, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, amount)
 
 	// check the balance was updated
 	newBalance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)

--- a/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_deposit_and_call_revert_with_call.go
@@ -11,8 +11,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageDepositOnRevertERC20 = "this is a test ERC20 deposit and call on revert"
-
 func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -21,13 +19,15 @@ func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageDepositOnRevertERC20, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	// perform the deposit
 	tx := r.V2ERC20DepositAndCall(r.TestDAppV2ZEVMAddr, amount, []byte("revert"), gatewayevm.RevertOptions{
 		RevertAddress:    r.TestDAppV2EVMAddr,
 		CallOnRevert:     true,
-		RevertMessage:    []byte(payloadMessageDepositOnRevertERC20),
+		RevertMessage:    []byte(payload),
 		OnRevertGasLimit: big.NewInt(200000),
 	})
 
@@ -37,5 +37,5 @@ func TestV2ERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageDepositOnRevertERC20, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call.go
@@ -11,15 +11,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageWithdrawERC20 = "this is a test ERC20 withdraw and call payload"
-
 func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCall")
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageWithdrawERC20, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -28,7 +28,7 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ERC20WithdrawAndCall(
 		r.TestDAppV2EVMAddr,
 		amount,
-		r.EncodeERC20Call(r.ERC20Addr, amount, payloadMessageWithdrawERC20),
+		r.EncodeERC20Call(r.ERC20Addr, amount, payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -37,5 +37,5 @@ func TestV2ERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageWithdrawERC20, amount)
+	r.AssertTestDAppEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_erc20_withdraw_and_call_revert_with_call.go
@@ -11,15 +11,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageWithdrawOnRevertERC20 = "this is a test ERC20 withdraw and call on revert"
-
 func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ERC20WithdrawAndCallRevertWithCall")
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageWithdrawOnRevertERC20, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -32,7 +32,7 @@ func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string
 		gatewayzevm.RevertOptions{
 			RevertAddress:    r.TestDAppV2ZEVMAddr,
 			CallOnRevert:     true,
-			RevertMessage:    []byte(payloadMessageWithdrawOnRevertERC20),
+			RevertMessage:    []byte(payload),
 			OnRevertGasLimit: big.NewInt(0),
 		},
 	)
@@ -42,5 +42,5 @@ func TestV2ERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppZEVMCalled(true, payloadMessageWithdrawOnRevertERC20, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call.go
@@ -12,15 +12,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageDepositETH = "this is a test ETH deposit and call payload"
-
 func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHDepositAndCall")
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageDepositETH, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	oldBalance, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -29,7 +29,7 @@ func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ETHDepositAndCall(
 		r.TestDAppV2ZEVMAddr,
 		amount,
-		[]byte(payloadMessageDepositETH),
+		[]byte(payload),
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -39,7 +39,7 @@ func TestV2ETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payloadMessageDepositETH, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, amount)
 
 	// check the balance was updated
 	newBalance, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)

--- a/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_deposit_and_call_revert_with_call.go
@@ -11,8 +11,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageDepositOnRevertETH = "this is a test ETH deposit and call on revert"
-
 func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
@@ -21,13 +19,15 @@ func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageDepositOnRevertETH, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	// perform the deposit
 	tx := r.V2ETHDepositAndCall(r.TestDAppV2ZEVMAddr, amount, []byte("revert"), gatewayevm.RevertOptions{
 		RevertAddress:    r.TestDAppV2EVMAddr,
 		CallOnRevert:     true,
-		RevertMessage:    []byte(payloadMessageDepositOnRevertETH),
+		RevertMessage:    []byte(payload),
 		OnRevertGasLimit: big.NewInt(200000),
 	})
 
@@ -37,5 +37,5 @@ func TestV2ETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageDepositOnRevertETH, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call.go
@@ -11,15 +11,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageWithdrawETH = "this is a test ETH withdraw and call payload"
-
 func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCall")
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageWithdrawETH, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppEVMCalled(false, payload, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -27,7 +27,7 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	tx := r.V2ETHWithdrawAndCall(
 		r.TestDAppV2EVMAddr,
 		amount,
-		r.EncodeGasCall(payloadMessageWithdrawETH),
+		r.EncodeGasCall(payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -36,5 +36,5 @@ func TestV2ETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payloadMessageWithdrawETH, amount)
+	r.AssertTestDAppEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_v2_eth_withdraw_and_call_revert_with_call.go
@@ -11,15 +11,15 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageWithdrawOnRevertETH = "this is a test ETH withdraw and call on revert"
-
 func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	amount, ok := big.NewInt(0).SetString(args[0], 10)
 	require.True(r, ok, "Invalid amount specified for TestV2ETHWithdrawAndCallRevertWithCall")
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageWithdrawOnRevertETH, amount)
+	payload := randomPayload(r)
+
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -31,7 +31,7 @@ func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 		gatewayzevm.RevertOptions{
 			RevertAddress:    r.TestDAppV2ZEVMAddr,
 			CallOnRevert:     true,
-			RevertMessage:    []byte(payloadMessageWithdrawOnRevertETH),
+			RevertMessage:    []byte(payload),
 			OnRevertGasLimit: big.NewInt(0),
 		},
 	)
@@ -41,5 +41,5 @@ func TestV2ETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppZEVMCalled(true, payloadMessageWithdrawOnRevertETH, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_v2_evm_to_zevm_call.go
@@ -11,17 +11,17 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageZEVMCall = "this is a test ZEVM call payload"
-
 func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	r.AssertTestDAppZEVMCalled(false, payloadMessageZEVMCall, big.NewInt(0))
+	payload := randomPayload(r)
+
+	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
 
 	// perform the withdraw
 	tx := r.V2EVMToZEMVCall(
 		r.TestDAppV2ZEVMAddr,
-		[]byte(payloadMessageZEVMCall),
+		[]byte(payload),
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
 	)
 
@@ -31,5 +31,5 @@ func TestV2EVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payloadMessageZEVMCall, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_v2_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_v2_zevm_to_evm_call.go
@@ -11,18 +11,18 @@ import (
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 )
 
-const payloadMessageEVMCall = "this is a test EVM call payload"
-
 func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	r.AssertTestDAppEVMCalled(false, payloadMessageEVMCall, big.NewInt(0))
+	payload := randomPayload(r)
+
+	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 
 	// Necessary approval for fee payment
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
 	// perform the withdraw
-	tx := r.V2ZEVMToEMVCall(r.TestDAppV2EVMAddr, r.EncodeSimpleCall(payloadMessageEVMCall), gatewayzevm.RevertOptions{
+	tx := r.V2ZEVMToEMVCall(r.TestDAppV2EVMAddr, r.EncodeSimpleCall(payload), gatewayzevm.RevertOptions{
 		OnRevertGasLimit: big.NewInt(0),
 	})
 
@@ -32,5 +32,5 @@ func TestV2ZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payloadMessageEVMCall, big.NewInt(0))
+	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/runner/v2_zevm.go
+++ b/e2e/runner/v2_zevm.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zeta-chain/protocol-contracts/v2/pkg/gatewayzevm.sol"
 )
 
-var gasLimit = big.NewInt(1000000)
+var gasLimit = big.NewInt(250000)
 
 // V2ETHWithdraw calls Withdraw of Gateway with gas token on ZEVM
 func (r *E2ERunner) V2ETHWithdraw(


### PR DESCRIPTION
# Description

Backport https://github.com/zeta-chain/node/pull/3061 to v20.

We don't need a to make a new release but these fixes are needed to test the gateway deployment on v20. It's proper using `release/v20` as reference to run the tests
