### PR TITLE
chore: upgrade cosmovisor and go

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -33,7 +33,7 @@ runs:
     - uses: actions/setup-go@v5
       if: ${{ inputs.skip_go == 'false' }}
       with:
-        go-version: '1.22'
+        go-version: '1.23'
         cache: false
 
     - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: go get node
         working-directory: contrib/rpcimportable
         run: go get github.com/zeta-chain/node@${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.63.4
           skip-cache: true
 
   nosec_alert:

--- a/.github/workflows/sast-linters.yml
+++ b/.github/workflows/sast-linters.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Install dependencies
         run: make runsim

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - misspell
     - goimports
     - govet
-    - gosec
     - stylecheck
     - typecheck
     - misspell

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -1,6 +1,6 @@
 # syntax=ghcr.io/zeta-chain/docker-dockerfile:1.9-labs
 # check=error=true
-FROM ghcr.io/zeta-chain/golang:1.22.7-bookworm AS base-build
+FROM ghcr.io/zeta-chain/golang:1.23.3-bookworm AS base-build
 
 ENV GOPATH=/go
 ENV GOOS=linux
@@ -27,10 +27,10 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     NODE_COMMIT=${NODE_COMMIT} \
     make install install-zetae2e
 
-FROM ghcr.io/zeta-chain/golang:1.22.7-bookworm AS cosmovisor-build
+FROM ghcr.io/zeta-chain/golang:1.23.3-bookworm AS cosmovisor-build
 RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.0
 
-FROM ghcr.io/zeta-chain/golang:1.22.7-bookworm AS base-runtime
+FROM ghcr.io/zeta-chain/golang:1.23.3-bookworm AS base-runtime
 
 RUN apt update && \
     apt install -yq jq yq curl tmux python3 openssh-server iputils-ping iproute2 bind9-host && \

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     make install install-zetae2e
 
 FROM ghcr.io/zeta-chain/golang:1.22.7-bookworm AS cosmovisor-build
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.6.0
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.0
 
 FROM ghcr.io/zeta-chain/golang:1.22.7-bookworm AS base-runtime
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOFLAGS := ""
 GOPATH ?= '$(HOME)/go'
 
 # common goreaser command definition
-GOLANG_CROSS_VERSION ?= v1.22.7@sha256:24b2d75007f0ec8e35d01f3a8efa40c197235b200a1a91422d78b851f67ecce4
+GOLANG_CROSS_VERSION ?= v1.23.3@sha256:380420abb74844aaebca5bf9e2d00b1d7c78f59ce9e6d47cdb3276281702ca23
 GORELEASER := $(DOCKER) run \
 	--rm \
 	--privileged \

--- a/go.mod
+++ b/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
@@ -249,8 +249,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/petermattis/goid v0.0.0-20230317030725-371a4b8eda08 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.4.0 // indirect
-	github.com/prometheus/common v0.42.0 // indirect
+	github.com/prometheus/client_model v0.4.0
+	github.com/prometheus/common v0.42.0
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect

--- a/pkg/graceful/graceful.go
+++ b/pkg/graceful/graceful.go
@@ -147,9 +147,9 @@ func (p *Process) ShutdownNow() {
 	}
 }
 
-// panicToErr converts panic to error WITH exact line of panic.
+// panicToErr converts recoverVal to error WITH exact line of panic.
 // Note the offset should be determined empirically.
-func panicToErr(panic any, offset int) error {
+func panicToErr(recoverVal any, offset int) error {
 	stack := string(debug.Stack())
 	lines := strings.Split(stack, "\n")
 	line := ""
@@ -158,7 +158,7 @@ func panicToErr(panic any, offset int) error {
 		line = strings.TrimSpace(lines[offset])
 	}
 
-	return fmt.Errorf("panic: %v at %s", panic, line)
+	return fmt.Errorf("panic: %v at %s", recoverVal, line)
 }
 
 // NewSigChan creates a new signal channel.

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -303,9 +303,9 @@ func BaseFeeFromEvents(events []abci.Event) *big.Int {
 
 // CheckTxFee is an internal function used to check whether the fee of
 // the given transaction is _reasonable_(under the cap).
-func CheckTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
+func CheckTxFee(gasPrice *big.Int, gas uint64, feeCap float64) error {
 	// Short circuit if there is no cap for transaction fee at all.
-	if cap == 0 {
+	if feeCap == 0 {
 		return nil
 	}
 	totalfee := new(big.Float).SetInt(new(big.Int).Mul(gasPrice, new(big.Int).SetUint64(gas)))
@@ -315,8 +315,8 @@ func CheckTxFee(gasPrice *big.Int, gas uint64, cap float64) error {
 	feeEth := new(big.Float).Quo(totalfee, oneToken)
 	// no need to check error from parsing
 	feeFloat, _ := feeEth.Float64()
-	if feeFloat > cap {
-		return fmt.Errorf("tx fee (%.2f ether) exceeds the configured cap (%.2f ether)", feeFloat, cap)
+	if feeFloat > feeCap {
+		return fmt.Errorf("tx fee (%.2f ether) exceeds the configured cap (%.2f ether)", feeFloat, feeCap)
 	}
 	return nil
 }

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -6,7 +6,7 @@ set -e
 if ! command -v golangci-lint &> /dev/null
 then
     echo "golangci-lint is not found, installing..."
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 fi
 
 if ! command -v golines &> /dev/null

--- a/x/observer/types/ballot.go
+++ b/x/observer/types/ballot.go
@@ -79,8 +79,8 @@ func (m Ballot) IsFinalizingVote() (Ballot, bool) {
 	return m, false
 }
 
-func CreateVotes(len int) []VoteType {
-	voterList := make([]VoteType, len)
+func CreateVotes(listSize int) []VoteType {
+	voterList := make([]VoteType, listSize)
 	for i := range voterList {
 		voterList[i] = VoteType_NotYetVoted
 	}


### PR DESCRIPTION
https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.7.0

Requires go 1.23 for some reason.

goreleaser-cross hasn't published a 1.23.4 so sticking with 1.23.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `cosmovisor` tool from version 1.6.0 to version 1.7.0 in the build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->