### PR TITLE
chore(zetaclient): mask compliance addresses

### DIFF
--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -167,6 +167,7 @@ func (c Config) StringMasked() string {
 	// create a masker
 	masker := mask.NewMasker()
 	masker.RegisterMaskStringFunc(mask.MaskTypeFilled, masker.MaskFilledString)
+	masker.RegisterMaskAnyFunc(mask.MaskTypeFilled, masker.MaskZero)
 
 	// mask the config
 	masked, err := masker.Mask(c)

--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -68,7 +68,7 @@ type TONConfig struct {
 // ComplianceConfig is the config for compliance
 type ComplianceConfig struct {
 	LogPath             string   `json:"LogPath"`
-	RestrictedAddresses []string `json:"RestrictedAddresses"`
+	RestrictedAddresses []string `json:"RestrictedAddresses" mask:"zero"`
 }
 
 // Config is the config for ZetaClient


### PR DESCRIPTION
Mask compliance addresses to prevent log spam on zetaclient. We configure hundreds/thousands of these which are currently spamming the logs every zetaclient boot.

Reference: https://github.com/showa-93/go-mask?tab=readme-ov-file#mask-tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced privacy measures for handling sensitive data by masking restricted addresses in the compliance configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->