### PR TITLE
chore: add coderabbit instructions for tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,6 +33,10 @@ reviews:
       instructions: >-
         Review the shell scripts, point out issues relative to security,
         performance, and maintainability.
+    - path: '{*e2e*,*_test.go}'
+      instructions: >-
+        Errors in tests may be handled via require.NoError(t, err) rather
+        than explicitly returning error.
 
   auto_review:
     drafts: false


### PR DESCRIPTION
I see a lot of pointless coderabbit spam on e2e tests about error handling. Let's try to provide some instructions to avoid that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new path instruction for end-to-end tests and Go test files to enhance testing processes.
  
- **Documentation**
	- Updated instructions for handling errors in tests to improve clarity and consistency in error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->