### PR TITLE
fix(ci): do not run rpcimportable on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
   rpcimportable:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
+    # do not run this on forks as they are not installable
+    # it will still be check in the merge queue in this case
+    if: github.repository == 'zeta-chain/node'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go


### PR DESCRIPTION
Do not run the `rpcimportable` test on forks. This check will still be run in the mergequeue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved CI workflow by adding conditional execution for specific jobs on forked repositories.
	- Enhanced comments for better clarity on workflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->