### PR TITLE
refactor: use major version in release upgrade handlers

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -94,38 +94,6 @@ jobs:
         run: |
           echo "continue"
 
-  check-upgrade-handler-updated:
-    needs:
-      - check-branch
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    steps:
-
-      - uses: actions/checkout@v4
-        if: inputs.skip_checks != true
-        with:
-          fetch-depth: 0
-
-      - name: Major Version in Upgrade Handler Must Match Tag
-        if: inputs.skip_checks != true
-        run: |
-          UPGRADE_HANDLER_MAJOR_VERSION=$(cat app/setup_handlers.go | grep "const releaseVersion" | cut -d ' ' -f4 | tr -d '"' | cut -d '.' -f 1 | tr -d '\n')
-          USER_INPUT_VERSION=$(echo "${{ inputs.version }}" | cut -d '.' -f 1 | tr -d '\n')
-          echo "Upgrade Handler Major Version: ${UPGRADE_HANDLER_MAJOR_VERSION}"
-          echo "User Inputted Release Version: ${USER_INPUT_VERSION}"
-          if [ ${USER_INPUT_VERSION} != $UPGRADE_HANDLER_MAJOR_VERSION ]; then
-            echo "ERROR: The input version doesn't match the release handler for the branch selected. Please ensure the upgrade handler of the branch you selected when you ran the pipeline matches the input version."
-            echo "Did you forget to update the 'releaseVersion' in app/setup_handlers.go?" 
-            exit 1
-          fi
-          echo "The major version found in 'releaseVersion' in app/setup_handlers.go matches this tagged release - Moving Forward!"
-
-      - name: Mark Job Complete Skipped
-        if: inputs.skip_checks == true
-        shell: bash
-        run: |
-          echo "continue"
-
   publish-release:
     permissions:
       id-token: write
@@ -134,7 +102,6 @@ jobs:
     if: inputs.skip_release != true
     needs:
       - check-changelog
-      - check-upgrade-handler-updated
       - check-branch
       - check-goreleaser
     runs-on: ${{ vars.RELEASE_RUNNER }}

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -9,7 +9,22 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/zeta-chain/node/pkg/constant"
+	"golang.org/x/mod/semver"
 )
+
+// GetDefaultUpgradeHandlerVersion prints the default upgrade handler version
+//
+// There may be multiple upgrade handlers configured on some releases if different
+// migrations needto be run in different environment
+func GetDefaultUpgradeHandlerVersion() string {
+	// development builds always use the full version in the release handlers
+	if semver.Build(constant.Version) != "" || semver.Prerelease(constant.Version) != "" {
+		return constant.Version
+	}
+
+	// release builds use just the major version (v22.0.0 -> v22)
+	return semver.Major(constant.Version)
+}
 
 func SetupHandlers(app *App) {
 	allUpgrades := upgradeTracker{
@@ -50,10 +65,12 @@ func SetupHandlers(app *App) {
 		upgradeHandlerFns, storeUpgrades = allUpgrades.mergeAllUpgrades()
 	}
 
+	upgradeHandlerVersion := GetDefaultUpgradeHandlerVersion()
+
 	app.UpgradeKeeper.SetUpgradeHandler(
-		constant.Version,
+		upgradeHandlerVersion,
 		func(ctx sdk.Context, _ types.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			app.Logger().Info("Running upgrade handler for " + constant.Version)
+			app.Logger().Info("Running upgrade handler for " + upgradeHandlerVersion)
 
 			var err error
 			for _, upgradeHandler := range upgradeHandlerFns {
@@ -71,7 +88,7 @@ func SetupHandlers(app *App) {
 	if err != nil {
 		panic(err)
 	}
-	if upgradeInfo.Name == constant.Version && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if upgradeInfo.Name == upgradeHandlerVersion && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		// Use upgrade store loader for the initial loading of all stores when app starts,
 		// it checks if version == upgradeHeight and applies store upgrades before loading the stores,
 		// so that new stores start with the correct version (the current height of chain),

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -17,13 +17,16 @@ import (
 // There may be multiple upgrade handlers configured on some releases if different
 // migrations needto be run in different environment
 func GetDefaultUpgradeHandlerVersion() string {
+	// semver must have v prefix, but we store without prefix
+	vVersion := "v" + constant.Version
+
 	// development builds always use the full version in the release handlers
-	if semver.Build(constant.Version) != "" || semver.Prerelease(constant.Version) != "" {
+	if semver.Build(vVersion) != "" || semver.Prerelease(vVersion) != "" {
 		return constant.Version
 	}
 
 	// release builds use just the major version (v22.0.0 -> v22)
-	return semver.Major(constant.Version)
+	return semver.Major(vVersion)
 }
 
 func SetupHandlers(app *App) {

--- a/app/setup_handlers.go
+++ b/app/setup_handlers.go
@@ -7,9 +7,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"golang.org/x/mod/semver"
 
 	"github.com/zeta-chain/node/pkg/constant"
-	"golang.org/x/mod/semver"
 )
 
 // GetDefaultUpgradeHandlerVersion prints the default upgrade handler version

--- a/cmd/zetacored/root.go
+++ b/cmd/zetacored/root.go
@@ -145,6 +145,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig types.EncodingConfig) {
 		GetPubKeyCmd(),
 		CollectObserverInfoCmd(),
 		AddrConversionCmd(),
+		UpgradeHandlerVersionCmd(),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		ethermintclient.NewTestnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),
 

--- a/cmd/zetacored/version.go
+++ b/cmd/zetacored/version.go
@@ -12,7 +12,7 @@ func UpgradeHandlerVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upgrade-handler-version",
 		Short: "Print the default upgrade handler version",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Println(app.GetDefaultUpgradeHandlerVersion())
 		},
 	}

--- a/cmd/zetacored/version.go
+++ b/cmd/zetacored/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/zeta-chain/node/app"
 )
 

--- a/cmd/zetacored/version.go
+++ b/cmd/zetacored/version.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/zeta-chain/node/app"
+)
+
+func UpgradeHandlerVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "upgrade-handler-version",
+		Short: "Print the upgrade handler version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(app.GetDefaultUpgradeHandlerVersion())
+		},
+	}
+}

--- a/cmd/zetacored/version.go
+++ b/cmd/zetacored/version.go
@@ -10,7 +10,7 @@ import (
 func UpgradeHandlerVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "upgrade-handler-version",
-		Short: "Print the upgrade handler version",
+		Short: "Print the default upgrade handler version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(app.GetDefaultUpgradeHandlerVersion())
 		},

--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -39,7 +39,7 @@ fi
 # get new zetacored version
 curl -L -o /tmp/zetacored.new "${ZETACORED_URL}"
 chmod +x /tmp/zetacored.new
-UPGRADE_NAME=$(/tmp/zetacored.new version)
+UPGRADE_NAME=$(/tmp/zetacored.new upgrade-handler-version)
 
 # if explicit upgrade height not provided, use dumb estimator
 if [[ -z $UPGRADE_HEIGHT ]]; then

--- a/docs/cli/zetacored/cli.md
+++ b/docs/cli/zetacored/cli.md
@@ -39,6 +39,7 @@ Zetacore Daemon (server)
 * [zetacored tendermint](#zetacored-tendermint)	 - Tendermint subcommands
 * [zetacored testnet](#zetacored-testnet)	 - subcommands for starting or configuring local testnets
 * [zetacored tx](#zetacored-tx)	 - Transactions subcommands
+* [zetacored upgrade-handler-version](#zetacored-upgrade-handler-version)	 - Print the default upgrade handler version
 * [zetacored validate-genesis](#zetacored-validate-genesis)	 - validates the genesis file at the default location or at the location passed as an arg
 * [zetacored version](#zetacored-version)	 - Print the application binary version information
 
@@ -14345,6 +14346,34 @@ zetacored tx vesting create-vesting-account [to_address] [amount] [end_time] [fl
 ### SEE ALSO
 
 * [zetacored tx vesting](#zetacored-tx-vesting)	 - Vesting transaction subcommands
+
+## zetacored upgrade-handler-version
+
+Print the default upgrade handler version
+
+```
+zetacored upgrade-handler-version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for upgrade-handler-version
+```
+
+### Options inherited from parent commands
+
+```
+      --home string         directory for config and data 
+      --log_format string   The logging format (json|plain) 
+      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) 
+      --log_no_color        Disable colored logs
+      --trace               print out full stack trace on errors
+```
+
+### SEE ALSO
+
+* [zetacored](#zetacored)	 - Zetacore Daemon (server)
 
 ## zetacored validate-genesis
 

--- a/version.sh
+++ b/version.sh
@@ -22,7 +22,7 @@ short_commit=$(git rev-parse --short HEAD)
 
 # append -dirty for dirty builds
 if ! git diff --no-ext-diff --quiet --exit-code ; then
-    echo "0.0.${commit_timestamp}+${short_commit}-dirty"
+    echo "0.0.${commit_timestamp}+${short_commit}.dirty"
     exit
 fi
 

--- a/version.sh
+++ b/version.sh
@@ -22,8 +22,8 @@ short_commit=$(git rev-parse --short HEAD)
 
 # append -dirty for dirty builds
 if ! git diff --no-ext-diff --quiet --exit-code ; then
-    echo "0.0.${commit_timestamp}-${short_commit}-dirty"
+    echo "0.0.${commit_timestamp}+${short_commit}-dirty"
     exit
 fi
 
-echo "0.0.${commit_timestamp}-${short_commit}"
+echo "0.0.${commit_timestamp}+${short_commit}"


### PR DESCRIPTION
Typically I/we have to manually rewrite the upgrade handlers when a release branch is cut. We can detect a release version build by the absense of the prerelease and build sections of the semver string.

Also use + rather than - in the development versions for semver 2.0 compliance.

Related to https://github.com/zeta-chain/noderelease2proposal/issues/7

```
  node git:(upgrade-handler-cmd) make install
--> Installing zetacored, zetaclientd, and zetaclientd-supervisor
  node git:(upgrade-handler-cmd) zetacored version
0.0.1731604964+09d0aafa0
  node git:(upgrade-handler-cmd) zetacored upgrade-handler-version
0.0.1731604964+09d0aafa0
  node git:(upgrade-handler-cmd) git tag v1.2.3
  node git:(upgrade-handler-cmd) make install
--> Installing zetacored, zetaclientd, and zetaclientd-supervisor
  node git:(upgrade-handler-cmd) zetacored version
1.2.3
  node git:(upgrade-handler-cmd) zetacored upgrade-handler-version
v1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new command `upgrade-handler-version` to display the default upgrade handler version.
	- Enhanced command-line interface for better version upgrade management.

- **Bug Fixes**
	- Updated the version string format for both dirty and clean builds for consistency.

- **Documentation**
	- Added documentation for the new `upgrade-handler-version` command and made minor formatting improvements in CLI documentation.

- **Chores**
	- Refined the upgrade process script for improved clarity and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->