### PR TITLE
refactor(e2e): use strict event typing

### DIFF
--- a/e2e/e2etests/test_migrate_chain_support.go
+++ b/e2e/e2etests/test_migrate_chain_support.go
@@ -167,12 +167,10 @@ func TestMigrateChainSupport(r *runner.E2ERunner, _ []string) {
 	))
 	require.NoError(r, err)
 
-	// retrieve zrc20 and cctx from event
-	whitelistCCTXIndex, err := txserver.FetchAttributeFromTxResponse(res, "whitelist_cctx_index")
-	require.NoError(r, err)
-
-	erc20zrc20Addr, err := txserver.FetchAttributeFromTxResponse(res, "zrc20_address")
-	require.NoError(r, err)
+	event, ok := txserver.EventOfType[*crosschaintypes.EventERC20Whitelist](res.Events)
+	require.True(r, ok, "no EventERC20Whitelist in %s", res.TxHash)
+	erc20zrc20Addr := event.Zrc20Address
+	whitelistCCTXIndex := event.WhitelistCctxIndex
 
 	// wait for the whitelist cctx to be mined
 	newRunner.WaitForMinedCCTXFromIndex(whitelistCCTXIndex)

--- a/e2e/e2etests/test_whitelist_erc20.go
+++ b/e2e/e2etests/test_whitelist_erc20.go
@@ -43,12 +43,10 @@ func TestWhitelistERC20(r *runner.E2ERunner, _ []string) {
 	))
 	require.NoError(r, err)
 
-	// retrieve zrc20 and cctx from event
-	whitelistCCTXIndex, err := txserver.FetchAttributeFromTxResponse(res, "whitelist_cctx_index")
-	require.NoError(r, err)
-
-	erc20zrc20Addr, err := txserver.FetchAttributeFromTxResponse(res, "zrc20_address")
-	require.NoError(r, err)
+	event, ok := txserver.EventOfType[*crosschaintypes.EventERC20Whitelist](res.Events)
+	require.True(r, ok, "no EventERC20Whitelist in %s", res.TxHash)
+	erc20zrc20Addr := event.Zrc20Address
+	whitelistCCTXIndex := event.WhitelistCctxIndex
 
 	err = r.ZetaTxServer.InitializeLiquidityCaps(erc20zrc20Addr)
 	require.NoError(r, err)

--- a/e2e/runner/v2_migration.go
+++ b/e2e/runner/v2_migration.go
@@ -149,9 +149,9 @@ func (r *E2ERunner) migrateERC20CustodyFunds() {
 	res, err := r.ZetaTxServer.BroadcastTx(utils.AdminPolicyName, msgPausing)
 	require.NoError(r, err)
 
-	// fetch cctx index from tx response
-	cctxIndex, err := txserver.FetchAttributeFromTxResponse(res, "cctx_index")
-	require.NoError(r, err)
+	migrationEvent, ok := txserver.EventOfType[*crosschaintypes.EventERC20CustodyFundsMigration](res.Events)
+	require.True(r, ok, "no EventERC20CustodyFundsMigration in %s", res.TxHash)
+	cctxIndex := migrationEvent.CctxIndex
 
 	cctxRes, err := r.CctxClient.Cctx(r.Ctx, &crosschaintypes.QueryGetCctxRequest{Index: cctxIndex})
 	require.NoError(r, err)
@@ -188,9 +188,9 @@ func (r *E2ERunner) migrateERC20CustodyFunds() {
 	res, err = r.ZetaTxServer.BroadcastTx(utils.AdminPolicyName, msgMigration)
 	require.NoError(r, err)
 
-	// fetch cctx index from tx response
-	cctxIndex, err = txserver.FetchAttributeFromTxResponse(res, "cctx_index")
-	require.NoError(r, err)
+	migrationEvent, ok = txserver.EventOfType[*crosschaintypes.EventERC20CustodyFundsMigration](res.Events)
+	require.True(r, ok, "no EventERC20CustodyFundsMigration in %s", res.TxHash)
+	cctxIndex = migrationEvent.CctxIndex
 
 	cctxRes, err = r.CctxClient.Cctx(r.Ctx, &crosschaintypes.QueryGetCctxRequest{Index: cctxIndex})
 	require.NoError(r, err)

--- a/e2e/txserver/zeta_tx_server.go
+++ b/e2e/txserver/zeta_tx_server.go
@@ -32,6 +32,7 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/samber/lo"
 	"github.com/zeta-chain/ethermint/crypto/hd"
 	etherminttypes "github.com/zeta-chain/ethermint/types"
@@ -661,7 +662,7 @@ func newFactory(clientCtx client.Context) tx.Factory {
 }
 
 // EventsOfType gets events of a specified type
-func EventsOfType[T any](events []abci.Event) ([]T, bool) {
+func EventsOfType[T proto.Message](events []abci.Event) ([]T, bool) {
 	var filteredEvents []T
 	for _, ev := range events {
 		pEvent, err := sdktypes.ParseTypedEvent(ev)
@@ -676,7 +677,7 @@ func EventsOfType[T any](events []abci.Event) ([]T, bool) {
 }
 
 // EventOfType gets one event of a specific type
-func EventOfType[T any](events []abci.Event) (T, bool) {
+func EventOfType[T proto.Message](events []abci.Event) (T, bool) {
 	var event T
 	for _, ev := range events {
 		pEvent, err := sdktypes.ParseTypedEvent(ev)


### PR DESCRIPTION
# Description

Always use strict event typing in e2e tests. This improves confidence during refactors and enables easily finding where the event is emitted:


https://github.com/user-attachments/assets/342f2c9e-aeec-4c91-8e71-dfce21e56bee

Based on https://github.com/zeta-chain/node/pull/3077 since I started using strictly typed events in that PR


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced error handling and event-based retrieval for ERC20 custody funds migration and whitelisting.
	- Introduced support for broadcasting multiple messages in a single transaction.
	- Added utility functions for improved event handling.

- **Bug Fixes**
	- Improved reliability and clarity in event handling for custody contracts and migrations.

- **Documentation**
	- Updated comments to reflect new logic and enhance clarity in event-driven processes.

- **Refactor**
	- Streamlined transaction server methods for better performance and maintainability.
	- Transitioned to an event-driven approach for retrieving critical data, enhancing clarity and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->