### PR TITLE
chore(e2e): tolerate multiple runs of precompiled tests

### DIFF
--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -185,3 +185,13 @@ func parseBitcoinWithdrawArgs(r *runner.E2ERunner, args []string, defaultReceive
 
 	return receiver, amount
 }
+
+// bigAdd is shorthand for new(big.Int).Add(x, y)
+func bigAdd(x *big.Int, y *big.Int) *big.Int {
+	return new(big.Int).Add(x, y)
+}
+
+// bigSub is shorthand for new(big.Int).Sub(x, y)
+func bigSub(x *big.Int, y *big.Int) *big.Int {
+	return new(big.Int).Sub(x, y)
+}

--- a/e2e/e2etests/test_precompiles_bank.go
+++ b/e2e/e2etests/test_precompiles_bank.go
@@ -46,6 +46,12 @@ func TestPrecompilesBank(r *runner.E2ERunner, args []string) {
 		utils.RequireTxSuccessful(r, receipt, "Resetting balance failed")
 	}()
 
+	// Ensure starting allowance is zero; this is needed when running the tests multiple times
+	tx, err := r.ERC20ZRC20.Approve(r.ZEVMAuth, bankAddress, big.NewInt(0))
+	require.NoError(r, err)
+	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+	utils.RequireTxSuccessful(r, receipt, "Resetting allowance failed")
+
 	// Get ERC20ZRC20.
 	txHash := r.DepositERC20WithAmountAndMessage(r.EVMAddress(), totalAmount, []byte{})
 	utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
@@ -54,15 +60,18 @@ func TestPrecompilesBank(r *runner.E2ERunner, args []string) {
 	bankContract, err := bank.NewIBank(bank.ContractAddress, r.ZEVMClient)
 	require.NoError(r, err, "Failed to create bank contract caller")
 
-	// Cosmos coin balance should be 0 at this point.
-	cosmosBalance, err := bankContract.BalanceOf(&bind.CallOpts{Context: r.Ctx}, r.ERC20ZRC20Addr, spender)
+	// get starting balances
+	startSpenderCosmosBalance, err := bankContract.BalanceOf(&bind.CallOpts{Context: r.Ctx}, r.ERC20ZRC20Addr, spender)
 	require.NoError(r, err, "Call bank.BalanceOf()")
-	require.Equal(r, uint64(0), cosmosBalance.Uint64(), "spender cosmos coin balance should be 0")
+	startSpenderZRC20Balance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, spender)
+	require.NoError(r, err, "Call bank.BalanceOf()")
+	startBankZRC20Balance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, bankAddress)
+	require.NoError(r, err, "Call ERC20ZRC20.BalanceOf")
 
 	// Approve allowance of 500 ERC20ZRC20 tokens for the bank contract. Should pass.
-	tx, err := r.ERC20ZRC20.Approve(r.ZEVMAuth, bankAddress, depositAmount)
+	tx, err = r.ERC20ZRC20.Approve(r.ZEVMAuth, bankAddress, depositAmount)
 	require.NoError(r, err)
-	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+	receipt = utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 	utils.RequireTxSuccessful(r, receipt, "Approve ETHZRC20 bank allowance tx failed")
 
 	// Deposit 501 ERC20ZRC20 tokens to the bank contract.
@@ -99,17 +108,27 @@ func TestPrecompilesBank(r *runner.E2ERunner, args []string) {
 	require.Equal(r, depositAmount, eventDeposit.Amount, "Deposit event amount should be 500")
 
 	// Spender: cosmos coin balance should be 500 at this point.
-	cosmosBalance, err = bankContract.BalanceOf(&bind.CallOpts{Context: r.Ctx}, r.ERC20ZRC20Addr, spender)
+	spenderCosmosBalance, err := bankContract.BalanceOf(&bind.CallOpts{Context: r.Ctx}, r.ERC20ZRC20Addr, spender)
 	require.NoError(r, err, "Call bank.BalanceOf()")
-	require.Equal(r, uint64(500), cosmosBalance.Uint64(), "spender cosmos coin balance should be 500")
+	require.Equal(
+		r,
+		startSpenderCosmosBalance.Int64()+500,
+		spenderCosmosBalance.Int64(),
+		"spender cosmos coin balance should be +500",
+	)
 
 	// Bank: ERC20ZRC20 balance should be 500 tokens locked.
 	bankZRC20Balance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, bankAddress)
 	require.NoError(r, err, "Call ERC20ZRC20.BalanceOf")
-	require.Equal(r, uint64(500), bankZRC20Balance.Uint64(), "bank ERC20ZRC20 balance should be 500")
+	require.Equal(
+		r,
+		startBankZRC20Balance.Int64()+500,
+		bankZRC20Balance.Int64(),
+		"bank ERC20ZRC20 balance should be +500",
+	)
 
-	// Try to withdraw 501 ERC20ZRC20 tokens. Should fail.
-	tx, err = bankContract.Withdraw(r.ZEVMAuth, r.ERC20ZRC20Addr, big.NewInt(501))
+	// Try to withdraw one more than current balance. Should fail.
+	tx, err = bankContract.Withdraw(r.ZEVMAuth, r.ERC20ZRC20Addr, new(big.Int).Add(spenderCosmosBalance, big.NewInt(1)))
 	require.NoError(r, err, "Error calling bank.withdraw()")
 	receipt = utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 	utils.RequiredTxFailed(r, receipt, "Withdrawing more than cosmos coin balance amount should fail")
@@ -118,7 +137,12 @@ func TestPrecompilesBank(r *runner.E2ERunner, args []string) {
 	// No tokens should be unlocked with a failed withdraw.
 	bankZRC20Balance, err = r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, bankAddress)
 	require.NoError(r, err, "Call ERC20ZRC20.BalanceOf")
-	require.Equal(r, uint64(500), bankZRC20Balance.Uint64(), "bank ERC20ZRC20 balance should be 500")
+	require.Equal(
+		r,
+		startBankZRC20Balance.Int64()+500,
+		bankZRC20Balance.Int64(),
+		"bank ERC20ZRC20 balance should be +500",
+	)
 
 	// Try to withdraw 500 ERC20ZRC20 tokens. Should pass.
 	tx, err = bankContract.Withdraw(r.ZEVMAuth, r.ERC20ZRC20Addr, depositAmount)
@@ -133,20 +157,35 @@ func TestPrecompilesBank(r *runner.E2ERunner, args []string) {
 	require.Equal(r, r.ERC20ZRC20Addr, eventWithdraw.Zrc20Token, "Withdraw event token should be ERC20ZRC20Addr")
 	require.Equal(r, depositAmount, eventWithdraw.Amount, "Withdraw event amount should be 500")
 
-	// Spender: cosmos coin balance should be 0 at this point.
-	cosmosBalance, err = bankContract.BalanceOf(&bind.CallOpts{Context: r.Ctx}, r.ERC20ZRC20Addr, spender)
+	// Spender: cosmos coin balance should be +0 at this point.
+	spenderCosmosBalance, err = bankContract.BalanceOf(&bind.CallOpts{Context: r.Ctx}, r.ERC20ZRC20Addr, spender)
 	require.NoError(r, err, "Call bank.BalanceOf()")
-	require.Equal(r, uint64(0), cosmosBalance.Uint64(), "spender cosmos coin balance should be 0")
+	require.Equal(
+		r,
+		startSpenderCosmosBalance.Int64(),
+		spenderCosmosBalance.Int64(),
+		"spender cosmos coin balance should match starting balance",
+	)
 
-	// Spender: ERC20ZRC20 balance should be 1000 at this point.
-	zrc20Balance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, spender)
-	require.NoError(r, err, "Call bank.BalanceOf()")
-	require.Equal(r, uint64(1000), zrc20Balance.Uint64(), "spender ERC20ZRC20 balance should be 1000")
+	// Spender: ERC20ZRC20 balance should be +0 at this point.
+	spenderZRC20Balance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, spender)
+	require.NoError(r, err, "Call ERC20ZRC20.BalanceOf")
+	require.Equal(
+		r,
+		startSpenderZRC20Balance.Int64(),
+		spenderZRC20Balance.Int64(),
+		"spender ERC20ZRC20 balance should match starting balance",
+	)
 
-	// Bank: ERC20ZRC20 balance should be 0 tokens locked.
+	// Bank: ERC20ZRC20 balance should be +0 tokens locked.
 	bankZRC20Balance, err = r.ERC20ZRC20.BalanceOf(&bind.CallOpts{Context: r.Ctx}, bankAddress)
 	require.NoError(r, err, "Call ERC20ZRC20.BalanceOf")
-	require.Equal(r, uint64(0), bankZRC20Balance.Uint64(), "bank ERC20ZRC20 balance should be 0")
+	require.Equal(
+		r,
+		startBankZRC20Balance.Int64(),
+		bankZRC20Balance.Int64(),
+		"bank ERC20ZRC20 balance should match starting balance",
+	)
 }
 
 func TestPrecompilesBankNonZRC20(r *runner.E2ERunner, args []string) {


### PR DESCRIPTION
Closes https://github.com/zeta-chain/node/issues/3201

Use relative balances when possible in the precompiled contract tests to enable running multiple times.

The staking contracts cannot be run multiple times so disable them if the block height is greater than 100 (indicating an unclean test environment).

I need to add a CI check that verifies e2e can be run multiple times to prevent future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced end-to-end testing functionality with improved conditional logic based on blockchain state.
  - Added utility functions for simplified arithmetic operations on large integers.

- **Bug Fixes**
  - Improved robustness of tests by ensuring clean state checks for ERC20 token allowances and balances.

- **Documentation**
  - Updated comments for clarity on expected outcomes and balance checks in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->