### PR TITLE
ci: skip cache build for dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
   # forked pull request will fall back to slow build
   build-zetanode:
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node'
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'zeta-chain/node') && github.actor != 'dependabot[bot]'
     env:
       DOCKER_IMAGE: ghcr.io/${{ github.repository_owner }}/zetanode
       DOCKER_TAG: ${{ github.ref == 'refs/heads/develop' && 'develop' || github.sha }}


### PR DESCRIPTION
Skip build-zetanode step for depdenabot PRs as dependabot cannot push to ghcr.io. dependabot PRs will just use the slow build like fork PRs do.

[reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events).

Related to https://github.com/zeta-chain/node/pull/3269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced end-to-end (E2E) testing workflow with improved conditions for job execution.
	- Added Slack notifications for E2E test results, including success and failure formatting.

- **Bug Fixes**
	- Adjusted job triggers to exclude specific automated actors from initiating certain jobs.

- **Documentation**
	- Updated workflow logic to reflect changes in test execution conditions based on pull request context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->