### PR TITLE
fix: remove minimum rent exempt check for SPL token withdrawals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 * [3360](https://github.com/zeta-chain/node/pull/3360) - update protocol contract imports using consolidated path
 * [3349](https://github.com/zeta-chain/node/pull/3349) - implement new bitcoin rpc in zetaclient with improved performance and observability
 
+### Fixes
+
+* [3374](https://github.com/zeta-chain/node/pull/3374) - remove minimum rent exempt check for SPL token withdrawals
+
 ## v25.0.0
 
 ## Unreleased

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -453,7 +453,7 @@ var AllE2ETests = []runner.E2ETest{
 		TestSPLWithdrawName,
 		"withdraw SPL from ZEVM",
 		[]runner.ArgDefinition{
-			{Description: "amount in spl tokens", DefaultValue: "1000000"},
+			{Description: "amount in spl tokens", DefaultValue: "100000"},
 		},
 		TestSPLWithdraw,
 	),

--- a/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
+++ b/x/crosschain/keeper/cctx_orchestrator_validate_outbound.go
@@ -198,6 +198,7 @@ func (k Keeper) processFailedOutboundOnExternalChain(
 		err = k.validateZRC20Withdrawal(
 			ctx,
 			cctx.GetCurrentOutboundParam().ReceiverChainId,
+			cctx.InboundParams.CoinType,
 			cctx.GetCurrentOutboundParam().Amount.BigInt(),
 			[]byte(cctx.GetCurrentOutboundParam().Receiver),
 		)

--- a/x/crosschain/keeper/evm_hooks.go
+++ b/x/crosschain/keeper/evm_hooks.go
@@ -342,6 +342,8 @@ func (k Keeper) validateZRC20Withdrawal(
 			return errorsmod.Wrapf(types.ErrInvalidAddress, "unsupported address %s", string(to))
 		}
 	} else if chains.IsSolanaChain(chainID, additionalChains) {
+		// The rent exempt check is not needed for ZRC20 (SPL) tokens because withdrawing SPL token
+		// already needs a non-trivial amount of SOL for potential ATA creation so we can skip the check.
 		if coinType == coin.CoinType_Gas && value.Cmp(big.NewInt(constant.SolanaWalletRentExempt)) < 0 {
 			return errorsmod.Wrapf(
 				types.ErrInvalidWithdrawalAmount,

--- a/x/crosschain/keeper/evm_hooks.go
+++ b/x/crosschain/keeper/evm_hooks.go
@@ -133,7 +133,7 @@ func (k Keeper) ProcessZEVMInboundV1(
 
 		// If Validation fails, we will not process the event and return and error. This condition means that the event was correct, and emitted from a registered ZRC20 contract
 		// But the information entered by the user is incorrect. In this case we can return an error and roll back the transaction
-		if err := k.ValidateZRC20WithdrawEvent(ctx, eventZRC20Withdrawal, coin.ForeignChainId); err != nil {
+		if err := k.ValidateZRC20WithdrawEvent(ctx, eventZRC20Withdrawal, coin.ForeignChainId, coin.CoinType); err != nil {
 			return err
 		}
 		// If the event is valid, we will process it and create a new CCTX
@@ -305,14 +305,25 @@ func (k Keeper) ProcessZetaSentEvent(
 
 // ValidateZRC20WithdrawEvent checks if the ZRC20Withdrawal event is valid
 // It verifies event information for BTC chains and returns an error if the event is invalid
-func (k Keeper) ValidateZRC20WithdrawEvent(ctx sdk.Context, event *zrc20.ZRC20Withdrawal, chainID int64) error {
+func (k Keeper) ValidateZRC20WithdrawEvent(
+	ctx sdk.Context,
+	event *zrc20.ZRC20Withdrawal,
+	chainID int64,
+	coinType coin.CoinType,
+) error {
 	// The event was parsed; that means the user has deposited tokens to the contract.
-	return k.validateZRC20Withdrawal(ctx, chainID, event.Value, event.To)
+	return k.validateZRC20Withdrawal(ctx, chainID, coinType, event.Value, event.To)
 }
 
 // validateZRC20Withdrawal validates the data of a ZRC20 Withdrawal event (version 1 or 2)
 // it checks if the withdrawal amount is valid and the destination address is supported depending on the chain
-func (k Keeper) validateZRC20Withdrawal(ctx sdk.Context, chainID int64, value *big.Int, to []byte) error {
+func (k Keeper) validateZRC20Withdrawal(
+	ctx sdk.Context,
+	chainID int64,
+	coinType coin.CoinType,
+	value *big.Int,
+	to []byte,
+) error {
 	additionalChains := k.GetAuthorityKeeper().GetAdditionalChainList(ctx)
 	if chains.IsBitcoinChain(chainID, additionalChains) {
 		if value.Cmp(big.NewInt(constant.BTCWithdrawalDustAmount)) < 0 {
@@ -331,7 +342,7 @@ func (k Keeper) validateZRC20Withdrawal(ctx sdk.Context, chainID int64, value *b
 			return errorsmod.Wrapf(types.ErrInvalidAddress, "unsupported address %s", string(to))
 		}
 	} else if chains.IsSolanaChain(chainID, additionalChains) {
-		if value.Cmp(big.NewInt(constant.SolanaWalletRentExempt)) < 0 {
+		if coinType == coin.CoinType_Gas && value.Cmp(big.NewInt(constant.SolanaWalletRentExempt)) < 0 {
 			return errorsmod.Wrapf(
 				types.ErrInvalidWithdrawalAmount,
 				"withdraw amount %s is less than rent exempt %d",

--- a/x/crosschain/keeper/v2_zevm_inbound.go
+++ b/x/crosschain/keeper/v2_zevm_inbound.go
@@ -75,7 +75,7 @@ func (k Keeper) ProcessZEVMInboundV2(
 		}
 
 		// validate data of the withdrawal event
-		if err := k.validateZRC20Withdrawal(ctx, foreignCoin.ForeignChainId, value, receiver); err != nil {
+		if err := k.validateZRC20Withdrawal(ctx, foreignCoin.ForeignChainId, foreignCoin.CoinType, value, receiver); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
# Description

The minimum rent exempt `1_000_000 lamports` was intended to avoid SOL token withdraw failure on gateway program when a Solana receiver account doesn't have enough lamports.

This rent exempt restriction should not be applied on SPL token because withdrawing SPL token already needs a non trivial amount of SOL for potential ATA creation so we can skip the minimal withdraw amount checking. Its already anti spam.

Changes:

1. Skip rent exempt check in method `validateZRC20Withdrawal` for non-Gas token.
2. Reduce default SPL withdraw amount `1_000_000 -> 100_000` in SPL withdraw E2E test.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Fixes**
	- Removed minimum rent exempt check for SPL token withdrawals
	- Updated validation logic for ZRC20 withdrawal events to support different coin types

- **Testing**
	- Enhanced test coverage for withdrawal events across different coin types
	- Updated test cases for BTC and SOL withdrawals

- **Improvements**
	- Added coin type parameter to withdrawal validation methods
	- Refined validation process for cross-chain transactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->