### PR TITLE
fix(zetaclient): distinguish between known and connected peers

### DIFF
--- a/zetaclient/metrics/telemetry.go
+++ b/zetaclient/metrics/telemetry.go
@@ -31,6 +31,7 @@ type TelemetryServer struct {
 	status                 types.Status
 	ipAddress              string
 	HotKeyBurnRate         *BurnRate
+	knownPeers             []peer.AddrInfo
 	connectedPeers         []peer.AddrInfo
 	rtt                    map[peer.ID]int64
 }
@@ -42,6 +43,7 @@ func NewTelemetryServer() *TelemetryServer {
 		lastScannedBlockNumber: make(map[int64]uint64),
 		lastStartTimestamp:     time.Now(),
 		HotKeyBurnRate:         NewBurnRate(100),
+		knownPeers:             make([]peer.AddrInfo, 0),
 		connectedPeers:         make([]peer.AddrInfo, 0),
 		rtt:                    make(map[peer.ID]int64),
 	}
@@ -65,6 +67,18 @@ func (t *TelemetryServer) GetPingRTT() map[peer.ID]int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.rtt
+}
+
+func (t *TelemetryServer) SetKnownPeers(peers []peer.AddrInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.knownPeers = peers
+}
+
+func (t *TelemetryServer) GetKnownPeers() []peer.AddrInfo {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.knownPeers
 }
 
 func (t *TelemetryServer) SetConnectedPeers(peers []peer.AddrInfo) {
@@ -175,6 +189,7 @@ func (t *TelemetryServer) Handlers() http.Handler {
 	router.Handle("/ip", http.HandlerFunc(t.ipHandler)).Methods(http.MethodGet)
 	router.Handle("/hotkeyburnrate", http.HandlerFunc(t.hotKeyFeeBurnRate)).Methods(http.MethodGet)
 	router.Handle("/connectedpeers", http.HandlerFunc(t.connectedPeersHandler)).Methods(http.MethodGet)
+	router.Handle("/knownpeers", http.HandlerFunc(t.knownPeersHandler)).Methods(http.MethodGet)
 	router.Handle("/pingrtt", http.HandlerFunc(t.pingRTTHandler)).Methods(http.MethodGet)
 	router.Use(logMiddleware())
 
@@ -283,7 +298,19 @@ func (t *TelemetryServer) connectedPeersHandler(w http.ResponseWriter, _ *http.R
 	peers := t.GetConnectedPeers()
 	data, err := json.Marshal(peers)
 	if err != nil {
-		t.logger.Error().Err(err).Msg("Failed to marshal connected peers")
+		t.logger.Error().Err(err).Msg("Failed to marshal known peers")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintf(w, "%s", string(data))
+}
+
+func (t *TelemetryServer) knownPeersHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	peers := t.GetKnownPeers()
+	data, err := json.Marshal(peers)
+	if err != nil {
+		t.logger.Error().Err(err).Msg("Failed to marshal known peers")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/zetaclient/tss/service.go
+++ b/zetaclient/tss/service.go
@@ -48,6 +48,7 @@ type Zetacore interface {
 type Telemetry interface {
 	SetP2PID(id string)
 	SetConnectedPeers(peers []peer.AddrInfo)
+	SetKnownPeers(peers []peer.AddrInfo)
 	SetPingRTT(peers map[peer.ID]int64)
 }
 


### PR DESCRIPTION
"Known peers" should not be exposed as "connected peers". They are two completely separate things which should not be mixed to avoid confusion.

Add new `/knownpeers` endpoint which will expose this info. Expose connected peers in `/connectedpeers`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new HTTP endpoint `/knownpeers` to retrieve and manage known peers.
	- Enhanced health check functionality to differentiate between known and connected peers.
	- Added methods to manage known peers within the telemetry service.

- **Bug Fixes**
	- Improved error handling for JSON marshaling in the known peers response.

- **Documentation**
	- Updated documentation to reflect new metrics and functionalities related to known peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->