### PR TITLE
fix(zetaclient): lock pingRTT for writing (#3181)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v22.1.2
+
+## Fixes
+
+- [3181](https://github.com/zeta-chain/node/pull/3181) - add lock around pingRTT to prevent crash
+
 ## v22.1.1
 
 ## Fixes

--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -241,6 +241,7 @@ func start(_ *cobra.Command, _ []string) error {
 	go func() {
 		host := server.GetP2PHost()
 		pingRTT := make(map[peer.ID]int64)
+		pingRTTLock := sync.Mutex{}
 		for {
 			var wg sync.WaitGroup
 			for _, p := range whitelistedPeers {
@@ -250,6 +251,8 @@ func start(_ *cobra.Command, _ []string) error {
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer cancel()
 					result := <-ping.Ping(ctx, host, p)
+					pingRTTLock.Lock()
+					defer pingRTTLock.Unlock()
 					if result.Error != nil {
 						masterLogger.Error().Err(result.Error).Msg("ping error")
 						pingRTT[p] = -1 // RTT -1 indicate ping error


### PR DESCRIPTION
Backport https://github.com/zeta-chain/node/pull/3181