### PR TITLE
refactor(e2e): only build zetanode once

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,12 +28,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # this cannot run on forks as forks cannot push packages in pull request context
+  # forked pull request will fall back to slow build
   build-zetanode:
     runs-on: ubuntu-22.04
-    permissions:
-      packages: write
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node'
     env:
-      DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}/zetanode
+      DOCKER_IMAGE: ghcr.io/${{ github.repository_owner }}/zetanode
       DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}
     outputs:
       image: ${{ fromJson(steps.build.outputs.metadata)['image.name'] }}
@@ -46,7 +47,6 @@ jobs:
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node'
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_ONLY }}
@@ -55,7 +55,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore go cache
@@ -304,7 +304,7 @@ jobs:
 
       - run: |
           result="${{ needs.build-zetanode.result }}"
-          if [[ $result != "success" ]]; then
+          if [[ $result != "success" || $result == "skipped" ]]; then
             exit 1
           fi
           result="${{ needs.e2e.result }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
   build-zetanode:
     runs-on: ubuntu-22.04
     env:
-      DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}/zetanode
+      DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}/zetanode
       DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}
     outputs:
       image: ${{ fromJson(steps.build.outputs.metadata)['image.name'] }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -198,6 +198,7 @@ jobs:
     needs:
       - build-zetanode
       - matrix-conditionals
+    if: always()
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,13 @@ jobs:
       # so that we can use the buildkit cache
       - uses: depot/use-containerd-snapshotter-action@v1
 
+      - name: Login to Docker Hub registry
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node'
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_READ_ONLY }}
+
       - name: Login to github docker registry
         uses: docker/login-action@v3
         with:
@@ -92,6 +99,7 @@ jobs:
           build-args: |
             NODE_VERSION=${{ env.NODE_VERSION }}
             NODE_COMMIT=${{ env.NODE_COMMIT }}
+      - run: echo "${{ steps.build.outputs.metadata }}"
 
   matrix-conditionals:
     needs: build-zetanode

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -306,7 +306,7 @@ jobs:
 
       - run: |
           result="${{ needs.build-zetanode.result }}"
-          if [[ $result != "success" || $result == "skipped" ]]; then
+          if [[ $result == "failed" ]]; then
             exit 1
           fi
           result="${{ needs.e2e.result }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,8 @@ jobs:
   build-zetanode:
     runs-on: ubuntu-22.04
     env:
-      DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}/zetanode
+      GHCR_USERNAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+      DOCKER_IMAGE: ghcr.io/${{ env.GHCR_USERNAME }}/zetanode
       DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}
     outputs:
       image: ${{ fromJson(steps.build.outputs.metadata)['image.name'] }}
@@ -53,7 +54,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.GHCR_USERNAME }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore go cache

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,7 @@ jobs:
 
   matrix-conditionals:
     needs: build-zetanode
+    if: always()
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,8 +31,7 @@ jobs:
   build-zetanode:
     runs-on: ubuntu-22.04
     env:
-      GHCR_USERNAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}
-      DOCKER_IMAGE: ghcr.io/${{ env.GHCR_USERNAME }}/zetanode
+      DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}/zetanode
       DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}
     outputs:
       image: ${{ fromJson(steps.build.outputs.metadata)['image.name'] }}
@@ -54,7 +53,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_USERNAME }}
+          username: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore go cache

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,8 @@ concurrency:
 jobs:
   build-zetanode:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     env:
       DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login || github.repository_owner }}/zetanode
       DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,7 +99,6 @@ jobs:
           build-args: |
             NODE_VERSION=${{ env.NODE_VERSION }}
             NODE_COMMIT=${{ env.NODE_COMMIT }}
-      - run: echo "${{ steps.build.outputs.metadata }}"
 
   matrix-conditionals:
     needs: build-zetanode
@@ -246,7 +245,7 @@ jobs:
       runs-on: ${{ matrix.runs-on}}
       run: ${{ matrix.run }}
       timeout-minutes: "${{ matrix.timeout-minutes || 25 }}"
-      zetanode-image: ${{ needs.zetanode-build.outputs.image }}
+      zetanode-image: ${{ needs.build-zetanode.outputs.image }}
       enable-monitoring: ${{ needs.matrix-conditionals.outputs.ENABLE_MONITORING == 'true' }}
     secrets: inherit
   # this allows you to set a required status check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-zetanode:
+    runs-on: ubuntu-22.04
+    env:
+      DOCKER_IMAGE: ghcr.io/${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}/zetanode
+      DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}
+    outputs:
+      image: ${{ fromJson(steps.build.outputs.metadata)['image.name'] }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # configure docker to use the containerd snapshotter
+      # so that we can use the buildkit cache
+      - uses: depot/use-containerd-snapshotter-action@v1
+
+      - name: Login to github docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore go cache
+        uses: actions/cache@v4
+        id: restore-go-cache
+        with:
+          path: |
+            go-cache
+          key: cache-${{ hashFiles('go.sum') }}
+
+      - name: Inject go cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+        with:
+          cache-map: |
+            {
+              "go-cache": "/root/.cache/go-build"
+            }
+          skip-extraction: ${{ steps.restore-go-cache.outputs.cache-hit || github.event_name != 'push' }}
+
+      # this ensures that the version is consistent between cache build and make build
+      - name: Set version for cache
+        run: |
+          NODE_VERSION=$(./version.sh)
+          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
+          NODE_COMMIT=$(git log -1 --format='%H')
+          echo "NODE_COMMIT=$NODE_COMMIT" >> $GITHUB_ENV
+
+      # build zetanode with cache options
+      - name: Build zetanode for cache
+        id: build
+        uses: docker/build-push-action@v6
+        env:
+          CACHE_FROM_CONFIG: "type=registry,ref=ghcr.io/${{ github.repository }}:buildcache"
+          CACHE_TO_CONFIG: "type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max"
+        with:
+          context: .
+          file: ./Dockerfile-localnet
+          push: true
+          tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_TAG }}
+          cache-from: ${{ env.CACHE_FROM_CONFIG }}
+          cache-to: ${{ github.event_name == 'push' && env.CACHE_TO_CONFIG || '' }}
+          target: latest-runtime
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
+            NODE_COMMIT=${{ env.NODE_COMMIT }}
+
   matrix-conditionals:
+    needs: build-zetanode
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ github.token }}
@@ -119,7 +185,9 @@ jobs:
             }
 
   e2e:
-    needs: matrix-conditionals
+    needs:
+      - build-zetanode
+      - matrix-conditionals
     strategy:
       fail-fast: false
       matrix:
@@ -170,12 +238,14 @@ jobs:
       runs-on: ${{ matrix.runs-on}}
       run: ${{ matrix.run }}
       timeout-minutes: "${{ matrix.timeout-minutes || 25 }}"
+      zetanode-image: ${{ needs.zetanode-build.outputs.image }}
       enable-monitoring: ${{ needs.matrix-conditionals.outputs.ENABLE_MONITORING == 'true' }}
     secrets: inherit
   # this allows you to set a required status check
   e2e-ok:
     runs-on: ubuntu-22.04
     needs:
+      - build-zetanode
       - matrix-conditionals
       - e2e
     if: always()
@@ -224,6 +294,10 @@ jobs:
 
 
       - run: |
+          result="${{ needs.build-zetanode.result }}"
+          if [[ $result != "success" ]]; then
+            exit 1
+          fi
           result="${{ needs.e2e.result }}"
           if [[ $result == "success" || $result == "skipped" ]]; then
             exit 0

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
         default: 'ubuntu-20.04'
+      zetanode-image:
+        description: 'docker image to use for zetanode'
+        required: true
+        type: string
       enable-monitoring:
         description: 'Enable the monitoring stack for this run'
         type: boolean
@@ -31,12 +35,10 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     strategy:
       fail-fast: false
+    env:
+      ZETANODE_IMAGE: ${{ inputs.zetanode-image }}
     steps:
       - uses: actions/checkout@v4
-      
-      # configure docker to use the containerd snapshotter
-      # so that we can use the buildkit cache
-      - uses: depot/use-containerd-snapshotter-action@v1
 
       - name: Login to Docker Hub registry
         uses: docker/login-action@v3
@@ -51,50 +53,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Restore go cache
-        uses: actions/cache@v4
-        id: restore-go-cache
-        with:
-          path: |
-            go-cache
-          key: cache-${{ hashFiles('go.sum') }}
-
-      - name: Inject go cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
-        with:
-          cache-map: |
-            {
-              "go-cache": "/root/.cache/go-build"
-            }
-          skip-extraction: ${{ steps.restore-go-cache.outputs.cache-hit || github.event_name != 'push' }}
-
-      # this ensures that the version is consistent between cache build and make build
-      - name: Set version for cache
-        run: |
-          NODE_VERSION=$(./version.sh)
-          echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
-          NODE_COMMIT=$(git log -1 --format='%H')
-          echo "NODE_COMMIT=$NODE_COMMIT" >> $GITHUB_ENV
-
-      # build zetanode with cache options
-      - name: Build zetanode for cache
-        uses: docker/build-push-action@v6
-        env:
-          CACHE_FROM_CONFIG: "type=registry,ref=ghcr.io/${{ github.repository }}:buildcache"
-          CACHE_TO_CONFIG: "type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max"
-        with:
-          context: .
-          file: ./Dockerfile-localnet
-          push: false
-          tags: zetanode:latest
-          cache-from: ${{ env.CACHE_FROM_CONFIG }}
-          cache-to: ${{ github.event_name == 'push' && env.CACHE_TO_CONFIG || '' }}
-          target: latest-runtime
-          build-args: |
-            NODE_VERSION=${{ env.NODE_VERSION }}
-            NODE_COMMIT=${{ env.NODE_COMMIT }}
-
+      
       - name: Enable monitoring
         if: inputs.enable-monitoring
         run: |

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -67,7 +67,8 @@ COPY --from=latest-build /go/bin/zetacored /go/bin/zetaclientd /go/bin/zetaclien
 
 # Optional old version build (from source). This old build is used as the genesis version in the upgrade tests. 
 # Use --target latest-runtime to skip.
-FROM base-build AS old-build-source
+# you must have already built the latest image (which the Makefile does)
+FROM zetanode:latest AS old-build-source
 
 ARG OLD_VERSION
 RUN git clone https://github.com/zeta-chain/node.git
@@ -84,13 +85,12 @@ COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
 
 # Optional old version build (from binary).
 # Use --target latest-runtime to skip.
-FROM base-runtime AS old-runtime
+# you must have already built the latest image (which the Makefile does)
+FROM zetanode:latest AS old-runtime
 
 ARG OLD_VERSION
 ARG BUILDARCH
 
-COPY --from=cosmovisor-build /go/bin/cosmovisor /usr/local/bin
-COPY --from=latest-build /go/bin/zetaclientd-supervisor /usr/local/bin
 RUN curl -Lo /usr/local/bin/zetacored ${OLD_VERSION}/zetacored-linux-${BUILDARCH} && \
     chmod 755 /usr/local/bin/zetacored && \
     curl -Lo /usr/local/bin/zetaclientd ${OLD_VERSION}/zetaclientd-linux-${BUILDARCH} && \

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ ifdef ZETANODE_IMAGE
 zetanode:
 	@echo "Pulling zetanode image"
 	$(DOCKER) pull $(ZETANODE_IMAGE)
-	$(DOCKER) tag $(ZETANODE_IMAGE) zetanode
+	$(DOCKER) tag $(ZETANODE_IMAGE) zetanode:latest
 .PHONY: zetanode
 else
 zetanode:

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,8 @@ generate: proto-gen openapi specs typescript docs-zetacored mocks precompiles fm
 ###############################################################################
 ###                         Localnet                          				###
 ###############################################################################
-start-localnet: zetanode start-localnet-skip-build
+e2e-images: zetanode orchestrator
+start-localnet: e2e-images start-localnet-skip-build
 
 start-localnet-skip-build:
 	@echo "--> Starting localnet"
@@ -242,11 +243,23 @@ stop-localnet:
 ###                         E2E tests               						###
 ###############################################################################
 
+ifdef ZETANODE_IMAGE
+zetanode:
+	@echo "Pulling zetanode image"
+	$(DOCKER) pull $(ZETANODE_IMAGE)
+	$(DOCKER) tag $(ZETANODE_IMAGE) zetanode
+.PHONY: zetanode
+else
 zetanode:
 	@echo "Building zetanode"
 	$(DOCKER) build -t zetanode --build-arg NODE_VERSION=$(NODE_VERSION) --build-arg NODE_COMMIT=$(NODE_COMMIT) --target latest-runtime -f ./Dockerfile-localnet .
-	$(DOCKER) build -t orchestrator -f contrib/localnet/orchestrator/Dockerfile.fastbuild .
 .PHONY: zetanode
+endif
+
+orchestrator:
+	@echo "Building e2e orchestrator"
+	$(DOCKER) build -t orchestrator -f contrib/localnet/orchestrator/Dockerfile.fastbuild .
+.PHONY: orchestrator
 
 install-zetae2e: go.sum
 	@echo "--> Installing zetae2e"
@@ -257,47 +270,47 @@ solana:
 	@echo "Building solana docker image"
 	$(DOCKER) build -t solana-local -f contrib/localnet/solana/Dockerfile contrib/localnet/solana/
 
-start-e2e-test: zetanode
+start-e2e-test: e2e-images
 	@echo "--> Starting e2e test"
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d 
 
-start-e2e-admin-test: zetanode
+start-e2e-admin-test: e2e-images
 	@echo "--> Starting e2e admin test"
 	export E2E_ARGS="--skip-regular --test-admin" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile eth2 up -d
 
-start-e2e-performance-test: zetanode
+start-e2e-performance-test: e2e-images
 	@echo "--> Starting e2e performance test"
 	export E2E_ARGS="--test-performance" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
-start-e2e-import-mainnet-test: zetanode
+start-e2e-import-mainnet-test: e2e-images
 	@echo "--> Starting e2e import-data test"
 	export ZETACORED_IMPORT_GENESIS_DATA=true && \
 	export ZETACORED_START_PERIOD=15m && \
 	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) up -d
 
-start-stress-test: zetanode
+start-stress-test: e2e-images
 	@echo "--> Starting stress test"
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
-start-tss-migration-test: zetanode
+start-tss-migration-test: e2e-images
 	@echo "--> Starting tss migration test"
 	export LOCALNET_MODE=tss-migrate && \
 	export E2E_ARGS="--test-tss-migration" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
 
-start-solana-test: zetanode solana
+start-solana-test: e2e-images solana
 	@echo "--> Starting solana test"
 	export E2E_ARGS="--skip-regular --test-solana" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile solana up -d
 
-start-ton-test: zetanode
+start-ton-test: e2e-images
 	@echo "--> Starting TON test"
 	export E2E_ARGS="--skip-regular --test-ton" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile ton up -d
 
-start-v2-test: zetanode
+start-v2-test: e2e-images
 	@echo "--> Starting e2e smart contracts v2 test"
 	export E2E_ARGS="--skip-regular --test-v2" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
@@ -309,7 +322,7 @@ start-v2-test: zetanode
 # build from source only if requested
 # NODE_VERSION and NODE_COMMIT must be set as old-runtime depends on lastest-runtime
 ifdef UPGRADE_TEST_FROM_SOURCE
-zetanode-upgrade: zetanode
+zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
 		--build-arg OLD_VERSION='release/v21' \
@@ -318,7 +331,7 @@ zetanode-upgrade: zetanode
 		.
 .PHONY: zetanode-upgrade
 else
-zetanode-upgrade: zetanode
+zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
 	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v21.0.0' \

--- a/contrib/localnet/orchestrator/Dockerfile.fastbuild
+++ b/contrib/localnet/orchestrator/Dockerfile.fastbuild
@@ -1,17 +1,11 @@
 # syntax=ghcr.io/zeta-chain/docker-dockerfile:1.9-labs
 # check=error=true
-FROM zetanode:latest AS zeta
 FROM ghcr.io/zeta-chain/ethereum-client-go:v1.10.26 AS geth
 FROM ghcr.io/zeta-chain/solana-docker:1.18.15 AS solana
-FROM ghcr.io/zeta-chain/golang:1.22.7-bookworm AS orchestrator
-
-RUN apt update && \
-    apt install -yq jq yq curl tmux python3 openssh-server iputils-ping iproute2 bind9-host && \
-    rm -rf /var/lib/apt/lists/*
+FROM zetanode:latest
 
 COPY --from=geth /usr/local/bin/geth /usr/local/bin/
 COPY --from=solana /usr/bin/solana /usr/local/bin/
-COPY --from=zeta /usr/local/bin/zetacored /usr/local/bin/zetaclientd /usr/local/bin/zetae2e /usr/local/bin/
 
 COPY contrib/localnet/orchestrator/start-zetae2e.sh /work/
 COPY contrib/localnet/scripts/wait-for-ton.sh /work/


### PR DESCRIPTION
# Description

Only build the zetanode image once per e2e matrix. Local development flow should be unchanged.

The zetanode localnet image is already quite slim so pushing is quite fast (less than 10 seconds in my tests).

Unrelated but this also give you a bit more time to add e2e labels to your PR when opening as the matrix computation is deferred a bit now.

Also unrelated but now you can rerun a failed job without having to wait for the build again.

Related to #3120. When merged, it will push `ghcr.io/zeta-chain/zetanode:develop` image.

Fork context tested here: https://github.com/zeta-chain/node/pull/3123. Update, looks like this will never work for forks as [they can never push packages](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (even to their own user's packages). Will workaround by just falling back to the slow build on forks I guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new job `build-zetanode` in the CI workflow to streamline the building of the Zeta node image.
  - Added a new input parameter `zetanode-image` to the reusable E2E testing workflow for improved image handling.

- **Improvements**
  - Simplified Dockerfile processes by changing base images and removing unnecessary package installations.
  - Enhanced Makefile structure for better clarity and dependency management in testing workflows.

- **Bug Fixes**
  - Updated job dependencies to ensure proper execution order in CI, reducing potential errors during builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->