### PR TITLE
chore: use v22 as base in upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
-		--build-arg OLD_VERSION='release/v21' \
+		--build-arg OLD_VERSION='release/v22' \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg NODE_COMMIT=$(NODE_COMMIT)
 		.
@@ -336,7 +336,7 @@ else
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v21.0.0' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v22.0.0' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ else
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v22.0.0' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v22.1.1' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.


### PR DESCRIPTION
Should also be backported to release/v23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the software version from v21 to v22 for improved performance and features. 

- **Bug Fixes**
	- Resolved issues related to outdated version references in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->