### PR TITLE
chore: bump solana docker version

### DIFF
--- a/contrib/localnet/solana/Dockerfile
+++ b/contrib/localnet/solana/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zeta-chain/solana-docker:1.18.15
+FROM ghcr.io/zeta-chain/solana-docker:2.0.24
 
 WORKDIR /data
 COPY ./start-solana.sh /usr/bin/start-solana.sh


### PR DESCRIPTION
https://github.com/zeta-chain/solana-docker/commit/e8699b0646b780318cafaeb3e1ed70412570469a

CPU usage seems much better on this version. And this is the version that is suggested for mainnet usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Solana Docker base image from version 1.18.15 to 2.0.24

<!-- end of auto-generated comment: release notes by coderabbit.ai -->