### PR TITLE
feat: improve build reproducability

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -48,9 +48,9 @@ jobs:
     runs-on: ${{ vars.RELEASE_RUNNER }}
     steps:
       - uses: actions/checkout@v4
-      - name: Release build dry-run
+      - name: Build release snapshot
         run: |
-          make release-dry-run
+          make release-snapshot
           
   check-changelog:
     needs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,11 +54,16 @@ builds:
       - -X github.com/cosmos/cosmos-sdk/version.ClientName=zetaclientd
       - -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }}
       - -X github.com/cosmos/cosmos-sdk/version.Commit={{ .FullCommit }}
+      - -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb
       - -X github.com/zeta-chain/node/pkg/constant.Name=zetacored
       - -X github.com/zeta-chain/node/pkg/constant.Version={{ .Version }}
       - -X github.com/zeta-chain/node/pkg/constant.CommitHash={{ .FullCommit }}
-      - -X github.com/zeta-chain/node/pkg/constant.BuildTime={{ .Env.BUILDTIME }}
-      - -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb
+      - -X github.com/zeta-chain/node/pkg/constant.BuildTime={{ .CommitDate }}
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .CommitDate }}
+      - -buildid=
+      - -s -w
 
   - id: "zetaclientd"
     main: ./cmd/zetaclientd

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ test-sim-after-import-long
 release-snapshot:
 	$(GORELEASER) --clean --skip=validate --skip=publish --snapshot
 
-release-dry-run:
+release-build-only:
 	$(GORELEASER) --clean --skip=validate --skip=publish
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 PACKAGE_NAME := github.com/zeta-chain/node
 NODE_VERSION := $(shell ./version.sh)
 NODE_COMMIT := $(shell [ -z "${NODE_COMMIT}" ] && git log -1 --format='%H' || echo ${NODE_COMMIT} )
-NODE_BUILDTIME := "0000-00-00T00:00:00Z"
 DOCKER ?= docker
 # allow setting of NODE_COMPOSE_ARGS to pass additional args to docker compose
 # useful for setting profiles and/ort optional overlays
@@ -34,8 +33,6 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=zetacore \
 	-X github.com/zeta-chain/node/pkg/constant.Name=zetacored \
 	-X github.com/zeta-chain/node/pkg/constant.Version=$(NODE_VERSION) \
 	-X github.com/zeta-chain/node/pkg/constant.CommitHash=$(NODE_COMMIT) \
-	-X github.com/zeta-chain/node/pkg/constant.BuildTime=$(NODE_BUILDTIME) \
-	-X main.BuildTime=$(NODE_BUILDTIME) \
 	-buildid= \
 	-s -w
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Features
 
 * [2984](https://github.com/zeta-chain/node/pull/2984) - add Whitelist message ability to whitelist SPL tokens on Solana
+* [3091](https://github.com/zeta-chain/node/pull/3091) - improve build reproducability. `make release{,-build-only}` checksums should now be stable.
 
 ### Tests
 * [3075](https://github.com/zeta-chain/node/pull/3075) - ton: withdraw concurrent, deposit & revert.


### PR DESCRIPTION
# Description

Attempt to make builds bit perfect reproducable. If this is successful, two machines performing a build with the same code should build a binary with the exact same hash.

Steps taken:
- use stable time for build time
  - just leave this unset in localnet/CI
  - use commit timestamp in goreleaser
- set empty `buildid` as this is usually random
- strip debug symbols as these are not stable
- set strict sha256 on goreleaser cross version

Make targets are now:
- `make release-snapshot`: build a release without a tag
- `make release-build-only`: build a release with a tag but without uploading the artifacts
- `make release`: build a release with a tag and upload the artifacts

[goreleaser reference](https://goreleaser.com/blog/reproducible-builds/#what-are-reproducible-builds)

<details>
<summary>goreleaser output</summary>

```
  node git:(improve-build-reproducability) ✗ make release-snapshot
docker run --rm --privileged -e CGO_ENABLED=1 -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/go/src/github.com/zeta-chain/node -w /go/src/github.com/zeta-chain/node -e "GITHUB_TOKEN=" ghcr.io/goreleaser/goreleaser-cross:v1.22.7@sha256:24b2d75007f0ec8e35d01f3a8efa40c197235b200a1a91422d78b851f67ecce4 --clean --skip=validate --skip=publish --snapshot
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=af1baddd318097e2dd23dbbd446f86fe484fc1aa branch=improve-build-reproducability current_tag=v12.3.0-rc previous_tag=v12.1.0 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v12.3.0-rc-next
  • running before hooks
    • running                                        hook=go mod download
    • running                                        hook=go mod tidy
    • took: 57s
  • checking distribution directory
    • cleaning dist
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/zetaclientd_linux_amd64_v1/zetaclientd-linux-amd64
    • building                                       binary=dist/zetacored_darwin_arm64/zetacored-darwin-arm64
    • building                                       binary=dist/zetacored_linux_arm64/zetacored-linux-arm64
    • building                                       binary=dist/zetacored_windows_amd64_v1/zetacored-windows-amd64.exe
    • building                                       binary=dist/zetaclientd_linux_arm64/zetaclientd-linux-arm64
    • building                                       binary=dist/zetacored_darwin_amd64_v1/zetacored-darwin-amd64
    • building                                       binary=dist/zetacored_linux_amd64_v1/zetacored-linux-amd64
    • took: 2m48s
  • archives
    • skip archiving                                 binary=zetacored-linux-amd64 name=zetacored-linux-amd64
    • skip archiving                                 binary=zetaclientd-linux-amd64 name=zetaclientd-linux-amd64
    • skip archiving                                 binary=zetacored-linux-arm64 name=zetacored-linux-arm64
    • skip archiving                                 binary=zetaclientd-linux-arm64 name=zetaclientd-linux-arm64
    • skip archiving                                 binary=zetacored-darwin-arm64 name=zetacored-darwin-arm64
    • skip archiving                                 binary=zetacored-windows-amd64.exe name=zetacored-windows-amd64.exe
    • skip archiving                                 binary=zetacored-darwin-amd64 name=zetacored-darwin-amd64
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 3m49s
  • thanks for using goreleaser!
  node git:(improve-build-reproducability) ✗ cat dist/checksums.txt
323fb7defda08ffc7686d34030f67cdba1481932481bc92c1a43cf60c419afbf  zetaclientd-linux-amd64
242a7035d6b7eae273bb8bfa672877fc052f03fc0cd1b725696bb47235891793  zetaclientd-linux-arm64
e718df515a9789b784067702fda4a7b446f4bca4410d1d103abcd89b23f12730  zetacored-darwin-amd64
bc88222b7726521e6a55c88fd16ea3ccb1137359e379e7f20c7860545eb29af2  zetacored-darwin-arm64
3111a51160ee01f231a82603591a1fa4043cb87769c73bb184e9467b50778ed4  zetacored-linux-amd64
304276695b3cb9995ad4c7aa1813b3e618180083fe64e9ce6e322ac4c3afc555  zetacored-linux-arm64
a6912c62f5259eb4687b5e3e6589e1f606f43374d929ea0e64b6b47e8c3ce6e8  zetacored-windows-amd64.exe
```

</details>

<details>
<summary>make install-zetacore output</summary>

```
  node git:(improve-build-reproducability) ✗ export GOBIN=~/tmp/gobin
  node git:(improve-build-reproducability) ✗ make install-zetacore; sha256sum ~/tmp/gobin/zetacored
--> Installing zetacored
d919c999a06c86309e627769edc4c3a5f7cf3854e18885d7f969ddef37319ffe  /Users/alex/tmp/gobin/zetacored
  node git:(improve-build-reproducability) ✗ rm ~/tmp/gobin/zetacored
  node git:(improve-build-reproducability) ✗ make install-zetacore; sha256sum ~/tmp/gobin/zetacored
--> Installing zetacored
d919c999a06c86309e627769edc4c3a5f7cf3854e18885d7f969ddef37319ffe  /Users/alex/tmp/gobin/zetacored
```

</details>

<details>
<summary>ci-testing-node workflow runs</summary>

first run: https://github.com/zeta-chain/ci-testing-node/actions/runs/11674433708

```
  Downloads cat checksums.txt
6d53dc94191579ebe6f1c5e5399343d901a25154424d445d188454d4241fc8b3  zetaclientd-linux-amd64
25ef3e667a72564c5dcd8b67236fccf8fa8184df1c3f706d613170bc040d5ef6  zetaclientd-linux-arm64
03eee8a920f930df25d23ec584b97e8947b148fbee25d583b0ccfc40c6e013f4  zetacored-darwin-amd64
795507364b57d75126fc7d46edaa1d13e9fe5fd89f6a70b0dbb95533ba8c3380  zetacored-darwin-arm64
3821cf19cf9d9adae1e9b2f9b7880814308b03ea09da5c16877f392f419c0f7c  zetacored-linux-amd64
8d9c941f934d2ae6d6dc2132433fd989dc226703a3a03558480f76adf658a39d  zetacored-linux-arm64
527a57682cc112c98de97b0954db842a8920a1f1fd25f6dd998f9a9d4fe11cbf  zetacored-windows-amd64.exe
```

second run: https://github.com/zeta-chain/ci-testing-node/actions/runs/11674641533

```
  Downloads cat checksums.txt
6d53dc94191579ebe6f1c5e5399343d901a25154424d445d188454d4241fc8b3  zetaclientd-linux-amd64
25ef3e667a72564c5dcd8b67236fccf8fa8184df1c3f706d613170bc040d5ef6  zetaclientd-linux-arm64
03eee8a920f930df25d23ec584b97e8947b148fbee25d583b0ccfc40c6e013f4  zetacored-darwin-amd64
795507364b57d75126fc7d46edaa1d13e9fe5fd89f6a70b0dbb95533ba8c3380  zetacored-darwin-arm64
3821cf19cf9d9adae1e9b2f9b7880814308b03ea09da5c16877f392f419c0f7c  zetacored-linux-amd64
8d9c941f934d2ae6d6dc2132433fd989dc226703a3a03558480f76adf658a39d  zetacored-linux-arm64
527a57682cc112c98de97b0954db842a8920a1f1fd25f6dd998f9a9d4fe11cbf  zetacored-windows-amd64.exe
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced input parameters to control pre-release checks and release processes.
	- Added a step to ensure the changelog is updated before a release.
	- Enhanced version consistency checks for the upgrade handler.

- **Bug Fixes**
	- Improved handling of existing release tags to prevent conflicts.

- **Refactor**
	- Streamlined the build and release commands in the Makefile.
	- Updated linker flags in the build configuration for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->