### PR TITLE
chore: use protocol-engineering team for codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @brewmaster012 @kingpinXD @lumtis @ws4charlie @skosito @swift1337
+* @zeta-chain/protocol-engineering
 
 .github/** @zeta-chain/devops


### PR DESCRIPTION
Using a team is the correct way to do CODEOWNERS

You should request review of individuals if you would specifically like their review on a change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated code ownership to streamline team management by designating the `@zeta-chain/protocol-engineering` team as the primary code owner for specified paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->