### PR TITLE
docs(changelogs): add breaking changes for v27

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## v27.0.0
 
+### Breaking Changes
+
+* Universal contract calls from Bitcoin and Solana now follow the Protocol Contract V2 workflow.
+  * For `depositAndCall` and `call operations`, the `onCall` method is invoked on the Universal Contract from the gateway, replacing the previous behavior where `onCrossChainCall` was triggered by the `systemContract`.
+  * The interfaces of both functions remain the same.
+
 ### Features
 
 * [3353](https://github.com/zeta-chain/node/pull/3353) - add liquidity cap parameter to ZRC20 creation

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 * Universal contract calls from Bitcoin and Solana now follow the Protocol Contract V2 workflow.
-  * For `depositAndCall` and `call operations`, the `onCall` method is invoked on the Universal Contract from the gateway, replacing the previous behavior where `onCrossChainCall` was triggered by the `systemContract`.
+  * For `depositAndCall` and `call` operations, the `onCall` method is invoked on the Universal Contract from the gateway, replacing the previous behavior where `onCrossChainCall` was triggered by the `systemContract`.
   * The interfaces of both functions remain the same.
 
 ### Features


### PR DESCRIPTION
Breaking changes related to Solana and Bitcoin Universal Contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Universal contract calls for Bitcoin and Solana now follow an updated execution workflow, affecting deposit and call operations while maintaining the same interfaces.
- **Documentation**
	- The release notes for version 27.0.0 have been updated to outline these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->