### PR TITLE
ci(e2e): use !cancelled() rather than always()

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,7 @@ jobs:
 
   matrix-conditionals:
     needs: build-zetanode
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     env:
       GH_TOKEN: ${{ github.token }}
@@ -217,7 +217,7 @@ jobs:
     needs:
       - build-zetanode
       - matrix-conditionals
-    if: always()
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -281,7 +281,7 @@ jobs:
       - build-zetanode
       - matrix-conditionals
       - e2e
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Send slack message with results
         uses: actions/github-script@v7


### PR DESCRIPTION
It is suggested in the docs to use this: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always

This should make concurrency cancellations work again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the control flow of end-to-end testing workflows to prevent execution if cancelled.
	- Enhanced logic for determining which tests to run based on workflow trigger conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->