### PR TITLE
feat(e2e): add optional minimum version to test

### DIFF
--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -303,6 +303,7 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in wei", DefaultValue: "10000000000000000"},
 		},
 		TestETHWithdrawAndCallRevertWithWithdraw,
+		runner.WithMinimumVersion("v26.0.0"),
 	),
 	runner.NewE2ETest(
 		TestDepositAndCallOutOfGasName,

--- a/e2e/runner/e2etest.go
+++ b/e2e/runner/e2etest.go
@@ -6,6 +6,16 @@ import "fmt"
 // It takes a E2ERunner as an argument
 type E2ETestFunc func(*E2ERunner, []string)
 
+type E2ETestOpt func(*E2ETest)
+
+// WithMinimumVersion sets a minimum zetacored version that is required to run the test.
+// The test will be skipped if the minimum version is not satisfied.
+func WithMinimumVersion(version string) E2ETestOpt {
+	return func(t *E2ETest) {
+		t.MinimumVersion = version
+	}
+}
+
 // E2ETest represents a E2E test with a name, args, description and test func
 type E2ETest struct {
 	Name           string
@@ -13,17 +23,27 @@ type E2ETest struct {
 	Args           []string
 	ArgsDefinition []ArgDefinition
 	E2ETest        E2ETestFunc
+	MinimumVersion string
 }
 
 // NewE2ETest creates a new instance of E2ETest with specified parameters.
-func NewE2ETest(name, description string, argsDefinition []ArgDefinition, e2eTestFunc E2ETestFunc) E2ETest {
-	return E2ETest{
+func NewE2ETest(
+	name, description string,
+	argsDefinition []ArgDefinition,
+	e2eTestFunc E2ETestFunc,
+	opts ...E2ETestOpt,
+) E2ETest {
+	test := E2ETest{
 		Name:           name,
 		Description:    description,
 		ArgsDefinition: argsDefinition,
 		E2ETest:        e2eTestFunc,
 		Args:           []string{},
 	}
+	for _, opt := range opts {
+		opt(&test)
+	}
+	return test
 }
 
 // ArgDefinition defines a structure for holding an argument's description along with it's default value.
@@ -83,12 +103,13 @@ func (r *E2ERunner) GetE2ETestsToRunByConfig(
 		if !found {
 			return nil, fmt.Errorf("e2e test %s not found", testSpec.Name)
 		}
-		e2eTestToRun := NewE2ETest(
-			e2eTest.Name,
-			e2eTest.Description,
-			e2eTest.ArgsDefinition,
-			e2eTest.E2ETest,
-		)
+		e2eTestToRun := E2ETest{
+			Name:           e2eTest.Name,
+			Description:    e2eTest.Description,
+			ArgsDefinition: e2eTest.ArgsDefinition,
+			E2ETest:        e2eTest.E2ETest,
+			MinimumVersion: e2eTest.MinimumVersion,
+		}
 		// update e2e test args
 		e2eTestToRun.Args = testSpec.Args
 		tests = append(tests, e2eTestToRun)

--- a/e2e/runner/run.go
+++ b/e2e/runner/run.go
@@ -3,11 +3,19 @@ package runner
 import (
 	"fmt"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
 
 // RunE2ETests runs a list of e2e tests
 func (r *E2ERunner) RunE2ETests(e2eTests []E2ETest) (err error) {
+	zetacoredVersion := r.GetZetacoredVersion()
 	for _, e2eTest := range e2eTests {
+		if semver.Major(zetacoredVersion) != "v0" && semver.Compare(zetacoredVersion, e2eTest.MinimumVersion) < 0 {
+			// note: spacing is padded to width of completed message
+			r.Logger.Print("⚠️ skipping  - %s (minimum version %s)", e2eTest.Name, e2eTest.MinimumVersion)
+			continue
+		}
 		if err := r.Ctx.Err(); err != nil {
 			return fmt.Errorf("context cancelled: %w", err)
 		}


### PR DESCRIPTION
Add optional minimum version parameter to e2e tests. If this constraint is not satisfied, the test will be skipped. This allows you to introduce new/breaking content without breaking the upgrade tests. The test will start running during upgrades after the release that exceeds the minimum version. We always run all test on development versions (`v0.0.x`).

Example:

```
v2-eth-rever | ✅ completed - eth_withdraw_and_call_revert_with_call (duration 18.611013727s)
v2-eth-rever | ⚠️ skipping  - eth_withdraw_and_call_revert_with_withdraw (minimum version v26.0.0)
v2-eth-rever | ⏳ running   - deposit_and_call_out_of_gas
```

The test will still run on the second run after the upgrade has completed.

This test is what is causing the nightly upgrade failures. Related to https://github.com/zeta-chain/node/pull/3404 and https://github.com/zeta-chain/node/issues/2708. Based on https://github.com/zeta-chain/node/pull/3406 since there are some conflicting changes.