### PR TITLE
fix!: set per transaction gas limit to 10M

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -143,8 +143,9 @@ func init() {
 }
 
 var (
-	NodeDir         = ".zetacored"
-	DefaultNodeHome = os.ExpandEnv("$HOME/") + NodeDir
+	NodeDir                    = ".zetacored"
+	DefaultNodeHome            = os.ExpandEnv("$HOME/") + NodeDir
+	TransactionGasLimit uint64 = 10_000_000
 )
 
 func getGovProposalHandlers() []govclient.ProposalHandler {
@@ -784,7 +785,6 @@ func New(
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 
-	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
 	options := ante.HandlerOptions{
 		AccountKeeper:   app.AccountKeeper,
 		BankKeeper:      app.BankKeeper,
@@ -792,7 +792,7 @@ func New(
 		FeeMarketKeeper: app.FeeMarketKeeper,
 		SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 		SigGasConsumer:  evmante.DefaultSigVerificationGasConsumer,
-		MaxTxGasWanted:  maxGasWanted,
+		MaxTxGasWanted:  TransactionGasLimit,
 		DisabledAuthzMsgs: []string{
 			sdk.MsgTypeURL(
 				&evmtypes.MsgEthereumTx{},

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * [3289](https://github.com/zeta-chain/node/pull/3289) - remove all dynamic peer discovery (zetaclient)
 * [3314](https://github.com/zeta-chain/node/pull/3314) - update `last_scanned_block_number` metrics more frequently for Solana chain
 * [3321](https://github.com/zeta-chain/node/pull/3321) - make crosschain-call with invalid withdraw revert
+* [3342](https://github.com/zeta-chain/node/pull/3342) - set per transaction gas limit to 10M
 
 ## v24.0.0
 


### PR DESCRIPTION
Set the per-transaction gas limit so that the 99.9th-percentile transaction is allowed, but the maximum gas-value transaction is not. A limit of 10M is significantly higher than the 99.9th-percentile value to avoid disrupting legitimate transactions.

This will ensure that ridiculously large transactions do not degrade the network performance.

Will backport to develop.

<img width="1380" alt="image" src="https://github.com/user-attachments/assets/2ba00020-60de-4c04-b077-e51ca499c3a2" />
