### PR TITLE
fix: move relayer key check after tss keysign

### DIFF
--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -127,12 +127,6 @@ func (signer *Signer) TryProcessOutbound(
 	nonce := params.TssNonce
 	coinType := cctx.InboundParams.CoinType
 
-	// skip relaying the transaction if this signer hasn't set the relayer key
-	if !signer.HasRelayerKey() {
-		logger.Warn().Msgf("TryProcessOutbound: no relayer key configured")
-		return
-	}
-
 	var tx *solana.Transaction
 
 	switch coinType {
@@ -165,6 +159,12 @@ func (signer *Signer) TryProcessOutbound(
 	default:
 		logger.Error().
 			Msgf("TryProcessOutbound: can only send SOL to the Solana network")
+		return
+	}
+
+	// skip relaying the transaction if this signer hasn't set the relayer key
+	if !signer.HasRelayerKey() {
+		logger.Warn().Msgf("TryProcessOutbound: no relayer key configured")
 		return
 	}
 

--- a/zetaclient/keys/relayer_key.go
+++ b/zetaclient/keys/relayer_key.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/crypto"
@@ -67,6 +68,8 @@ func LoadRelayerKey(relayerKeyPath string, network chains.Network, password stri
 		relayerKey.PrivateKey = privateKey
 		return relayerKey, nil
 	}
+
+	log.Logger.Warn().Msgf("relayer key file not found: %s", fileName)
 
 	// relayer key is optional, so it's okay if the relayer key is not provided
 	return nil, nil


### PR DESCRIPTION
# Description

Move the relayer key existence checking after TSS keysign so that all tss signers can continue scheduling keysign without a configured Solana relayer key.

![image](https://github.com/user-attachments/assets/d97518bb-33d3-47be-bf2c-2f0cadfd419b)


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
