### PR TITLE
chore: upgrade bitcoin-core to 28.0

### DIFF
--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -195,7 +195,7 @@ services:
         ipv4_address: 172.20.0.102
 
   bitcoin:
-    image: ghcr.io/zeta-chain/bitcoin-core-docker:27.2
+    image: ghcr.io/zeta-chain/bitcoin-core-docker:28.0
     container_name: bitcoin
     hostname: bitcoin
     networks:
@@ -211,6 +211,7 @@ services:
       -rpcauth=smoketest:63acf9b8dccecce914d85ff8c044b78b$$5892f9bbc84f4364e79f0970039f88bdd823f168d4acc76099ab97b14a766a99
       -txindex=1
       -deprecatedrpc=create_bdb
+      -deprecatedrpc=warnings
 
   solana:
     image: solana-local:latest

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -195,7 +195,7 @@ services:
         ipv4_address: 172.20.0.102
 
   bitcoin:
-    image: ghcr.io/zeta-chain/ruimarinho-bitcoin-core:22 # version 23 is not working with btcd 0.22.0 due to change in createwallet rpc
+    image: ghcr.io/zeta-chain/bitcoin-core-docker:27.2
     container_name: bitcoin
     hostname: bitcoin
     networks:
@@ -210,6 +210,7 @@ services:
       -rpcbind=0.0.0.0
       -rpcauth=smoketest:63acf9b8dccecce914d85ff8c044b78b$$5892f9bbc84f4364e79f0970039f88bdd823f168d4acc76099ab97b14a766a99
       -txindex=1
+      -deprecatedrpc=create_bdb
 
   solana:
     image: solana-local:latest


### PR DESCRIPTION
Upgrade to bitcoin-core 28.0

This requires four things:
- manually constructing the `createwallet` rpc with the `descriptors` argument set to false (it defaults to true in bitcoin-core 23+)
- setting `-deprecatedrpc=create_bdb` to allow `createwallet` with `descriptors=false`. This is required in bitcoin-core 26+.
- setting `-deprecatedrpc=warnings` to avoid the issue described here: https://github.com/btcsuite/btcd/issues/2224. Can be removed once btcd does a new release.
- Build our own docker images for bitcoin-core in https://github.com/zeta-chain/bitcoin-core-docker

We need to upgrade to bitcoin-core 28.0 for [testnet4 support](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.0.md#testnet4bip94-support). Related to https://github.com/zeta-chain/node/issues/2242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new `eth2`, `upgrade-host`, and `upgrade-orchestrator` services for enhanced functionality.
	- Added command option for the `bitcoin` service to support deprecated RPC.
  
- **Improvements**
	- Updated the `bitcoin` service image for better performance.
	- Simplified the wallet setup process by modifying method signatures and enhancing error handling.

- **Bug Fixes**
	- Improved error handling during wallet creation to address existing database issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->