### PR TITLE
chore: use bitcoin core wallet script

### DIFF
--- a/cmd/zetae2e/config/local.yml
+++ b/cmd/zetae2e/config/local.yml
@@ -95,8 +95,8 @@ rpcs:
   evm: "http://localhost:8545"
   bitcoin:
     host: "localhost:18443"
-    user: "smoketest"
-    pass: "123"
+    user: "admin"
+    pass: "admin"
     http_post_mode: true
     disable_tls: true
     params: regnet

--- a/cmd/zetae2e/config/localnet.yml
+++ b/cmd/zetae2e/config/localnet.yml
@@ -93,8 +93,8 @@ rpcs:
   evm: "http://eth:8545"
   bitcoin:
     host: "bitcoin:18443"
-    user: "smoketest"
-    pass: "123"
+    user: "admin"
+    pass: "admin"
     http_post_mode: true
     disable_tls: true
     params: regnet

--- a/contrib/localnet/docker-compose.yml
+++ b/contrib/localnet/docker-compose.yml
@@ -198,7 +198,7 @@ services:
         ipv4_address: 172.20.0.102
 
   bitcoin:
-    image: ghcr.io/zeta-chain/bitcoin-core-docker:28.0
+    image: ghcr.io/zeta-chain/bitcoin-core-docker:a94b52f
     container_name: bitcoin
     hostname: bitcoin
     networks:
@@ -206,15 +206,13 @@ services:
         ipv4_address: 172.20.0.101
     ports:
       - "18443:18443"
-    command:
-      -printtoconsole
-      -regtest=1
-      -rpcallowip=0.0.0.0/0
-      -rpcbind=0.0.0.0
-      -rpcauth=smoketest:63acf9b8dccecce914d85ff8c044b78b$$5892f9bbc84f4364e79f0970039f88bdd823f168d4acc76099ab97b14a766a99
-      -txindex=1
-      -deprecatedrpc=create_bdb
-      -deprecatedrpc=warnings
+    command: /opt/wallet.sh
+    environment:
+      - CHAIN=regtest
+      - RPC_USER=smoketest
+      - RPC_PASSWORD=123
+      - ADMIN_RPC_USER=admin
+      - ADMIN_RPC_PASSWORD=admin
 
   solana:
     image: solana-local:latest


### PR DESCRIPTION
Use the `/opt/wallet.sh` script from bitcoin-core-docker. This ensure that the rpc whitelist and credential generation is fully covered by node CI.

We use the admin user in zetae2e since it needs to setup the wallet and mine blocks. We use the smoketest user in zetaclient which is limited to specific RPCs.

Related to https://github.com/zeta-chain/bitcoin-core-docker/pull/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated authentication credentials for Bitcoin RPC in `local.yml` and `localnet.yml`.
	- Modified the `docker-compose.yml` to change the Bitcoin service image and command, and added new environment variables.
- **Bug Fixes**
	- Removed outdated command parameters for the Bitcoin service to streamline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->