### PR TITLE
fix: register the group module sdk.tx interface to the cosmos `InterfaceRegistry`

### DIFF
--- a/app/encoding.go
+++ b/app/encoding.go
@@ -28,7 +28,6 @@ import (
 func MakeEncodingConfig() ethermint.EncodingConfig {
 	encodingConfig := evmenc.MakeConfig()
 	registry := encodingConfig.InterfaceRegistry
-
 	// TODO test if we need to register these interfaces again as MakeConfig already registers them
 	// https://github.com/zeta-chain/node/issues/3003
 	cryptocodec.RegisterInterfaces(registry)

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -24,7 +24,7 @@ import (
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
-// MakeEncodingConfig creates an EncodingConfig for testing
+// MakeEncodingConfig creates an EncodingConfig
 func MakeEncodingConfig() ethermint.EncodingConfig {
 	encodingConfig := evmenc.MakeConfig()
 	registry := encodingConfig.InterfaceRegistry

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -9,6 +9,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	groupmodule "github.com/cosmos/cosmos-sdk/x/group"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	evmenc "github.com/zeta-chain/ethermint/encoding"
@@ -48,6 +49,7 @@ func MakeEncodingConfig() ethermint.EncodingConfig {
 	fungibletypes.RegisterInterfaces(registry)
 	observertypes.RegisterInterfaces(registry)
 	lightclienttypes.RegisterInterfaces(registry)
+	groupmodule.RegisterInterfaces(registry)
 
 	return encodingConfig
 }

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -5,16 +5,22 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	groupmodule "github.com/cosmos/cosmos-sdk/x/group"
+	proposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	evmenc "github.com/zeta-chain/ethermint/encoding"
 	ethermint "github.com/zeta-chain/ethermint/types"
 	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
+	feemarkettypes "github.com/zeta-chain/ethermint/x/feemarket/types"
 
 	authoritytypes "github.com/zeta-chain/node/x/authority/types"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
@@ -49,6 +55,13 @@ func MakeEncodingConfig() ethermint.EncodingConfig {
 	observertypes.RegisterInterfaces(registry)
 	lightclienttypes.RegisterInterfaces(registry)
 	groupmodule.RegisterInterfaces(registry)
+	govtypesv1beta1.RegisterInterfaces(registry)
+	govtypesv1.RegisterInterfaces(registry)
+	proposaltypes.RegisterInterfaces(registry)
+	crisistypes.RegisterInterfaces(registry)
+	feemarkettypes.RegisterInterfaces(registry)
+	consensusparamtypes.RegisterInterfaces(registry)
+	vestingtypes.RegisterInterfaces(registry)
 
 	return encodingConfig
 }

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 ### Fixes
 
 * [3416](https://github.com/zeta-chain/node/pull/3416) - add a check for nil gas price in the CheckTxFee function
+* [3460](https://github.com/zeta-chain/node/pull/3460) - add group module to the cosmos interface registry
 
 ## v26.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v27.0.1
+
+### Fixes
+
+* [3460](https://github.com/zeta-chain/node/pull/3460) - add `group`,`gov`,`params`,`consensus`,`feemarket` ,`crisis`,`vesting` modules to the cosmos interface registry to enable parsing of tx results.
+
 ## v27.0.0
 
 ### Breaking Changes
@@ -34,7 +40,6 @@
 ### Fixes
 
 * [3416](https://github.com/zeta-chain/node/pull/3416) - add a check for nil gas price in the CheckTxFee function
-* [3460](https://github.com/zeta-chain/node/pull/3460) - add missing module to the cosmos interface registry
 
 ## v26.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -34,7 +34,7 @@
 ### Fixes
 
 * [3416](https://github.com/zeta-chain/node/pull/3416) - add a check for nil gas price in the CheckTxFee function
-* [3460](https://github.com/zeta-chain/node/pull/3460) - add group module to the cosmos interface registry
+* [3460](https://github.com/zeta-chain/node/pull/3460) - add missing module to the cosmos interface registry
 
 ## v26.0.0
 


### PR DESCRIPTION
# Description

Add the group module to the cosmos interface registry 


# How Has This Been Tested

Used the following query to verify 
```
zetacored q tx 1BB1551D2360A1BFBEE17F658B8B2E55B019E23ECB05A2BCFCF17D79C9A9C617 --node=https://zetachain-mainnet.g.allthatnode.com:443/archive/tendermint
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated contract interactions for Bitcoin and Solana following a new protocol workflow.
	- Introduced a liquidity cap option for token creation.
	- Added a CLI command to fetch inbound ballots.
	- Enabled inscription parsing on Bitcoin mainnet.
	- Integrated enhanced group management capabilities.
- **Bug Fixes**
	- Improved fee validation with additional safeguards.
- **Refactor**
	- Upgraded infrastructure components for better performance and clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->