### PR TITLE
fix: out of gas on ZetaClient during `onRevert` (v22 backport)

### DIFF
--- a/zetaclient/zetacore/client_monitor.go
+++ b/zetaclient/zetacore/client_monitor.go
@@ -81,7 +81,7 @@ func (c *Client) monitorVoteOutboundResult(
 			}
 		}
 	default:
-		c.logger.Debug().Fields(logFields).Msg("monitorVoteOutboundResult: successful")
+		c.logger.Info().Fields(logFields).Msg("monitorVoteOutboundResult: successful")
 	}
 
 	return nil
@@ -159,7 +159,7 @@ func (c *Client) monitorVoteInboundResult(
 		}
 
 	default:
-		c.logger.Debug().Fields(logFields).Msgf("monitorVoteInboundResult: successful")
+		c.logger.Info().Fields(logFields).Msgf("monitorVoteInboundResult: successful")
 	}
 
 	return nil

--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -47,7 +47,7 @@ const (
 
 	// PostVoteOutboundRevertGasLimit is the gas limit for voting on observed outbound tx for revert (when outbound fails)
 	// The value needs to be higher because reverting implies interacting with the EVM to perform swaps for the gas token
-	PostVoteOutboundRevertGasLimit = 4_000_000
+	PostVoteOutboundRevertGasLimit = 7_000_000
 )
 
 // constants for monitoring tx results

--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -19,7 +19,7 @@ const (
 	PostTSSGasLimit = 500_000
 
 	// PostVoteInboundExecutionGasLimit is the gas limit for voting on observed inbound tx and executing it
-	PostVoteInboundExecutionGasLimit = 7_000_000
+	PostVoteInboundExecutionGasLimit = 10_000_000
 
 	// PostVoteInboundMessagePassingExecutionGasLimit is the gas limit for voting on, and executing ,observed inbound tx related to message passing (coin_type == zeta)
 	PostVoteInboundMessagePassingExecutionGasLimit = 4_000_000


### PR DESCRIPTION
# Description

Backport https://github.com/zeta-chain/node/pull/3144 to v22