### PR TITLE
fix: hardcode erc20 asset strings to align with the data in foreign coin store

### DIFF
--- a/pkg/contracts/solana/inbound_test.go
+++ b/pkg/contracts/solana/inbound_test.go
@@ -160,7 +160,28 @@ func Test_ParseInboundAsDepositAndCall(t *testing.T) {
 	// solana e2e deployer account
 	sender := "37yGiHAnLvWZUNVwu9esp74YQFqxU1qHCbABkDvRddUQ"
 	// example contract deployed during e2e test, read from tx result
-	expectedReceiver := []byte{117, 160, 106, 140, 37, 135, 57, 218, 223, 226, 53, 45, 87, 151, 61, 239, 158, 231, 162, 186}
+	expectedReceiver := []byte{
+		117,
+		160,
+		106,
+		140,
+		37,
+		135,
+		57,
+		218,
+		223,
+		226,
+		53,
+		45,
+		87,
+		151,
+		61,
+		239,
+		158,
+		231,
+		162,
+		186,
+	}
 	expectedMsg := []byte("hello lamports")
 	expectedDeposit := &Deposit{
 		Sender: sender,

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -746,6 +746,8 @@ func (ob *Observer) BuildInboundVoteMsgForDepositedEvent(
 	}
 
 	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	// TODO: remove once the checksum conversion is fixed in the protocol
+	// https://github.com/zeta-chain/node/issues/3274
 	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
 
 	message := hex.EncodeToString(event.Message)

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zeta-chain/protocol-contracts/v1/pkg/contracts/evm/erc20custody.sol"
 	"github.com/zeta-chain/protocol-contracts/v1/pkg/contracts/evm/zetaconnector.non-eth.sol"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/pkg/memo"
@@ -33,6 +34,76 @@ import (
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
+
+var (
+	// erc20AddressToForeignCoinAssetMap maps the chain id and foreign ERC20 address to the coin asset string
+	erc20AddressToForeignCoinAssetMap = map[int64]map[ethcommon.Address]string{
+		// Ethereum mainnet
+		chains.Ethereum.ChainId: {
+			// USDC.ETH
+			ethcommon.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"): "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+			// PEPE.ETH
+			ethcommon.HexToAddress("0x6982508145454ce325ddbe47a25d4ec3d2311933"): "0x6982508145454ce325ddbe47a25d4ec3d2311933",
+			// SHIB.ETH
+			ethcommon.HexToAddress("0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"): "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+			// USDT.ETH
+			ethcommon.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"): "0xdac17f958d2ee523a2206206994597c13d831ec7",
+			// DAI.ETH
+			ethcommon.HexToAddress("0x6b175474e89094c44da98b954eedeac495271d0f"): "0x6b175474e89094c44da98b954eedeac495271d0f",
+			// ULTI.ETH
+			ethcommon.HexToAddress("0x0E7779e698052f8fe56C415C3818FCf89de9aC6D"): "0x0E7779e698052f8fe56C415C3818FCf89de9aC6D",
+		},
+
+		// BSC mainnet
+		chains.BscMainnet.ChainId: {
+			// USDC.BSC
+			ethcommon.HexToAddress("0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"): "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+			// USDT.BSC
+			ethcommon.HexToAddress("0x55d398326f99059ff775485246999027b3197955"): "0x55d398326f99059ff775485246999027b3197955",
+			// ULTI.BSC
+			ethcommon.HexToAddress("0x0E7779e698052f8fe56C415C3818FCf89de9aC6D"): "0x0E7779e698052f8fe56C415C3818FCf89de9aC6D",
+		},
+
+		// Polygon mainnet
+		chains.Polygon.ChainId: {
+			// USDT.POL
+			ethcommon.HexToAddress("0xc2132d05d31c914a87c6611c10748aeb04b58e8f"): "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+			// USDC.POL
+			ethcommon.HexToAddress("0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"): "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+		},
+
+		// Polygon Amoy
+		chains.Amoy.ChainId: {
+			// USDC.AMOY
+			ethcommon.HexToAddress("0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582"): "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",
+		},
+
+		// Base mainnet
+		chains.BaseMainnet.ChainId: {
+			// USDC.BASE
+			ethcommon.HexToAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"): "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+		},
+	}
+)
+
+// ERC20AddressToForeignCoinAsset
+func ERC20AddressToForeignCoinAsset(chainID int64, erc20Address ethcommon.Address) string {
+	addressToAsset, found := erc20AddressToForeignCoinAssetMap[chainID]
+	switch {
+	case found:
+		// if found, convert the address to asset in foreigh coin store
+		asset, found := addressToAsset[erc20Address]
+		if found {
+			return asset
+		}
+
+		// use the checksum address as asset string by default
+		return erc20Address.Hex()
+	default:
+		// use the checksum address as asset string by default
+		return erc20Address.Hex()
+	}
+}
 
 // WatchInbound watches evm chain for incoming txs and post votes to zetacore
 // TODO(revamp): move ticker function to a separate file
@@ -672,11 +743,15 @@ func (ob *Observer) BuildInboundVoteMsgForDepositedEvent(
 			Msgf("thank you rich folk for your donation! tx %s chain %d", event.Raw.TxHash.Hex(), ob.Chain().ChainId)
 		return nil
 	}
+
+	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
+
 	message := hex.EncodeToString(event.Message)
 	ob.Logger().Inbound.Info().
-		Msgf("ERC20CustodyDeposited inbound detected on chain %d tx %s block %d from %s value %s message %s",
+		Msgf("ERC20CustodyDeposited inbound detected on chain %d tx %s block %d from %s value %s asset %s message %s",
 			ob.Chain().
-				ChainId, event.Raw.TxHash.Hex(), event.Raw.BlockNumber, sender.Hex(), event.Amount.String(), message)
+				ChainId, event.Raw.TxHash.Hex(), event.Raw.BlockNumber, sender.Hex(), event.Amount.String(), asset, message)
 
 	return zetacore.GetInboundVoteMessage(
 		sender.Hex(),
@@ -690,7 +765,7 @@ func (ob *Observer) BuildInboundVoteMsgForDepositedEvent(
 		event.Raw.BlockNumber,
 		1_500_000,
 		coin.CoinType_ERC20,
-		event.Asset.String(),
+		asset,
 		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
 		event.Raw.Index,
 	)

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	// erc20AddressToForeignCoinAssetMap maps the chain id and foreign ERC20 address to the coin asset string
+	// this is currently necessary because of the following issue: https://github.com/zeta-chain/node/issues/3274
 	erc20AddressToForeignCoinAssetMap = map[int64]map[ethcommon.Address]string{
 		// Ethereum mainnet
 		chains.Ethereum.ChainId: {

--- a/zetaclient/chains/evm/observer/inbound_test.go
+++ b/zetaclient/chains/evm/observer/inbound_test.go
@@ -215,7 +215,7 @@ func Test_CheckAndVoteInboundTokenERC20(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("should pass for archived inbound, receipt and cctx", func(t *testing.T) {
-		tx, receipt, cctx := testutils.LoadEVMInboundNReceiptNCctx(
+		tx, receipt, _ := testutils.LoadEVMInboundNReceiptNCctx(
 			t,
 			TestDataDir,
 			chainID,
@@ -226,9 +226,8 @@ func Test_CheckAndVoteInboundTokenERC20(t *testing.T) {
 		lastBlock := receipt.BlockNumber.Uint64() + confirmation
 
 		ob, _ := MockEVMObserver(t, chain, nil, nil, nil, nil, lastBlock, chainParam)
-		ballot, err := ob.CheckAndVoteInboundTokenERC20(ctx, tx, receipt, false)
+		_, err := ob.CheckAndVoteInboundTokenERC20(ctx, tx, receipt, false)
 		require.NoError(t, err)
-		require.Equal(t, cctx.InboundParams.BallotIndex, ballot)
 	})
 	t.Run("should fail on unconfirmed inbound", func(t *testing.T) {
 		tx, receipt, _ := testutils.LoadEVMInboundNReceiptNCctx(
@@ -423,7 +422,6 @@ func Test_BuildInboundVoteMsgForDepositedEvent(t *testing.T) {
 	chainID := chain.ChainId
 	inboundHash := "0x4ea69a0e2ff36f7548ab75791c3b990e076e2a4bffeb616035b239b7d33843da"
 	tx, receipt := testutils.LoadEVMInboundNReceipt(t, TestDataDir, chainID, inboundHash, coin.CoinType_ERC20)
-	cctx := testutils.LoadCctxByInbound(t, chainID, coin.CoinType_ERC20, inboundHash)
 
 	// parse Deposited event
 	ob, _ := MockEVMObserver(t, chain, nil, nil, nil, nil, 1, mocks.MockChainParams(1, 1))
@@ -439,7 +437,6 @@ func Test_BuildInboundVoteMsgForDepositedEvent(t *testing.T) {
 	t.Run("should return vote msg for archived Deposited event", func(t *testing.T) {
 		msg := ob.BuildInboundVoteMsgForDepositedEvent(event, sender)
 		require.NotNil(t, msg)
-		require.Equal(t, cctx.InboundParams.BallotIndex, msg.Digest())
 	})
 	t.Run("should return nil msg if sender is restricted", func(t *testing.T) {
 		cfg.ComplianceConfig.RestrictedAddresses = []string{sender.Hex()}

--- a/zetaclient/chains/evm/observer/inbound_test.go
+++ b/zetaclient/chains/evm/observer/inbound_test.go
@@ -27,7 +27,7 @@ import (
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 )
 
-func Test_ERC20AddressToForeignCoinAsset(t *testing.T) {
+func Test_PatchZRC20Asset(t *testing.T) {
 	tests := []struct {
 		name         string
 		chainID      int64
@@ -65,12 +65,6 @@ func Test_ERC20AddressToForeignCoinAsset(t *testing.T) {
 			erc20Address: ethcommon.HexToAddress("0x6b175474e89094c44da98b954eedeac495271d0f"),
 			assetString:  "0x6b175474e89094c44da98b954eedeac495271d0f",
 		},
-		{
-			name:         "ULTI.ETH",
-			chainID:      chains.Ethereum.ChainId,
-			erc20Address: ethcommon.HexToAddress("0x0E7779e698052f8fe56C415C3818FCf89de9aC6D"),
-			assetString:  "0x0E7779e698052f8fe56C415C3818FCf89de9aC6D",
-		},
 		// BSC Mainnet
 		{
 			name:         "USDC.BSC",
@@ -83,12 +77,6 @@ func Test_ERC20AddressToForeignCoinAsset(t *testing.T) {
 			chainID:      chains.BscMainnet.ChainId,
 			erc20Address: ethcommon.HexToAddress("0x55d398326f99059ff775485246999027b3197955"),
 			assetString:  "0x55d398326f99059ff775485246999027b3197955",
-		},
-		{
-			name:         "ULTI.BSC",
-			chainID:      chains.BscMainnet.ChainId,
-			erc20Address: ethcommon.HexToAddress("0x0E7779e698052f8fe56C415C3818FCf89de9aC6D"),
-			assetString:  "0x0E7779e698052f8fe56C415C3818FCf89de9aC6D",
 		},
 		// Polygon Mainnet
 		{
@@ -110,18 +98,11 @@ func Test_ERC20AddressToForeignCoinAsset(t *testing.T) {
 			erc20Address: ethcommon.HexToAddress("0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582"),
 			assetString:  "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",
 		},
-		// Base Mainnet
-		{
-			name:         "USDC.BASE",
-			chainID:      chains.BaseMainnet.ChainId,
-			erc20Address: ethcommon.HexToAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
-			assetString:  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			asset := observer.ERC20AddressToForeignCoinAsset(tt.chainID, tt.erc20Address)
+			asset := observer.PatchZRC20Asset(tt.chainID, tt.erc20Address)
 			require.Equal(t, tt.assetString, asset)
 		})
 	}

--- a/zetaclient/chains/evm/observer/inbound_test.go
+++ b/zetaclient/chains/evm/observer/inbound_test.go
@@ -19,12 +19,113 @@ import (
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/zetaclient/chains/evm"
+	"github.com/zeta-chain/node/zetaclient/chains/evm/observer"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 )
+
+func Test_ERC20AddressToForeignCoinAsset(t *testing.T) {
+	tests := []struct {
+		name         string
+		chainID      int64
+		erc20Address ethcommon.Address
+		assetString  string
+	}{
+		// Ethereum Mainnet
+		{
+			name:         "USDC.ETH",
+			chainID:      chains.Ethereum.ChainId,
+			erc20Address: ethcommon.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+			assetString:  "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+		},
+		{
+			name:         "PEPE.ETH",
+			chainID:      chains.Ethereum.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x6982508145454ce325ddbe47a25d4ec3d2311933"),
+			assetString:  "0x6982508145454ce325ddbe47a25d4ec3d2311933",
+		},
+		{
+			name:         "SHIB.ETH",
+			chainID:      chains.Ethereum.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce"),
+			assetString:  "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+		},
+		{
+			name:         "USDT.ETH",
+			chainID:      chains.Ethereum.ChainId,
+			erc20Address: ethcommon.HexToAddress("0xdac17f958d2ee523a2206206994597c13d831ec7"),
+			assetString:  "0xdac17f958d2ee523a2206206994597c13d831ec7",
+		},
+		{
+			name:         "DAI.ETH",
+			chainID:      chains.Ethereum.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x6b175474e89094c44da98b954eedeac495271d0f"),
+			assetString:  "0x6b175474e89094c44da98b954eedeac495271d0f",
+		},
+		{
+			name:         "ULTI.ETH",
+			chainID:      chains.Ethereum.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x0E7779e698052f8fe56C415C3818FCf89de9aC6D"),
+			assetString:  "0x0E7779e698052f8fe56C415C3818FCf89de9aC6D",
+		},
+		// BSC Mainnet
+		{
+			name:         "USDC.BSC",
+			chainID:      chains.BscMainnet.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"),
+			assetString:  "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+		},
+		{
+			name:         "USDT.BSC",
+			chainID:      chains.BscMainnet.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x55d398326f99059ff775485246999027b3197955"),
+			assetString:  "0x55d398326f99059ff775485246999027b3197955",
+		},
+		{
+			name:         "ULTI.BSC",
+			chainID:      chains.BscMainnet.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x0E7779e698052f8fe56C415C3818FCf89de9aC6D"),
+			assetString:  "0x0E7779e698052f8fe56C415C3818FCf89de9aC6D",
+		},
+		// Polygon Mainnet
+		{
+			name:         "USDT.POL",
+			chainID:      chains.Polygon.ChainId,
+			erc20Address: ethcommon.HexToAddress("0xc2132d05d31c914a87c6611c10748aeb04b58e8f"),
+			assetString:  "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+		},
+		{
+			name:         "USDC.POL",
+			chainID:      chains.Polygon.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"),
+			assetString:  "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+		},
+		// Polygon Amoy
+		{
+			name:         "USDC.AMOY",
+			chainID:      chains.Amoy.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582"),
+			assetString:  "0x41e94eb019c0762f9bfcf9fb1e58725bfb0e7582",
+		},
+		// Base Mainnet
+		{
+			name:         "USDC.BASE",
+			chainID:      chains.BaseMainnet.ChainId,
+			erc20Address: ethcommon.HexToAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
+			assetString:  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset := observer.ERC20AddressToForeignCoinAsset(tt.chainID, tt.erc20Address)
+			require.Equal(t, tt.assetString, asset)
+		})
+	}
+}
 
 func Test_CheckAndVoteInboundTokenZeta(t *testing.T) {
 	// load archived ZetaSent inbound, receipt and cctx

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -181,11 +181,10 @@ func (ob *Observer) newDepositInboundVote(event *gatewayevm.GatewayEVMDeposited)
 		isCrossChainCall = true
 	}
 
-	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
-	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	// get patched asset string so that it matches the one in the foreign coin store
 	// TODO: remove once the checksum conversion is fixed in the protocol
 	// https://github.com/zeta-chain/node/issues/3274
-	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
+	asset := PatchZRC20Asset(ob.Chain().ChainId, event.Asset)
 	if asset != event.Asset.Hex() {
 		ob.Logger().
 			Inbound.Info().
@@ -465,10 +464,10 @@ func (ob *Observer) newDepositAndCallInboundVote(event *gatewayevm.GatewayEVMDep
 		coinType = coin.CoinType_Gas
 	}
 
-	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	// get patched asset string so that it matches the one in the foreign coin store
 	// TODO: remove once the checksum conversion is fixed in the protocol
 	// https://github.com/zeta-chain/node/issues/3274
-	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
+	asset := PatchZRC20Asset(ob.Chain().ChainId, event.Asset)
 	if asset != event.Asset.Hex() {
 		ob.Logger().
 			Inbound.Info().

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -182,6 +182,9 @@ func (ob *Observer) newDepositInboundVote(event *gatewayevm.GatewayEVMDeposited)
 	}
 
 	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	// TODO: remove once the checksum conversion is fixed in the protocol
+	// https://github.com/zeta-chain/node/issues/3274
 	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
 	if asset != event.Asset.Hex() {
 		ob.Logger().

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -466,6 +466,8 @@ func (ob *Observer) newDepositAndCallInboundVote(event *gatewayevm.GatewayEVMDep
 	}
 
 	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	// TODO: remove once the checksum conversion is fixed in the protocol
+	// https://github.com/zeta-chain/node/issues/3274
 	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
 	if asset != event.Asset.Hex() {
 		ob.Logger().

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -181,6 +181,14 @@ func (ob *Observer) newDepositInboundVote(event *gatewayevm.GatewayEVMDeposited)
 		isCrossChainCall = true
 	}
 
+	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
+	if asset != event.Asset.Hex() {
+		ob.Logger().
+			Inbound.Info().
+			Msgf("newDepositInboundVote converted asset %s to %s for chain %d", event.Asset.Hex(), asset, ob.Chain().ChainId)
+	}
+
 	return *types.NewMsgVoteInbound(
 		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
 		event.Sender.Hex(),
@@ -194,7 +202,7 @@ func (ob *Observer) newDepositInboundVote(event *gatewayevm.GatewayEVMDeposited)
 		event.Raw.BlockNumber,
 		zetacore.PostVoteInboundCallOptionsGasLimit,
 		coinType,
-		event.Asset.Hex(),
+		asset,
 		event.Raw.Index,
 		types.ProtocolContractVersion_V2,
 		false, // currently not relevant since calls are not arbitrary
@@ -454,6 +462,14 @@ func (ob *Observer) newDepositAndCallInboundVote(event *gatewayevm.GatewayEVMDep
 		coinType = coin.CoinType_Gas
 	}
 
+	// convert erc20Address to asset in foreign coin store to avoid checksum mismatch
+	asset := ERC20AddressToForeignCoinAsset(ob.Chain().ChainId, event.Asset)
+	if asset != event.Asset.Hex() {
+		ob.Logger().
+			Inbound.Info().
+			Msgf("newDepositAndCallInboundVote converted asset %s to %s for chain %d", event.Asset.Hex(), asset, ob.Chain().ChainId)
+	}
+
 	return *types.NewMsgVoteInbound(
 		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
 		event.Sender.Hex(),
@@ -467,7 +483,7 @@ func (ob *Observer) newDepositAndCallInboundVote(event *gatewayevm.GatewayEVMDep
 		event.Raw.BlockNumber,
 		1_500_000,
 		coinType,
-		event.Asset.Hex(),
+		asset,
 		event.Raw.Index,
 		types.ProtocolContractVersion_V2,
 		false, // currently not relevant since calls are not arbitrary


### PR DESCRIPTION
# Description

ERC20 deposits were not well observed in BSC, Polygon. These were caused by foreign coin asset mismatch in the `MsgVoteInbound`. See:

BSC failed vote: https://explorer.zetachain.com/cosmos/tx/5F81D3F623B57E64FBF4ADE684C778BF83ACA8AC059A86B7D2273908930A2022
Polygon failed vote: https://explorer.zetachain.com/cosmos/tx/1C54E4CAFBE226B17E82D838291DF65EF51EE07EDCFD2B7DDE39EA735E7FAC67

Solution:
Taking the [list of foreign ERC20 tokens](https://zetachain.blockpi.network/lcd/v1/public/zeta-chain/fungible/foreign_coins), and hardcoded the mapping `ERC20 address --> asset` so that zetaclients can use the correct asset string in their inbound ERC20 votes.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
