### PR TITLE
refactor: remove unused method `FilterSolanaInboundEvents`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@
 * [3390](https://github.com/zeta-chain/node/pull/3390) - orchestrator V2: EVM observer-signer
 * [3326](https://github.com/zeta-chain/node/pull/3326) - improve error messages for cctx status object
 * [3418](https://github.com/zeta-chain/node/pull/3418) - orchestrator V2: TON observer-signer
-
+* [3440](https://github.com/zeta-chain/node/pull/3440) - remove unused method `FilterSolanaInboundEvents`
 
 ### Fixes
 

--- a/zetaclient/chains/solana/observer/inbound.go
+++ b/zetaclient/chains/solana/observer/inbound.go
@@ -14,7 +14,6 @@ import (
 	"github.com/zeta-chain/node/pkg/coin"
 	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/chains/base"
 	solanarpc "github.com/zeta-chain/node/zetaclient/chains/solana/rpc"
 	"github.com/zeta-chain/node/zetaclient/compliance"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
@@ -269,112 +268,6 @@ func FilterInboundEvents(
 			}
 		} else {
 			logger.Warn().Msgf("FilterInboundEvents: multiple SPL deposits detected in sig %s instruction %d", tx.Signatures[0], i)
-		}
-	}
-
-	return events, nil
-}
-
-// FilterSolanaInboundEvents filters inbound events from a tx result.
-// Note: for consistency with EVM chains, this method
-//   - takes at one event (the first) per token (SOL or SPL) per transaction.
-//   - takes at most two events (one SOL + one SPL) per transaction.
-//   - ignores exceeding events.
-func FilterSolanaInboundEvents(txResult *rpc.GetTransactionResult,
-	logger *base.ObserverLogger,
-	gatewayID solana.PublicKey,
-	senderChainID int64) ([]*clienttypes.InboundEvent, error) {
-	if logger == nil {
-		return nil, errors.New("logger is nil")
-	}
-	// unmarshal transaction
-	tx, err := txResult.Transaction.GetTransaction()
-	if err != nil {
-		return nil, errors.Wrap(err, "error unmarshaling transaction")
-	}
-
-	// there should be at least one instruction and one account, otherwise skip
-	if len(tx.Message.Instructions) <= 0 {
-		return nil, nil
-	}
-
-	// create event array to collect all events in the transaction
-	seenDeposit := false
-	seenDepositSPL := false
-	events := make([]*clienttypes.InboundEvent, 0)
-
-	// loop through instruction list to filter the 1st valid event
-	for i, instruction := range tx.Message.Instructions {
-		// get the program ID
-		programPk, err := tx.Message.Program(instruction.ProgramIDIndex)
-		if err != nil {
-			logger.
-				Inbound.Err(err).
-				Msgf("no program found at index %d for sig %s", instruction.ProgramIDIndex, tx.Signatures[0])
-			continue
-		}
-
-		// skip instructions that are irrelevant to the gateway program invocation
-		if !programPk.Equals(gatewayID) {
-			continue
-		}
-
-		// try parsing the instruction as a 'deposit' if not seen yet
-		if !seenDeposit {
-			deposit, err := solanacontracts.ParseInboundAsDeposit(tx, i, txResult.Slot)
-			if err != nil {
-				return nil, errors.Wrap(err, "error ParseInboundAsDeposit")
-			} else if deposit != nil {
-				seenDeposit = true
-				events = append(events, &clienttypes.InboundEvent{
-					SenderChainID: senderChainID,
-					Sender:        deposit.Sender,
-					Receiver:      "", // receiver will be pulled out from memo later
-					TxOrigin:      deposit.Sender,
-					Amount:        deposit.Amount,
-					Memo:          deposit.Memo,
-					BlockNumber:   deposit.Slot, // instead of using block, Solana explorer uses slot for indexing
-					TxHash:        tx.Signatures[0].String(),
-					Index:         0, // hardcode to 0 for Solana, not a EVM smart contract call
-					CoinType:      coin.CoinType_Gas,
-					Asset:         deposit.Asset,
-				})
-				logger.Inbound.Info().Msg("FilterInboundEvents: deposit detected")
-
-				logger.Inbound.Info().
-					Msgf("FilterInboundEvents: deposit detected in sig %s instruction %d", tx.Signatures[0], i)
-			}
-		} else {
-			logger.Inbound.Warn().
-				Msgf("FilterInboundEvents: multiple deposits detected in sig %s instruction %d", tx.Signatures[0], i)
-		}
-
-		// try parsing the instruction as a 'deposit_spl_token' if not seen yet
-		if !seenDepositSPL {
-			deposit, err := solanacontracts.ParseInboundAsDepositSPL(tx, i, txResult.Slot)
-			if err != nil {
-				return nil, errors.Wrap(err, "error ParseInboundAsDepositSPL")
-			} else if deposit != nil {
-				seenDepositSPL = true
-				events = append(events, &clienttypes.InboundEvent{
-					SenderChainID: senderChainID,
-					Sender:        deposit.Sender,
-					Receiver:      "", // receiver will be pulled out from memo later
-					TxOrigin:      deposit.Sender,
-					Amount:        deposit.Amount,
-					Memo:          deposit.Memo,
-					BlockNumber:   deposit.Slot, // instead of using block, Solana explorer uses slot for indexing
-					TxHash:        tx.Signatures[0].String(),
-					Index:         0, // hardcode to 0 for Solana, not a EVM smart contract call
-					CoinType:      coin.CoinType_ERC20,
-					Asset:         deposit.Asset,
-				})
-				logger.Inbound.Info().
-					Msgf("FilterInboundEvents: SPL deposit detected in sig %s instruction %d", tx.Signatures[0], i)
-			}
-		} else {
-			logger.Inbound.Warn().
-				Msgf("FilterInboundEvents: multiple SPL deposits detected in sig %s instruction %d", tx.Signatures[0], i)
 		}
 	}
 

--- a/zetaclient/chains/solana/observer/inbound_test.go
+++ b/zetaclient/chains/solana/observer/inbound_test.go
@@ -98,23 +98,6 @@ func Test_FilterInboundEvents(t *testing.T) {
 	})
 }
 
-func Test_FilterSolanaInboundEvents(t *testing.T) {
-	// load archived inbound deposit tx result
-	// https://explorer.solana.com/tx/MS3MPLN7hkbyCZFwKqXcg8fmEvQMD74fN6Ps2LSWXJoRxPW5ehaxBorK9q1JFVbqnAvu9jXm6ertj7kT7HpYw1j?cluster=devnet
-	txHash := "24GzWsxYCFcwwJ2rzAsWwWC85aYKot6Rz3jWnBP1GvoAg5A9f1WinYyvyKseYM52q6i3EkotZdJuQomGGq5oxRYr"
-	chain := chains.SolanaDevnet
-	txResult := testutils.LoadSolanaInboundTxResult(t, TestDataDir, chain.ChainId, txHash, false)
-
-	// parse gateway ID
-	gatewayID, _, err := contracts.ParseGatewayWithPDA(testutils.OldSolanaGatewayAddressDevnet)
-	require.NoError(t, err)
-
-	t.Run("should return early if logger is empty", func(t *testing.T) {
-		_, err = observer.FilterSolanaInboundEvents(txResult, nil, gatewayID, chain.ChainId)
-		require.ErrorContains(t, err, "logger is nil")
-	})
-}
-
 func Test_BuildInboundVoteMsgFromEvent(t *testing.T) {
 	// create test observer
 	chain := chains.SolanaDevnet


### PR DESCRIPTION
# Description

Remove unused `FilterSolanaInboundEvents` and the corresponding unit test purely for nil logger.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed unused method `FilterSolanaInboundEvents`
	- Streamlined event filtering process for Solana inbound events

- **Cleanup**
	- Removed associated test function for the deprecated method
	- Updated changelog to reflect recent project changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->