### PR TITLE
test: add liquidty cap field to sim tests for MsgWhitelistERC20

### DIFF
--- a/x/crosschain/simulation/operation_whitelist_erc20.go
+++ b/x/crosschain/simulation/operation_whitelist_erc20.go
@@ -3,6 +3,7 @@ package simulation
 import (
 	"math/rand"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
@@ -116,6 +117,7 @@ func SimulateMsgWhitelistERC20(k keeper.Keeper) simtypes.Operation {
 			Decimals:     18,
 			Name:         sample.StringRandom(r, nameLength),
 			Symbol:       sample.StringRandom(r, 3),
+			LiquidityCap: sdkmath.NewUint(sample.Uint64InRangeFromRand(r, 1, 1000000000000000000)),
 		}
 
 		err = msg.ValidateBasic()


### PR DESCRIPTION

Add liquidity cap field to sim tests for MsgWhitelistERC20




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a liquidity cap parameter for ERC20 whitelisting operations
	- Introduced support for configurable liquidity limits during cross-chain token whitelisting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->