### PR TITLE
chore(e2e): move block production monitor before any transactions

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -182,6 +182,11 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	)
 	noError(err)
 
+	// monitor block production to ensure we fail fast if there are consensus failures
+	// this is not run in an errgroup since only returning an error will not exit immedately
+	// this needs to be early to quickly detect consensus failure during genesis
+	go monitorBlockProductionExit(ctx, conf)
+
 	// set the authority client to the zeta tx server to be able to query message permissions
 	deployerRunner.ZetaTxServer.SetAuthorityClient(deployerRunner.AuthorityClient)
 
@@ -189,10 +194,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipSetup {
 		noError(deployerRunner.FundEmissionsPool())
 	}
-
-	// monitor block production to ensure we fail fast if there are consensus failures
-	// this is not run in an errgroup since only returning an error will not exit immedately
-	go monitorBlockProductionExit(ctx, conf)
 
 	// wait for keygen to be completed
 	// if setup is skipped, we assume that the keygen is already completed


### PR DESCRIPTION
# Description

The block production monitor should cause the e2e tests to fail fast even if consensus fails immediately at genesis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced monitoring for block production during the genesis phase, allowing for quicker detection of consensus failures.
  
- **Bug Fixes**
	- Improved responsiveness of consensus issue detection without impacting the immediate exit of tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->