### PR TITLE
fix(ci): do not run rpcimportable on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     timeout-minutes: 15
     # do not run this on forks as they are not installable
     # it will still be check in the merge queue in this case
-    if: github.repository == 'zeta-chain/node'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v3
-        if: (github.event_name == 'push' && github.repository == 'zeta-chain/node') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'zeta-chain/node')
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node'
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_ONLY }}


### PR DESCRIPTION
Try https://github.com/zeta-chain/node/pull/3087 again

Also simplify e2e expression.

Making this PR from my fork this time to actually test it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced execution criteria for the `rpcimportable` job in the CI workflow, allowing it to run under broader conditions.
	- Simplified conditional logic for Docker Hub login in the reusable E2E workflow, enabling login under more scenarios.
  
- **Bug Fixes**
	- Improved reliability of job executions in the CI workflows by adjusting conditions for running specific jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->