### PR TITLE
fix: look into Solana program log message to determine SPL token failure

### DIFF
--- a/zetaclient/chains/solana/observer/outbound_test.go
+++ b/zetaclient/chains/solana/observer/outbound_test.go
@@ -507,7 +507,7 @@ func Test_ParseInstructionWithdrawSPL(t *testing.T) {
 		inst, err := contracts.ParseInstructionWithdrawSPL(instruction)
 
 		// ASSERT
-		require.ErrorContains(t, err, "not a withdraw instruction")
+		require.ErrorContains(t, err, "not a withdraw_spl_token instruction")
 		require.Nil(t, inst)
 	})
 }


### PR DESCRIPTION
# Description

The context of the issue: https://github.com/zeta-chain/protocol-contracts-solana/issues/63

1. Define a constant message [MsgWithdrawSPLTokenNonExistentAta](https://github.com/zeta-chain/node/blob/withdraw-spl-non-existent-ata/pkg/contracts/solana/instruction.go#L21) which will be emitted from `withdraw_spl_token`. It is up to @skosito to use whatever message text reasonable for this purpose.
2. `zetaclient` looks into log message to determine if the SPL token withdraw should be failed or not and then post corresponding outbound status to zetacore to finalize or abort (on failure) the cctx.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
