### PR TITLE
fix(ci): move skip_checks to step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,11 +44,11 @@ jobs:
           echo "${{ github.ref }}"
 
   check-goreleaser:
-    if: inputs.skip_checks != true
     runs-on: ${{ vars.RELEASE_RUNNER }}
     steps:
       - uses: actions/checkout@v4
       - name: Build release snapshot
+        if: inputs.skip_checks != true
         run: |
           make release-snapshot
           


### PR DESCRIPTION
`check-goreleaser` is a required step for doing the release. So we need to move the conditional to the step rather than the job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control over the release process with options to skip checks and releases based on user inputs.
  
- **Bug Fixes**
	- Improved execution flow for jobs related to release verification and changelog checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->