### PR TITLE
fix: remove all dynamic peer discovery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * [3242](https://github.com/zeta-chain/node/pull/3242) - set the `Receiver` of `MsgVoteInbound` to the address pulled from solana memo
 * [3253](https://github.com/zeta-chain/node/pull/3253) - fix solana inbound version 0 queries and move tss keysign prior to relayer key checking
 * [3278](https://github.com/zeta-chain/node/pull/3278) - enforce checksum format for asset address in ZRC20
+* [3289](https://github.com/zeta-chain/node/pull/3289) - remove all dynamic peer discovery (zetaclient)
 
 ## v23.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -371,5 +371,5 @@ replace (
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 	github.com/ethereum/go-ethereum => github.com/zeta-chain/go-ethereum v1.13.16-0.20241022183758-422c6ef93ccc
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
-	gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20241115165301-8535262eb16f
+	gitlab.com/thorchain/tss/go-tss => github.com/zeta-chain/go-tss v0.0.0-20241216161449-be92b20f8102
 )

--- a/go.sum
+++ b/go.sum
@@ -1526,8 +1526,8 @@ github.com/zeta-chain/go-ethereum v1.13.16-0.20241022183758-422c6ef93ccc h1:FVOt
 github.com/zeta-chain/go-ethereum v1.13.16-0.20241022183758-422c6ef93ccc/go.mod h1:MgO2/CmxFnj6W7v/5hrz3ypco3kHkb8856pRnFkY4xQ=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
-github.com/zeta-chain/go-tss v0.0.0-20241115165301-8535262eb16f h1:zKBTanf2jf/oyr3f27GgvibSdVThmCdcV9sc5/6uOyQ=
-github.com/zeta-chain/go-tss v0.0.0-20241115165301-8535262eb16f/go.mod h1:nqelgf4HKkqlXaVg8X38a61WfyYB+ivCt6nnjoTIgCc=
+github.com/zeta-chain/go-tss v0.0.0-20241216161449-be92b20f8102 h1:jMb9ydfDFjgdlxpn8zClEPlUIJcz9ElahaAAXUPNFv0=
+github.com/zeta-chain/go-tss v0.0.0-20241216161449-be92b20f8102/go.mod h1:nqelgf4HKkqlXaVg8X38a61WfyYB+ivCt6nnjoTIgCc=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c h1:ZoFxMMZtivRLquXVq1sEVlT45UnTPMO1MSXtc88nDv4=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20241021075719-d40d2e28467c/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20241108171442-e48d82f94892 h1:oI5qCrw2SXDf2a2UYAn0tpaKHbKpJcR+XDtceyY00wE=

--- a/zetaclient/tss/healthcheck.go
+++ b/zetaclient/tss/healthcheck.go
@@ -92,12 +92,6 @@ func HealthcheckWorker(ctx context.Context, server *tss.TssServer, p Healthcheck
 		return nil
 	}
 
-	knownPeersCounter := func(_ context.Context, _ *ticker.Ticker) error {
-		peers := server.GetKnownPeers()
-		p.Telemetry.SetKnownPeers(peers)
-		return nil
-	}
-
 	connectedPeersCounter := func(_ context.Context, _ *ticker.Ticker) error {
 		p2pHost := server.GetP2PHost()
 		connectedPeers := lo.Map(p2pHost.Network().Conns(), func(conn libp2p_network.Conn, _ int) peer.AddrInfo {
@@ -112,7 +106,6 @@ func HealthcheckWorker(ctx context.Context, server *tss.TssServer, p Healthcheck
 	}
 
 	runBackgroundTicker(ctx, pinger, p.Interval, "TSSHealthcheckPeersPing", logger)
-	runBackgroundTicker(ctx, knownPeersCounter, p.Interval, "TSSHealthcheckKnownPeersCounter", logger)
 	runBackgroundTicker(ctx, connectedPeersCounter, p.Interval, "TSSHealthcheckConnectedPeersCounter", logger)
 
 	return nil

--- a/zetaclient/tss/service.go
+++ b/zetaclient/tss/service.go
@@ -48,7 +48,6 @@ type Zetacore interface {
 type Telemetry interface {
 	SetP2PID(id string)
 	SetConnectedPeers(peers []peer.AddrInfo)
-	SetKnownPeers(peers []peer.AddrInfo)
 	SetPingRTT(peers map[peer.ID]int64)
 }
 


### PR DESCRIPTION
We've had to revert the new private peer discovery for two releases. It didn't work on live networks because it's very hard to discover which port is actually publicly accessible on our zetaclients because of the sentry architecture.

We've been using a static address book for awhile now which isn't that hard to manage on the operations side.

Related to https://github.com/zeta-chain/node/pull/3277

go-tss change: https://github.com/zeta-chain/go-tss/pull/40



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependency versions for improved stability and performance.
  
- **Bug Fixes**
	- Removed obsolete tracking of known peers from telemetry and health check functionalities, streamlining operations.

- **Refactor**
	- Simplified telemetry interface by eliminating the `SetKnownPeers` method, enhancing peer management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->