### PR TITLE
chore(e2e): enable solana persistence and use volume labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,10 @@ start-localnet-skip-build:
 stop-localnet:
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile all down --remove-orphans
 
+# delete any volume ending in persist
+clear-localnet-persistence:
+	docker volume rm $(docker volume ls -qf "label=localnet=true")
+
 ###############################################################################
 ###                         E2E tests               						###
 ###############################################################################

--- a/contrib/localnet/docker-compose-persistent.yml
+++ b/contrib/localnet/docker-compose-persistent.yml
@@ -46,26 +46,72 @@ services:
     volumes:
       - eth-data-persist:/root/data
 
+  solana:
+    volumes:
+      - solana-ledger-persist:/data/test-ledger
+    profiles:
+      - solana
+      - all
+
   orchestrator:
     volumes:
       - orchestrator-state-persist:/root/state
 
 volumes:
   zetacore0-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetacore1-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetacore2-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetacore3-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetaclient0-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetaclient0-tss-persist:
+    labels:
+      - "localnet=true"
   zetaclient0-zetaclient-persist:
+    labels:
+      - "localnet=true"
   zetaclient1-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetaclient1-tss-persist:
+    labels:
+      - "localnet=true"
   zetaclient1-zetaclient-persist:
+    labels:
+      - "localnet=true"
   zetaclient2-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetaclient2-tss-persist:
+    labels:
+      - "localnet=true"
   zetaclient2-zetaclient-persist:
+    labels:
+      - "localnet=true"
   zetaclient3-zetacored-persist:
+    labels:
+      - "localnet=true"
   zetaclient3-tss-persist:
+    labels:
+      - "localnet=true"
   zetaclient3-zetaclient-persist:
+    labels:
+      - "localnet=true"
   eth-data-persist:
+    labels:
+      - "localnet=true"
   orchestrator-state-persist:
+    labels:
+      - "localnet=true"
+  solana-ledger-persist:
+    labels:
+      - "localnet=true"


### PR DESCRIPTION
Enable persistence for the solana localnet container so that it can be recreated and keep it's state.

Also use volume labels and add a make target to clear localnet persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new cleanup command to remove persistent storage associated with local network operations, streamlining maintenance.
  - Added a dedicated ledger service with persistent volume configuration and specific operational profiles for improved network capabilities.
  - Enhanced storage management with additional metadata labels, offering better control over persistent data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->