### PR TITLE
fix: register the group module sdk.tx interface to the cosmos `InterfaceRegistry`

### DIFF
--- a/app/encoding.go
+++ b/app/encoding.go
@@ -58,7 +58,6 @@ func MakeEncodingConfig() ethermint.EncodingConfig {
 	govtypesv1beta1.RegisterInterfaces(registry)
 	govtypesv1.RegisterInterfaces(registry)
 	proposaltypes.RegisterInterfaces(registry)
-	crisistypes.RegisterInterfaces(registry)
 	feemarkettypes.RegisterInterfaces(registry)
 	consensusparamtypes.RegisterInterfaces(registry)
 	vestingtypes.RegisterInterfaces(registry)

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -5,15 +5,22 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	groupmodule "github.com/cosmos/cosmos-sdk/x/group"
+	proposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	evmenc "github.com/zeta-chain/ethermint/encoding"
 	ethermint "github.com/zeta-chain/ethermint/types"
 	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
+	feemarkettypes "github.com/zeta-chain/ethermint/x/feemarket/types"
 
 	authoritytypes "github.com/zeta-chain/node/x/authority/types"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
@@ -23,11 +30,10 @@ import (
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
-// MakeEncodingConfig creates an EncodingConfig for testing
+// MakeEncodingConfig creates an EncodingConfig
 func MakeEncodingConfig() ethermint.EncodingConfig {
 	encodingConfig := evmenc.MakeConfig()
 	registry := encodingConfig.InterfaceRegistry
-
 	// TODO test if we need to register these interfaces again as MakeConfig already registers them
 	// https://github.com/zeta-chain/node/issues/3003
 	cryptocodec.RegisterInterfaces(registry)
@@ -48,6 +54,14 @@ func MakeEncodingConfig() ethermint.EncodingConfig {
 	fungibletypes.RegisterInterfaces(registry)
 	observertypes.RegisterInterfaces(registry)
 	lightclienttypes.RegisterInterfaces(registry)
+	groupmodule.RegisterInterfaces(registry)
+	govtypesv1beta1.RegisterInterfaces(registry)
+	govtypesv1.RegisterInterfaces(registry)
+	proposaltypes.RegisterInterfaces(registry)
+	crisistypes.RegisterInterfaces(registry)
+	feemarkettypes.RegisterInterfaces(registry)
+	consensusparamtypes.RegisterInterfaces(registry)
+	vestingtypes.RegisterInterfaces(registry)
 
 	return encodingConfig
 }


### PR DESCRIPTION
Backport #3460

No changelog as already released on v27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the encoding configuration to support a broader range of functionalities, improving overall module compatibility and system integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->