### PR TITLE
test: fix evm signer instability

### DIFF
--- a/zetaclient/chains/evm/signer/sign_test.go
+++ b/zetaclient/chains/evm/signer/sign_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 )
 
@@ -15,7 +16,7 @@ func TestSigner_SignConnectorOnReceive(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -33,8 +34,7 @@ func TestSigner_SignConnectorOnReceive(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify Signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 	})
 	t.Run("SignConnectorOnReceive - should fail if keysign fails", func(t *testing.T) {
 		// Pause tss to make keysign fail
@@ -53,8 +53,7 @@ func TestSigner_SignConnectorOnReceive(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify Signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// check that by default tx type is legacy tx
 		assert.Equal(t, ethtypes.LegacyTxType, int(tx.Type()))
@@ -86,7 +85,7 @@ func TestSigner_SignConnectorOnReceive(t *testing.T) {
 		require.NoError(t, err)
 
 		// ASSERT
-		verifyTxSignature(t, tx, mocks.NewTSSMainnet().Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// check that by default tx type is a dynamic fee tx
 		assert.Equal(t, ethtypes.DynamicFeeTxType, int(tx.Type()))
@@ -101,7 +100,7 @@ func TestSigner_SignConnectorOnRevert(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -118,8 +117,7 @@ func TestSigner_SignConnectorOnRevert(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		// Note: Revert tx calls connector contract with 0 gas token
@@ -140,7 +138,7 @@ func TestSigner_SignCancel(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -157,12 +155,11 @@ func TestSigner_SignCancel(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		// Note: Cancel tx sends 0 gas token to TSS self address
-		verifyTxBodyBasics(t, tx, evmSigner.TSS().EVMAddress(), txData.nonce, big.NewInt(0))
+		verifyTxBodyBasics(t, tx, tss.EVMAddress(), txData.nonce, big.NewInt(0))
 	})
 	t.Run("SignCancel - should fail if keysign fails", func(t *testing.T) {
 		// Pause tss to make keysign fail
@@ -179,7 +176,7 @@ func TestSigner_SignGasWithdraw(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -196,8 +193,7 @@ func TestSigner_SignGasWithdraw(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, txData.amount)
@@ -217,7 +213,7 @@ func TestSigner_SignERC20Withdraw(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -233,8 +229,7 @@ func TestSigner_SignERC20Withdraw(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		// Note: Withdraw tx calls erc20 custody contract with 0 gas token

--- a/zetaclient/chains/evm/signer/signer_admin_test.go
+++ b/zetaclient/chains/evm/signer/signer_admin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
@@ -16,7 +17,8 @@ func TestSigner_SignAdminTx(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	evmSigner, err := getNewEvmSigner(nil)
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
+	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
 	// Setup txData struct
@@ -36,8 +38,7 @@ func TestSigner_SignAdminTx(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		// Note: Revert tx calls erc20 custody contract with 0 gas token
@@ -57,8 +58,7 @@ func TestSigner_SignAdminTx(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		// Note: Revert tx calls erc20 custody contract with 0 gas token
@@ -73,8 +73,7 @@ func TestSigner_SignAdminTx(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		// Note: Revert tx calls erc20 custody contract with 0 gas token
@@ -88,8 +87,7 @@ func TestSigner_SignAdminTx(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, txData.amount)
@@ -100,7 +98,7 @@ func TestSigner_SignWhitelistERC20Cmd(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -121,8 +119,7 @@ func TestSigner_SignWhitelistERC20Cmd(t *testing.T) {
 		require.NotNil(t, tx)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, zeroValue)
@@ -178,8 +175,7 @@ func TestSigner_SignMigrateERC20CustodyFundsCmd(t *testing.T) {
 		require.NotNil(t, tx)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, zeroValue)
@@ -238,8 +234,7 @@ func TestSigner_SignUpdateERC20CustodyPauseStatusCmd(t *testing.T) {
 		require.NotNil(t, tx)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, zeroValue)
@@ -255,8 +250,7 @@ func TestSigner_SignUpdateERC20CustodyPauseStatusCmd(t *testing.T) {
 		require.NotNil(t, tx)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, zeroValue)
@@ -293,7 +287,7 @@ func TestSigner_SignMigrateTssFundsCmd(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -313,8 +307,7 @@ func TestSigner_SignMigrateTssFundsCmd(t *testing.T) {
 		require.NotNil(t, tx)
 
 		// Verify tx signature
-		tss := mocks.NewTSSMainnet()
-		verifyTxSignature(t, tx, tss.Pubkey(), evmSigner.EvmSigner())
+		verifyTxSender(t, tx, tss.EVMAddress(), evmSigner.EvmSigner())
 
 		// Verify tx body basics
 		verifyTxBodyBasics(t, tx, txData.to, txData.nonce, txData.amount)

--- a/zetaclient/chains/evm/signer/signer_admin_test.go
+++ b/zetaclient/chains/evm/signer/signer_admin_test.go
@@ -146,7 +146,7 @@ func TestSigner_SignMigrateERC20CustodyFundsCmd(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestSigner_SignUpdateERC20CustodyPauseStatusCmd(t *testing.T) {
 	ctx := makeCtx(t)
 
 	// Setup evm signer
-	tss := mocks.NewTSSMainnet()
+	tss := mocks.NewDerivedTSS(chains.BitcoinMainnet)
 	evmSigner, err := getNewEvmSigner(tss)
 	require.NoError(t, err)
 

--- a/zetaclient/chains/evm/signer/signer_test.go
+++ b/zetaclient/chains/evm/signer/signer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	"github.com/ethereum/go-ethereum/common"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/rs/zerolog"
@@ -117,7 +116,7 @@ func getInvalidCCTX(t *testing.T) *crosschaintypes.CrossChainTx {
 //
 // signer.Sender() will ecrecover the public key of the transaction internally
 // and will fail if the transaction is not valid or has been tampered with
-func verifyTxSender(t *testing.T, tx *ethtypes.Transaction, expectedSender common.Address, signer ethtypes.Signer) {
+func verifyTxSender(t *testing.T, tx *ethtypes.Transaction, expectedSender ethcommon.Address, signer ethtypes.Signer) {
 	senderAddr, err := signer.Sender(tx)
 	require.NoError(t, err)
 	require.Equal(t, expectedSender.String(), senderAddr.String())

--- a/zetaclient/chains/evm/signer/signer_test.go
+++ b/zetaclient/chains/evm/signer/signer_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -113,14 +113,14 @@ func getInvalidCCTX(t *testing.T) *crosschaintypes.CrossChainTx {
 	return cctx
 }
 
-// verifyTxSignature is a helper function to verify the signature of a transaction
-func verifyTxSignature(t *testing.T, tx *ethtypes.Transaction, tssPubkey []byte, signer ethtypes.Signer) {
-	_, r, s := tx.RawSignatureValues()
-	signature := append(r.Bytes(), s.Bytes()...)
-	hash := signer.Hash(tx)
-
-	verified := crypto.VerifySignature(tssPubkey, hash.Bytes(), signature)
-	require.True(t, verified)
+// verifyTxSender is a helper function to verify the signature of a transaction
+//
+// signer.Sender() will ecrecover the public key of the transaction internally
+// and will fail if the transaction is not valid or has been tampered with
+func verifyTxSender(t *testing.T, tx *ethtypes.Transaction, expectedSender common.Address, signer ethtypes.Signer) {
+	senderAddr, err := signer.Sender(tx)
+	require.NoError(t, err)
+	require.Equal(t, expectedSender.String(), senderAddr.String())
 }
 
 // verifyTxBodyBasics is a helper function to verify 'to', 'nonce' and 'amount' of a transaction

--- a/zetaclient/testutils/mocks/tss_signer.go
+++ b/zetaclient/testutils/mocks/tss_signer.go
@@ -63,6 +63,16 @@ func NewTSSAthens3() *TSS {
 	return NewMockTSS(chains.BscTestnet, testutils.TSSAddressEVMAthens3, testutils.TSSAddressBTCAthens3)
 }
 
+// NewDerivedTSS creates a TSS where evmAddress and btcAdresses are always derived from the test
+// private key
+func NewDerivedTSS(chain chains.Chain) *TSS {
+	return &TSS{
+		paused:  false,
+		chain:   chain,
+		PrivKey: TestPrivateKey,
+	}
+}
+
 func NewGeneratedTSS(t *testing.T, chain chains.Chain) *TSS {
 	pk, err := crypto.GenerateKey()
 	require.NoError(t, err)


### PR DESCRIPTION
The current usage of `verifyTxSignature` is not correct as it assumes a very specific signature style. It seems we could actually get transactions with a few different signature styles.

There is not actually a stable way to verify the raw signature/ecrecover exported in go-ethereum.`signer.Sender(tx)` seems to be the only stable way exported so let's use that instead. It will internally determine which signer was used, properly ecrecover the public key, and return the address.

<details>

<summary>Snippets from go-ethereum showing how different transactions need to be verified differently</summary>

```
func (s londonSigner) Sender(tx *Transaction) (common.Address, error) {
	if tx.Type() != DynamicFeeTxType {
		return s.eip2930Signer.Sender(tx)
	}
	V, R, S := tx.RawSignatureValues()
	// DynamicFee txs are defined to use 0 and 1 as their recovery
	// id, add 27 to become equivalent to unprotected Homestead signatures.
	V = new(big.Int).Add(V, big.NewInt(27))
	if tx.ChainId().Cmp(s.chainId) != 0 {
		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
	}
	return recoverPlain(s.Hash(tx), R, S, V, true)
}
```

```
func (s eip2930Signer) Sender(tx *Transaction) (common.Address, error) {
	V, R, S := tx.RawSignatureValues()
	switch tx.Type() {
	case LegacyTxType:
		return s.EIP155Signer.Sender(tx)
	case AccessListTxType:
		// AL txs are defined to use 0 and 1 as their recovery
		// id, add 27 to become equivalent to unprotected Homestead signatures.
		V = new(big.Int).Add(V, big.NewInt(27))
	default:
		return common.Address{}, ErrTxTypeNotSupported
	}
	if tx.ChainId().Cmp(s.chainId) != 0 {
		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
	}
	return recoverPlain(s.Hash(tx), R, S, V, true)
}
```

```
func (s EIP155Signer) Sender(tx *Transaction) (common.Address, error) {
	if tx.Type() != LegacyTxType {
		return common.Address{}, ErrTxTypeNotSupported
	}
	if !tx.Protected() {
		return HomesteadSigner{}.Sender(tx)
	}
	if tx.ChainId().Cmp(s.chainId) != 0 {
		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
	}
	V, R, S := tx.RawSignatureValues()
	V = new(big.Int).Sub(V, s.chainIdMul)
	V.Sub(V, big8)
	return recoverPlain(s.Hash(tx), R, S, V, true)
}
```

```
func (hs HomesteadSigner) Sender(tx *Transaction) (common.Address, error) {
	if tx.Type() != LegacyTxType {
		return common.Address{}, ErrTxTypeNotSupported
	}
	v, r, s := tx.RawSignatureValues()
	return recoverPlain(hs.Hash(tx), r, s, v, true)
}
```


</details>

There's also some confusion with current MockTSS signers where the addresses are not derived from the private key of the signer. At least in the signer tests, we should always use a TSS implementation where the keys match. Add `NewDerivedTSS` which ensure this happens.

Closes https://github.com/zeta-chain/node/issues/3081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for creating a derived TSS instance, enhancing the predictability of address generation in tests.

- **Bug Fixes**
	- Updated signature verification methods in tests to align with the new TSS instantiation, ensuring accurate transaction validation.

- **Documentation**
	- Improved comments for clarity in the signature verification process within the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->