### PR TITLE
chore: demo e2e consensus failure

### DIFF
--- a/precompiles/staking/method_distribute.go
+++ b/precompiles/staking/method_distribute.go
@@ -83,13 +83,6 @@ func (c *Contract) distribute(
 		"Denom", precompiletypes.ZRC20ToCosmosDenom(zrc20Addr),
 	)
 
-	if err := c.addDistributeLog(ctx, evm.StateDB, caller, zrc20Addr, amount); err != nil {
-		return nil, &precompiletypes.ErrUnexpected{
-			When: "AddDistributeLog",
-			Got:  err.Error(),
-		}
-	}
-
 	return method.Outputs.Pack(true)
 }
 


### PR DESCRIPTION
Commit has a consensus breaking change to a precompiled contract.

zetacored will print consensus failure logs and blocks will not be produced:

```
7:44PM INF received complete proposal block hash=183BE96C3F20FB8FA3476492D1B7FE4DBB6974D936524741D5DF30D49FA56740 height=77 module=consensus server=node
7:44PM ERR prevote step: consensus deems this block invalid; prevoting nil err="wrong Block.Header.LastResultsHash.  Expected 7AD79ED7B61E2D45F42847BF9F5D138FE7EBF82057F2BC8D5EB43FCAA067EDCD, got 79AD3CF784C1DF78A8830139B68F815422FF03CFFF3C8A320291757A236D6DA3" height=77 module=consensus round=2 server=node
7:44PM INF Timed out dur=2000 height=77 module=consensus round=2 server=node step=RoundStepPrevoteWait
7:44PM INF Timed out dur=2000 height=77 module=consensus round=2 server=node step=RoundStepPrecommitWait
7:44PM INF resetting proposal info height=77 module=consensus proposer=F2F6B1C8C25DD9EC0DB1CF5A76B8D414AB99DE16 round=3 server=node
7:44PM INF received proposal module=consensus proposal="Proposal{77/3 (93510FC359ABE0FE716B0E8A004DE2BFD2EA88FDA780F1F06610F17BA02F4E7B:1:C2720008A40F, -1) E542E24DDA34 @ 2024-11-07T19:44:06.457676841Z}" proposer=F2F6B1C8C25DD9EC0DB1CF5A76B8D414AB99DE16 server=node
7:44PM INF received complete proposal block hash=93510FC359ABE0FE716B0E8A004DE2BFD2EA88FDA780F1F06610F17BA02F4E7B height=77 module=consensus server=node
7:44PM INF Timed out dur=2500 height=77 module=consensus round=3 server=node step=RoundStepPrevoteWait
7:44PM INF Timed out dur=2500 height=77 module=consensus round=3 server=node step=RoundStepPrecommitWait
7:44PM INF resetting proposal info height=77 module=consensus proposer=07BFC16195ADB516D4B086397CC678E83A7F05CE round=4 server=node
7:44PM INF received proposal module=consensus proposal="Proposal{77/4 (EC3F90BAF2A1AE54A8DC7710422D012910242E55AB64038D65A38C96A4ABF427:1:053D0C753F49, -1) 8B5683B8858E @ 2024-11-07T19:44:11.85042429Z}" proposer=07BFC16195ADB516D4B086397CC678E83A7F05CE server=node
7:44PM INF received complete proposal block hash=EC3F90BAF2A1AE54A8DC7710422D012910242E55AB64038D65A38C96A4ABF427 height=77 module=consensus server=node
7:44PM ERR prevote step: consensus deems this block invalid; prevoting nil err="wrong Block.Header.LastResultsHash.  Expected 7AD79ED7B61E2D45F42847BF9F5D138FE7EBF82057F2BC8D5EB43FCAA067EDCD, got 79AD3CF784C1DF78A8830139B68F815422FF03CFFF3C8A320291757A236D6DA3" height=77 module=consensus round=4 server=node
7:44PM INF Timed out dur=3000 height=77 module=consensus round=4 server=node step=RoundStepPrevoteWait
```

e2e will fail fast becuase blocks are not being produced:

```
precompile | ⏳running - test stateful precompiled contracts distribute
erc20      | ⏳ depositing ERC20 into ZEVM
bitcoin    | ⏳ depositing ERC20 into ZEVM
ether      | ⏳running - withdraw Ether from ZEVM
zeta       | ⏳ depositing Ethers into ZEVM
zevm_mp    | ⏳ depositing Ethers into ZEVM
zeta       | ⏳running - withdraw ZETA from ZEVM to Ethereum
zevm_mp    | ⏳running - zevm -> evm message passing contract call
bitcoin    | ⚙️ setting up Bitcoin account
erc20      | ⏳running - withdraw ERC20 from ZEVM
bitcoin    | ✅ Bitcoin account setup in 149.883914ms
bitcoin    | ⏳ depositing BTC into ZEVM
❌ block monitor: timed out waiting for new block (last block 76)
e2e failed
```