### PR TITLE
chore: improve HeaderByNumber error message

### DIFF
--- a/zetaclient/chains/evm/rpc/rpc.go
+++ b/zetaclient/chains/evm/rpc/rpc.go
@@ -76,7 +76,7 @@ func CheckRPCStatus(ctx context.Context, client interfaces.EVMRPCClient) (time.T
 	// query latest block header
 	header, err := client.HeaderByNumber(ctx, new(big.Int).SetUint64(bn))
 	if err != nil {
-		return time.Time{}, errors.Wrap(err, "RPC failed on HeaderByNumber, RPC down?")
+		return time.Time{}, errors.Wrapf(err, "RPC failed on HeaderByNumber(%d), RPC down?", bn)
 	}
 
 	// convert block time to UTC


### PR DESCRIPTION
Include block number in error message for easier debugging. Current log makes it hard to tell why this is failing:

```
{"level":"error","chain":80002,"chain_network":"polygon","error":"RPC failed on HeaderByNumber, RPC down?: not found","time":"2025-01-15T23:13:40Z","message":"CheckRPCStatus failed"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting for RPC header retrieval by including the specific block number in error messages
  - Enhanced debugging information for RPC status checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->