### PR TITLE
ci: add option to run e2e twice

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -123,6 +123,7 @@ jobs:
       V2_TESTS: ${{ steps.matrix-conditionals.outputs.V2_TESTS }}
       V2_MIGRATION_TESTS: ${{ steps.matrix-conditionals.outputs.V2_MIGRATION_TESTS }}
       ENABLE_MONITORING: ${{ steps.matrix-conditionals.outputs.ENABLE_MONITORING }}
+      TWICE_TESTS: ${{ steps.matrix-conditionals.outputs.TWICE_TESTS }}
     steps:
       # use api rather than event context to avoid race conditions (label added after push)
       - id: matrix-conditionals
@@ -156,9 +157,11 @@ jobs:
               core.setOutput('V2_TESTS', labels.includes('V2_TESTS')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
               core.setOutput('V2_MIGRATION_TESTS', labels.includes('V2_MIGRATION_TESTS')); // for v2 tests, TODO: remove this once we fully migrate to v2 (https://github.com/zeta-chain/node/issues/2627)
               core.setOutput('ENABLE_MONITORING', labels.includes('ENABLE_MONITORING'));
+              core.setOutput('TWICE_TESTS', labels.includes('TWICE_TESTS'));
             } else if (context.eventName === 'merge_group') {
               // default mergequeue tests
               core.setOutput('DEFAULT_TESTS', true);
+              core.setOutput('TWICE_TESTS', true);
               core.setOutput('UPGRADE_LIGHT_TESTS', true);
 
               // conditional tests based on PR labels
@@ -224,6 +227,7 @@ jobs:
         include:
           - make-target: "start-e2e-test"
             runs-on: ubuntu-20.04
+            run-twice: ${{ needs.matrix-conditionals.outputs.TWICE_TESTS == 'true' }}
             run: ${{ needs.matrix-conditionals.outputs.DEFAULT_TESTS == 'true' }}
           - make-target: "start-e2e-consensus-test"
             runs-on: ubuntu-20.04
@@ -270,6 +274,7 @@ jobs:
       make-target: ${{ matrix.make-target }}
       runs-on: ${{ matrix.runs-on}}
       run: ${{ matrix.run }}
+      run-twice: ${{ matrix.run-twice || false }}
       timeout-minutes: "${{ matrix.timeout-minutes || 25 }}"
       zetanode-image: ${{ needs.build-zetanode.outputs.image }}
       enable-monitoring: ${{ needs.matrix-conditionals.outputs.ENABLE_MONITORING == 'true' }}

--- a/.github/workflows/reusable-e2e.yml
+++ b/.github/workflows/reusable-e2e.yml
@@ -27,6 +27,10 @@ on:
         description: 'Enable the monitoring stack for this run'
         type: boolean
         default: false
+      run-twice:
+        description: 'Run the tests a second time'
+        type: boolean
+        default: false
 
 jobs:
   e2e:
@@ -72,6 +76,17 @@ jobs:
         run: |
           container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
           docker logs -f "${container_id}" &
+          exit $(docker wait "${container_id}")
+
+      - name: Start Test (second run)
+        if: inputs.run-twice
+        run: make ${{ inputs.make-target }}
+
+      - name: Watch Test (second run)
+        if: inputs.run-twice
+        run: |
+          container_id=$(docker ps --filter "ancestor=orchestrator:latest" --format "{{.ID}}")
+          docker logs --since -10s -f "${container_id}" &
           exit $(docker wait "${container_id}")
 
       - name: Full Log Dump On Failure


### PR DESCRIPTION
Add option to run default e2e tests twice in CI. Always run twice in merge queue.

We want to ensure that the default e2e tests are never dependent on the system state.

Adds ~8 minutes to mergequeue times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new output variable `TWICE_TESTS` to conditionally run tests multiple times based on pull request labels.
	- Added a new input parameter `run-twice` to the reusable E2E testing workflow, allowing for a second execution of tests.
	- Implemented additional steps for a second test run and log monitoring based on the `run-twice` input.

- **Bug Fixes**
	- Enhanced the conditional execution logic for tests in the E2E workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->