### PR TITLE
refactor(e2e): setup zrc20 in one transaction

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -185,6 +185,11 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	// set the authority client to the zeta tx server to be able to query message permissions
 	deployerRunner.ZetaTxServer.SetAuthorityClient(deployerRunner.AuthorityClient)
 
+	// run setup steps that do not require tss
+	if !skipSetup {
+		noError(deployerRunner.FundEmissionsPool())
+	}
+
 	// wait for keygen to be completed
 	// if setup is skipped, we assume that the keygen is already completed
 	if !skipSetup {
@@ -229,7 +234,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		if testSolana {
 			deployerRunner.SetupSolana(conf.AdditionalAccounts.UserSolana.SolanaPrivateKey.String())
 		}
-		noError(deployerRunner.FundEmissionsPool())
 
 		deployerRunner.MintERC20OnEvm(1000000)
 

--- a/e2e/e2etests/test_whitelist_erc20.go
+++ b/e2e/e2etests/test_whitelist_erc20.go
@@ -50,7 +50,7 @@ func TestWhitelistERC20(r *runner.E2ERunner, _ []string) {
 	erc20zrc20Addr, err := txserver.FetchAttributeFromTxResponse(res, "zrc20_address")
 	require.NoError(r, err)
 
-	err = r.ZetaTxServer.InitializeLiquidityCap(erc20zrc20Addr)
+	err = r.ZetaTxServer.InitializeLiquidityCaps(erc20zrc20Addr)
 	require.NoError(r, err)
 
 	// ensure CCTX created


### PR DESCRIPTION
# Description

Deploy zrc20 contracts in one transaction to increase e2e setup speed. This reduces setup time by ~20 seconds. Also:

- automatically increase gas limit and fees if multiple messages are provided to broadcast 
- return error immediately if broadcast or transaction fails (code != 0)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction handling with support for broadcasting multiple messages in a single transaction.
	- Introduced batch deployment for ZRC20 contracts, allowing for more efficient contract management.
	- New methods added for enabling header verification, updating gateway addresses, deploying system contracts, funding emissions pools, and updating keygen.

- **Bug Fixes**
	- Improved error handling in transaction broadcasting to manage failures more effectively.

- **Refactor**
	- Updated method names and signatures for better clarity and functionality, reflecting changes in liquidity cap management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->