### PR TITLE
chore: use v23 as base in upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
-		--build-arg OLD_VERSION='release/v22' \
+		--build-arg OLD_VERSION='release/v23' \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg NODE_COMMIT=$(NODE_COMMIT)
 		.
@@ -336,7 +336,7 @@ else
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v22.1.1' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v23.1.5' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the `zetanode` component to version `23.1.5` for both source and binary builds. 

- **Bug Fixes**
	- Resolved issues related to the previous versioning scheme by updating build arguments to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->