### PR TITLE
fix: query solana inbound signatures using max version0 to avoid errors

### DIFF
--- a/zetaclient/chains/solana/observer/inbound_tracker.go
+++ b/zetaclient/chains/solana/observer/inbound_tracker.go
@@ -62,7 +62,11 @@ func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
 	for _, tracker := range trackers {
 		signature := solana.MustSignatureFromBase58(tracker.TxHash)
 		txResult, err := solanarpc.GetTransaction(ctx, ob.solClient, signature)
-		if err != nil && !errors.Is(err, solanarpc.ErrUnsupportedTxVersion) {
+		switch {
+		case errors.Is(err, solanarpc.ErrUnsupportedTxVersion):
+			ob.Logger().Inbound.Warn().Stringer("tx.signature", signature).Msg("skip inbound tracker hash")
+			continue
+		case err != nil:
 			return errors.Wrapf(err, "error GetTransaction for chain %d sig %s", chainID, signature)
 		}
 

--- a/zetaclient/chains/solana/observer/inbound_tracker.go
+++ b/zetaclient/chains/solana/observer/inbound_tracker.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
-	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/pkg/errors"
 
+	solanarpc "github.com/zeta-chain/node/zetaclient/chains/solana/rpc"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 )
@@ -61,10 +61,8 @@ func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
 	// process inbound trackers
 	for _, tracker := range trackers {
 		signature := solana.MustSignatureFromBase58(tracker.TxHash)
-		txResult, err := ob.solClient.GetTransaction(ctx, signature, &rpc.GetTransactionOpts{
-			Commitment: rpc.CommitmentFinalized,
-		})
-		if err != nil {
+		txResult, err := solanarpc.GetTransaction(ctx, ob.solClient, signature)
+		if err != nil && !errors.Is(err, solanarpc.ErrUnsupportedTxVersion) {
 			return errors.Wrapf(err, "error GetTransaction for chain %d sig %s", chainID, signature)
 		}
 

--- a/zetaclient/chains/solana/rpc/rpc.go
+++ b/zetaclient/chains/solana/rpc/rpc.go
@@ -85,12 +85,8 @@ func GetSignaturesForAddressUntil(
 	var allSignatures []*rpc.TransactionSignature
 
 	// make sure that the 'untilSig' exists to prevent undefined behavior on GetSignaturesForAddressWithOpts
-	_, err := client.GetTransaction(
-		ctx,
-		untilSig,
-		&rpc.GetTransactionOpts{Commitment: rpc.CommitmentFinalized},
-	)
-	if err != nil {
+	_, err := GetTransaction(ctx, client, untilSig)
+	if err != nil && !errors.Is(err, ErrUnsupportedTxVersion) {
 		return nil, errors.Wrapf(err, "error GetTransaction for untilSig %s", untilSig)
 	}
 
@@ -137,6 +133,7 @@ func GetTransaction(
 	sig solana.Signature,
 ) (*rpc.GetTransactionResult, error) {
 	txResult, err := client.GetTransaction(ctx, sig, &rpc.GetTransactionOpts{
+		Commitment:                     rpc.CommitmentFinalized,
 		MaxSupportedTransactionVersion: &rpc.MaxSupportedTransactionVersion0,
 	})
 

--- a/zetaclient/chains/solana/rpc/rpc_live_test.go
+++ b/zetaclient/chains/solana/rpc/rpc_live_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solanarpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/zetaclient/chains/solana/rpc"
 	"github.com/zeta-chain/node/zetaclient/common"
+	"github.com/zeta-chain/node/zetaclient/testutils"
 )
 
 // Test_SolanaRPCLive is a phony test to run all live tests
@@ -20,6 +22,7 @@ func Test_SolanaRPCLive(t *testing.T) {
 	LiveTest_GetTransactionWithVersion(t)
 	LiveTest_GetFirstSignatureForAddress(t)
 	LiveTest_GetSignaturesForAddressUntil(t)
+	LiveTest_GetSignaturesForAddressUntil_Version0(t)
 	LiveTest_CheckRPCStatus(t)
 }
 
@@ -78,6 +81,22 @@ func LiveTest_GetSignaturesForAddressUntil(t *testing.T) {
 	for _, sig := range sigs {
 		require.NotEqual(t, untilSig, sig.Signature)
 	}
+}
+
+func LiveTest_GetSignaturesForAddressUntil_Version0(t *testing.T) {
+	// create a Solana devnet RPC client
+	client := solanarpc.New(solanarpc.DevNet_RPC)
+
+	// program address and signature of version "0"
+	chain := chains.SolanaDevnet
+	address := solana.MustPublicKeyFromBase58(testutils.GatewayAddresses[chain.ChainId])
+	untilSig := solana.MustSignatureFromBase58(
+		"39fSgD2nteJCQRQP3ynqEcDMZAFSETCbfb61AUqLU6y7qbzSJL5rn2DHU2oM35zsf94Feb5C5QWd5L5UnncBsAay",
+	)
+
+	// should get all signatures for the address until a signature of version "0" successfully
+	_, err := rpc.GetSignaturesForAddressUntil(context.Background(), client, address, untilSig, 100)
+	require.NoError(t, err)
 }
 
 func LiveTest_CheckRPCStatus(t *testing.T) {


### PR DESCRIPTION
# Description

Athens is blocked by below RPC query error. This is because the function `GetSignaturesForAddressUntil` now only works when the passed `untilSig` argument is a legacy transaction. It returns error if `untilSig` is a version "0" tx and blocks inbound observation.

```
error GetTransaction for untilSig 39fSgD2nteJCQRQP3ynqEcDMZAFSETCbfb61AUqLU6y7qbzSJL5rn2DHU2oM35zsf94Feb5C5QWd5L5UnncBsAay: (*jsonrpc.RPCError)(0x40006de030)({
 Code: (int) -32015,
 Message: (string) (len=175) "Transaction version (0) is not supported by the requesting client. Please try the request again with the following configuration parameter: \"maxSupportedTransactionVersion\": 0",
 Data: (interface {}) <nil>
})

```

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
