### PR TITLE
chore: Add ADMIN_UPGRADE_TESTS label to test start-upgrade-test-admin

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -328,7 +328,6 @@ jobs:
               body: JSON.stringify({text: msg}),
             });
 
-
       - run: |
           result="${{ needs.build-zetanode.result }}"
           if [[ $result == "failed" ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
         default: false
 
-concurrency: 
+concurrency:
   group: e2e-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
@@ -115,6 +115,7 @@ jobs:
       UPGRADE_LIGHT_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_LIGHT_TESTS }}
       UPGRADE_IMPORT_MAINNET_TESTS: ${{ steps.matrix-conditionals.outputs.UPGRADE_IMPORT_MAINNET_TESTS }}
       ADMIN_TESTS: ${{ steps.matrix-conditionals.outputs.ADMIN_TESTS }}
+      ADMIN_UPGRADE_TESTS: ${{ steps.matrix-conditionals.outputs.ADMIN_UPGRADE_TESTS }}
       PERFORMANCE_TESTS: ${{ steps.matrix-conditionals.outputs.PERFORMANCE_TESTS }}
       STATEFUL_DATA_TESTS: ${{ steps.matrix-conditionals.outputs.STATEFUL_DATA_TESTS }}
       TSS_MIGRATION_TESTS: ${{ steps.matrix-conditionals.outputs.TSS_MIGRATION_TESTS }}
@@ -147,6 +148,7 @@ jobs:
               core.setOutput('UPGRADE_LIGHT_TESTS', labels.includes('UPGRADE_LIGHT_TESTS'));
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', labels.includes('UPGRADE_IMPORT_MAINNET_TESTS'));
               core.setOutput('ADMIN_TESTS', labels.includes('ADMIN_TESTS'));
+              core.setOutput('ADMIN_UPGRADE_TESTS', labels.includes('ADMIN_UPGRADE_TESTS'));
               core.setOutput('PERFORMANCE_TESTS', labels.includes('PERFORMANCE_TESTS'));
               core.setOutput('STATEFUL_DATA_TESTS', labels.includes('STATEFUL_DATA_TESTS'));
               core.setOutput('TSS_MIGRATION_TESTS', labels.includes('TSS_MIGRATION_TESTS'));
@@ -177,6 +179,7 @@ jobs:
               core.setOutput('UPGRADE_LIGHT_TESTS', true);
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', true);
               core.setOutput('ADMIN_TESTS', true);
+              core.setOutput('ADMIN_UPGRADE_TESTS', true);
               core.setOutput('PERFORMANCE_TESTS', true);
               core.setOutput('STATEFUL_DATA_TESTS', true);
               core.setOutput('SOLANA_TESTS', true);
@@ -188,6 +191,7 @@ jobs:
               core.setOutput('UPGRADE_LIGHT_TESTS', true);
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', true);
               core.setOutput('ADMIN_TESTS', true);
+              core.setOutput('ADMIN_UPGRADE_TESTS', true);
               core.setOutput('PERFORMANCE_TESTS', true);
               core.setOutput('STATEFUL_DATA_TESTS', true);
               core.setOutput('TSS_MIGRATION_TESTS', true);
@@ -201,6 +205,7 @@ jobs:
               core.setOutput('UPGRADE_LIGHT_TESTS', makeTargets.includes('upgrade-test-light'));
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', makeTargets.includes('upgrade-import-mainnet-test'));
               core.setOutput('ADMIN_TESTS', makeTargets.includes('admin-test'));
+              core.setOutput('ADMIN_UPGRADE_TESTS', makeTargets.includes('admin-upgrade-test'));
               core.setOutput('PERFORMANCE_TESTS', makeTargets.includes('performance-test'));
               core.setOutput('STATEFUL_DATA_TESTS', makeTargets.includes('import-mainnet-test'));
               core.setOutput('TSS_MIGRATION_TESTS', makeTargets.includes('tss-migration-test'));
@@ -238,6 +243,10 @@ jobs:
           - make-target: "start-e2e-admin-test"
             runs-on: ubuntu-20.04
             run: ${{ needs.matrix-conditionals.outputs.ADMIN_TESTS == 'true' }}
+          - make-target: "start-upgrade-test-admin"
+            runs-on: ubuntu-20.04
+            run: ${{ needs.matrix-conditionals.outputs.ADMIN_UPGRADE_TESTS == 'true' }}
+            timeout-minutes: 40
           - make-target: "start-e2e-performance-test"
             runs-on: buildjet-4vcpu-ubuntu-2204
             run: ${{ needs.matrix-conditionals.outputs.PERFORMANCE_TESTS == 'true' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -328,6 +328,7 @@ jobs:
               body: JSON.stringify({text: msg}),
             });
 
+
       - run: |
           result="${{ needs.build-zetanode.result }}"
           if [[ $result == "failed" ]]; then


### PR DESCRIPTION
# Description

Closes: [2708](https://github.com/zeta-chain/node/issues/2708)

This PR introduces the ADMIN_UPGRADE_TESTS label to trigger the start-upgrade-test-admin test in the GitHub Actions workflow. 

This change ensures that tests specific to administrative upgrade scenarios can be executed as part of the CI/CD pipeline. 

The label is added in the matrix-conditionals job and incorporated into the e2e test strategy matrix.

# Key Changes:

- Added ADMIN_UPGRADE_TESTS handling to the matrix-conditionals job.
- Included start-upgrade-test-admin in the e2e job matrix.
- Enabled ADMIN_UPGRADE_TESTS for push, schedule, and workflow_dispatch events.
- Integrated the label handling into Slack notifications dynamically.

# Dependencies

None. This change is self-contained and builds upon the existing e2e workflow.

# How Has This Been Tested?

Added the label and start-upgrade-test-admin are running.

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflow with new conditional testing capabilities
	- Added support for admin upgrade tests in continuous integration pipeline

- **Chores**
	- Updated test configuration to improve testing flexibility and coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->