### PR TITLE
fix: use different database file names for signet and testnet4 to avoid wrong height

### DIFF
--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tonkeeper/tongo/ton"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	btcobserver "github.com/zeta-chain/node/zetaclient/chains/bitcoin/observer"
@@ -31,10 +32,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/logs"
 	"github.com/zeta-chain/node/zetaclient/metrics"
 )
-
-// btcDatabaseFilename is the Bitcoin database file name now used in mainnet,
-// so we keep using it here for backward compatibility
-const btcDatabaseFilename = "btc_chain_client"
 
 // CreateSignerMap creates a map of interfaces.ChainSigner (by chainID) for all chains in the config.
 // Note that signer construction failure for a chain does not prevent the creation of signers for other chains.
@@ -363,7 +360,7 @@ func syncObserverMap(
 				continue
 			}
 
-			database, err := db.NewFromSqlite(dbpath, btcDatabaseFilename, true)
+			database, err := db.NewFromSqlite(dbpath, btcDatabaseFileName(*rawChain), true)
 			if err != nil {
 				logger.Std.Error().Err(err).Msgf("unable to open database for BTC chain %d", chainID)
 				continue
@@ -479,6 +476,20 @@ func syncObserverMap(
 	mapDeleteMissingKeys(observerMap, presentChainIDs, onBeforeRemove)
 
 	return added, removed, nil
+}
+
+func btcDatabaseFileName(chain chains.Chain) string {
+	// btcDatabaseFilename is the Bitcoin database file name now used in mainnet and testnet3
+	// so we keep using it here for backward compatibility
+	const btcDatabaseFilename = "btc_chain_client"
+
+	// For additional bitcoin networks, we can use the chain name as the database file name
+	switch chain.ChainId {
+	case chains.BitcoinMainnet.ChainId, chains.BitcoinTestnet.ChainId:
+		return btcDatabaseFilename
+	default:
+		return chain.Name
+	}
 }
 
 func makeTONClient(


### PR DESCRIPTION
# Description

The zetaclients in the Testnet are pulling last scanned height from wrong database file `btc_chain_client` which was intended only for `testnet3` and `mainnet`. The testnet3 block number is much higher than current signet block, the inbound observation will stop because no block will be treated as confirmed. See this [logic](https://github.com/zeta-chain/node/blob/fix-btc-signet-database-name/zetaclient/chains/bitcoin/observer/inbound.go#L103)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
