### PR TITLE
feat(zetaclient): process first solana transaction faster

### DIFF
--- a/zetaclient/chains/solana/solana.go
+++ b/zetaclient/chains/solana/solana.go
@@ -141,9 +141,10 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 		zetaHeight = uint64(zetaBlock.Block.Height)
 
 		// #nosec G115 positive
-		interval          = uint64(s.observer.ChainParams().OutboundScheduleInterval)
-		scheduleLookahead = s.observer.ChainParams().OutboundScheduleLookahead
-		scheduleLookback  = uint64(float64(scheduleLookahead) * outboundLookbackFactor)
+		interval           = uint64(s.observer.ChainParams().OutboundScheduleInterval)
+		scheduleLookahead  = s.observer.ChainParams().OutboundScheduleLookahead
+		scheduleLookback   = uint64(float64(scheduleLookahead) * outboundLookbackFactor)
+		needsProcessingCtr = 0
 	)
 
 	cctxList, _, err := s.observer.ZetacoreClient().ListPendingCCTX(ctx, chainID)
@@ -154,17 +155,15 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 	// schedule keysign for each pending cctx
 	for _, cctx := range cctxList {
 		var (
-			params     = cctx.GetCurrentOutboundParam()
-			nonce      = params.TssNonce
-			outboundID = base.OutboundIDFromCCTX(cctx)
+			params        = cctx.GetCurrentOutboundParam()
+			inboundParams = cctx.GetInboundParams()
+			nonce         = params.TssNonce
+			outboundID    = base.OutboundIDFromCCTX(cctx)
 		)
 
 		switch {
 		case params.ReceiverChainId != chainID:
 			s.outboundLogger(outboundID).Error().Msg("chain id mismatch")
-			continue
-		case s.signer.IsOutboundActive(outboundID):
-			// noop
 			continue
 		case params.TssNonce > cctxList[0].GetCurrentOutboundParam().TssNonce+scheduleLookback:
 			return fmt.Errorf(
@@ -173,6 +172,20 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 				outboundID,
 				cctxList[0].GetCurrentOutboundParam().TssNonce,
 			)
+		}
+
+		// schedule newly created cctx right away, no need to wait for next interval
+		// 1. schedule the very first cctx (there can be multiple) created in the last Zeta block.
+		// 2. schedule new cctx only when there is no other older cctx to process
+		isCCTXNewlyCreated := inboundParams.ObservedExternalHeight == zetaHeight
+		shouldProcessCCTXImmedately := isCCTXNewlyCreated && needsProcessingCtr == 0
+
+		// even if the outbound is currently active, we should increment this counter
+		// to avoid immediate processing logic
+		needsProcessingCtr++
+
+		if s.signer.IsOutboundActive(outboundID) {
+			continue
 		}
 
 		// vote outbound if it's already confirmed
@@ -186,8 +199,10 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 			continue
 		}
 
+		shouldScheduleProcess := nonce%interval == zetaHeight%interval
+
 		// schedule a TSS keysign
-		if nonce%interval == zetaHeight%interval {
+		if shouldProcessCCTXImmedately || shouldScheduleProcess {
 			go s.signer.TryProcessOutbound(
 				ctx,
 				cctx,


### PR DESCRIPTION
Apply a slight optimization to solana processing so that we initiate the first pending outbound transaction immediately rather than waiting for the `OutboundScheduleInterval`. `OutboundScheduleInterval` is 15 on testnet and mainnet so we could end up pointlessly waiting around in quite a few cases. And we really can't reduce that parameter since otherwise TSS will be spammed.

There should be little to no change in the performance test results in localnet since we set `OutboundScheduleInterval: 2`

Mark as consensus breaking since this would need to be deployed with coordination on testnet/mainnet to avoid signer desync.

Conflicts with https://github.com/zeta-chain/node/pull/3438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cross-chain transaction (CCTX) processing logic to improve responsiveness and handling of newly created transactions
	- Introduced more flexible scheduling mechanism for transaction processing

- **Improvements**
	- Updated transaction processing conditions to allow more immediate handling of new cross-chain transactions
	- Refined keysign scheduling strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->