### PR TITLE
fix: skip depositor fee calculation on irrelevant transactions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * [3106](https://github.com/zeta-chain/node/pull/3106) - prevent blocked CCTX on out of gas during omnichain calls
 * [3139](https://github.com/zeta-chain/node/pull/3139) - fix config resolution in orchestrator
 * [3149](https://github.com/zeta-chain/node/pull/3149) - abort the cctx if dust amount is detected in the revert outbound
+* [3161](https://github.com/zeta-chain/node/pull/3162) - skip depositor fee calculation if transaction does not involve TSS address
 
 ## v21.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@
 * [3106](https://github.com/zeta-chain/node/pull/3106) - prevent blocked CCTX on out of gas during omnichain calls
 * [3139](https://github.com/zeta-chain/node/pull/3139) - fix config resolution in orchestrator
 * [3149](https://github.com/zeta-chain/node/pull/3149) - abort the cctx if dust amount is detected in the revert outbound
-* [3161](https://github.com/zeta-chain/node/pull/3162) - skip depositor fee calculation if transaction does not involve TSS address
+* [3162](https://github.com/zeta-chain/node/pull/3162) - skip depositor fee calculation if transaction does not involve TSS address
 
 ## v21.0.0
 

--- a/zetaclient/chains/bitcoin/fee.go
+++ b/zetaclient/chains/bitcoin/fee.go
@@ -56,6 +56,9 @@ var (
 	DefaultDepositorFee = DepositorFee(defaultDepositorFeeRate)
 )
 
+// DepositorFeeCalculator is a function type to calculate the Bitcoin depositor fee
+type DepositorFeeCalculator func(interfaces.BTCRPCClient, *btcjson.TxRawResult, *chaincfg.Params) (float64, error)
+
 // FeeRateToSatPerByte converts a fee rate in BTC/KB to sat/byte.
 func FeeRateToSatPerByte(rate float64) *big.Int {
 	// #nosec G115 always in range

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -23,12 +23,20 @@ import (
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/observer"
+	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 	clientcommon "github.com/zeta-chain/node/zetaclient/common"
 	"github.com/zeta-chain/node/zetaclient/keys"
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 	"github.com/zeta-chain/node/zetaclient/testutils/testrpc"
 )
+
+// mockDepositFeeCalculator returns a mock depositor fee calculator that returns the given fee and error.
+func mockDepositFeeCalculator(fee float64, err error) bitcoin.DepositorFeeCalculator {
+	return func(interfaces.BTCRPCClient, *btcjson.TxRawResult, *chaincfg.Params) (float64, error) {
+		return fee, err
+	}
+}
 
 func TestAvgFeeRateBlock828440(t *testing.T) {
 	// load archived block 828440
@@ -278,6 +286,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 
 	// fee rate of above tx is 28 sat/vB
 	depositorFee := bitcoin.DepositorFee(28 * clientcommon.BTCOutboundGasPriceMultiplier)
+	feeCalculator := mockDepositFeeCalculator(depositorFee, nil)
 
 	// expected result
 	memo, err := hex.DecodeString(tx.Vout[1].ScriptPubKey.Hex[4:])
@@ -309,7 +318,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, eventExpected, event)
@@ -333,7 +342,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, eventExpected, event)
@@ -357,7 +366,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, eventExpected, event)
@@ -381,7 +390,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, eventExpected, event)
@@ -405,7 +414,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, eventExpected, event)
@@ -425,7 +434,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -445,7 +454,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -459,7 +468,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -479,9 +488,28 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
+		require.Nil(t, event)
+	})
+
+	t.Run("should return error if RPC failed to calculate depositor fee", func(t *testing.T) {
+		// load tx
+		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
+
+		// get BTC event
+		rpcClient := mocks.NewBTCRPCClient(t)
+		event, err := observer.GetBtcEventWithoutWitness(
+			rpcClient,
+			*tx,
+			tssAddress,
+			blockNumber,
+			log.Logger,
+			net,
+			mockDepositFeeCalculator(0.0, errors.New("rpc error")),
+		)
+		require.ErrorContains(t, err, "rpc error")
 		require.Nil(t, event)
 	})
 
@@ -499,7 +527,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -519,7 +547,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -539,7 +567,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -570,7 +598,7 @@ func TestGetBtcEventWithoutWitness(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Nil(t, event)
@@ -588,6 +616,7 @@ func TestGetBtcEventErrors(t *testing.T) {
 
 	// fee rate of above tx is 28 sat/vB
 	depositorFee := bitcoin.DepositorFee(28 * clientcommon.BTCOutboundGasPriceMultiplier)
+	feeCalculator := mockDepositFeeCalculator(depositorFee, nil)
 
 	t.Run("should return error on invalid Vout[0] script", func(t *testing.T) {
 		// load tx and modify Vout[0] script to invalid script
@@ -603,7 +632,7 @@ func TestGetBtcEventErrors(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.Error(t, err)
 		require.Nil(t, event)
@@ -623,7 +652,7 @@ func TestGetBtcEventErrors(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.ErrorContains(t, err, "no input found")
 		require.Nil(t, event)
@@ -645,7 +674,7 @@ func TestGetBtcEventErrors(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.ErrorContains(t, err, "error getting sender address")
 		require.Nil(t, event)
@@ -662,6 +691,8 @@ func TestGetBtcEvent(t *testing.T) {
 		net := &chaincfg.MainNetParams
 		// 2.992e-05, see avgFeeRate https://mempool.space/api/v1/blocks/835640
 		depositorFee := bitcoin.DepositorFee(22 * clientcommon.BTCOutboundGasPriceMultiplier)
+		feeCalculator := mockDepositFeeCalculator(depositorFee, nil)
+
 		txHash2 := "37777defed8717c581b4c0509329550e344bdc14ac38f71fc050096887e535c8"
 		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash2, false)
 		rpcClient := mocks.NewBTCRPCClient(t)
@@ -673,7 +704,7 @@ func TestGetBtcEvent(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, (*observer.BTCInboundEvent)(nil), event)
@@ -693,6 +724,7 @@ func TestGetBtcEvent(t *testing.T) {
 
 		// fee rate of above tx is 28 sat/vB
 		depositorFee := bitcoin.DepositorFee(28 * clientcommon.BTCOutboundGasPriceMultiplier)
+		feeCalculator := mockDepositFeeCalculator(depositorFee, nil)
 
 		// expected result
 		memo, err := hex.DecodeString(tx.Vout[1].ScriptPubKey.Hex[4:])
@@ -723,7 +755,7 @@ func TestGetBtcEvent(t *testing.T) {
 			blockNumber,
 			log.Logger,
 			net,
-			depositorFee,
+			feeCalculator,
 		)
 		require.NoError(t, err)
 		require.Equal(t, eventExpected, event)

--- a/zetaclient/chains/bitcoin/observer/witness.go
+++ b/zetaclient/chains/bitcoin/observer/witness.go
@@ -24,7 +24,7 @@ func GetBtcEventWithWitness(
 	blockNumber uint64,
 	logger zerolog.Logger,
 	netParams *chaincfg.Params,
-	depositorFee float64,
+	feeCalculator bitcoin.DepositorFeeCalculator,
 ) (*BTCInboundEvent, error) {
 	if len(tx.Vout) < 1 {
 		logger.Debug().Msgf("no output %s", tx.Txid)
@@ -38,6 +38,12 @@ func GetBtcEventWithWitness(
 	if err := isValidRecipient(tx.Vout[0].ScriptPubKey.Hex, tssAddress, netParams); err != nil {
 		logger.Debug().Msgf("irrelevant recipient %s for tx %s, err: %s", tx.Vout[0].ScriptPubKey.Hex, tx.Txid, err)
 		return nil, nil
+	}
+
+	// calculate depositor fee
+	depositorFee, err := feeCalculator(client, &tx, netParams)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error calculating depositor fee for inbound %s", tx.Txid)
 	}
 
 	isAmountValid, amount := isValidAmount(tx.Vout[0].Value, depositorFee)


### PR DESCRIPTION
# Description

The official fix that replaces https://github.com/zeta-chain/node/pull/3161

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added ability to whitelist SPL tokens on Solana.
	- Integrated SPL deposits and withdrawals for Solana.

- **Improvements**
	- Enhanced build reproducibility with stable checksums.

- **Bug Fixes**
	- Resolved issues with emissions module registration and out-of-gas errors during omnichain calls.
	- Improved handling of depositor fee calculations.

- **Refactor**
	- Streamlined fee calculation processes and updated related functions for better modularity.

- **Tests**
	- Introduced new tests for error handling in fee calculations and updated existing tests to enhance flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->