### PR TITLE
fix(e2e): always wait for at least height 1

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -61,7 +61,7 @@ func NewLocalCmd() *cobra.Command {
 		Run:   localE2ETest,
 	}
 	cmd.Flags().Bool(flagContractsDeployed, false, "set to to true if running tests again with existing state")
-	cmd.Flags().Int64(flagWaitForHeight, 0, "block height for tests to begin, ex. --wait-for 100")
+	cmd.Flags().Int64(flagWaitForHeight, 1, "block height for tests to begin, ex. --wait-for 100")
 	cmd.Flags().String(FlagConfigFile, "", "config file to use for the tests")
 	cmd.Flags().Bool(flagVerbose, false, "set to true to enable verbose logging")
 	cmd.Flags().Bool(flagTestAdmin, false, "set to true to run admin tests")
@@ -150,9 +150,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// wait for a specific height on ZetaChain
-	if waitForHeight != 0 {
-		noError(utils.WaitForBlockHeight(ctx, waitForHeight, conf.RPCs.ZetaCoreRPC, logger))
-	}
+	noError(utils.WaitForBlockHeight(ctx, waitForHeight, conf.RPCs.ZetaCoreRPC, logger))
 
 	zetaTxServer, err := txserver.NewZetaTxServer(
 		conf.RPCs.ZetaCoreRPC,

--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -44,7 +44,7 @@ done
 # need to wait for zetacore0 to be up
 while ! curl -s -o /dev/null zetacore0:26657/status ; do
     echo "Waiting for zetacore0 rpc"
-    sleep 20
+    sleep 10
 done
 
 # read HOTKEY_BACKEND env var for hotkey keyring backend and set default to test

--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -41,10 +41,10 @@ while [ ! -f ~/.ssh/authorized_keys ]; do
     sleep 1
 done
 
-# need to wait for zetacore0 to be up
-while ! curl -s -o /dev/null zetacore0:26657/status ; do
-    echo "Waiting for zetacore0 rpc"
-    sleep 10
+# need to wait for zetacore0 block 1 to be available
+while curl -s zetacore0:26657/block?height=1 | jq -e '.error != null' > /dev/null; do
+    echo "Waiting for zetacore0 block 1"
+    sleep 5
 done
 
 # read HOTKEY_BACKEND env var for hotkey keyring backend and set default to test

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -314,18 +314,19 @@ func WaitForBlockHeight(
 
 	var currentHeight int64
 	for i := 0; currentHeight < desiredHeight; i++ {
+		time.Sleep(1 * time.Second)
 		s, err := rpc.Status(ctx)
 		if err != nil {
-			return errors.Wrap(err, "unable to get status")
+			continue
 		}
-
 		currentHeight = s.SyncInfo.LatestBlockHeight
-
-		time.Sleep(1 * time.Second)
 
 		// prevent spamming logs
 		if i%10 == 0 {
 			logger.Info("waiting for block: %d, current height: %d\n", desiredHeight, currentHeight)
+		}
+		if i > 100 {
+			return errors.Wrapf(err, "unable to get status after %d attempts", i)
 		}
 	}
 

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -325,8 +325,8 @@ func WaitForBlockHeight(
 		if i%10 == 0 {
 			logger.Info("waiting for block: %d, current height: %d\n", desiredHeight, currentHeight)
 		}
-		if i > 100 {
-			return errors.Wrapf(err, "unable to get status after %d attempts", i)
+		if i > 30 {
+			return errors.Wrapf(err, "unable to get status after %d attempts (current height: %d)", i, currentHeight)
 		}
 	}
 

--- a/zetaclient/zetacore/client_subscriptions.go
+++ b/zetaclient/zetacore/client_subscriptions.go
@@ -79,7 +79,7 @@ func (c *Client) resolveBlockSubscriber() (*fanout.FanOut[ctypes.EventDataNewBlo
 				continue
 			}
 
-			c.logger.Info().Int64("height", newBlockEvent.Block.Height).Msg("Received new block event")
+			c.logger.Debug().Int64("height", newBlockEvent.Block.Height).Msg("Received new block event")
 
 			blockChan <- newBlockEvent
 		}


### PR DESCRIPTION
Seeing increased e2e failure rates after https://github.com/zeta-chain/node/pull/3357. Let's always wait for at least height 1 on e2e.

```
Unable to continue execution: rpc error: code = Unknown desc = zetacore is not ready; please wait for first block: invalid height.
```

Also change this info log spam to debug:

```
2025-01-24T20:12:56Z INF Received new block event height=42 module=zetacoreClient
2025-01-24T20:12:58Z INF Received new block event height=43 module=zetacoreClient
2025-01-24T20:13:01Z INF Received new block event height=44 module=zetacoreClient
2025-01-24T20:13:03Z INF Received new block event height=45 module=zetacoreClient
2025-01-24T20:13:06Z INF Received new block event height=46 module=zetacoreClient
2025-01-24T20:13:08Z INF Received new block event height=47 module=zetacoreClient
2025-01-24T20:13:10Z INF Received new block event height=48 module=zetacoreClient
2025-01-24T20:13:13Z INF Received new block event height=49 module=zetacoreClient
2025-01-24T20:13:15Z INF Received new block event height=50 module=zetacoreClient
2025-01-24T20:13:17Z INF Received new block event height=51 module=zetacoreClient
2025-01-24T20:13:20Z INF Received new block event height=52 module=zetacoreClient
2025-01-24T20:13:22Z INF Received new block event height=53 module=zetacoreClient
2025-01-24T20:13:24Z INF Received new block event height=54 module=zetacoreClient
2025-01-24T20:13:27Z INF Received new block event height=55 module=zetacoreClient
2025-01-24T20:13:29Z INF Received new block event height=56 module=zetacoreClient
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- None

- **Bug Fixes**
	- None

- **Improvements**
	- Reduced waiting time for `zetacore0` RPC availability from 20 to 10 seconds
	- Enhanced `WaitForBlockHeight` function with improved error handling and retry mechanism
	- Changed block event logging from info to debug level for reduced verbosity

- **Configuration Changes**
	- Updated default `waitForHeight` flag from 0 to 1 in local command tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->