### PR TITLE
chore: use v26 as reference for upgrade test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
-		--build-arg OLD_VERSION='release/v25' \
+		--build-arg OLD_VERSION='release/v26' \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg NODE_COMMIT=$(NODE_COMMIT)
 		.
@@ -336,7 +336,7 @@ else
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v25.0.0' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v26.0.0' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.


### PR DESCRIPTION
We were still using 25 for reference while both versions contains differences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the upgrade process to reference the latest release version, ensuring smoother and more consistent system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->