### PR TITLE
feat(e2e): add latency report to withdrawal performance tests

### DIFF
--- a/e2e/e2etests/test_stress_eth_withdraw.go
+++ b/e2e/e2etests/test_stress_eth_withdraw.go
@@ -78,7 +78,10 @@ func TestStressEtherWithdraw(r *runner.E2ERunner, args []string) {
 
 	err = eg.Wait()
 
-	desc, _ := stats.Describe(withdrawDurations, false, &[]float64{50.0, 75.0, 90.0, 95.0})
+	desc, descErr := stats.Describe(withdrawDurations, false, &[]float64{50.0, 75.0, 90.0, 95.0})
+	if descErr != nil {
+		r.Logger.Print("❌ failed to calculate latency report: %v", descErr)
+	}
 
 	r.Logger.Print("Latency report:")
 	r.Logger.Print("min:  %.2f", desc.Min)

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -81,7 +81,7 @@ func WaitCctxsMinedByInboundHash(
 		timedOut := time.Since(startTime) > timeout
 		require.False(t, timedOut, "waiting cctx timeout, cctx not mined, inbound hash: %s", inboundHash)
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 
 		// We use InTxHashToCctxData instead of InboundTrackerAllByChain to able to run these tests with the previous version
 		// for the update tests
@@ -90,7 +90,7 @@ func WaitCctxsMinedByInboundHash(
 		res, err := client.InTxHashToCctxData(ctx, in)
 		if err != nil {
 			// prevent spamming logs
-			if i%10 == 0 {
+			if i%20 == 0 {
 				logger.Info("Error getting cctx by inboundHash: %s", err.Error())
 			}
 			continue
@@ -113,7 +113,7 @@ func WaitCctxsMinedByInboundHash(
 			cctx := cctx
 			if !IsTerminalStatus(cctx.CctxStatus.Status) {
 				// prevent spamming logs
-				if i%10 == 0 {
+				if i%20 == 0 {
 					logger.Info(
 						"waiting for cctx index %d to be mined by inboundHash: %s, cctx status: %s, message: %s",
 						j,

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -154,7 +154,7 @@ func WaitCCTXMinedByIndex(
 		require.False(t, time.Since(startTime) > timeout, "waiting cctx timeout, cctx not mined, cctx: %s", cctxIndex)
 
 		if i > 0 {
-			time.Sleep(1 * time.Second)
+			time.Sleep(500 * time.Millisecond)
 		}
 
 		// fetch cctx by index
@@ -170,7 +170,7 @@ func WaitCCTXMinedByIndex(
 		cctx := res.CrossChainTx
 		if !IsTerminalStatus(cctx.CctxStatus.Status) {
 			// prevent spamming logs
-			if i%10 == 0 {
+			if i%20 == 0 {
 				logger.Info(
 					"waiting for cctx to be mined from index: %s, cctx status: %s, message: %s",
 					cctxIndex,

--- a/go.mod
+++ b/go.mod
@@ -340,6 +340,7 @@ require (
 
 require (
 	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20220328075252-7dd334e3daae // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3321,6 +3321,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/moricho/tparallel v0.2.1/go.mod h1:fXEIZxG2vdfl0ZF8b42f5a78EhjjD5mX8qUplsoSU4k=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 h1:mPMvm6X6tf4w8y7j9YIt6V9jfWhL6QlbEc7CCmeQlWk=


### PR DESCRIPTION
# Description

Add basic latency report to e2e stdout output:

```
perf_eth_w | index 83: withdraw cctx success in 2m14.816615704s
perf_eth_w | Latency report:
perf_eth_w | min:  11.54
perf_eth_w | max:  144.94
perf_eth_w | mean: 80.86
perf_eth_w | std:  35.27
perf_eth_w | p50:  73.83
perf_eth_w | p75:  107.65
perf_eth_w | p90:  132.86
perf_eth_w | p95:  139.84
perf_eth_w | all withdraws completed
perf_eth_w | ✅ completed in 5m36.469992612s - stress test Ether withdrawal
perf_eth_w | 🍾 Ethereum withdraw performance test completed in 5m48.522626564s
```

Also increase the cctx polling interval to improve stats accuracy

Related to https://github.com/zeta-chain/infrastructure/issues/1765

Future TODO:
- write this data out in a structured format and compare to info from previous nightly and/or release
- add more generic way to do this throughout e2e suite

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced stress testing for Ether withdrawal with detailed latency metrics and improved error handling.
  
- **Bug Fixes**
	- Adjusted timing and logging mechanisms for cross-chain transaction monitoring to optimize performance.

- **Chores**
	- Updated and added dependencies to ensure compatibility with newer library versions and improve project stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->