### PR TITLE
chore: upgrade attest-build-provenance

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Artifact Attestations
         id: attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
             dist/zetacored_**/*


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance/releases

> The attest-build-provenance action now supports attesting multiple subjects simultaneously.

This should make the offline/private verification process actually work:

```
gh attestation verify --owner zeta-chain -b attestation.json zetacored-linux-amd64
Loaded digest sha256:d47473b9c63613a2f7aa7aaa991cfac8d73d5ae335a4110dcc1c21db0a140df1 for file://zetacored-linux-amd64
Loaded 1 attestation from attestation.json

The following policy criteria will be enforced:
- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
- Source Repository Owner URI must match:... https://github.com/zeta-chain
- Predicate type must match:................ https://slsa.dev/provenance/v1
- Subject Alternative Name must match regex: (?i)^https://github.com/zeta-chain/

✓ Verification succeeded!

sha256:d47473b9c63613a2f7aa7aaa991cfac8d73d5ae335a4110dcc1c21db0a140df1 was attested by:
REPO                     PREDICATE_TYPE                  WORKFLOW
zeta-chain/node-private  https://slsa.dev/provenance/v1  .github/workflows/publish-release.yml@refs/heads/release/v0
```

I will need to upgrade noderelease2proposal to tolerate the individual json rather than the jsonl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use the latest version of the artifact attestation action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->