### PR TITLE
chore: use jsdelivr for swagger css/js

### DIFF
--- a/docs/openapi/openapi.html
+++ b/docs/openapi/openapi.html
@@ -5,18 +5,18 @@
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/swagger-ui-dist@4.18.1/swagger-ui.css"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.18.2/swagger-ui.min.css"
     />
     <link
       rel="icon"
       type="image/png"
-      href="https://unpkg.com/swagger-ui-dist@4.18.1/favicon-16x16.png"
+      href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.18.2/favicon-16x16.png"
     />
   </head>
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="https://unpkg.com/swagger-ui-dist@4.18.1/swagger-ui-bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.18.2/swagger-ui-bundle.min.js"></script>
     <script>
       window.onload = function() {
           window.ui = SwaggerUIBundle({


### PR DESCRIPTION
unpkg.com occasionally takes 20-30 seconds to load for some reason. Use jsdelivr instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated OpenAPI documentation to use the latest version of the Swagger UI library, enhancing performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->