### PR TITLE
fix: improve solana tx broadcasting in e2e tests

### DIFF
--- a/e2e/e2etests/test_solana_whitelist_spl.go
+++ b/e2e/e2etests/test_solana_whitelist_spl.go
@@ -2,6 +2,7 @@ package e2etests
 
 import (
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/e2e/runner"
@@ -26,7 +27,11 @@ func TestSolanaWhitelistSPL(r *runner.E2ERunner, _ []string) {
 	whitelistEntryPDA, _, err := solana.FindProgramAddress(seed, r.GatewayProgram)
 	require.NoError(r, err)
 
-	whitelistEntryInfo, err := r.SolanaClient.GetAccountInfo(r.Ctx, whitelistEntryPDA)
+	whitelistEntryInfo, err := r.SolanaClient.GetAccountInfoWithOpts(
+		r.Ctx,
+		whitelistEntryPDA,
+		&rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentConfirmed},
+	)
 	require.Error(r, err)
 	require.Nil(r, whitelistEntryInfo)
 
@@ -62,7 +67,11 @@ func TestSolanaWhitelistSPL(r *runner.E2ERunner, _ []string) {
 	r.WaitForMinedCCTXFromIndex(whitelistCCTXIndex)
 
 	// check that whitelist entry exists for this spl
-	whitelistEntryInfo, err = r.SolanaClient.GetAccountInfo(r.Ctx, whitelistEntryPDA)
+	whitelistEntryInfo, err = r.SolanaClient.GetAccountInfoWithOpts(
+		r.Ctx,
+		whitelistEntryPDA,
+		&rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentConfirmed},
+	)
 	require.NoError(r, err)
 	require.NotNil(r, whitelistEntryInfo)
 }

--- a/e2e/e2etests/test_spl_deposit.go
+++ b/e2e/e2etests/test_spl_deposit.go
@@ -23,11 +23,11 @@ func TestSPLDeposit(r *runner.E2ERunner, args []string) {
 	pda := r.ComputePdaAddress()
 	pdaAta := r.ResolveSolanaATA(privKey, pda, r.SPLAddr)
 
-	pdaBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentFinalized)
+	pdaBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
 	senderAta := r.ResolveSolanaATA(privKey, privKey.PublicKey(), r.SPLAddr)
-	senderBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentFinalized)
+	senderBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
 	// get zrc20 balance for recipient
@@ -45,10 +45,10 @@ func TestSPLDeposit(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, r.EVMAddress().Hex())
 
 	// verify balances are updated
-	pdaBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentFinalized)
+	pdaBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
-	senderBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentFinalized)
+	senderBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
 	zrc20BalanceAfter, err := r.SPLZRC20.BalanceOf(&bind.CallOpts{}, r.EVMAddress())

--- a/e2e/e2etests/test_spl_deposit_and_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call.go
@@ -29,11 +29,11 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	pda := r.ComputePdaAddress()
 	pdaAta := r.ResolveSolanaATA(privKey, pda, r.SPLAddr)
 
-	pdaBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentFinalized)
+	pdaBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
 	senderAta := r.ResolveSolanaATA(privKey, privKey.PublicKey(), r.SPLAddr)
-	senderBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentFinalized)
+	senderBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
 	// get zrc20 balance for recipient
@@ -55,10 +55,10 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.MustHaveCalledExampleContractWithMsg(r, contract, big.NewInt(int64(amount)), data)
 
 	// verify balances are updated
-	pdaBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentFinalized)
+	pdaBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
-	senderBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentFinalized)
+	senderBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
 	zrc20BalanceAfter, err := r.SPLZRC20.BalanceOf(&bind.CallOpts{}, contractAddr)

--- a/e2e/e2etests/test_spl_withdraw.go
+++ b/e2e/e2etests/test_spl_withdraw.go
@@ -40,7 +40,7 @@ func TestSPLWithdraw(r *runner.E2ERunner, args []string) {
 
 	// get receiver ata balance before withdraw
 	receiverAta := r.ResolveSolanaATA(privkey, privkey.PublicKey(), r.SPLAddr)
-	receiverBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, receiverAta, rpc.CommitmentFinalized)
+	receiverBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, receiverAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 	r.Logger.Info("receiver balance of SPL before withdraw: %s", receiverBalanceBefore.Value.Amount)
 
@@ -57,7 +57,7 @@ func TestSPLWithdraw(r *runner.E2ERunner, args []string) {
 	r.Logger.Info("runner balance of SPL after withdraw: %d", zrc20BalanceAfter)
 
 	// verify balances are updated
-	receiverBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, receiverAta, rpc.CommitmentFinalized)
+	receiverBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, receiverAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 	r.Logger.Info("receiver balance of SPL after withdraw: %s", receiverBalanceAfter.Value.Amount)
 

--- a/e2e/e2etests/test_spl_withdraw_and_create_receiver_ata.go
+++ b/e2e/e2etests/test_spl_withdraw_and_create_receiver_ata.go
@@ -45,7 +45,11 @@ func TestSPLWithdrawAndCreateReceiverAta(r *runner.E2ERunner, args []string) {
 	receiverAta, _, err := solana.FindAssociatedTokenAddress(receiverPrivKey.PublicKey(), r.SPLAddr)
 	require.NoError(r, err)
 
-	receiverAtaAcc, err := r.SolanaClient.GetAccountInfo(r.Ctx, receiverAta)
+	receiverAtaAcc, err := r.SolanaClient.GetAccountInfoWithOpts(
+		r.Ctx,
+		receiverAta,
+		&rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentConfirmed},
+	)
 	require.Error(r, err)
 	require.Nil(r, receiverAtaAcc)
 
@@ -62,12 +66,16 @@ func TestSPLWithdrawAndCreateReceiverAta(r *runner.E2ERunner, args []string) {
 	r.Logger.Info("runner balance of SPL after withdraw: %d", zrc20BalanceAfter)
 
 	// verify receiver ata was created
-	receiverAtaAcc, err = r.SolanaClient.GetAccountInfo(r.Ctx, receiverAta)
+	receiverAtaAcc, err = r.SolanaClient.GetAccountInfoWithOpts(
+		r.Ctx,
+		receiverAta,
+		&rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentConfirmed},
+	)
 	require.NoError(r, err)
 	require.NotNil(r, receiverAtaAcc)
 
 	// verify balances are updated
-	receiverBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, receiverAta, rpc.CommitmentFinalized)
+	receiverBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, receiverAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 	r.Logger.Info("receiver balance of SPL after withdraw: %s", receiverBalanceAfter.Value.Amount)
 

--- a/e2e/runner/balances.go
+++ b/e2e/runner/balances.go
@@ -104,7 +104,7 @@ func (r *E2ERunner) GetAccountBalances(skipBTC bool) (AccountBalances, error) {
 		solSOLBalance, err := r.SolanaClient.GetBalance(
 			r.Ctx,
 			solanaAddr,
-			rpc.CommitmentFinalized,
+			rpc.CommitmentConfirmed,
 		)
 		if err != nil {
 			return AccountBalances{}, fmt.Errorf("get sol balance: %w", err)
@@ -119,7 +119,7 @@ func (r *E2ERunner) GetAccountBalances(skipBTC bool) (AccountBalances, error) {
 				solanaAddr,
 				r.SPLAddr,
 			)
-			splBalance, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, ata, rpc.CommitmentFinalized)
+			splBalance, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, ata, rpc.CommitmentConfirmed)
 			if err != nil {
 				return AccountBalances{}, fmt.Errorf("get spl balance: %w", err)
 			}

--- a/e2e/runner/setup_solana.go
+++ b/e2e/runner/setup_solana.go
@@ -36,7 +36,7 @@ func (r *E2ERunner) SetupSolana(gatewayID, deployerPrivateKey string) {
 	// get deployer account balance
 	privkey, err := solana.PrivateKeyFromBase58(deployerPrivateKey)
 	require.NoError(r, err)
-	bal, err := r.SolanaClient.GetBalance(r.Ctx, privkey.PublicKey(), rpc.CommitmentFinalized)
+	bal, err := r.SolanaClient.GetBalance(r.Ctx, privkey.PublicKey(), rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 	r.Logger.Info("deployer address: %s, balance: %f SOL", privkey.PublicKey().String(), float64(bal.Value)/1e9)
 
@@ -68,7 +68,9 @@ func (r *E2ERunner) SetupSolana(gatewayID, deployerPrivateKey string) {
 	r.Logger.Info("initialize logs: %v", out.Meta.LogMessages)
 
 	// retrieve the PDA account info
-	pdaInfo, err := r.SolanaClient.GetAccountInfo(r.Ctx, pdaComputed)
+	pdaInfo, err := r.SolanaClient.GetAccountInfoWithOpts(r.Ctx, pdaComputed, &rpc.GetAccountInfoOpts{
+		Commitment: rpc.CommitmentConfirmed,
+	})
 	require.NoError(r, err)
 
 	// deserialize the PDA info

--- a/e2e/runner/verify.go
+++ b/e2e/runner/verify.go
@@ -42,7 +42,9 @@ func (r *E2ERunner) VerifySolanaWithdrawalAmountFromCCTX(cctx *crosschaintypes.C
 	require.NoError(r, err)
 
 	// query transaction by signature
-	txResult, err := r.SolanaClient.GetTransaction(r.Ctx, sig, &rpc.GetTransactionOpts{})
+	txResult, err := r.SolanaClient.GetTransaction(r.Ctx, sig, &rpc.GetTransactionOpts{
+		Commitment: rpc.CommitmentConfirmed,
+	})
 	require.NoError(r, err)
 
 	// unmarshal transaction


### PR DESCRIPTION
# Description

Improve broadcasting of solana txs in e2e test. This was tested on mainnet and contains couple of fixes, I tried 5 consecutive spl deposits and all worked without tx dropping.

For context, tx was dropped on mainnet and the biggest issue is that blockhash expired sometimes between tx signing and broadcasting, therefore changed to use confirmed commitment level, which is fine, especially for tests, since this should reduce that interval.

Other fixes:
- add cp limit and price so tx is better packed
- skip preflight for tests, as simulation is not needed for tests, and it speeds up broadcast
- add preflight commitment with max retry - this is the tip i found, no matter that preflight is skipped, it is still affecting automatic retry
- manual re-broadcast (this might be overkill as showed with latest testing, but still keeping it just in case, also would be ok to remove it for now imo, but leaving it in PR just in case)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes:

- **Improvements**
  - Enhanced Solana blockchain interaction by updating transaction commitment levels
  - Improved transaction handling and compute budget management
  - Added more robust error logging for transaction broadcasts

- **Technical Updates**
  - Updated account information retrieval methods
  - Modified balance checking mechanisms across multiple test scenarios
  - Introduced more granular transaction confirmation strategies

- **Performance**
  - Added compute unit limits and price settings for transactions
  - Optimized transaction broadcasting logic

These changes aim to improve the reliability and precision of blockchain interactions in our testing and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->