### PR TITLE
chore: prepare v25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
-		--build-arg OLD_VERSION='release/v23' \
+		--build-arg OLD_VERSION='release/v24' \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg NODE_COMMIT=$(NODE_COMMIT)
 		.
@@ -336,7 +336,7 @@ else
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v23.1.5' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v24.0.0' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,11 @@
 # CHANGELOG
 
-## Unreleased
+## v25.0.0
 
 ### Features
 
 * [3235](https://github.com/zeta-chain/node/pull/3235) - add /systemtime telemetry endpoint (zetaclient)
 * [3317](https://github.com/zeta-chain/node/pull/3317) - add configurable signer latency correction (zetaclient)
-
 
 ### Tests
 
@@ -15,7 +14,7 @@
 * [3095](https://github.com/zeta-chain/node/pull/3095) - initialize simulation tests for custom zetachain modules
 * [3276](https://github.com/zeta-chain/node/pull/3276) - add Solana E2E performance tests and improve Solana outbounds performance
 
-## Refactor
+### Refactor
 
 * [3170](https://github.com/zeta-chain/node/pull/3170) - revamp TSS package in zetaclient
 * [3291](https://github.com/zeta-chain/node/pull/3291) - revamp zetaclient initialization (+ graceful shutdown)

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -338,23 +338,23 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 
 	if !skipPrecompiles {
 		precompiledContractTests := []string{
-			e2etests.TestPrecompilesPrototypeName,
-			e2etests.TestPrecompilesPrototypeThroughContractName,
-			// Disabled until further notice, check https://github.com/zeta-chain/node/issues/3005.
-			// e2etests.TestPrecompilesStakingThroughContractName,
-			e2etests.TestPrecompilesBankName,
-			e2etests.TestPrecompilesBankFailName,
-			e2etests.TestPrecompilesBankThroughContractName,
+			//e2etests.TestPrecompilesPrototypeName,
+			//e2etests.TestPrecompilesPrototypeThroughContractName,
+			//// Disabled until further notice, check https://github.com/zeta-chain/node/issues/3005.
+			//// e2etests.TestPrecompilesStakingThroughContractName,
+			//e2etests.TestPrecompilesBankName,
+			//e2etests.TestPrecompilesBankFailName,
+			//e2etests.TestPrecompilesBankThroughContractName,
 		}
 		if e2eStartHeight < 100 {
 			// these tests require a clean system
 			// since unstaking has an unbonding period
-			precompiledContractTests = append(precompiledContractTests,
-				e2etests.TestPrecompilesStakingName,
-				e2etests.TestPrecompilesDistributeName,
-				e2etests.TestPrecompilesDistributeNonZRC20Name,
-				e2etests.TestPrecompilesDistributeThroughContractName,
-			)
+			//precompiledContractTests = append(precompiledContractTests,
+			//	e2etests.TestPrecompilesStakingName,
+			//	e2etests.TestPrecompilesDistributeName,
+			//	e2etests.TestPrecompilesDistributeNonZRC20Name,
+			//	e2etests.TestPrecompilesDistributeThroughContractName,
+			//)
 		} else {
 			logger.Print("⚠️ partial precompiled run (unclean state)")
 		}

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -355,6 +355,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			//	e2etests.TestPrecompilesDistributeNonZRC20Name,
 			//	e2etests.TestPrecompilesDistributeThroughContractName,
 			//)
+			// prevent lint error
+			_ = precompiledContractTests
 		} else {
 			logger.Print("⚠️ partial precompiled run (unclean state)")
 		}

--- a/precompiles/precompiles.go
+++ b/precompiles/precompiles.go
@@ -22,9 +22,9 @@ import (
 // This is useful for listing and reading from other packages, such as BlockedAddrs() function.
 // Setting to false a contract here will disable it, not being included in the blockchain.
 var EnabledStatefulContracts = map[common.Address]bool{
-	prototype.ContractAddress: true,
-	staking.ContractAddress:   true,
-	bank.ContractAddress:      true,
+	prototype.ContractAddress: false,
+	staking.ContractAddress:   false,
+	bank.ContractAddress:      false,
 }
 
 // StatefulContracts returns all the registered precompiled contracts.


### PR DESCRIPTION
# Description

- Wrap up changelogs
- Disable precompiles
- Set v24 for upgrade test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for v25.0.0

- **New Features**
  - Added `/systemtime` telemetry endpoint
  - Introduced configurable signer latency correction

- **Refactors**
  - Revamped TSS package
  - Enhanced zetaclient initialization with graceful shutdown
  - Implemented scheduler for zetaclient

- **Testing**
  - Relocated Bitcoin revert address test
  - Renamed v2 E2E tests to EVM tests
  - Added Solana E2E performance tests

- **Infrastructure**
  - Updated node upgrade process to version 24.0.0

- **Precompiles**
  - Disabled certain stateful precompiled contracts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->