### PR TITLE
fix: allow BTC revert with dust amount v20

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -247,33 +247,33 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipRegular {
 		// defines all tests, if light is enabled, only the most basic tests are run and advanced are skipped
 		erc20Tests := []string{
-			//e2etests.TestERC20WithdrawName,
-			//e2etests.TestMultipleERC20WithdrawsName,
-			//e2etests.TestERC20DepositAndCallRefundName,
-			//e2etests.TestZRC20SwapName,
+			e2etests.TestERC20WithdrawName,
+			e2etests.TestMultipleERC20WithdrawsName,
+			e2etests.TestERC20DepositAndCallRefundName,
+			e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
-			//e2etests.TestERC20DepositRestrictedName,
+			e2etests.TestERC20DepositRestrictedName,
 		}
 		zetaTests := []string{
-			//e2etests.TestZetaWithdrawName,
-			//e2etests.TestMessagePassingExternalChainsName,
-			//e2etests.TestMessagePassingRevertFailExternalChainsName,
-			//e2etests.TestMessagePassingRevertSuccessExternalChainsName,
+			e2etests.TestZetaWithdrawName,
+			e2etests.TestMessagePassingExternalChainsName,
+			e2etests.TestMessagePassingRevertFailExternalChainsName,
+			e2etests.TestMessagePassingRevertSuccessExternalChainsName,
 		}
 		zetaAdvancedTests := []string{
-			//e2etests.TestZetaDepositRestrictedName,
-			//e2etests.TestZetaDepositName,
-			//e2etests.TestZetaDepositNewAddressName,
+			e2etests.TestZetaDepositRestrictedName,
+			e2etests.TestZetaDepositName,
+			e2etests.TestZetaDepositNewAddressName,
 		}
 		zevmMPTests := []string{}
 		zevmMPAdvancedTests := []string{
-			//e2etests.TestMessagePassingZEVMToEVMName,
-			//e2etests.TestMessagePassingEVMtoZEVMName,
-			//e2etests.TestMessagePassingEVMtoZEVMRevertName,
-			//e2etests.TestMessagePassingZEVMtoEVMRevertName,
-			//e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
-			//e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
+			e2etests.TestMessagePassingZEVMToEVMName,
+			e2etests.TestMessagePassingEVMtoZEVMName,
+			e2etests.TestMessagePassingEVMtoZEVMRevertName,
+			e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
+			e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
 		}
 
 		bitcoinTests := []string{
@@ -294,13 +294,13 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestBitcoinWithdrawRestrictedName,
 		}
 		ethereumTests := []string{
-			//e2etests.TestEtherWithdrawName,
-			//e2etests.TestContextUpgradeName,
-			//e2etests.TestEtherDepositAndCallName,
-			//e2etests.TestEtherDepositAndCallRefundName,
+			e2etests.TestEtherWithdrawName,
+			e2etests.TestContextUpgradeName,
+			e2etests.TestEtherDepositAndCallName,
+			e2etests.TestEtherDepositAndCallRefundName,
 		}
 		ethereumAdvancedTests := []string{
-			//e2etests.TestEtherWithdrawRestrictedName,
+			e2etests.TestEtherWithdrawRestrictedName,
 		}
 
 		if !light {

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -247,38 +247,39 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	if !skipRegular {
 		// defines all tests, if light is enabled, only the most basic tests are run and advanced are skipped
 		erc20Tests := []string{
-			e2etests.TestERC20WithdrawName,
-			e2etests.TestMultipleERC20WithdrawsName,
-			e2etests.TestERC20DepositAndCallRefundName,
-			e2etests.TestZRC20SwapName,
+			//e2etests.TestERC20WithdrawName,
+			//e2etests.TestMultipleERC20WithdrawsName,
+			//e2etests.TestERC20DepositAndCallRefundName,
+			//e2etests.TestZRC20SwapName,
 		}
 		erc20AdvancedTests := []string{
-			e2etests.TestERC20DepositRestrictedName,
+			//e2etests.TestERC20DepositRestrictedName,
 		}
 		zetaTests := []string{
-			e2etests.TestZetaWithdrawName,
-			e2etests.TestMessagePassingExternalChainsName,
-			e2etests.TestMessagePassingRevertFailExternalChainsName,
-			e2etests.TestMessagePassingRevertSuccessExternalChainsName,
+			//e2etests.TestZetaWithdrawName,
+			//e2etests.TestMessagePassingExternalChainsName,
+			//e2etests.TestMessagePassingRevertFailExternalChainsName,
+			//e2etests.TestMessagePassingRevertSuccessExternalChainsName,
 		}
 		zetaAdvancedTests := []string{
-			e2etests.TestZetaDepositRestrictedName,
-			e2etests.TestZetaDepositName,
-			e2etests.TestZetaDepositNewAddressName,
+			//e2etests.TestZetaDepositRestrictedName,
+			//e2etests.TestZetaDepositName,
+			//e2etests.TestZetaDepositNewAddressName,
 		}
 		zevmMPTests := []string{}
 		zevmMPAdvancedTests := []string{
-			e2etests.TestMessagePassingZEVMToEVMName,
-			e2etests.TestMessagePassingEVMtoZEVMName,
-			e2etests.TestMessagePassingEVMtoZEVMRevertName,
-			e2etests.TestMessagePassingZEVMtoEVMRevertName,
-			e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
-			e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
+			//e2etests.TestMessagePassingZEVMToEVMName,
+			//e2etests.TestMessagePassingEVMtoZEVMName,
+			//e2etests.TestMessagePassingEVMtoZEVMRevertName,
+			//e2etests.TestMessagePassingZEVMtoEVMRevertName,
+			//e2etests.TestMessagePassingZEVMtoEVMRevertFailName,
+			//e2etests.TestMessagePassingEVMtoZEVMRevertFailName,
 		}
 
 		bitcoinTests := []string{
 			e2etests.TestBitcoinDepositName,
 			e2etests.TestBitcoinDepositRefundName,
+			e2etests.TestBitcoinDepositAndCallRevertWithDustName,
 			e2etests.TestBitcoinWithdrawSegWitName,
 			e2etests.TestBitcoinWithdrawInvalidAddressName,
 			e2etests.TestZetaWithdrawBTCRevertName,
@@ -293,13 +294,13 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestBitcoinWithdrawRestrictedName,
 		}
 		ethereumTests := []string{
-			e2etests.TestEtherWithdrawName,
-			e2etests.TestContextUpgradeName,
-			e2etests.TestEtherDepositAndCallName,
-			e2etests.TestEtherDepositAndCallRefundName,
+			//e2etests.TestEtherWithdrawName,
+			//e2etests.TestContextUpgradeName,
+			//e2etests.TestEtherDepositAndCallName,
+			//e2etests.TestEtherDepositAndCallRefundName,
 		}
 		ethereumAdvancedTests := []string{
-			e2etests.TestEtherWithdrawRestrictedName,
+			//e2etests.TestEtherWithdrawRestrictedName,
 		}
 
 		if !light {

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -63,17 +63,18 @@ const (
 	 Bitcoin tests
 	 Test transfer of Bitcoin asset across chains
 	*/
-	TestBitcoinDepositName                = "bitcoin_deposit"
-	TestBitcoinDepositRefundName          = "bitcoin_deposit_refund"
-	TestBitcoinWithdrawSegWitName         = "bitcoin_withdraw_segwit"
-	TestBitcoinWithdrawTaprootName        = "bitcoin_withdraw_taproot"
-	TestBitcoinWithdrawMultipleName       = "bitcoin_withdraw_multiple"
-	TestBitcoinWithdrawLegacyName         = "bitcoin_withdraw_legacy"
-	TestBitcoinWithdrawP2WSHName          = "bitcoin_withdraw_p2wsh"
-	TestBitcoinWithdrawP2SHName           = "bitcoin_withdraw_p2sh"
-	TestBitcoinWithdrawInvalidAddressName = "bitcoin_withdraw_invalid"
-	TestBitcoinWithdrawRestrictedName     = "bitcoin_withdraw_restricted"
-	TestExtractBitcoinInscriptionMemoName = "bitcoin_memo_from_inscription"
+	TestBitcoinDepositName                      = "bitcoin_deposit"
+	TestBitcoinDepositRefundName                = "bitcoin_deposit_refund"
+	TestBitcoinDepositAndCallRevertWithDustName = "bitcoin_deposit_and_call_revert_with_dust"
+	TestBitcoinWithdrawSegWitName               = "bitcoin_withdraw_segwit"
+	TestBitcoinWithdrawTaprootName              = "bitcoin_withdraw_taproot"
+	TestBitcoinWithdrawMultipleName             = "bitcoin_withdraw_multiple"
+	TestBitcoinWithdrawLegacyName               = "bitcoin_withdraw_legacy"
+	TestBitcoinWithdrawP2WSHName                = "bitcoin_withdraw_p2wsh"
+	TestBitcoinWithdrawP2SHName                 = "bitcoin_withdraw_p2sh"
+	TestBitcoinWithdrawInvalidAddressName       = "bitcoin_withdraw_invalid"
+	TestBitcoinWithdrawRestrictedName           = "bitcoin_withdraw_restricted"
+	TestExtractBitcoinInscriptionMemoName       = "bitcoin_memo_from_inscription"
 
 	/*
 	 Application tests
@@ -420,6 +421,11 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in btc", DefaultValue: "0.1"},
 		},
 		TestBitcoinDepositRefund,
+	),
+	runner.NewE2ETest(
+		TestBitcoinDepositAndCallRevertWithDustName,
+		"deposit Bitcoin into ZEVM; revert with dust amount that aborts the CCTX", []runner.ArgDefinition{},
+		TestBitcoinDepositAndCallRevertWithDust,
 	),
 	runner.NewE2ETest(
 		TestBitcoinWithdrawSegWitName,

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -1,0 +1,56 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/zetacore/e2e/runner"
+	"github.com/zeta-chain/zetacore/e2e/utils"
+	"github.com/zeta-chain/zetacore/testutil/sample"
+)
+
+// TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
+// Given the dust is too smart, the CCTX should revert
+func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
+	// ARRANGE
+	// Given BTC address
+	r.SetBtcAddress(r.Name, false)
+
+	require.Len(r, args, 0)
+
+	// Given "Live" BTC network
+	stop := r.MineBlocksIfLocalBitcoin()
+	defer stop()
+
+	// 0.002 BTC is consumed in a deposit and revert, the dust is set to 1000 satoshis in the protocol
+	// Therefore the deposit amount should be 0.002 + 0.000005 = 0.00200500 should trigger the condition
+	// As only 500 satoshis are left after the deposit
+
+	amount := 0.00200500
+
+	// Given a list of UTXOs
+	utxos, err := r.ListDeployerUTXOs()
+	require.NoError(r, err)
+	require.NotEmpty(r, utxos)
+
+	// ACT
+	// Send BTC to TSS address with a dummy memo
+	// zetacore should revert cctx if call is made on a non-existing address
+	nonExistReceiver := sample.EthAddress()
+	badMemo := append(nonExistReceiver.Bytes(), []byte("gibberish-memo")...)
+	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
+	require.NoError(r, err)
+	require.NotEmpty(r, txHash)
+
+	// ASSERT
+	// Now we want to make sure refund TX is completed.
+	cctx := utils.WaitCctxRevertedByInboundHash(r.Ctx, r, txHash.String(), r.CctxClient)
+
+	// Check revert tx receiver address and amount
+	receiver, value := r.QueryOutboundReceiverAndAmount(cctx.OutboundParams[1].Hash)
+	assert.Equal(r, r.BTCDeployerAddress.EncodeAddress(), receiver)
+	assert.Positive(r, value)
+
+	r.Logger.Print("BITCOIN: Amount received: %d", value)
+	r.Logger.Info("Sent %f BTC to TSS with invalid memo, got refund of %d satoshis", amount, value)
+}

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -24,10 +24,10 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	defer stop()
 
 	// 0.002 BTC is consumed in a deposit and revert, the dust is set to 1000 satoshis in the protocol
-	// Therefore the deposit amount should be 0.002 + 0.000005 = 0.00200500 should trigger the condition
-	// As only 500 satoshis are left after the deposit
+	// Therefore the deposit amount should be 0.002 + 0.000001 = 0.00200100 should trigger the condition
+	// As only 100 satoshis are left after the deposit
 
-	amount := 0.00200500
+	amount := 0.00200100
 	amount += zetabitcoin.DefaultDepositorFee
 
 	// Given a list of UTXOs

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -2,16 +2,16 @@ package e2etests
 
 import (
 	"github.com/stretchr/testify/require"
-	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
-	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 
 	"github.com/zeta-chain/zetacore/e2e/runner"
 	"github.com/zeta-chain/zetacore/e2e/utils"
+	"github.com/zeta-chain/zetacore/pkg/constant"
 	"github.com/zeta-chain/zetacore/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
+	zetabitcoin "github.com/zeta-chain/zetacore/zetaclient/chains/bitcoin"
 )
 
 // TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
-// Given the dust is too smart, the CCTX should revert
 func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
 	// ARRANGE
 	// Given BTC address
@@ -43,10 +43,12 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
-	r.Logger.Print("BITCOIN tx hash: %s", txHash.String())
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
-	r.Logger.CCTX(*cctx, "deposit")
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
+	r.Logger.CCTX(*cctx, "deposit_and_revert")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// check the test was effective: the revert outbound amount is less than the dust amount
+	require.Less(r, cctx.GetCurrentOutboundParam().Amount.Uint64(), uint64(constant.BTCWithdrawalDustAmount))
 }

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/pkg/coin"
+	"github.com/zeta-chain/zetacore/pkg/constant"
 	crosschaintypes "github.com/zeta-chain/zetacore/x/crosschain/types"
 	"github.com/zeta-chain/zetacore/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/zetacore/zetaclient/chains/bitcoin/rpc"
@@ -531,8 +532,8 @@ func (ob *Observer) checkTssOutboundResult(
 		return errors.Wrapf(err, "checkTssOutboundResult: invalid TSS Vin in outbound %s nonce %d", hash, nonce)
 	}
 
-	// differentiate between normal and restricted cctx
-	if compliance.IsCctxRestricted(cctx) {
+	// differentiate between normal and cancelled cctx
+	if compliance.IsCctxRestricted(cctx) || params.Amount.Uint64() < constant.BTCWithdrawalDustAmount {
 		err = ob.checkTSSVoutCancelled(params, rawResult.Vout)
 		if err != nil {
 			return errors.Wrapf(

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/zeta-chain/zetacore/pkg/chains"
 	"github.com/zeta-chain/zetacore/pkg/coin"
+	"github.com/zeta-chain/zetacore/pkg/constant"
 	"github.com/zeta-chain/zetacore/x/crosschain/types"
 	observertypes "github.com/zeta-chain/zetacore/x/observer/types"
 	"github.com/zeta-chain/zetacore/zetaclient/chains/base"
@@ -417,7 +418,7 @@ func (signer *Signer) TryProcessOutbound(
 	}
 
 	// check dust amount
-	dustAmount := false // params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
+	dustAmount := params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
 	if dustAmount {
 		logger.Warn().Msgf("dust amount %d sats, canceling tx", params.Amount.Uint64())
 	}


### PR DESCRIPTION
# Description

Check if the amount for a BTC revert outbound is below dust amount. In this case, cancel the tx (same logic as restricted address where there will be a tx but with 0 btc), cctx will be reverted.

Add a E2E test to test revert with dust amount. To check the effect, the "dustAmount" can be set to false in ZetaClient, the test will be stall because the outbound can't be signed
