### PR TITLE
fix: use different database file names for btc signet and testnet4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 * [3206](https://github.com/zeta-chain/node/pull/3206) - skip Solana unsupported transaction version to not block inbound observation
 * [3184](https://github.com/zeta-chain/node/pull/3184) - zetaclient should not retry if inbound vote message validation fails
+* [3225](https://github.com/zeta-chain/node/pull/3225) - use separate database file names for btc signet and testnet4
 
 ## v23.0.0
 

--- a/zetaclient/orchestrator/bootstap_test.go
+++ b/zetaclient/orchestrator/bootstap_test.go
@@ -395,6 +395,46 @@ func TestCreateChainObserverMap(t *testing.T) {
 	})
 }
 
+func TestBtcDatabaseFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		chain    chains.Chain
+		expected string
+	}{
+		{
+			name:     "should use legacy file name for bitcoin mainnet",
+			chain:    chains.BitcoinMainnet,
+			expected: "btc_chain_client",
+		},
+		{
+			name:     "should use legacy file name for bitcoin testnet3",
+			chain:    chains.BitcoinTestnet,
+			expected: "btc_chain_client",
+		},
+		{
+			name:     "should use new file name for bitcoin regtest",
+			chain:    chains.BitcoinRegtest,
+			expected: "btc_chain_client_18444",
+		},
+		{
+			name:     "should use new file name for bitcoin signet",
+			chain:    chains.BitcoinSignetTestnet,
+			expected: "btc_chain_client_18333",
+		},
+		{
+			name:     "should use new file name for bitcoin testnet4",
+			chain:    chains.BitcoinTestnet4,
+			expected: "btc_chain_client_18334",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, btcDatabaseFileName(tt.chain))
+		})
+	}
+}
+
 func chainParams(supportedChains []chains.Chain) ([]chains.Chain, map[int64]*observertypes.ChainParams) {
 	params := make(map[int64]*observertypes.ChainParams)
 

--- a/zetaclient/orchestrator/bootstap_test.go
+++ b/zetaclient/orchestrator/bootstap_test.go
@@ -414,17 +414,17 @@ func TestBtcDatabaseFileName(t *testing.T) {
 		{
 			name:     "should use new file name for bitcoin regtest",
 			chain:    chains.BitcoinRegtest,
-			expected: "btc_chain_client_18444",
+			expected: "btc_chain_client_btc_regtest",
 		},
 		{
 			name:     "should use new file name for bitcoin signet",
 			chain:    chains.BitcoinSignetTestnet,
-			expected: "btc_chain_client_18333",
+			expected: "btc_chain_client_btc_signet_testnet",
 		},
 		{
 			name:     "should use new file name for bitcoin testnet4",
 			chain:    chains.BitcoinTestnet4,
-			expected: "btc_chain_client_18334",
+			expected: "btc_chain_client_btc_testnet4",
 		},
 	}
 

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tonkeeper/tongo/ton"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	btcobserver "github.com/zeta-chain/node/zetaclient/chains/bitcoin/observer"
@@ -31,10 +32,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/logs"
 	"github.com/zeta-chain/node/zetaclient/metrics"
 )
-
-// btcDatabaseFilename is the Bitcoin database file name now used in mainnet,
-// so we keep using it here for backward compatibility
-const btcDatabaseFilename = "btc_chain_client"
 
 // CreateSignerMap creates a map of interfaces.ChainSigner (by chainID) for all chains in the config.
 // Note that signer construction failure for a chain does not prevent the creation of signers for other chains.
@@ -363,7 +360,7 @@ func syncObserverMap(
 				continue
 			}
 
-			database, err := db.NewFromSqlite(dbpath, btcDatabaseFilename, true)
+			database, err := db.NewFromSqlite(dbpath, btcDatabaseFileName(*rawChain), true)
 			if err != nil {
 				logger.Std.Error().Err(err).Msgf("unable to open database for BTC chain %d", chainID)
 				continue
@@ -479,6 +476,20 @@ func syncObserverMap(
 	mapDeleteMissingKeys(observerMap, presentChainIDs, onBeforeRemove)
 
 	return added, removed, nil
+}
+
+func btcDatabaseFileName(chain chains.Chain) string {
+	// btcDatabaseFilename is the Bitcoin database file name now used in mainnet and testnet3
+	// so we keep using it here for backward compatibility
+	const btcDatabaseFilename = "btc_chain_client"
+
+	// For additional bitcoin networks, we use the chain name as the database file name
+	switch chain.ChainId {
+	case chains.BitcoinMainnet.ChainId, chains.BitcoinTestnet.ChainId:
+		return btcDatabaseFilename
+	default:
+		return chain.Name
+	}
 }
 
 func makeTONClient(

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -489,7 +489,7 @@ func btcDatabaseFileName(chain chains.Chain) string {
 	case chains.BitcoinMainnet.ChainId, chains.BitcoinTestnet.ChainId:
 		return legacyBTCDatabaseFilename
 	default:
-		return fmt.Sprintf("%s_%d", legacyBTCDatabaseFilename, chain.ChainId)
+		return fmt.Sprintf("%s_%s", legacyBTCDatabaseFilename, chain.Name)
 	}
 }
 

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -479,16 +480,16 @@ func syncObserverMap(
 }
 
 func btcDatabaseFileName(chain chains.Chain) string {
-	// btcDatabaseFilename is the Bitcoin database file name now used in mainnet and testnet3
+	// legacyBTCDatabaseFilename is the Bitcoin database file name now used in mainnet and testnet3
 	// so we keep using it here for backward compatibility
-	const btcDatabaseFilename = "btc_chain_client"
+	const legacyBTCDatabaseFilename = "btc_chain_client"
 
 	// For additional bitcoin networks, we use the chain name as the database file name
 	switch chain.ChainId {
 	case chains.BitcoinMainnet.ChainId, chains.BitcoinTestnet.ChainId:
-		return btcDatabaseFilename
+		return legacyBTCDatabaseFilename
 	default:
-		return chain.Name
+		return fmt.Sprintf("%s_%d", legacyBTCDatabaseFilename, chain.ChainId)
 	}
 }
 


### PR DESCRIPTION
# Description

This PR picks necessary changes in the PR: https://github.com/zeta-chain/node/pull/3224

All external observer signers must have already updated their zetaclient config files by next release, so there is no need to pick the special handling fallback logic around the old/new Bitcoin config.

Closes: https://github.com/zeta-chain/node/issues/3223

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced separate database file names for Bitcoin signet and testnet4 environments.
- **Bug Fixes**
	- Enhanced inbound observation by skipping unsupported transaction versions for Solana.
	- Streamlined error handling by preventing retries on failed inbound vote message validation.
- **Refactor**
	- Revamped TSS package in the ZetaClient for improved functionality.
- **Tests**
	- Moved Bitcoin revert address test to an advanced group to avoid upgrade test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->