### PR TITLE
fix(zetatool): use correct testnet rpc url

### DIFF
--- a/cmd/zetatool/config/config.go
+++ b/cmd/zetatool/config/config.go
@@ -18,7 +18,7 @@ const (
 
 func TestnetConfig() *Config {
 	return &Config{
-		ZetaChainRPC: "https://zetachain-testnet-grpc.itrocket.net:443",
+		ZetaChainRPC: "https://zetachain-testnet-rpc.itrocket.net:443",
 		EthereumRPC:  "https://ethereum-sepolia-rpc.publicnode.com",
 		ZetaChainID:  101,
 		BtcUser:      "",

--- a/cmd/zetatool/config/config_test.go
+++ b/cmd/zetatool/config/config_test.go
@@ -36,7 +36,7 @@ func TestGetConfig(t *testing.T) {
 
 		cfg, err = config.GetConfig(chains.Sepolia, "")
 		require.NoError(t, err)
-		require.Equal(t, "https://zetachain-testnet-grpc.itrocket.net:443", cfg.ZetaChainRPC)
+		require.Equal(t, "https://zetachain-testnet-rpc.itrocket.net:443", cfg.ZetaChainRPC)
 
 		cfg, err = config.GetConfig(chains.GoerliLocalnet, "")
 		require.NoError(t, err)


### PR DESCRIPTION
RPC not gRPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the testnet configuration to use a new endpoint for improved connection to the ZetaChain RPC service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->