### PR TITLE
fix(crosschain): do not check zetachain sender for failed revert outbound

### DIFF
--- a/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
+++ b/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
@@ -339,7 +339,7 @@ func (k Keeper) processFailedOutboundV2(ctx sdk.Context, cctx *types.CrossChainT
 				cctx.InboundParams.SenderChainId,
 			)
 		}
-		
+
 		//  get the chain ID of the connected chain
 		chainID := cctx.GetCurrentOutboundParam().ReceiverChainId
 

--- a/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
+++ b/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
@@ -320,7 +320,7 @@ func (k Keeper) processFailedZETAOutboundOnZEVM(ctx sdk.Context, cctx *types.Cro
 
 // processFailedOutboundV2 processes a failed outbound transaction for protocol version 2
 // for revert, in V2 we have some assumption simplifying the logic
-// - sender chain is always ZetaChain
+// - sender chain is ZetaChain for regular outbound (not revert outbound)
 // - all coin type use the same workflow
 // TODO: consolidate logic with above function
 // https://github.com/zeta-chain/node/issues/2627

--- a/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
+++ b/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
@@ -325,22 +325,21 @@ func (k Keeper) processFailedZETAOutboundOnZEVM(ctx sdk.Context, cctx *types.Cro
 // TODO: consolidate logic with above function
 // https://github.com/zeta-chain/node/issues/2627
 func (k Keeper) processFailedOutboundV2(ctx sdk.Context, cctx *types.CrossChainTx) error {
-	// check the sender is ZetaChain
-	zetaChain, err := chains.ZetaChainFromCosmosChainID(ctx.ChainID())
-	if err != nil {
-		return errors.Wrap(err, "failed to get ZetaChain chainID")
-	}
-	if cctx.InboundParams.SenderChainId != zetaChain.ChainId {
-		return fmt.Errorf(
-			"sender chain for withdraw cctx is not ZetaChain expected %d got %d",
-			zetaChain.ChainId,
-			cctx.InboundParams.SenderChainId,
-		)
-	}
-
 	switch cctx.CctxStatus.Status {
 	case types.CctxStatus_PendingOutbound:
-
+		// check the sender is ZetaChain
+		zetaChain, err := chains.ZetaChainFromCosmosChainID(ctx.ChainID())
+		if err != nil {
+			return errors.Wrap(err, "failed to get ZetaChain chainID")
+		}
+		if cctx.InboundParams.SenderChainId != zetaChain.ChainId {
+			return fmt.Errorf(
+				"sender chain for withdraw cctx is not ZetaChain expected %d got %d",
+				zetaChain.ChainId,
+				cctx.InboundParams.SenderChainId,
+			)
+		}
+		
 		//  get the chain ID of the connected chain
 		chainID := cctx.GetCurrentOutboundParam().ReceiverChainId
 


### PR DESCRIPTION
# Description

If status is `CctxStatus_PendingRevert` when processing a failed outbound then the sender chain will not be ZetaChain but the chain that initiated the inbound

Closes: https://github.com/zeta-chain/node/issues/3165



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved sender chain validation for outbound transactions to ensure it occurs before processing, enhancing clarity and reliability.
  
- **Refactor**
	- Reorganized code for better flow and consistency in error handling related to sender chain validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->