### PR TITLE
fix(zetaclient): lock pingRTT for writing

### DIFF
--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -231,6 +231,7 @@ func Start(_ *cobra.Command, _ []string) error {
 	go func() {
 		host := tssServer.GetP2PHost()
 		pingRTT := make(map[peer.ID]int64)
+		pingRTTLock := sync.Mutex{}
 		for {
 			var wg sync.WaitGroup
 			for _, p := range whitelistedPeers {
@@ -240,6 +241,8 @@ func Start(_ *cobra.Command, _ []string) error {
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer cancel()
 					result := <-ping.Ping(ctx, host, p)
+					pingRTTLock.Lock()
+					defer pingRTTLock.Unlock()
 					if result.Error != nil {
 						masterLogger.Error().Err(result.Error).Msg("ping error")
 						pingRTT[p] = -1 // RTT -1 indicate ping error


### PR DESCRIPTION
```
fatal error: concurrent map writes

goroutine 180835 [running]:
main.start.func4.1({0x4000ff8600, 0x27})
	/go/src/github.com/zeta-chain/node/cmd/zetaclientd/start.go:258 +0x17c
created by main.start.func4 in goroutine 872
	/go/src/github.com/zeta-chain/node/cmd/zetaclientd/start.go:248 +0xb8
```

Closes https://github.com/zeta-chain/node/issues/3180. Will backport to v22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for pinging whitelisted peers with improved error handling.
  
- **Bug Fixes**
	- Improved error logging for better insights into failure points.

- **Chores**
	- Added synchronization for concurrent access to the ping round-trip time data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->