### PR TITLE
fix: allow BTC revert with dust amount

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -268,66 +268,66 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipRegular {
 		// defines all tests, if light is enabled, only the most basic tests are run and advanced are skipped
 		erc20Tests := []string{
-			//e2etests.TestERC20WithdrawName,
-			//e2etests.TestMultipleERC20WithdrawsName,
-			//e2etests.TestERC20DepositAndCallRefundName,
-			//e2etests.TestZRC20SwapName,
+			e2etests.TestERC20WithdrawName,
+			e2etests.TestMultipleERC20WithdrawsName,
+			e2etests.TestERC20DepositAndCallRefundName,
+			e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
-			//e2etests.TestERC20DepositRestrictedName,
+			e2etests.TestERC20DepositRestrictedName,
 		}
 		zetaTests := []string{
-			//e2etests.TestZetaWithdrawName,
-			//e2etests.TestMessagePassingExternalChainsName,
-			//e2etests.TestMessagePassingRevertFailExternalChainsName,
-			//e2etests.TestMessagePassingRevertSuccessExternalChainsName,
+			e2etests.TestZetaWithdrawName,
+			e2etests.TestMessagePassingExternalChainsName,
+			e2etests.TestMessagePassingRevertFailExternalChainsName,
+			e2etests.TestMessagePassingRevertSuccessExternalChainsName,
 		}
 		zetaAdvancedTests := []string{
-			//e2etests.TestZetaDepositRestrictedName,
-			//e2etests.TestZetaDepositName,
-			//e2etests.TestZetaDepositNewAddressName,
+			e2etests.TestZetaDepositRestrictedName,
+			e2etests.TestZetaDepositName,
+			e2etests.TestZetaDepositNewAddressName,
 		}
 		zevmMPTests := []string{}
 		zevmMPAdvancedTests := []string{
-			//e2etests.TestMessagePassingZEVMToEVMName,
-			//e2etests.TestMessagePassingEVMtoZEVMName,
-			//e2etests.TestMessagePassingEVMtoZEVMRevertName,
-			//e2etests.TestMessagePassingZEVMtoEVMRevertName,
-			//e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
-			//e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
+			e2etests.TestMessagePassingZEVMToEVMName,
+			e2etests.TestMessagePassingEVMtoZEVMName,
+			e2etests.TestMessagePassingEVMtoZEVMRevertName,
+			e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
+			e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
 		}
 
 		bitcoinTests := []string{
-			//e2etests.TestBitcoinDonationName,
-			//e2etests.TestBitcoinDepositName,
-			//e2etests.TestBitcoinDepositAndCallName,
-			//e2etests.TestBitcoinDepositAndCallRevertName,
+			e2etests.TestBitcoinDonationName,
+			e2etests.TestBitcoinDepositName,
+			e2etests.TestBitcoinDepositAndCallName,
+			e2etests.TestBitcoinDepositAndCallRevertName,
 			e2etests.TestBitcoinDepositAndCallRevertWithDustName,
-			//e2etests.TestBitcoinWithdrawSegWitName,
-			//e2etests.TestBitcoinWithdrawInvalidAddressName,
-			//e2etests.TestZetaWithdrawBTCRevertName,
-			//e2etests.TestCrosschainSwapName,
+			e2etests.TestBitcoinWithdrawSegWitName,
+			e2etests.TestBitcoinWithdrawInvalidAddressName,
+			e2etests.TestZetaWithdrawBTCRevertName,
+			e2etests.TestCrosschainSwapName,
 		}
 		bitcoinAdvancedTests := []string{
-			//e2etests.TestBitcoinWithdrawTaprootName,
-			//e2etests.TestBitcoinWithdrawLegacyName,
-			//e2etests.TestBitcoinWithdrawMultipleName,
-			//e2etests.TestBitcoinWithdrawP2SHName,
-			//e2etests.TestBitcoinWithdrawP2WSHName,
-			//e2etests.TestBitcoinWithdrawRestrictedName,
-			//e2etests.TestBitcoinStdMemoDepositName,
-			//e2etests.TestBitcoinStdMemoDepositAndCallName,
-			//e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
-			//e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
+			e2etests.TestBitcoinWithdrawTaprootName,
+			e2etests.TestBitcoinWithdrawLegacyName,
+			e2etests.TestBitcoinWithdrawMultipleName,
+			e2etests.TestBitcoinWithdrawP2SHName,
+			e2etests.TestBitcoinWithdrawP2WSHName,
+			e2etests.TestBitcoinWithdrawRestrictedName,
+			e2etests.TestBitcoinStdMemoDepositName,
+			e2etests.TestBitcoinStdMemoDepositAndCallName,
+			e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
+			e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
 		}
 		ethereumTests := []string{
-			//e2etests.TestEtherWithdrawName,
-			//e2etests.TestContextUpgradeName,
-			//e2etests.TestEtherDepositAndCallName,
-			//e2etests.TestEtherDepositAndCallRefundName,
+			e2etests.TestEtherWithdrawName,
+			e2etests.TestContextUpgradeName,
+			e2etests.TestEtherDepositAndCallName,
+			e2etests.TestEtherDepositAndCallRefundName,
 		}
 		ethereumAdvancedTests := []string{
-			//e2etests.TestEtherWithdrawRestrictedName,
+			e2etests.TestEtherWithdrawRestrictedName,
 		}
 		precompiledContractTests := []string{}
 

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -268,65 +268,66 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipRegular {
 		// defines all tests, if light is enabled, only the most basic tests are run and advanced are skipped
 		erc20Tests := []string{
-			e2etests.TestERC20WithdrawName,
-			e2etests.TestMultipleERC20WithdrawsName,
-			e2etests.TestERC20DepositAndCallRefundName,
-			e2etests.TestZRC20SwapName,
+			//e2etests.TestERC20WithdrawName,
+			//e2etests.TestMultipleERC20WithdrawsName,
+			//e2etests.TestERC20DepositAndCallRefundName,
+			//e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
-			e2etests.TestERC20DepositRestrictedName,
+			//e2etests.TestERC20DepositRestrictedName,
 		}
 		zetaTests := []string{
-			e2etests.TestZetaWithdrawName,
-			e2etests.TestMessagePassingExternalChainsName,
-			e2etests.TestMessagePassingRevertFailExternalChainsName,
-			e2etests.TestMessagePassingRevertSuccessExternalChainsName,
+			//e2etests.TestZetaWithdrawName,
+			//e2etests.TestMessagePassingExternalChainsName,
+			//e2etests.TestMessagePassingRevertFailExternalChainsName,
+			//e2etests.TestMessagePassingRevertSuccessExternalChainsName,
 		}
 		zetaAdvancedTests := []string{
-			e2etests.TestZetaDepositRestrictedName,
-			e2etests.TestZetaDepositName,
-			e2etests.TestZetaDepositNewAddressName,
+			//e2etests.TestZetaDepositRestrictedName,
+			//e2etests.TestZetaDepositName,
+			//e2etests.TestZetaDepositNewAddressName,
 		}
 		zevmMPTests := []string{}
 		zevmMPAdvancedTests := []string{
-			e2etests.TestMessagePassingZEVMToEVMName,
-			e2etests.TestMessagePassingEVMtoZEVMName,
-			e2etests.TestMessagePassingEVMtoZEVMRevertName,
-			e2etests.TestMessagePassingZEVMtoEVMRevertName,
-			e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
-			e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
+			//e2etests.TestMessagePassingZEVMToEVMName,
+			//e2etests.TestMessagePassingEVMtoZEVMName,
+			//e2etests.TestMessagePassingEVMtoZEVMRevertName,
+			//e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			//e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
+			//e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
 		}
 
 		bitcoinTests := []string{
-			e2etests.TestBitcoinDonationName,
-			e2etests.TestBitcoinDepositName,
-			e2etests.TestBitcoinDepositAndCallName,
-			e2etests.TestBitcoinDepositAndCallRevertName,
-			e2etests.TestBitcoinWithdrawSegWitName,
-			e2etests.TestBitcoinWithdrawInvalidAddressName,
-			e2etests.TestZetaWithdrawBTCRevertName,
-			e2etests.TestCrosschainSwapName,
+			//e2etests.TestBitcoinDonationName,
+			//e2etests.TestBitcoinDepositName,
+			//e2etests.TestBitcoinDepositAndCallName,
+			//e2etests.TestBitcoinDepositAndCallRevertName,
+			e2etests.TestBitcoinDepositAndCallRevertWithDustName,
+			//e2etests.TestBitcoinWithdrawSegWitName,
+			//e2etests.TestBitcoinWithdrawInvalidAddressName,
+			//e2etests.TestZetaWithdrawBTCRevertName,
+			//e2etests.TestCrosschainSwapName,
 		}
 		bitcoinAdvancedTests := []string{
-			e2etests.TestBitcoinWithdrawTaprootName,
-			e2etests.TestBitcoinWithdrawLegacyName,
-			e2etests.TestBitcoinWithdrawMultipleName,
-			e2etests.TestBitcoinWithdrawP2SHName,
-			e2etests.TestBitcoinWithdrawP2WSHName,
-			e2etests.TestBitcoinWithdrawRestrictedName,
-			e2etests.TestBitcoinStdMemoDepositName,
-			e2etests.TestBitcoinStdMemoDepositAndCallName,
-			e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
-			e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
+			//e2etests.TestBitcoinWithdrawTaprootName,
+			//e2etests.TestBitcoinWithdrawLegacyName,
+			//e2etests.TestBitcoinWithdrawMultipleName,
+			//e2etests.TestBitcoinWithdrawP2SHName,
+			//e2etests.TestBitcoinWithdrawP2WSHName,
+			//e2etests.TestBitcoinWithdrawRestrictedName,
+			//e2etests.TestBitcoinStdMemoDepositName,
+			//e2etests.TestBitcoinStdMemoDepositAndCallName,
+			//e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
+			//e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
 		}
 		ethereumTests := []string{
-			e2etests.TestEtherWithdrawName,
-			e2etests.TestContextUpgradeName,
-			e2etests.TestEtherDepositAndCallName,
-			e2etests.TestEtherDepositAndCallRefundName,
+			//e2etests.TestEtherWithdrawName,
+			//e2etests.TestContextUpgradeName,
+			//e2etests.TestEtherDepositAndCallName,
+			//e2etests.TestEtherDepositAndCallRefundName,
 		}
 		ethereumAdvancedTests := []string{
-			e2etests.TestEtherWithdrawRestrictedName,
+			//e2etests.TestEtherWithdrawRestrictedName,
 		}
 		precompiledContractTests := []string{}
 

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -75,6 +75,7 @@ const (
 	TestBitcoinDepositName                                 = "bitcoin_deposit"
 	TestBitcoinDepositAndCallName                          = "bitcoin_deposit_and_call"
 	TestBitcoinDepositAndCallRevertName                    = "bitcoin_deposit_and_call_revert"
+	TestBitcoinDepositAndCallRevertWithDustName            = "bitcoin_deposit_and_call_revert_with_dust"
 	TestBitcoinDonationName                                = "bitcoin_donation"
 	TestBitcoinStdMemoDepositName                          = "bitcoin_std_memo_deposit"
 	TestBitcoinStdMemoDepositAndCallName                   = "bitcoin_std_memo_deposit_and_call"
@@ -507,6 +508,11 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in btc", DefaultValue: "0.1"},
 		},
 		TestBitcoinDepositAndCallRevert,
+	),
+	runner.NewE2ETest(
+		TestBitcoinDepositAndCallRevertWithDustName,
+		"deposit Bitcoin into ZEVM; revert with dust amount that aborts the CCTX", []runner.ArgDefinition{},
+		TestBitcoinDepositAndCallRevertWithDust,
 	),
 	runner.NewE2ETest(
 		TestBitcoinStdMemoDepositName,

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert.go
@@ -24,8 +24,6 @@ func TestBitcoinDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	amount := parseFloat(r, args[0])
 	amount += zetabitcoin.DefaultDepositorFee
 
-	r.Logger.Print("BITCOIN: Amount to send: %s", args[0])
-
 	// Given a list of UTXOs
 	utxos, err := r.ListDeployerUTXOs()
 	require.NoError(r, err)
@@ -48,10 +46,6 @@ func TestBitcoinDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	receiver, value := r.QueryOutboundReceiverAndAmount(cctx.OutboundParams[1].Hash)
 	assert.Equal(r, r.BTCDeployerAddress.EncodeAddress(), receiver)
 	assert.Positive(r, value)
-
-	r.Logger.Print("BITCOIN: Amount received: %d", value)
-
-	// 0.002
 
 	r.Logger.Info("Sent %f BTC to TSS with invalid memo, got refund of %d satoshis", amount, value)
 }

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -2,16 +2,16 @@ package e2etests
 
 import (
 	"github.com/stretchr/testify/require"
-	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
-	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 )
 
 // TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
-// Given the dust is too smart, the CCTX should revert
 func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
 	// ARRANGE
 	// Given BTC address
@@ -43,10 +43,12 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
-	r.Logger.Print("BITCOIN tx hash: %s", txHash.String())
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
-	r.Logger.CCTX(*cctx, "deposit")
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
+	r.Logger.CCTX(*cctx, "deposit_and_revert")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// check the test was effective: the revert outbound amount is less than the dust amount
+	require.Less(r, cctx.GetCurrentOutboundParam().Amount.Uint64(), uint64(constant.BTCWithdrawalDustAmount))
 }

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -24,10 +24,10 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	defer stop()
 
 	// 0.002 BTC is consumed in a deposit and revert, the dust is set to 1000 satoshis in the protocol
-	// Therefore the deposit amount should be 0.002 + 0.000005 = 0.00200500 should trigger the condition
-	// As only 500 satoshis are left after the deposit
+	// Therefore the deposit amount should be 0.002 + 0.000001 = 0.00200100 should trigger the condition
+	// As only 100 satoshis are left after the deposit
 
-	amount := 0.00200500
+	amount := 0.00200100
 	amount += zetabitcoin.DefaultDepositorFee
 
 	// Given a list of UTXOs

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -1,8 +1,9 @@
 package e2etests
 
 import (
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
@@ -27,6 +28,7 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	// As only 500 satoshis are left after the deposit
 
 	amount := 0.00200500
+	amount += zetabitcoin.DefaultDepositorFee
 
 	// Given a list of UTXOs
 	utxos, err := r.ListDeployerUTXOs()
@@ -41,16 +43,10 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
+	r.Logger.Print("BITCOIN tx hash: %s", txHash.String())
 
-	// ASSERT
-	// Now we want to make sure refund TX is completed.
-	cctx := utils.WaitCctxRevertedByInboundHash(r.Ctx, r, txHash.String(), r.CctxClient)
-
-	// Check revert tx receiver address and amount
-	receiver, value := r.QueryOutboundReceiverAndAmount(cctx.OutboundParams[1].Hash)
-	assert.Equal(r, r.BTCDeployerAddress.EncodeAddress(), receiver)
-	assert.Positive(r, value)
-
-	r.Logger.Print("BITCOIN: Amount received: %d", value)
-	r.Logger.Info("Sent %f BTC to TSS with invalid memo, got refund of %d satoshis", amount, value)
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 }

--- a/testutil/keeper/mocks/fungible/bank.go
+++ b/testutil/keeper/mocks/fungible/bank.go
@@ -13,24 +13,6 @@ type FungibleBankKeeper struct {
 	mock.Mock
 }
 
-// GetSupply provides a mock function with given fields: ctx, denom
-func (_m *FungibleBankKeeper) GetSupply(ctx types.Context, denom string) types.Coin {
-	ret := _m.Called(ctx, denom)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetSupply")
-	}
-
-	var r0 types.Coin
-	if rf, ok := ret.Get(0).(func(types.Context, string) types.Coin); ok {
-		r0 = rf(ctx, denom)
-	} else {
-		r0 = ret.Get(0).(types.Coin)
-	}
-
-	return r0
-}
-
 // MintCoins provides a mock function with given fields: ctx, moduleName, amt
 func (_m *FungibleBankKeeper) MintCoins(ctx types.Context, moduleName string, amt types.Coins) error {
 	ret := _m.Called(ctx, moduleName, amt)

--- a/x/fungible/keeper/deposits_test.go
+++ b/x/fungible/keeper/deposits_test.go
@@ -437,10 +437,6 @@ func TestKeeper_DepositCoinZeta(t *testing.T) {
 		b := sdkk.BankKeeper.GetBalance(ctx, zetaToAddress, config.BaseDenom)
 		require.Equal(t, int64(0), b.Amount.Int64())
 		errorMint := errors.New("", 1, "error minting coins")
-
-		bankMock.On("GetSupply", ctx, mock.Anything, mock.Anything).
-			Return(sdk.NewCoin(config.BaseDenom, sdk.NewInt(0))).
-			Once()
 		bankMock.On("MintCoins", ctx, types.ModuleName, mock.Anything).Return(errorMint).Once()
 		err := k.DepositCoinZeta(ctx, to, amount)
 		require.ErrorIs(t, err, errorMint)

--- a/x/fungible/keeper/zeta.go
+++ b/x/fungible/keeper/zeta.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"errors"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,24 +9,9 @@ import (
 	"github.com/zeta-chain/node/x/fungible/types"
 )
 
-// ZETAMaxSupplyStr is the maximum mintable ZETA in the fungible module
-// 1.85 billion ZETA
-const ZETAMaxSupplyStr = "1850000000000000000000000000"
-
 // MintZetaToEVMAccount mints ZETA (gas token) to the given address
 // NOTE: this method should be used with a temporary context, and it should not be committed if the method returns an error
 func (k *Keeper) MintZetaToEVMAccount(ctx sdk.Context, to sdk.AccAddress, amount *big.Int) error {
-	zetaMaxSupply, ok := sdk.NewIntFromString(ZETAMaxSupplyStr)
-	if !ok {
-		return errors.New("failed to parse ZETA max supply")
-	}
-
-	// Check if the max supply is reached
-	supply := k.bankKeeper.GetSupply(ctx, config.BaseDenom)
-	if supply.Amount.Add(sdk.NewIntFromBigInt(amount)).GT(zetaMaxSupply) {
-		return types.ErrMaxSupplyReached
-	}
-
 	coins := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, sdk.NewIntFromBigInt(amount)))
 	// Mint coins
 	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, coins); err != nil {
@@ -39,17 +23,6 @@ func (k *Keeper) MintZetaToEVMAccount(ctx sdk.Context, to sdk.AccAddress, amount
 }
 
 func (k *Keeper) MintZetaToFungibleModule(ctx sdk.Context, amount *big.Int) error {
-	zetaMaxSupply, ok := sdk.NewIntFromString(ZETAMaxSupplyStr)
-	if !ok {
-		return errors.New("failed to parse ZETA max supply")
-	}
-
-	// Check if the max supply is reached
-	supply := k.bankKeeper.GetSupply(ctx, config.BaseDenom)
-	if supply.Amount.Add(sdk.NewIntFromBigInt(amount)).GT(zetaMaxSupply) {
-		return types.ErrMaxSupplyReached
-	}
-
 	coins := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, sdk.NewIntFromBigInt(amount)))
 	// Mint coins
 	return k.bankKeeper.MintCoins(ctx, types.ModuleName, coins)

--- a/x/fungible/keeper/zeta_test.go
+++ b/x/fungible/keeper/zeta_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"errors"
-	"github.com/stretchr/testify/mock"
 	"math/big"
 	"testing"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/zeta-chain/node/cmd/zetacored/config"
 	testkeeper "github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
-	"github.com/zeta-chain/node/x/fungible/keeper"
 	"github.com/zeta-chain/node/x/fungible/types"
 )
 
@@ -31,46 +29,6 @@ func TestKeeper_MintZetaToEVMAccount(t *testing.T) {
 		require.True(t, bal.Amount.Equal(sdk.NewInt(42)))
 	})
 
-	t.Run("mint the token to reach max supply", func(t *testing.T) {
-		k, ctx, sdkk, _ := testkeeper.FungibleKeeper(t)
-		k.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName)
-
-		acc := sample.Bech32AccAddress()
-		bal := sdkk.BankKeeper.GetBalance(ctx, acc, config.BaseDenom)
-		require.True(t, bal.IsZero())
-
-		zetaMaxSupply, ok := sdk.NewIntFromString(keeper.ZETAMaxSupplyStr)
-		require.True(t, ok)
-
-		supply := sdkk.BankKeeper.GetSupply(ctx, config.BaseDenom).Amount
-
-		newAmount := zetaMaxSupply.Sub(supply)
-
-		err := k.MintZetaToEVMAccount(ctx, acc, newAmount.BigInt())
-		require.NoError(t, err)
-		bal = sdkk.BankKeeper.GetBalance(ctx, acc, config.BaseDenom)
-		require.True(t, bal.Amount.Equal(newAmount))
-	})
-
-	t.Run("can't mint more than max supply", func(t *testing.T) {
-		k, ctx, sdkk, _ := testkeeper.FungibleKeeper(t)
-		k.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName)
-
-		acc := sample.Bech32AccAddress()
-		bal := sdkk.BankKeeper.GetBalance(ctx, acc, config.BaseDenom)
-		require.True(t, bal.IsZero())
-
-		zetaMaxSupply, ok := sdk.NewIntFromString(keeper.ZETAMaxSupplyStr)
-		require.True(t, ok)
-
-		supply := sdkk.BankKeeper.GetSupply(ctx, config.BaseDenom).Amount
-
-		newAmount := zetaMaxSupply.Sub(supply).Add(sdk.NewInt(1))
-
-		err := k.MintZetaToEVMAccount(ctx, acc, newAmount.BigInt())
-		require.ErrorIs(t, err, types.ErrMaxSupplyReached)
-	})
-
 	coins42 := sdk.NewCoins(sdk.NewCoin(config.BaseDenom, sdk.NewInt(42)))
 
 	t.Run("should fail if minting fail", func(t *testing.T) {
@@ -78,9 +36,6 @@ func TestKeeper_MintZetaToEVMAccount(t *testing.T) {
 
 		mockBankKeeper := testkeeper.GetFungibleBankMock(t, k)
 
-		mockBankKeeper.On("GetSupply", ctx, mock.Anything, mock.Anything).
-			Return(sdk.NewCoin(config.BaseDenom, sdk.NewInt(0))).
-			Once()
 		mockBankKeeper.On(
 			"MintCoins",
 			ctx,
@@ -100,9 +55,6 @@ func TestKeeper_MintZetaToEVMAccount(t *testing.T) {
 
 		mockBankKeeper := testkeeper.GetFungibleBankMock(t, k)
 
-		mockBankKeeper.On("GetSupply", ctx, mock.Anything, mock.Anything).
-			Return(sdk.NewCoin(config.BaseDenom, sdk.NewInt(0))).
-			Once()
 		mockBankKeeper.On(
 			"MintCoins",
 			ctx,
@@ -122,35 +74,5 @@ func TestKeeper_MintZetaToEVMAccount(t *testing.T) {
 		require.Error(t, err)
 
 		mockBankKeeper.AssertExpectations(t)
-	})
-}
-
-func TestKeeper_MintZetaToFungibleModule(t *testing.T) {
-	t.Run("should mint the token in the specified balance", func(t *testing.T) {
-		k, ctx, sdkk, _ := testkeeper.FungibleKeeper(t)
-		acc := k.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName).GetAddress()
-
-		bal := sdkk.BankKeeper.GetBalance(ctx, acc, config.BaseDenom)
-		require.True(t, bal.IsZero())
-
-		err := k.MintZetaToEVMAccount(ctx, acc, big.NewInt(42))
-		require.NoError(t, err)
-		bal = sdkk.BankKeeper.GetBalance(ctx, acc, config.BaseDenom)
-		require.True(t, bal.Amount.Equal(sdk.NewInt(42)))
-	})
-
-	t.Run("can't mint more than max supply", func(t *testing.T) {
-		k, ctx, sdkk, _ := testkeeper.FungibleKeeper(t)
-		k.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName)
-
-		zetaMaxSupply, ok := sdk.NewIntFromString(keeper.ZETAMaxSupplyStr)
-		require.True(t, ok)
-
-		supply := sdkk.BankKeeper.GetSupply(ctx, config.BaseDenom).Amount
-
-		newAmount := zetaMaxSupply.Sub(supply).Add(sdk.NewInt(1))
-
-		err := k.MintZetaToFungibleModule(ctx, newAmount.BigInt())
-		require.ErrorIs(t, err, types.ErrMaxSupplyReached)
 	})
 }

--- a/x/fungible/keeper/zevm_message_passing_test.go
+++ b/x/fungible/keeper/zevm_message_passing_test.go
@@ -146,9 +146,6 @@ func TestKeeper_ZEVMDepositAndCallContract(t *testing.T) {
 		})
 		require.NoError(t, err)
 		errorMint := errors.New("", 10, "error minting coins")
-		bankMock.On("GetSupply", ctx, mock.Anything, mock.Anything).
-			Return(sdk.NewCoin(config.BaseDenom, sdk.NewInt(0))).
-			Once()
 		bankMock.On("MintCoins", ctx, types.ModuleName, mock.Anything).Return(errorMint).Once()
 
 		_, err = k.ZETADepositAndCallContract(
@@ -299,9 +296,6 @@ func TestKeeper_ZEVMRevertAndCallContract(t *testing.T) {
 		})
 		require.NoError(t, err)
 		errorMint := errors.New("", 101, "error minting coins")
-		bankMock.On("GetSupply", ctx, mock.Anything, mock.Anything).
-			Return(sdk.NewCoin(config.BaseDenom, sdk.NewInt(0))).
-			Once()
 		bankMock.On("MintCoins", ctx, types.ModuleName, mock.Anything).Return(errorMint).Once()
 
 		_, err = k.ZETARevertAndCallContract(

--- a/x/fungible/types/errors.go
+++ b/x/fungible/types/errors.go
@@ -34,5 +34,4 @@ var (
 	ErrZRC20NilABI             = cosmoserrors.Register(ModuleName, 1132, "ZRC20 ABI is nil")
 	ErrZeroAddress             = cosmoserrors.Register(ModuleName, 1133, "address cannot be zero")
 	ErrInvalidAmount           = cosmoserrors.Register(ModuleName, 1134, "invalid amount")
-	ErrMaxSupplyReached        = cosmoserrors.Register(ModuleName, 1135, "max supply reached")
 )

--- a/x/fungible/types/expected_keepers.go
+++ b/x/fungible/types/expected_keepers.go
@@ -33,7 +33,6 @@ type BankKeeper interface {
 		amt sdk.Coins,
 	) error
 	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
-	GetSupply(ctx sdk.Context, denom string) sdk.Coin
 }
 
 type ObserverKeeper interface {

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/rpc"
@@ -531,8 +532,8 @@ func (ob *Observer) checkTssOutboundResult(
 		return errors.Wrapf(err, "checkTssOutboundResult: invalid TSS Vin in outbound %s nonce %d", hash, nonce)
 	}
 
-	// differentiate between normal and restricted cctx
-	if compliance.IsCctxRestricted(cctx) {
+	// differentiate between normal and cancelled cctx
+	if compliance.IsCctxRestricted(cctx) || params.Amount.Uint64() < constant.BTCWithdrawalDustAmount {
 		err = ob.checkTSSVoutCancelled(params, rawResult.Vout)
 		if err != nil {
 			return errors.Wrapf(

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -413,13 +413,25 @@ func (signer *Signer) TryProcessOutbound(
 	gasprice.Add(gasprice, satPerByte)
 
 	// compliance check
-	cancelTx := compliance.IsCctxRestricted(cctx)
-	if cancelTx {
+	restrictedCCTX := compliance.IsCctxRestricted(cctx)
+	if restrictedCCTX {
 		compliance.PrintComplianceLog(logger, signer.Logger().Compliance,
 			true, chain.ChainId, cctx.Index, cctx.InboundParams.Sender, params.Receiver, "BTC")
-		amount = 0.0 // zero out the amount to cancel the tx
 	}
-	logger.Info().Msgf("SignGasWithdraw: to %s, value %d sats", to.EncodeAddress(), params.Amount.Uint64())
+
+	// check dust amount
+	dustAmount := false // params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
+	if dustAmount {
+		logger.Warn().Msgf("dust amount %d sats, canceling tx", params.Amount.Uint64())
+	}
+
+	// set the amount to 0 when the tx should be cancelled
+	cancelTx := restrictedCCTX || dustAmount
+	if cancelTx {
+		amount = 0.0
+	} else {
+		logger.Info().Msgf("SignGasWithdraw: to %s, value %d sats", to.EncodeAddress(), params.Amount.Uint64())
+	}
 
 	// sign withdraw tx
 	tx, err := signer.SignWithdrawTx(

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
@@ -420,7 +421,7 @@ func (signer *Signer) TryProcessOutbound(
 	}
 
 	// check dust amount
-	dustAmount := false // params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
+	dustAmount := params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
 	if dustAmount {
 		logger.Warn().Msgf("dust amount %d sats, canceling tx", params.Amount.Uint64())
 	}


### PR DESCRIPTION
# Description

Check if the amount for a BTC revert outbound is below dust amount. In this case, cancel the tx (same logic as restricted address where there will be a tx but with 0 btc), cctx will be reverted.

Add a E2E test to test revert with dust amount. To check the effect, the "dustAmount" can be set to false in ZetaClient, the test will be stall because the outbound can't be signed