### PR TITLE
chore(e2e): use 2 spaces for yaml

### DIFF
--- a/cmd/zetae2e/init.go
+++ b/cmd/zetae2e/init.go
@@ -20,12 +20,14 @@ func NewInitCmd() *cobra.Command {
 	}
 
 	InitCmd.Flags().StringVar(&initConf.RPCs.EVM, "ethURL", initConf.RPCs.EVM, "--ethURL http://eth:8545")
-	InitCmd.Flags().StringVar(&initConf.RPCs.ZetaCoreGRPC, "grpcURL", initConf.RPCs.ZetaCoreGRPC, "--grpcURL zetacore0:9090")
+	InitCmd.Flags().
+		StringVar(&initConf.RPCs.ZetaCoreGRPC, "grpcURL", initConf.RPCs.ZetaCoreGRPC, "--grpcURL zetacore0:9090")
 	InitCmd.Flags().
 		StringVar(&initConf.RPCs.ZetaCoreRPC, "rpcURL", initConf.RPCs.ZetaCoreRPC, "--rpcURL http://zetacore0:26657")
 	InitCmd.Flags().
 		StringVar(&initConf.RPCs.Zevm, "zevmURL", initConf.RPCs.Zevm, "--zevmURL http://zetacore0:8545")
-	InitCmd.Flags().StringVar(&initConf.RPCs.Bitcoin.Host, "btcURL", initConf.RPCs.Bitcoin.Host, "--grpcURL bitcoin:18443")
+	InitCmd.Flags().
+		StringVar(&initConf.RPCs.Bitcoin.Host, "btcURL", initConf.RPCs.Bitcoin.Host, "--btcURL bitcoin:18443")
 	InitCmd.Flags().
 		StringVar(&initConf.RPCs.Solana, "solanaURL", initConf.RPCs.Solana, "--solanaURL http://solana:8899")
 	InitCmd.Flags().

--- a/cmd/zetae2e/init.go
+++ b/cmd/zetae2e/init.go
@@ -9,7 +9,7 @@ import (
 	"github.com/zeta-chain/node/e2e/config"
 )
 
-var initConf = config.Config{}
+var initConf = config.DefaultConfig()
 var configFile = ""
 
 func NewInitCmd() *cobra.Command {
@@ -19,18 +19,18 @@ func NewInitCmd() *cobra.Command {
 		RunE:  initConfig,
 	}
 
-	InitCmd.Flags().StringVar(&initConf.RPCs.EVM, "ethURL", "http://eth:8545", "--ethURL http://eth:8545")
-	InitCmd.Flags().StringVar(&initConf.RPCs.ZetaCoreGRPC, "grpcURL", "zetacore0:9090", "--grpcURL zetacore0:9090")
+	InitCmd.Flags().StringVar(&initConf.RPCs.EVM, "ethURL", initConf.RPCs.EVM, "--ethURL http://eth:8545")
+	InitCmd.Flags().StringVar(&initConf.RPCs.ZetaCoreGRPC, "grpcURL", initConf.RPCs.ZetaCoreGRPC, "--grpcURL zetacore0:9090")
 	InitCmd.Flags().
-		StringVar(&initConf.RPCs.ZetaCoreRPC, "rpcURL", "http://zetacore0:26657", "--rpcURL http://zetacore0:26657")
+		StringVar(&initConf.RPCs.ZetaCoreRPC, "rpcURL", initConf.RPCs.ZetaCoreRPC, "--rpcURL http://zetacore0:26657")
 	InitCmd.Flags().
-		StringVar(&initConf.RPCs.Zevm, "zevmURL", "http://zetacore0:8545", "--zevmURL http://zetacore0:8545")
-	InitCmd.Flags().StringVar(&initConf.RPCs.Bitcoin.Host, "btcURL", "bitcoin:18443", "--grpcURL bitcoin:18443")
+		StringVar(&initConf.RPCs.Zevm, "zevmURL", initConf.RPCs.Zevm, "--zevmURL http://zetacore0:8545")
+	InitCmd.Flags().StringVar(&initConf.RPCs.Bitcoin.Host, "btcURL", initConf.RPCs.Bitcoin.Host, "--grpcURL bitcoin:18443")
 	InitCmd.Flags().
-		StringVar(&initConf.RPCs.Solana, "solanaURL", "http://solana:8899", "--solanaURL http://solana:8899")
+		StringVar(&initConf.RPCs.Solana, "solanaURL", initConf.RPCs.Solana, "--solanaURL http://solana:8899")
 	InitCmd.Flags().
-		StringVar(&initConf.RPCs.TONSidecarURL, "tonSidecarURL", "http://ton:8000", "--tonSidecarURL http://ton:8000")
-	InitCmd.Flags().StringVar(&initConf.ZetaChainID, "chainID", "athens_101-1", "--chainID athens_101-1")
+		StringVar(&initConf.RPCs.TONSidecarURL, "tonSidecarURL", initConf.RPCs.TONSidecarURL, "--tonSidecarURL http://ton:8000")
+	InitCmd.Flags().StringVar(&initConf.ZetaChainID, "chainID", initConf.ZetaChainID, "--chainID athens_101-1")
 	InitCmd.Flags().StringVar(&configFile, local.FlagConfigFile, "e2e.config", "--cfg ./e2e.config")
 
 	return InitCmd

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -208,12 +208,14 @@ func WriteConfig(file string, config Config) error {
 		return errors.New("file name cannot be empty")
 	}
 
+	// #nosec G304 -- the variable is expected to be controlled by the user
 	fHandle, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("open file: %w", err)
 	}
 	defer fHandle.Close()
 
+	// use a custom encoder so we can set the indentation level
 	encoder := yaml.NewEncoder(fHandle)
 	defer encoder.Close()
 	encoder.SetIndent(2)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -208,13 +208,17 @@ func WriteConfig(file string, config Config) error {
 		return errors.New("file name cannot be empty")
 	}
 
-	b, err := yaml.Marshal(config)
+	fHandle, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return err
+		return fmt.Errorf("open file: %w", err)
 	}
-	err = os.WriteFile(file, b, 0600)
+	defer fHandle.Close()
+
+	encoder := yaml.NewEncoder(fHandle)
+	encoder.SetIndent(2)
+	err = encoder.Encode(config)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode config: %w", err)
 	}
 	return nil
 }

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -215,6 +215,7 @@ func WriteConfig(file string, config Config) error {
 	defer fHandle.Close()
 
 	encoder := yaml.NewEncoder(fHandle)
+	defer encoder.Close()
 	encoder.SetIndent(2)
 	err = encoder.Encode(config)
 	if err != nil {


### PR DESCRIPTION
# Description

Our `cmd/zetae2e/config/*.yml` files use 2 spaces, but the config generated by e2e init (or saved with --config-out) uses 4 spaces. Use the same amount of spaces to avoid diffs.

Also use `config.DefaultConfig()` for default parameters.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command configuration to utilize dynamic values instead of hardcoded defaults, improving flexibility for users.
	- Improved YAML configuration file writing with better formatting and error handling for a more user-friendly experience.

- **Bug Fixes**
	- Updated error handling in configuration writing to provide clearer context for issues encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->