### PR TITLE
fix: allow BTC revert with dust amount v22

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -268,66 +268,66 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipRegular {
 		// defines all tests, if light is enabled, only the most basic tests are run and advanced are skipped
 		erc20Tests := []string{
-			//e2etests.TestERC20WithdrawName,
-			//e2etests.TestMultipleERC20WithdrawsName,
-			//e2etests.TestERC20DepositAndCallRefundName,
-			//e2etests.TestZRC20SwapName,
+			e2etests.TestERC20WithdrawName,
+			e2etests.TestMultipleERC20WithdrawsName,
+			e2etests.TestERC20DepositAndCallRefundName,
+			e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
-			//e2etests.TestERC20DepositRestrictedName,
+			e2etests.TestERC20DepositRestrictedName,
 		}
 		zetaTests := []string{
-			//e2etests.TestZetaWithdrawName,
-			//e2etests.TestMessagePassingExternalChainsName,
-			//e2etests.TestMessagePassingRevertFailExternalChainsName,
-			//e2etests.TestMessagePassingRevertSuccessExternalChainsName,
+			e2etests.TestZetaWithdrawName,
+			e2etests.TestMessagePassingExternalChainsName,
+			e2etests.TestMessagePassingRevertFailExternalChainsName,
+			e2etests.TestMessagePassingRevertSuccessExternalChainsName,
 		}
 		zetaAdvancedTests := []string{
-			//e2etests.TestZetaDepositRestrictedName,
-			//e2etests.TestZetaDepositName,
-			//e2etests.TestZetaDepositNewAddressName,
+			e2etests.TestZetaDepositRestrictedName,
+			e2etests.TestZetaDepositName,
+			e2etests.TestZetaDepositNewAddressName,
 		}
 		zevmMPTests := []string{}
 		zevmMPAdvancedTests := []string{
-			//e2etests.TestMessagePassingZEVMToEVMName,
-			//e2etests.TestMessagePassingEVMtoZEVMName,
-			//e2etests.TestMessagePassingEVMtoZEVMRevertName,
-			//e2etests.TestMessagePassingZEVMtoEVMRevertName,
-			//e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
-			//e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
+			e2etests.TestMessagePassingZEVMToEVMName,
+			e2etests.TestMessagePassingEVMtoZEVMName,
+			e2etests.TestMessagePassingEVMtoZEVMRevertName,
+			e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
+			e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
 		}
 
 		bitcoinTests := []string{
-			//e2etests.TestBitcoinDonationName,
-			//e2etests.TestBitcoinDepositName,
-			//e2etests.TestBitcoinDepositAndCallName,
-			//e2etests.TestBitcoinDepositAndCallRevertName,
+			e2etests.TestBitcoinDonationName,
+			e2etests.TestBitcoinDepositName,
+			e2etests.TestBitcoinDepositAndCallName,
+			e2etests.TestBitcoinDepositAndCallRevertName,
 			e2etests.TestBitcoinDepositAndCallRevertWithDustName,
-			//e2etests.TestBitcoinWithdrawSegWitName,
-			//e2etests.TestBitcoinWithdrawInvalidAddressName,
-			//e2etests.TestZetaWithdrawBTCRevertName,
-			//e2etests.TestCrosschainSwapName,
+			e2etests.TestBitcoinWithdrawSegWitName,
+			e2etests.TestBitcoinWithdrawInvalidAddressName,
+			e2etests.TestZetaWithdrawBTCRevertName,
+			e2etests.TestCrosschainSwapName,
 		}
 		bitcoinAdvancedTests := []string{
-			//e2etests.TestBitcoinWithdrawTaprootName,
-			//e2etests.TestBitcoinWithdrawLegacyName,
-			//e2etests.TestBitcoinWithdrawMultipleName,
-			//e2etests.TestBitcoinWithdrawP2SHName,
-			//e2etests.TestBitcoinWithdrawP2WSHName,
-			//e2etests.TestBitcoinWithdrawRestrictedName,
-			//e2etests.TestBitcoinStdMemoDepositName,
-			//e2etests.TestBitcoinStdMemoDepositAndCallName,
-			//e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
-			//e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
+			e2etests.TestBitcoinWithdrawTaprootName,
+			e2etests.TestBitcoinWithdrawLegacyName,
+			e2etests.TestBitcoinWithdrawMultipleName,
+			e2etests.TestBitcoinWithdrawP2SHName,
+			e2etests.TestBitcoinWithdrawP2WSHName,
+			e2etests.TestBitcoinWithdrawRestrictedName,
+			e2etests.TestBitcoinStdMemoDepositName,
+			e2etests.TestBitcoinStdMemoDepositAndCallName,
+			e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
+			e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
 		}
 		ethereumTests := []string{
-			//e2etests.TestEtherWithdrawName,
-			//e2etests.TestContextUpgradeName,
-			//e2etests.TestEtherDepositAndCallName,
-			//e2etests.TestEtherDepositAndCallRefundName,
+			e2etests.TestEtherWithdrawName,
+			e2etests.TestContextUpgradeName,
+			e2etests.TestEtherDepositAndCallName,
+			e2etests.TestEtherDepositAndCallRefundName,
 		}
 		ethereumAdvancedTests := []string{
-			//e2etests.TestEtherWithdrawRestrictedName,
+			e2etests.TestEtherWithdrawRestrictedName,
 		}
 		precompiledContractTests := []string{}
 

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -268,65 +268,66 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipRegular {
 		// defines all tests, if light is enabled, only the most basic tests are run and advanced are skipped
 		erc20Tests := []string{
-			e2etests.TestERC20WithdrawName,
-			e2etests.TestMultipleERC20WithdrawsName,
-			e2etests.TestERC20DepositAndCallRefundName,
-			e2etests.TestZRC20SwapName,
+			//e2etests.TestERC20WithdrawName,
+			//e2etests.TestMultipleERC20WithdrawsName,
+			//e2etests.TestERC20DepositAndCallRefundName,
+			//e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
-			e2etests.TestERC20DepositRestrictedName,
+			//e2etests.TestERC20DepositRestrictedName,
 		}
 		zetaTests := []string{
-			e2etests.TestZetaWithdrawName,
-			e2etests.TestMessagePassingExternalChainsName,
-			e2etests.TestMessagePassingRevertFailExternalChainsName,
-			e2etests.TestMessagePassingRevertSuccessExternalChainsName,
+			//e2etests.TestZetaWithdrawName,
+			//e2etests.TestMessagePassingExternalChainsName,
+			//e2etests.TestMessagePassingRevertFailExternalChainsName,
+			//e2etests.TestMessagePassingRevertSuccessExternalChainsName,
 		}
 		zetaAdvancedTests := []string{
-			e2etests.TestZetaDepositRestrictedName,
-			e2etests.TestZetaDepositName,
-			e2etests.TestZetaDepositNewAddressName,
+			//e2etests.TestZetaDepositRestrictedName,
+			//e2etests.TestZetaDepositName,
+			//e2etests.TestZetaDepositNewAddressName,
 		}
 		zevmMPTests := []string{}
 		zevmMPAdvancedTests := []string{
-			e2etests.TestMessagePassingZEVMToEVMName,
-			e2etests.TestMessagePassingEVMtoZEVMName,
-			e2etests.TestMessagePassingEVMtoZEVMRevertName,
-			e2etests.TestMessagePassingZEVMtoEVMRevertName,
-			e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
-			e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
+			//e2etests.TestMessagePassingZEVMToEVMName,
+			//e2etests.TestMessagePassingEVMtoZEVMName,
+			//e2etests.TestMessagePassingEVMtoZEVMRevertName,
+			//e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			//e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
+			//e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
 		}
 
 		bitcoinTests := []string{
-			e2etests.TestBitcoinDonationName,
-			e2etests.TestBitcoinDepositName,
-			e2etests.TestBitcoinDepositAndCallName,
-			e2etests.TestBitcoinDepositAndCallRevertName,
-			e2etests.TestBitcoinWithdrawSegWitName,
-			e2etests.TestBitcoinWithdrawInvalidAddressName,
-			e2etests.TestZetaWithdrawBTCRevertName,
-			e2etests.TestCrosschainSwapName,
+			//e2etests.TestBitcoinDonationName,
+			//e2etests.TestBitcoinDepositName,
+			//e2etests.TestBitcoinDepositAndCallName,
+			//e2etests.TestBitcoinDepositAndCallRevertName,
+			e2etests.TestBitcoinDepositAndCallRevertWithDustName,
+			//e2etests.TestBitcoinWithdrawSegWitName,
+			//e2etests.TestBitcoinWithdrawInvalidAddressName,
+			//e2etests.TestZetaWithdrawBTCRevertName,
+			//e2etests.TestCrosschainSwapName,
 		}
 		bitcoinAdvancedTests := []string{
-			e2etests.TestBitcoinWithdrawTaprootName,
-			e2etests.TestBitcoinWithdrawLegacyName,
-			e2etests.TestBitcoinWithdrawMultipleName,
-			e2etests.TestBitcoinWithdrawP2SHName,
-			e2etests.TestBitcoinWithdrawP2WSHName,
-			e2etests.TestBitcoinWithdrawRestrictedName,
-			e2etests.TestBitcoinStdMemoDepositName,
-			e2etests.TestBitcoinStdMemoDepositAndCallName,
-			e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
-			e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
+			//e2etests.TestBitcoinWithdrawTaprootName,
+			//e2etests.TestBitcoinWithdrawLegacyName,
+			//e2etests.TestBitcoinWithdrawMultipleName,
+			//e2etests.TestBitcoinWithdrawP2SHName,
+			//e2etests.TestBitcoinWithdrawP2WSHName,
+			//e2etests.TestBitcoinWithdrawRestrictedName,
+			//e2etests.TestBitcoinStdMemoDepositName,
+			//e2etests.TestBitcoinStdMemoDepositAndCallName,
+			//e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
+			//e2etests.TestBitcoinStdMemoDepositAndCallRevertOtherAddressName,
 		}
 		ethereumTests := []string{
-			e2etests.TestEtherWithdrawName,
-			e2etests.TestContextUpgradeName,
-			e2etests.TestEtherDepositAndCallName,
-			e2etests.TestEtherDepositAndCallRefundName,
+			//e2etests.TestEtherWithdrawName,
+			//e2etests.TestContextUpgradeName,
+			//e2etests.TestEtherDepositAndCallName,
+			//e2etests.TestEtherDepositAndCallRefundName,
 		}
 		ethereumAdvancedTests := []string{
-			e2etests.TestEtherWithdrawRestrictedName,
+			//e2etests.TestEtherWithdrawRestrictedName,
 		}
 		precompiledContractTests := []string{}
 

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -75,6 +75,7 @@ const (
 	TestBitcoinDepositName                                 = "bitcoin_deposit"
 	TestBitcoinDepositAndCallName                          = "bitcoin_deposit_and_call"
 	TestBitcoinDepositAndCallRevertName                    = "bitcoin_deposit_and_call_revert"
+	TestBitcoinDepositAndCallRevertWithDustName            = "bitcoin_deposit_and_call_revert_with_dust"
 	TestBitcoinDonationName                                = "bitcoin_donation"
 	TestBitcoinStdMemoDepositName                          = "bitcoin_std_memo_deposit"
 	TestBitcoinStdMemoDepositAndCallName                   = "bitcoin_std_memo_deposit_and_call"
@@ -507,6 +508,11 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in btc", DefaultValue: "0.1"},
 		},
 		TestBitcoinDepositAndCallRevert,
+	),
+	runner.NewE2ETest(
+		TestBitcoinDepositAndCallRevertWithDustName,
+		"deposit Bitcoin into ZEVM; revert with dust amount that aborts the CCTX", []runner.ArgDefinition{},
+		TestBitcoinDepositAndCallRevertWithDust,
 	),
 	runner.NewE2ETest(
 		TestBitcoinStdMemoDepositName,

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert.go
@@ -24,8 +24,6 @@ func TestBitcoinDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	amount := parseFloat(r, args[0])
 	amount += zetabitcoin.DefaultDepositorFee
 
-	r.Logger.Print("BITCOIN: Amount to send: %s", args[0])
-
 	// Given a list of UTXOs
 	utxos, err := r.ListDeployerUTXOs()
 	require.NoError(r, err)
@@ -48,10 +46,6 @@ func TestBitcoinDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	receiver, value := r.QueryOutboundReceiverAndAmount(cctx.OutboundParams[1].Hash)
 	assert.Equal(r, r.BTCDeployerAddress.EncodeAddress(), receiver)
 	assert.Positive(r, value)
-
-	r.Logger.Print("BITCOIN: Amount received: %d", value)
-
-	// 0.002
 
 	r.Logger.Info("Sent %f BTC to TSS with invalid memo, got refund of %d satoshis", amount, value)
 }

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -2,16 +2,16 @@ package e2etests
 
 import (
 	"github.com/stretchr/testify/require"
-	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
-	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 )
 
 // TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
-// Given the dust is too smart, the CCTX should revert
 func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
 	// ARRANGE
 	// Given BTC address
@@ -43,10 +43,12 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
-	r.Logger.Print("BITCOIN tx hash: %s", txHash.String())
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
-	r.Logger.CCTX(*cctx, "deposit")
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
+	r.Logger.CCTX(*cctx, "deposit_and_revert")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// check the test was effective: the revert outbound amount is less than the dust amount
+	require.Less(r, cctx.GetCurrentOutboundParam().Amount.Uint64(), uint64(constant.BTCWithdrawalDustAmount))
 }

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -24,10 +24,10 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	defer stop()
 
 	// 0.002 BTC is consumed in a deposit and revert, the dust is set to 1000 satoshis in the protocol
-	// Therefore the deposit amount should be 0.002 + 0.000005 = 0.00200500 should trigger the condition
-	// As only 500 satoshis are left after the deposit
+	// Therefore the deposit amount should be 0.002 + 0.000001 = 0.00200100 should trigger the condition
+	// As only 100 satoshis are left after the deposit
 
-	amount := 0.00200500
+	amount := 0.00200100
 	amount += zetabitcoin.DefaultDepositorFee
 
 	// Given a list of UTXOs

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -1,8 +1,9 @@
 package e2etests
 
 import (
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
@@ -27,6 +28,7 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	// As only 500 satoshis are left after the deposit
 
 	amount := 0.00200500
+	amount += zetabitcoin.DefaultDepositorFee
 
 	// Given a list of UTXOs
 	utxos, err := r.ListDeployerUTXOs()
@@ -41,16 +43,10 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
+	r.Logger.Print("BITCOIN tx hash: %s", txHash.String())
 
-	// ASSERT
-	// Now we want to make sure refund TX is completed.
-	cctx := utils.WaitCctxRevertedByInboundHash(r.Ctx, r, txHash.String(), r.CctxClient)
-
-	// Check revert tx receiver address and amount
-	receiver, value := r.QueryOutboundReceiverAndAmount(cctx.OutboundParams[1].Hash)
-	assert.Equal(r, r.BTCDeployerAddress.EncodeAddress(), receiver)
-	assert.Positive(r, value)
-
-	r.Logger.Print("BITCOIN: Amount received: %d", value)
-	r.Logger.Info("Sent %f BTC to TSS with invalid memo, got refund of %d satoshis", amount, value)
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 }

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/rpc"
@@ -531,8 +532,8 @@ func (ob *Observer) checkTssOutboundResult(
 		return errors.Wrapf(err, "checkTssOutboundResult: invalid TSS Vin in outbound %s nonce %d", hash, nonce)
 	}
 
-	// differentiate between normal and restricted cctx
-	if compliance.IsCctxRestricted(cctx) {
+	// differentiate between normal and cancelled cctx
+	if compliance.IsCctxRestricted(cctx) || params.Amount.Uint64() < constant.BTCWithdrawalDustAmount {
 		err = ob.checkTSSVoutCancelled(params, rawResult.Vout)
 		if err != nil {
 			return errors.Wrapf(

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -413,13 +413,25 @@ func (signer *Signer) TryProcessOutbound(
 	gasprice.Add(gasprice, satPerByte)
 
 	// compliance check
-	cancelTx := compliance.IsCctxRestricted(cctx)
-	if cancelTx {
+	restrictedCCTX := compliance.IsCctxRestricted(cctx)
+	if restrictedCCTX {
 		compliance.PrintComplianceLog(logger, signer.Logger().Compliance,
 			true, chain.ChainId, cctx.Index, cctx.InboundParams.Sender, params.Receiver, "BTC")
-		amount = 0.0 // zero out the amount to cancel the tx
 	}
-	logger.Info().Msgf("SignGasWithdraw: to %s, value %d sats", to.EncodeAddress(), params.Amount.Uint64())
+
+	// check dust amount
+	dustAmount := false // params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
+	if dustAmount {
+		logger.Warn().Msgf("dust amount %d sats, canceling tx", params.Amount.Uint64())
+	}
+
+	// set the amount to 0 when the tx should be cancelled
+	cancelTx := restrictedCCTX || dustAmount
+	if cancelTx {
+		amount = 0.0
+	} else {
+		logger.Info().Msgf("SignGasWithdraw: to %s, value %d sats", to.EncodeAddress(), params.Amount.Uint64())
+	}
 
 	// sign withdraw tx
 	tx, err := signer.SignWithdrawTx(

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
@@ -420,7 +421,7 @@ func (signer *Signer) TryProcessOutbound(
 	}
 
 	// check dust amount
-	dustAmount := false // params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
+	dustAmount := params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
 	if dustAmount {
 		logger.Warn().Msgf("dust amount %d sats, canceling tx", params.Amount.Uint64())
 	}


### PR DESCRIPTION
# Description

Check if the amount for a BTC revert outbound is below dust amount. In this case, cancel the tx (same logic as restricted address where there will be a tx but with 0 btc), cctx will be reverted.

Add a E2E test to test revert with dust amount. To check the effect, the "dustAmount" can be set to false in ZetaClient, the test will be stall because the outbound can't be signed
