### PR TITLE
test: add e2e consensus test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,6 +111,7 @@ jobs:
     outputs:
       DEFAULT_TESTS: ${{ steps.matrix-conditionals.outputs.DEFAULT_TESTS }}
       UPGRADE_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_TESTS }}
+      CONSENSUS_TESTS: ${{ steps.matrix-conditionals.outputs.CONSENSUS_TESTS }}
       UPGRADE_LIGHT_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_LIGHT_TESTS }}
       UPGRADE_IMPORT_MAINNET_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_IMPORT_MAINNET_TESTS }}
       ADMIN_TESTS: ${{ steps.matrix-conditionals.outputs.ADMIN_TESTS }}
@@ -138,6 +139,7 @@ jobs:
               console.log("labels:", labels);
               core.setOutput('DEFAULT_TESTS', true);
               core.setOutput('UPGRADE_TESTS', labels.includes('UPGRADE_TESTS'));
+              core.setOutput('CONSENSUS_TESTS', !labels.includes('CONSENSUS_BREAKING_ACK'));
               core.setOutput('UPGRADE_LIGHT_TESTS', labels.includes('UPGRADE_LIGHT_TESTS'));
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', labels.includes('UPGRADE_IMPORT_MAINNET_TESTS'));
               core.setOutput('ADMIN_TESTS', labels.includes('ADMIN_TESTS'));
@@ -206,6 +208,9 @@ jobs:
           - make-target: "start-e2e-test"
             runs-on: ubuntu-20.04
             run: ${{ needs.matrix-conditionals.outputs.DEFAULT_TESTS == 'true' }}
+          - make-target: "start-e2e-consensus-test"
+            runs-on: ubuntu-20.04
+            run: ${{ needs.matrix-conditionals.outputs.CONSENSUS_TESTS == 'true' }}
           - make-target: "start-upgrade-test"
             runs-on: ubuntu-20.04
             run: ${{ needs.matrix-conditionals.outputs.UPGRADE_TESTS == 'true' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,17 +129,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.eventName === 'pull_request') {
+            const getPrLabels = async (pull_number) => {
               const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-              });
-              const labels = pr.labels.map(label => label.name);
-              console.log("labels:", labels);
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pull_number,
+                });
+                const labels = pr.labels.map(label => label.name);
+                console.log(`labels for ${pull_number}:`, labels);
+                return labels;
+            }
+
+            if (context.eventName === 'pull_request') {
+              const labels = await getPrLabels(context.payload.pull_request.number);
               core.setOutput('DEFAULT_TESTS', true);
               core.setOutput('UPGRADE_TESTS', labels.includes('UPGRADE_TESTS'));
-              core.setOutput('CONSENSUS_TESTS', !labels.includes('CONSENSUS_BREAKING_ACK'));
+              core.setOutput('CONSENSUS_TESTS', labels.includes('CONSENSUS_TESTS'));
               core.setOutput('UPGRADE_LIGHT_TESTS', labels.includes('UPGRADE_LIGHT_TESTS'));
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', labels.includes('UPGRADE_IMPORT_MAINNET_TESTS'));
               core.setOutput('ADMIN_TESTS', labels.includes('ADMIN_TESTS'));
@@ -152,8 +157,20 @@ jobs:
               core.setOutput('V2_MIGRATION_TESTS', labels.includes('V2_MIGRATION_TESTS')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
               core.setOutput('ENABLE_MONITORING', labels.includes('ENABLE_MONITORING'));
             } else if (context.eventName === 'merge_group') {
+              // default mergequeue tests
               core.setOutput('DEFAULT_TESTS', true);
               core.setOutput('UPGRADE_LIGHT_TESTS', true);
+
+              // conditional tests based on PR labels
+              const commit_message = context.payload.merge_group.head_commit.message;
+              const pr_match = commit_message.split('\n')[0].match(/\(#(\d+)\)$/);
+              if (!pr_match) {
+                console.error("unable to extract PR number from mergequeue commit message");
+                return;
+              }
+              const pr_number = pr_match[1];
+              const pr_labels = getPrLabels(pr_number);
+              core.setOutput('CONSENSUS_TESTS', !labels.includes('CONSENSUS_BREAKING_ACK'));
             } else if (context.eventName === 'push' && context.ref === 'refs/heads/develop') {
               core.setOutput('DEFAULT_TESTS', true);
             } else if (context.eventName === 'push' && context.ref.startsWith('refs/heads/release/')) {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -169,8 +169,8 @@ jobs:
                 return;
               }
               const pr_number = pr_match[1];
-              const pr_labels = getPrLabels(pr_number);
-              core.setOutput('CONSENSUS_TESTS', !labels.includes('CONSENSUS_BREAKING_ACK'));
+              const pr_labels = await getPrLabels(pr_number);
+              core.setOutput('CONSENSUS_TESTS', !pr_labels.includes('CONSENSUS_BREAKING_ACK'));
             } else if (context.eventName === 'push' && context.ref === 'refs/heads/develop') {
               core.setOutput('DEFAULT_TESTS', true);
             } else if (context.eventName === 'push' && context.ref.startsWith('refs/heads/release/')) {

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ solana:
 
 start-e2e-test: e2e-images
 	@echo "--> Starting e2e test"
-	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d 
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
 
 start-e2e-admin-test: e2e-images
 	@echo "--> Starting e2e admin test"
@@ -285,6 +285,12 @@ start-e2e-import-mainnet-test: e2e-images
 	export ZETACORED_IMPORT_GENESIS_DATA=true && \
 	export ZETACORED_START_PERIOD=15m && \
 	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) up -d
+
+start-e2e-consensus-test: e2e-images
+	@echo "--> Starting e2e consensus test"
+	export ZETACORE1_IMAGE=ghcr.io/zeta-chain/zetanode:develop && \
+	export ZETACORE1_PLATFORM=linux/amd64 && \
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d 
 
 start-stress-test: e2e-images
 	@echo "--> Starting stress test"

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -190,6 +190,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		noError(deployerRunner.FundEmissionsPool())
 	}
 
+	// monitor block production to ensure we fail fast if there are consensus failures
+	// this is not run in an errgroup since only returning an error will not exit immedately
+	go monitorBlockProductionExit(ctx, conf)
+
 	// wait for keygen to be completed
 	// if setup is skipped, we assume that the keygen is already completed
 	if !skipSetup {

--- a/cmd/zetae2e/local/monitor_block_production.go
+++ b/cmd/zetae2e/local/monitor_block_production.go
@@ -1,0 +1,55 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	cometbft_types "github.com/cometbft/cometbft/types"
+
+	"github.com/zeta-chain/node/e2e/config"
+)
+
+// monitorBlockProductionExit calls monitorBlockProduction and exits upon any error
+func monitorBlockProductionExit(ctx context.Context, conf config.Config) {
+	err := monitorBlockProduction(ctx, conf)
+	if err != nil {
+		fmt.Printf("❌ block monitor: %v\n", err)
+		os.Exit(2)
+	}
+}
+
+// monitorBlockProduction subscribes to new block events to monitor if blocks are being produced
+// at least every four seconds
+func monitorBlockProduction(ctx context.Context, conf config.Config) error {
+	rpcClient, err := rpchttp.New(conf.RPCs.ZetaCoreRPC, "/websocket")
+	if err != nil {
+		return fmt.Errorf("new zetacore rpc: %w", err)
+	}
+
+	err = rpcClient.WSEvents.Start()
+	if err != nil {
+		return fmt.Errorf("start ws events: %w", err)
+	}
+	blockEventChan, err := rpcClient.WSEvents.Subscribe(ctx, "", "tm.event='NewBlock'")
+	if err != nil {
+		return fmt.Errorf("subscribe: %w", err)
+	}
+	latestNewBlockEvent := cometbft_types.EventDataNewBlock{}
+	for {
+		select {
+		case event := <-blockEventChan:
+			newBlockEvent, ok := event.Data.(cometbft_types.EventDataNewBlock)
+			if !ok {
+				return fmt.Errorf("expecting new block event, got %T", event.Data)
+			}
+			latestNewBlockEvent = newBlockEvent
+		case <-time.After(4 * time.Second):
+			return fmt.Errorf("timed out waiting for new block (last block %d)", latestNewBlockEvent.Block.Height)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -67,7 +67,8 @@ services:
       - ~/.zetacored/genesis_data:/root/genesis_data
 
   zetacore1:
-    image: zetanode:latest
+    image: ${ZETACORE1_IMAGE-zetanode:latest}
+    platform: ${ZETACORE1_PLATFORM-}
     container_name: zetacore1
     hostname: zetacore1
     networks:


### PR DESCRIPTION
# Description

Add `start-e2e-consensus-test` which starts up localnet with the develop version of zetacored pushed in #3121.

Opt in on your PR with the `CONSENSUS_TESTS` label. This will generally require your PR to be up to date with develop.

To acknowledge a breaking change, you must add the `CONSENSUS_BREAKING_ACK` label to your PR. If your PR is consensus breaking, you should also have an explanation point in your PR title (`feat!`, `fix!`, etc).

If `CONSENSUS_BREAKING_ACK` is not applied to your PR, the consensus tests will be run on the mergequeue automatically. The mergequeue is the best place to run this test as the head branch is guaranteed to be one commit above develop (at least with our current config).

e2e will still point at zetacore0 so any rpc only changes should not result in failure.

Also add block production monitor to `zetae2e local` which will halt the e2e tests quickly if blocks are not being produced.

Demo in https://github.com/zeta-chain/node/pull/3129

Closes https://github.com/zeta-chain/node/issues/3120

# How Has This Been Tested?

- [x] `make start-e2e-consensus-test` on arm64 macos


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new end-to-end consensus test that can be initiated via a new Makefile target.
	- Enhanced the GitHub Actions workflow to conditionally execute tests based on pull request labels and merge events.

- **Improvements**
	- Updated the `zetacore1` service in the Docker Compose configuration for improved configurability with dynamic image and platform settings.

- **Bug Fixes**
	- Minor formatting adjustments made in the Makefile for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->