### PR TITLE
fix(ci): adjust sim conditional logic

### DIFF
--- a/.github/workflows/reusable-sim.yml
+++ b/.github/workflows/reusable-sim.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
 

--- a/.github/workflows/reusable-sim.yml
+++ b/.github/workflows/reusable-sim.yml
@@ -1,0 +1,37 @@
+name: Reusable Sim Workflow
+on:
+  workflow_call:
+    inputs:
+      make-target:
+        description: 'Makefile target to execute'
+        required: true
+        type: string
+      run:
+        description: 'Whether to run the job or not'
+        required: true
+        type: boolean
+      runs-on:
+        description: 'The runner to use for the job'
+        type: string
+        default: 'ubuntu-22.04'
+jobs:
+  sim:
+    if: ${{ inputs.run }}
+    runs-on: ${{ inputs.runs-on }}
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Install dependencies
+        run: make runsim
+
+      - name: Run ${{ inputs.make-target }}
+        run: |
+          make ${{ inputs.make-target }}

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -23,20 +23,19 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
-      modified_files: ${{ steps.changes.outputs.modified_files }}
+      x_changed: ${{ steps.x-changes.outputs.any_changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get changed files in x directory
-        id: changes
-        run: |
-          echo "::set-output name=modified_files::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '^x/' | xargs)"
+        id: x-changes
+        uses: tj-actions/changed-files@v45
+        with:
+          files: x/**
 
   matrix-conditionals:
     needs: changed-files
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'SIM_TESTS') || needs.changed-files.outputs.modified_files
     runs-on: ubuntu-22.04
     outputs:
       SIM_TEST_NOND: ${{ steps.matrix-conditionals.outputs.SIM_TEST_NOND }}
@@ -48,11 +47,29 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const makeTargetsInput = context.payload.inputs ? context.payload.inputs['make-targets'] : null;
             const defaultTargets = ['test-sim-nondeterminism', 'test-sim-fullappsimulation', 'test-sim-import-export', 'test-sim-after-import'];
+            let makeTargets = [];
+            if (context.eventName === 'pull_request') {
+              const changedFiles = ${{ needs.changed-files.outputs.x_changed }};
+              const pull_number = context.payload.pull_request.number;
+              const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pull_number,
+                });
+              const labels = pr.labels.map(label => label.name);
+              console.log(`labels for ${pull_number}:`, labels);
+              console.log(`changedFiles for ${pull_number}:`, changedFiles);
 
-            const makeTargets = makeTargetsInput ? makeTargetsInput.split(',') : defaultTargets;
+              if (changedFiles || labels.includes('SIM_TESTS')) {
+                makeTargets = defaultTargets;
+              }
+            } else {
+              const makeTargetsInput = context.payload.inputs ? context.payload.inputs['make-targets'] : null;
+              makeTargets = makeTargetsInput ? makeTargetsInput.split(',') : defaultTargets;
+            }
 
+            console.log('makeTargets: ', makeTargets);
             core.setOutput('SIM_TEST_NOND', makeTargets.includes('test-sim-nondeterminism'));
             core.setOutput('SIM_TEST_FULL', makeTargets.includes('test-sim-fullappsimulation'));
             core.setOutput('SIM_TEST_IMPORT_EXPORT', makeTargets.includes('test-sim-import-export'));
@@ -61,8 +78,6 @@ jobs:
   simulation-tests:
     needs:
       - matrix-conditionals
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'SIM_TESTS') || needs.changed-files.outputs.modified_files
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -77,6 +92,7 @@ jobs:
           - make-target: "test-sim-after-import"
             condition: ${{ needs.matrix-conditionals.outputs.SIM_TEST_AFTER_IMPORT == 'true' }}
     name: ${{ matrix.make-target }}
+    if: ${{ matrix.condition }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -90,15 +106,12 @@ jobs:
         run: make runsim
 
       - name: Run ${{ matrix.make-target }}
-        if: ${{ matrix.condition }}
         run: |
           make ${{ matrix.make-target }}
 
   sim-ok:
     needs:
       - simulation-tests
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'SIM_TESTS') || needs.changed-files.outputs.modified_files
     runs-on: ubuntu-22.04
     steps:
       - name: Aggregate Results

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - release/*
   pull_request:
     types: [opened, synchronize, labeled]
   schedule:

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -78,41 +78,28 @@ jobs:
   simulation-tests:
     needs:
       - matrix-conditionals
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
           - make-target: "test-sim-nondeterminism"
-            condition: ${{ needs.matrix-conditionals.outputs.SIM_TEST_NOND == 'true' }}
+            run: ${{ needs.matrix-conditionals.outputs.SIM_TEST_NOND == 'true' }}
           - make-target: "test-sim-fullappsimulation"
-            condition: ${{ needs.matrix-conditionals.outputs.SIM_TEST_FULL == 'true' }}
+            run: ${{ needs.matrix-conditionals.outputs.SIM_TEST_FULL == 'true' }}
           - make-target: "test-sim-import-export"
-            condition: ${{ needs.matrix-conditionals.outputs.SIM_TEST_IMPORT_EXPORT == 'true' }}
+            run: ${{ needs.matrix-conditionals.outputs.SIM_TEST_IMPORT_EXPORT == 'true' }}
           - make-target: "test-sim-after-import"
-            condition: ${{ needs.matrix-conditionals.outputs.SIM_TEST_AFTER_IMPORT == 'true' }}
+            run: ${{ needs.matrix-conditionals.outputs.SIM_TEST_AFTER_IMPORT == 'true' }}
     name: ${{ matrix.make-target }}
-    if: ${{ matrix.condition }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-
-      - name: Install dependencies
-        run: make runsim
-
-      - name: Run ${{ matrix.make-target }}
-        run: |
-          make ${{ matrix.make-target }}
-
+    uses: ./.github/workflows/reusable-sim.yml
+    with:
+      make-target: ${{ matrix.make-target }}
+      run: ${{ matrix.run }}
   sim-ok:
+    runs-on: ubuntu-22.04
     needs:
       - simulation-tests
-    runs-on: ubuntu-22.04
+    if: ${{ !cancelled() }}
     steps:
       - name: Aggregate Results
         run: |


### PR DESCRIPTION
Sim tests weren't automatically running on https://github.com/zeta-chain/node/pull/3357 for changed files in `x/`.

Updates:
- Just use `tj-actions/changed-files` which should better handle complicated branch history vs `git diff`
- Align workflow logic to match e2e.yml logic
  - get PR labels via API rather than context to avoid race conditions (if you apply label after you open PR it will miss with context)
  - always run sim tests on merge queue. This should allow setting sim-ok as a required status check.
  - use reusable workflow for matrix logic so jobs show as skipped on pull request status
  - run on push to `release/*` branch

Run with no change and no label: https://github.com/zeta-chain/node/actions/runs/12914920558
Run with change in `x/`: https://github.com/zeta-chain/node/actions/runs/12914963998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new reusable GitHub Actions workflow for running simulation tests
	- Enhanced workflow to dynamically handle different Makefile targets
	- Improved test execution logic with more flexible triggering conditions

- **Workflow Updates**
	- Updated GitHub Actions workflow to support `release/*` branch pattern
	- Refined file change detection and test targeting mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->