### PR TITLE
chore: prepare v21.0.1

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -302,6 +302,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestBitcoinDepositName,
 			e2etests.TestBitcoinDepositAndCallName,
 			e2etests.TestBitcoinDepositAndCallRevertName,
+			e2etests.TestBitcoinDepositAndCallRevertWithDustName,
 			e2etests.TestBitcoinWithdrawSegWitName,
 			e2etests.TestBitcoinWithdrawInvalidAddressName,
 			e2etests.TestZetaWithdrawBTCRevertName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -75,6 +75,7 @@ const (
 	TestBitcoinDepositName                                 = "bitcoin_deposit"
 	TestBitcoinDepositAndCallName                          = "bitcoin_deposit_and_call"
 	TestBitcoinDepositAndCallRevertName                    = "bitcoin_deposit_and_call_revert"
+	TestBitcoinDepositAndCallRevertWithDustName            = "bitcoin_deposit_and_call_revert_with_dust"
 	TestBitcoinDonationName                                = "bitcoin_donation"
 	TestBitcoinStdMemoDepositName                          = "bitcoin_std_memo_deposit"
 	TestBitcoinStdMemoDepositAndCallName                   = "bitcoin_std_memo_deposit_and_call"
@@ -507,6 +508,11 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in btc", DefaultValue: "0.1"},
 		},
 		TestBitcoinDepositAndCallRevert,
+	),
+	runner.NewE2ETest(
+		TestBitcoinDepositAndCallRevertWithDustName,
+		"deposit Bitcoin into ZEVM; revert with dust amount that aborts the CCTX", []runner.ArgDefinition{},
+		TestBitcoinDepositAndCallRevertWithDust,
 	),
 	runner.NewE2ETest(
 		TestBitcoinStdMemoDepositName,

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -1,0 +1,54 @@
+package e2etests
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	zetabitcoin "github.com/zeta-chain/node/zetaclient/chains/bitcoin"
+)
+
+// TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
+func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
+	// ARRANGE
+	// Given BTC address
+	r.SetBtcAddress(r.Name, false)
+
+	require.Len(r, args, 0)
+
+	// Given "Live" BTC network
+	stop := r.MineBlocksIfLocalBitcoin()
+	defer stop()
+
+	// 0.002 BTC is consumed in a deposit and revert, the dust is set to 1000 satoshis in the protocol
+	// Therefore the deposit amount should be 0.002 + 0.000001 = 0.00200100 should trigger the condition
+	// As only 100 satoshis are left after the deposit
+
+	amount := 0.00200100
+	amount += zetabitcoin.DefaultDepositorFee
+
+	// Given a list of UTXOs
+	utxos, err := r.ListDeployerUTXOs()
+	require.NoError(r, err)
+	require.NotEmpty(r, utxos)
+
+	// ACT
+	// Send BTC to TSS address with a dummy memo
+	// zetacore should revert cctx if call is made on a non-existing address
+	nonExistReceiver := sample.EthAddress()
+	badMemo := append(nonExistReceiver.Bytes(), []byte("gibberish-memo")...)
+	txHash, err := r.SendToTSSFromDeployerWithMemo(amount, utxos, badMemo)
+	require.NoError(r, err)
+	require.NotEmpty(r, txHash)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit_and_revert")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// check the test was effective: the revert outbound amount is less than the dust amount
+	require.Less(r, cctx.GetCurrentOutboundParam().Amount.Uint64(), uint64(constant.BTCWithdrawalDustAmount))
+}

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/rpc"
@@ -531,8 +532,8 @@ func (ob *Observer) checkTssOutboundResult(
 		return errors.Wrapf(err, "checkTssOutboundResult: invalid TSS Vin in outbound %s nonce %d", hash, nonce)
 	}
 
-	// differentiate between normal and restricted cctx
-	if compliance.IsCctxRestricted(cctx) {
+	// differentiate between normal and cancelled cctx
+	if compliance.IsCctxRestricted(cctx) || params.Amount.Uint64() < constant.BTCWithdrawalDustAmount {
 		err = ob.checkTSSVoutCancelled(params, rawResult.Vout)
 		if err != nil {
 			return errors.Wrapf(

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
@@ -413,13 +414,25 @@ func (signer *Signer) TryProcessOutbound(
 	gasprice.Add(gasprice, satPerByte)
 
 	// compliance check
-	cancelTx := compliance.IsCctxRestricted(cctx)
-	if cancelTx {
+	restrictedCCTX := compliance.IsCctxRestricted(cctx)
+	if restrictedCCTX {
 		compliance.PrintComplianceLog(logger, signer.Logger().Compliance,
 			true, chain.ChainId, cctx.Index, cctx.InboundParams.Sender, params.Receiver, "BTC")
-		amount = 0.0 // zero out the amount to cancel the tx
 	}
-	logger.Info().Msgf("SignGasWithdraw: to %s, value %d sats", to.EncodeAddress(), params.Amount.Uint64())
+
+	// check dust amount
+	dustAmount := params.Amount.Uint64() < constant.BTCWithdrawalDustAmount
+	if dustAmount {
+		logger.Warn().Msgf("dust amount %d sats, canceling tx", params.Amount.Uint64())
+	}
+
+	// set the amount to 0 when the tx should be cancelled
+	cancelTx := restrictedCCTX || dustAmount
+	if cancelTx {
+		amount = 0.0
+	} else {
+		logger.Info().Msgf("SignGasWithdraw: to %s, value %d sats", to.EncodeAddress(), params.Amount.Uint64())
+	}
 
 	// sign withdraw tx
 	tx, err := signer.SignWithdrawTx(

--- a/zetaclient/zetacore/client_monitor.go
+++ b/zetaclient/zetacore/client_monitor.go
@@ -81,7 +81,7 @@ func (c *Client) monitorVoteOutboundResult(
 			}
 		}
 	default:
-		c.logger.Debug().Fields(logFields).Msg("monitorVoteOutboundResult: successful")
+		c.logger.Info().Fields(logFields).Msg("monitorVoteOutboundResult: successful")
 	}
 
 	return nil
@@ -159,7 +159,7 @@ func (c *Client) monitorVoteInboundResult(
 		}
 
 	default:
-		c.logger.Debug().Fields(logFields).Msgf("monitorVoteInboundResult: successful")
+		c.logger.Info().Fields(logFields).Msgf("monitorVoteInboundResult: successful")
 	}
 
 	return nil

--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -19,7 +19,7 @@ const (
 	PostTSSGasLimit = 500_000
 
 	// PostVoteInboundExecutionGasLimit is the gas limit for voting on observed inbound tx and executing it
-	PostVoteInboundExecutionGasLimit = 7_000_000
+	PostVoteInboundExecutionGasLimit = 10_000_000
 
 	// PostVoteInboundMessagePassingExecutionGasLimit is the gas limit for voting on, and executing ,observed inbound tx related to message passing (coin_type == zeta)
 	PostVoteInboundMessagePassingExecutionGasLimit = 4_000_000
@@ -47,7 +47,7 @@ const (
 
 	// PostVoteOutboundRevertGasLimit is the gas limit for voting on observed outbound tx for revert (when outbound fails)
 	// The value needs to be higher because reverting implies interacting with the EVM to perform swaps for the gas token
-	PostVoteOutboundRevertGasLimit = 4_000_000
+	PostVoteOutboundRevertGasLimit = 7_000_000
 )
 
 // constants for monitoring tx results


### PR DESCRIPTION
# Description

Backport of https://github.com/zeta-chain/node/pull/3144 to v21. The following is lifted from that PR's description:

> Use 7M gas instead of 4M when processing a revert outbound.
> 
> To test the change, the onRevert hook on ZetaChain testDApp consume 300k more gas
> 
> To check the change is effective:
> Revert back this line: https://github.com/zeta-chain/node/pull/3144/files#diff-503de1565f57cda7a6a71c86db258cf0b5eb1a346eb009991b2f2ea1d30df70eR50
> The v2EthWithdrawAndRevertTest will fail because of the current issue (outbound not observed)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
