### PR TITLE
chore: disable coderabbit top level status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,7 @@ tone_instructions: >-
 reviews:
   profile: chill
   high_level_summary: true
+  review_status: false
 
   # disables the cringe
   poem: false


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b2d54eb2-f3bb-4d28-bed8-375ca5bdaf84)


Disable the top level coderabbit status message. I find this to just be visual clutter.