### PR TITLE
fix(e2e): use new ErrorMessageRevert field in test

### DIFF
--- a/e2e/e2etests/test_solana_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_solana_deposit_and_call_revert_with_dust.go
@@ -30,5 +30,8 @@ func TestSolanaDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string) 
 	// Now we want to make sure cctx is aborted.
 	cctx := utils.WaitCctxAbortedByInboundHash(r.Ctx, r, sig.String(), r.CctxClient)
 	require.True(r, cctx.GetCurrentOutboundParam().Amount.Uint64() < constant.SolanaWalletRentExempt)
-	require.True(r, strings.Contains(cctx.CctxStatus.ErrorMessage, crosschaintypes.ErrInvalidWithdrawalAmount.Error()))
+	require.True(
+		r,
+		strings.Contains(cctx.CctxStatus.ErrorMessageRevert, crosschaintypes.ErrInvalidWithdrawalAmount.Error()),
+	)
 }


### PR DESCRIPTION
Revert error message field was added in https://github.com/zeta-chain/node/pull/3326 but this solana test was not updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated end-to-end test for Solana deposit and call transaction to improve error message validation
	- Refined assertion for checking transaction revert error message

<!-- end of auto-generated comment: release notes by coderabbit.ai -->