### PR TITLE
fix: avoid endless tx rescan when the inbound vote message is invalid

### DIFF
--- a/x/crosschain/types/message_vote_inbound.go
+++ b/x/crosschain/types/message_vote_inbound.go
@@ -22,7 +22,7 @@ const MaxMessageLength = 10240
 // InboundVoteOption is a function that sets some option on the inbound vote message
 type InboundVoteOption func(*MsgVoteInbound)
 
-// WithMemoRevertOptions sets the revert options for inbound vote message
+// WithRevertOptions sets the revert options for inbound vote message
 func WithRevertOptions(revertOptions RevertOptions) InboundVoteOption {
 	return func(msg *MsgVoteInbound) {
 		msg.RevertOptions = revertOptions

--- a/zetaclient/chains/bitcoin/observer/event_test.go
+++ b/zetaclient/chains/bitcoin/observer/event_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zeta-chain/node/zetaclient/keys"
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
+	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 )
 
 // createTestBtcEvent creates a test BTC inbound event
@@ -41,7 +42,7 @@ func createTestBtcEvent(
 	}
 }
 
-func Test_CheckProcessability(t *testing.T) {
+func Test_Processability(t *testing.T) {
 	// setup compliance config
 	cfg := config.Config{
 		ComplianceConfig: sample.ComplianceConfig(),
@@ -52,7 +53,7 @@ func Test_CheckProcessability(t *testing.T) {
 	tests := []struct {
 		name     string
 		event    *observer.BTCInboundEvent
-		expected observer.InboundProcessability
+		expected clienttypes.InboundProcessability
 	}{
 		{
 			name: "should return InboundProcessabilityGood for a processable inbound event",
@@ -60,7 +61,7 @@ func Test_CheckProcessability(t *testing.T) {
 				FromAddress: "tb1quhassyrlj43qar0mn0k5sufyp6mazmh2q85lr6ex8ehqfhxpzsksllwrsu",
 				ToAddress:   testutils.TSSAddressBTCAthens3,
 			},
-			expected: observer.InboundProcessabilityGood,
+			expected: clienttypes.InboundProcessabilityGood,
 		},
 		{
 			name: "should return InboundProcessabilityComplianceViolation for a restricted sender address",
@@ -68,7 +69,7 @@ func Test_CheckProcessability(t *testing.T) {
 				FromAddress: sample.RestrictedBtcAddressTest,
 				ToAddress:   testutils.TSSAddressBTCAthens3,
 			},
-			expected: observer.InboundProcessabilityComplianceViolation,
+			expected: clienttypes.InboundProcessabilityComplianceViolation,
 		},
 		{
 			name: "should return InboundProcessabilityComplianceViolation for a restricted receiver address in standard memo",
@@ -81,7 +82,7 @@ func Test_CheckProcessability(t *testing.T) {
 					},
 				},
 			},
-			expected: observer.InboundProcessabilityComplianceViolation,
+			expected: clienttypes.InboundProcessabilityComplianceViolation,
 		},
 		{
 			name: "should return InboundProcessabilityComplianceViolation for a restricted revert address in standard memo",
@@ -96,7 +97,7 @@ func Test_CheckProcessability(t *testing.T) {
 					},
 				},
 			},
-			expected: observer.InboundProcessabilityComplianceViolation,
+			expected: clienttypes.InboundProcessabilityComplianceViolation,
 		},
 		{
 			name: "should return InboundProcessabilityDonation for a donation inbound event",
@@ -105,7 +106,7 @@ func Test_CheckProcessability(t *testing.T) {
 				ToAddress:   testutils.TSSAddressBTCAthens3,
 				MemoBytes:   []byte(constant.DonationMessage),
 			},
-			expected: observer.InboundProcessabilityDonation,
+			expected: clienttypes.InboundProcessabilityDonation,
 		},
 	}
 

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -157,7 +157,9 @@ func Test_GetInboundVoteFromBtcEvent(t *testing.T) {
 
 	// create test observer
 	ob := MockBTCObserver(t, chain, params, nil)
-	zetacoreClient := mocks.NewZetacoreClient(t).WithKeys(&keys.Keys{}).WithZetaChain()
+	zetacoreClient := mocks.NewZetacoreClient(t).WithKeys(&keys.Keys{
+		OperatorAddress: sample.Bech32AccAddress(),
+	}).WithZetaChain()
 	ob.WithZetacoreClient(zetacoreClient)
 
 	// test cases

--- a/zetaclient/chains/solana/observer/inbound.go
+++ b/zetaclient/chains/solana/observer/inbound.go
@@ -1,7 +1,6 @@
 package observer
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -13,12 +12,12 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/zeta-chain/node/pkg/coin"
-	"github.com/zeta-chain/node/pkg/constant"
 	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	solanarpc "github.com/zeta-chain/node/zetaclient/chains/solana/rpc"
 	"github.com/zeta-chain/node/zetaclient/compliance"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
+	"github.com/zeta-chain/node/zetaclient/logs"
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
@@ -256,19 +255,29 @@ func (ob *Observer) FilterInboundEvents(txResult *rpc.GetTransactionResult) ([]*
 
 // BuildInboundVoteMsgFromEvent builds a MsgVoteInbound from an inbound event
 func (ob *Observer) BuildInboundVoteMsgFromEvent(event *clienttypes.InboundEvent) *crosschaintypes.MsgVoteInbound {
-	// compliance check. Return nil if the inbound contains restricted addresses
-	if compliance.DoesInboundContainsRestrictedAddress(event, ob.Logger()) {
+	// prepare logger fields
+	lf := map[string]any{
+		logs.FieldModule: logs.ModNameInbound,
+		logs.FieldMethod: "BuildInboundVoteMsgFromEvent",
+		logs.FieldChain:  ob.Chain().ChainId,
+		logs.FieldTx:     event.TxHash,
+	}
+
+	// decode event memo bytes to get the receiver
+	err := event.DecodeMemo()
+	if err != nil {
+		ob.Logger().Inbound.Info().Fields(lf).Msgf("invalid memo bytes: %s", hex.EncodeToString(event.Memo))
 		return nil
 	}
 
-	// donation check
-	if bytes.Equal(event.Memo, []byte(constant.DonationMessage)) {
-		ob.Logger().Inbound.Info().
-			Msgf("thank you rich folk for your donation! tx %s chain %d", event.TxHash, event.SenderChainID)
+	// check if the event is processable
+	if !ob.CheckEventProcessability(*event) {
 		return nil
 	}
 
-	return zetacore.GetInboundVoteMessage(
+	// create inbound vote message
+	msg := crosschaintypes.NewMsgVoteInbound(
+		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
 		event.Sender,
 		event.SenderChainID,
 		event.Sender,
@@ -281,7 +290,39 @@ func (ob *Observer) BuildInboundVoteMsgFromEvent(event *clienttypes.InboundEvent
 		0,
 		event.CoinType,
 		event.Asset,
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
 		0, // not a smart contract call
+		crosschaintypes.ProtocolContractVersion_V1,
+		false, // not relevant for v1
 	)
+
+	// make sure the message is valid before posting to zetacore
+	err = msg.ValidateBasic()
+	if err != nil {
+		ob.Logger().Inbound.Error().Err(err).Fields(lf).Msg("invalid inbound vote message")
+		return nil
+	}
+
+	return msg
+}
+
+// CheckEventProcessability checks if the inbound event is processable
+func (ob *Observer) CheckEventProcessability(event clienttypes.InboundEvent) bool {
+	switch result := event.Processability(); result {
+	case clienttypes.InboundProcessabilityGood:
+		return true
+	case clienttypes.InboundProcessabilityDonation:
+		logFields := map[string]any{
+			logs.FieldChain: ob.Chain().ChainId,
+			logs.FieldTx:    event.TxHash,
+		}
+		ob.Logger().Inbound.Info().Fields(logFields).Msgf("thank you rich folk for your donation!")
+		return false
+	case clienttypes.InboundProcessabilityComplianceViolation:
+		compliance.PrintComplianceLog(ob.Logger().Inbound, ob.Logger().Compliance,
+			false, ob.Chain().ChainId, event.TxHash, event.Sender, event.Receiver, event.CoinType.String())
+		return false
+	default:
+		ob.Logger().Inbound.Error().Msgf("unreachable code got InboundProcessability: %v", result)
+		return false
+	}
 }

--- a/zetaclient/chains/solana/observer/inbound_test.go
+++ b/zetaclient/chains/solana/observer/inbound_test.go
@@ -2,6 +2,7 @@ package observer_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,7 @@ import (
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/solana/observer"
 	"github.com/zeta-chain/node/zetaclient/config"
@@ -108,7 +110,9 @@ func Test_BuildInboundVoteMsgFromEvent(t *testing.T) {
 	params := sample.ChainParams(chain.ChainId)
 	params.GatewayAddress = sample.SolanaAddress(t)
 	zetacoreClient := mocks.NewZetacoreClient(t)
-	zetacoreClient.WithKeys(&keys.Keys{}).WithZetaChain().WithPostVoteInbound("", "")
+	zetacoreClient.WithKeys(&keys.Keys{
+		OperatorAddress: sample.Bech32AccAddress(),
+	}).WithZetaChain().WithPostVoteInbound("", "")
 
 	database, err := db.NewFromSqliteInMemory(true)
 	require.NoError(t, err)
@@ -129,7 +133,17 @@ func Test_BuildInboundVoteMsgFromEvent(t *testing.T) {
 		msg := ob.BuildInboundVoteMsgFromEvent(event)
 		require.NotNil(t, msg)
 	})
-	t.Run("should return nil msg if sender is restricted", func(t *testing.T) {
+
+	t.Run("should return nil if failed to decode memo", func(t *testing.T) {
+		sender := sample.SolanaAddress(t)
+		memo := []byte("a memo too short")
+		event := sample.InboundEvent(chain.ChainId, sender, sender, 1280, memo)
+
+		msg := ob.BuildInboundVoteMsgFromEvent(event)
+		require.Nil(t, msg)
+	})
+
+	t.Run("should return nil if event is not processable", func(t *testing.T) {
 		sender := sample.SolanaAddress(t)
 		receiver := sample.SolanaAddress(t)
 		event := sample.InboundEvent(chain.ChainId, sender, receiver, 1280, nil)
@@ -141,25 +155,63 @@ func Test_BuildInboundVoteMsgFromEvent(t *testing.T) {
 		msg := ob.BuildInboundVoteMsgFromEvent(event)
 		require.Nil(t, msg)
 	})
-	t.Run("should return nil msg if receiver is restricted", func(t *testing.T) {
-		sender := sample.SolanaAddress(t)
-		receiver := sample.SolanaAddress(t)
-		memo := sample.EthAddress().Bytes()
-		event := sample.InboundEvent(chain.ChainId, sender, receiver, 1280, []byte(memo))
 
-		// restrict receiver
-		cfg.ComplianceConfig.RestrictedAddresses = []string{receiver}
-		config.LoadComplianceConfig(cfg)
-
-		msg := ob.BuildInboundVoteMsgFromEvent(event)
-		require.Nil(t, msg)
-	})
-	t.Run("should return nil msg on donation transaction", func(t *testing.T) {
+	t.Run("should return nil if message basic validation fails", func(t *testing.T) {
 		// create event with donation memo
 		sender := sample.SolanaAddress(t)
-		event := sample.InboundEvent(chain.ChainId, sender, sender, 1280, []byte(constant.DonationMessage))
+		maxMsgBytes := crosschaintypes.MaxMessageLength / 2
+		event := sample.InboundEvent(chain.ChainId, sender, sender, 1280, []byte(strings.Repeat("a", maxMsgBytes+1)))
 
 		msg := ob.BuildInboundVoteMsgFromEvent(event)
 		require.Nil(t, msg)
 	})
+}
+
+func Test_CheckEventProcessability(t *testing.T) {
+	// parepare params
+	chain := chains.SolanaDevnet
+	params := sample.ChainParams(chain.ChainId)
+	params.GatewayAddress = sample.SolanaAddress(t)
+
+	// create test observer
+	ob := MockSolanaObserver(t, chain, nil, *params, nil, nil)
+
+	// setup compliance config
+	cfg := config.Config{
+		ComplianceConfig: sample.ComplianceConfig(),
+	}
+	config.LoadComplianceConfig(cfg)
+
+	// test cases
+	tests := []struct {
+		name   string
+		event  clienttypes.InboundEvent
+		result bool
+	}{
+		{
+			name:   "should return true for processable event",
+			event:  clienttypes.InboundEvent{Sender: sample.SolanaAddress(t), Receiver: sample.SolanaAddress(t)},
+			result: true,
+		},
+		{
+			name:   "should return false on donation message",
+			event:  clienttypes.InboundEvent{Memo: []byte(constant.DonationMessage)},
+			result: false,
+		},
+		{
+			name: "should return false on compliance violation",
+			event: clienttypes.InboundEvent{
+				Sender:   sample.RestrictedSolAddressTest,
+				Receiver: sample.EthAddress().Hex(),
+			},
+			result: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ob.CheckEventProcessability(tt.event)
+			require.Equal(t, tt.result, result)
+		})
+	}
 }

--- a/zetaclient/compliance/compliance.go
+++ b/zetaclient/compliance/compliance.go
@@ -2,16 +2,10 @@
 package compliance
 
 import (
-	"encoding/hex"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
 
-	"github.com/zeta-chain/node/pkg/memo"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/config"
-	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 )
 
 // IsCctxRestricted returns true if the cctx involves restricted addresses
@@ -60,22 +54,4 @@ func PrintComplianceLog(
 
 	inboundLoggerWithFields.Warn().Msg(logMsg)
 	complianceLoggerWithFields.Warn().Msg(logMsg)
-}
-
-// DoesInboundContainsRestrictedAddress returns true if the inbound event contains restricted addresses
-func DoesInboundContainsRestrictedAddress(event *clienttypes.InboundEvent, logger *base.ObserverLogger) bool {
-	// parse memo-specified receiver
-	receiver := ""
-	parsedAddress, _, err := memo.DecodeLegacyMemoHex(hex.EncodeToString(event.Memo))
-	if err == nil && parsedAddress != (ethcommon.Address{}) {
-		receiver = parsedAddress.Hex()
-	}
-
-	// check restricted addresses
-	if config.ContainRestrictedAddress(event.Sender, event.Receiver, receiver) {
-		PrintComplianceLog(logger.Inbound, logger.Compliance,
-			false, event.SenderChainID, event.TxHash, event.Sender, receiver, event.CoinType.String())
-		return true
-	}
-	return false
 }

--- a/zetaclient/types/event.go
+++ b/zetaclient/types/event.go
@@ -1,7 +1,31 @@
 package types
 
 import (
+	"bytes"
+	"encoding/hex"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/pkg/crypto"
+	"github.com/zeta-chain/node/pkg/memo"
+	"github.com/zeta-chain/node/zetaclient/config"
+)
+
+// InboundProcessability is an enum representing the processability of an inbound
+type InboundProcessability int
+
+const (
+	// InboundProcessabilityGood represents a processable inbound
+	InboundProcessabilityGood InboundProcessability = iota
+
+	// InboundProcessabilityDonation represents a donation inbound
+	InboundProcessabilityDonation
+
+	// InboundProcessabilityComplianceViolation represents a compliance violation
+	InboundProcessabilityComplianceViolation
 )
 
 // InboundEvent represents an inbound event
@@ -40,4 +64,48 @@ type InboundEvent struct {
 
 	// Asset is the asset of the inbound
 	Asset string
+}
+
+// DecodeMemo decodes the receiver from the memo bytes
+func (event *InboundEvent) DecodeMemo() error {
+	// skip decoding donation tx as it won't go through zetacore
+	if bytes.Equal(event.Memo, []byte(constant.DonationMessage)) {
+		return nil
+	}
+
+	// decode receiver address from memo
+	parsedAddress, _, err := memo.DecodeLegacyMemoHex(hex.EncodeToString(event.Memo))
+	if err != nil { // unreachable code
+		return errors.Wrap(err, "invalid memo hex")
+	}
+
+	// ensure the receiver is valid
+	if crypto.IsEmptyAddress(parsedAddress) {
+		return errors.New("got empty receiver address from memo")
+	}
+	event.Receiver = parsedAddress.Hex()
+
+	return nil
+}
+
+// Processability returns the processability of the inbound event
+func (event *InboundEvent) Processability() InboundProcessability {
+	// parse memo-specified receiver
+	receiver := ""
+	parsedAddress, _, err := memo.DecodeLegacyMemoHex(hex.EncodeToString(event.Memo))
+	if err == nil && parsedAddress != (ethcommon.Address{}) {
+		receiver = parsedAddress.Hex()
+	}
+
+	// check restricted addresses
+	if config.ContainRestrictedAddress(event.Sender, event.Receiver, event.TxOrigin, receiver) {
+		return InboundProcessabilityComplianceViolation
+	}
+
+	// donation check
+	if bytes.Equal(event.Memo, []byte(constant.DonationMessage)) {
+		return InboundProcessabilityDonation
+	}
+
+	return InboundProcessabilityGood
 }

--- a/zetaclient/types/event_test.go
+++ b/zetaclient/types/event_test.go
@@ -1,0 +1,124 @@
+package types_test
+
+import (
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/testutil/sample"
+	"github.com/zeta-chain/node/zetaclient/config"
+	"github.com/zeta-chain/node/zetaclient/types"
+)
+
+func Test_DecodeMemo(t *testing.T) {
+	testReceiver := sample.EthAddress()
+
+	// test cases
+	tests := []struct {
+		name             string
+		event            *types.InboundEvent
+		expectedReceiver string
+		errMsg           string
+	}{
+		{
+			name: "should decode receiver address successfully",
+			event: &types.InboundEvent{
+				Memo: testReceiver.Bytes(),
+			},
+			expectedReceiver: testReceiver.Hex(),
+		},
+		{
+			name: "should skip decoding donation message",
+			event: &types.InboundEvent{
+				Memo: []byte(constant.DonationMessage),
+			},
+			expectedReceiver: "",
+		},
+		{
+			name: "should return error if got an empty receiver address",
+			event: &types.InboundEvent{
+				Memo: []byte(""),
+			},
+			errMsg:           "got empty receiver address from memo",
+			expectedReceiver: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.event.DecodeMemo()
+			if tt.errMsg != "" {
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedReceiver, tt.event.Receiver)
+		})
+	}
+}
+
+func Test_Processability(t *testing.T) {
+	// setup compliance config
+	cfg := config.Config{
+		ComplianceConfig: sample.ComplianceConfig(),
+	}
+	config.LoadComplianceConfig(cfg)
+
+	// test cases
+	tests := []struct {
+		name     string
+		event    *types.InboundEvent
+		expected types.InboundProcessability
+	}{
+		{
+			name: "should return InboundProcessabilityGood for a processable inbound event",
+			event: &types.InboundEvent{
+				Sender:   sample.SolanaAddress(t),
+				Receiver: sample.EthAddress().Hex(),
+			},
+			expected: types.InboundProcessabilityGood,
+		},
+		{
+			name: "should return InboundProcessabilityComplianceViolation for a restricted sender address",
+			event: &types.InboundEvent{
+				Sender:   sample.RestrictedSolAddressTest,
+				Receiver: sample.EthAddress().Hex(),
+			},
+			expected: types.InboundProcessabilityComplianceViolation,
+		},
+		{
+			name: "should return InboundProcessabilityComplianceViolation for a restricted receiver address",
+			event: &types.InboundEvent{
+				Sender:   sample.SolanaAddress(t),
+				Receiver: sample.RestrictedSolAddressTest,
+			},
+			expected: types.InboundProcessabilityComplianceViolation,
+		},
+		{
+			name: "should return InboundProcessabilityComplianceViolation for a restricted receiver address in memo",
+			event: &types.InboundEvent{
+				Sender:   sample.SolanaAddress(t),
+				Receiver: sample.EthAddress().Hex(),
+				Memo:     ethcommon.HexToAddress(sample.RestrictedEVMAddressTest).Bytes(),
+			},
+			expected: types.InboundProcessabilityComplianceViolation,
+		},
+		{
+			name: "should return InboundProcessabilityDonation for a donation inbound event",
+			event: &types.InboundEvent{
+				Sender:   sample.SolanaAddress(t),
+				Receiver: sample.EthAddress().Hex(),
+				Memo:     []byte(constant.DonationMessage),
+			},
+			expected: types.InboundProcessabilityDonation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.event.Processability()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Description

The maximum inbound message length supported is `const MaxMessageLength = 10240`. If for some reason (it is impossible at the moment), an inbound transaction carries a message longer message, the `PostVoteInbound` RPC call in observer code below will return an error (due to `ValidateBasic` failure), which result in endless rescan of the tx.

To avoid potential endless tx rescan, zetaclient should skip the inbound if a vote message basic validation fails.

```
// post inbound vote message to zetacore
for _, event := range events {
	msg := ob.GetInboundVoteFromBtcEvent(event)
	if msg != nil {
	    _, err = ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
	    if err != nil {
		return errors.Wrapf(err, "error PostVoteInbound") // we have to re-scan this block next time
	    }
	}
}
```

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
