### PR TITLE
test: disable preflight check so we can see failure message in explorer

### DIFF
--- a/e2e/runner/solana.go
+++ b/e2e/runner/solana.go
@@ -327,7 +327,7 @@ func (r *E2ERunner) BroadcastTxSync(tx *solana.Transaction) (solana.Signature, *
 	// broadcast the transaction
 	r.Logger.Info("Broadcast start")
 	sig, err := r.SolanaClient.SendTransactionWithOpts(r.Ctx, tx, rpc.TransactionOpts{
-		PreflightCommitment: rpc.CommitmentProcessed,
+		SkipPreflight: true,
 	})
 	require.NoError(r, err)
 	r.Logger.Info("broadcast success! tx sig %s; waiting for confirmation...", sig)


### PR DESCRIPTION
# Description

Skip pre-flight check to force send the deposit so we can see details of the failure for debugging purpose.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
