### PR TITLE
chore: test v22 upgrade with v20 base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
-		--build-arg OLD_VERSION='release/v21' \
+		--build-arg OLD_VERSION='release/v20' \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg NODE_COMMIT=$(NODE_COMMIT)
 		.
@@ -310,7 +310,7 @@ else
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v21.0.0' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v20.0.0' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.
@@ -320,7 +320,7 @@ endif
 start-upgrade-test: zetanode-upgrade
 	@echo "--> Starting upgrade test"
 	export LOCALNET_MODE=upgrade && \
-	export UPGRADE_HEIGHT=225 && \
+	export UPGRADE_HEIGHT=330 && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 start-upgrade-test-light: zetanode-upgrade
@@ -351,7 +351,7 @@ start-upgrade-import-mainnet-test: zetanode-upgrade
 	export LOCALNET_MODE=upgrade && \
 	export ZETACORED_IMPORT_GENESIS_DATA=true && \
 	export ZETACORED_START_PERIOD=15m && \
-	export UPGRADE_HEIGHT=225 && \
+	export UPGRADE_HEIGHT=330 && \
 	cd contrib/localnet/ && ./scripts/import-data.sh mainnet && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ else
 zetanode-upgrade: zetanode
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v20.0.0' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v20.0.7' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	TestTimeout = 15 * time.Minute
+	TestTimeout = 20 * time.Minute
 )
 
 var noError = testutil.NoError

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -13,6 +13,10 @@ import (
 
 // TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
 func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
+	// this test is not compatible with v20 base
+	if r.IsRunningUpgrade() {
+		return
+	}
 	// ARRANGE
 	// Given BTC address
 	r.SetBtcAddress(r.Name, false)

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -13,10 +13,6 @@ import (
 
 // TestBitcoinDepositAndCallRevertWithDust sends a Bitcoin deposit that reverts with a dust amount in the revert outbound.
 func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) {
-	// this test is not compatible with v20 base
-	if r.IsRunningUpgrade() {
-		return
-	}
 	// ARRANGE
 	// Given BTC address
 	r.SetBtcAddress(r.Name, false)


### PR DESCRIPTION
Test v20 -> v22 upgrade since that will be what actually runs on mainnet.

https://github.com/zeta-chain/node/issues/3174 requires us to bump the upgrade height