### PR TITLE
chore: revert go-tss to v21/v22 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -371,5 +371,5 @@ replace (
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 	github.com/ethereum/go-ethereum => github.com/zeta-chain/go-ethereum v1.13.16-0.20241022183758-422c6ef93ccc
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
-	gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20241115165301-8535262eb16f
+	gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20241028192852-b5233fc8c2b3
 )

--- a/go.sum
+++ b/go.sum
@@ -1527,8 +1527,8 @@ github.com/zeta-chain/go-ethereum v1.13.16-0.20241022183758-422c6ef93ccc h1:FVOt
 github.com/zeta-chain/go-ethereum v1.13.16-0.20241022183758-422c6ef93ccc/go.mod h1:MgO2/CmxFnj6W7v/5hrz3ypco3kHkb8856pRnFkY4xQ=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
-github.com/zeta-chain/go-tss v0.0.0-20241115165301-8535262eb16f h1:zKBTanf2jf/oyr3f27GgvibSdVThmCdcV9sc5/6uOyQ=
-github.com/zeta-chain/go-tss v0.0.0-20241115165301-8535262eb16f/go.mod h1:nqelgf4HKkqlXaVg8X38a61WfyYB+ivCt6nnjoTIgCc=
+github.com/zeta-chain/go-tss v0.0.0-20241028192852-b5233fc8c2b3 h1:IecdEwyguY3dtI7xRT+yW6ml/Z9cfIVHiB4q6huBhc4=
+github.com/zeta-chain/go-tss v0.0.0-20241028192852-b5233fc8c2b3/go.mod h1:B1FDE6kHs8hozKSX1/iXgCdvlFbS6+FeAupoBHDK0Cc=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c h1:ZoFxMMZtivRLquXVq1sEVlT45UnTPMO1MSXtc88nDv4=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20241108171442-e48d82f94892 h1:oI5qCrw2SXDf2a2UYAn0tpaKHbKpJcR+XDtceyY00wE=

--- a/zetaclient/tss/tss_signer.go
+++ b/zetaclient/tss/tss_signer.go
@@ -150,7 +150,6 @@ func SetupTSSServer(
 	cfg config.Config,
 	tssPassword string,
 	enableMonitor bool,
-	whitelistedPeers []gopeer.ID,
 ) (*tss.TssServer, error) {
 	bootstrapPeers := peer
 	log.Info().Msgf("Peers AddrList %v", bootstrapPeers)
@@ -176,6 +175,7 @@ func SetupTSSServer(
 		bootstrapPeers,
 		6668,
 		privkey,
+		"MetaMetaOpenTheDoor",
 		tsspath,
 		thorcommon.TssConfig{
 			EnableMonitor:   enableMonitor,
@@ -187,7 +187,6 @@ func SetupTSSServer(
 		preParams, // use pre-generated pre-params if non-nil
 		IP,        // for docker test
 		tssPassword,
-		whitelistedPeers,
 	)
 	if err != nil {
 		log.Error().Err(err).Msg("NewTSS error")


### PR DESCRIPTION
V22.1.2 is causing signing to stop on testnet. Revert go-tss to v21/v22 version.