### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Meta Protocol, Inc.
+Copyright (c) 2025 Meta Protocol, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the copyright year from 2022 to 2025 in the LICENSE file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated LICENSE copyright year from 2022 to 2025 for Meta Protocol, Inc.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->