### PR TITLE
fix(zetaclient): use chain name in metrics

### DIFF
--- a/pkg/rpc/clients_crosschain.go
+++ b/pkg/rpc/clients_crosschain.go
@@ -114,7 +114,7 @@ func (c *Clients) ListPendingCCTXWithinRateLimit(
 	return resp, nil
 }
 
-// ListPendingCCTX returns a list of pending cctxs for a given chainID
+// ListPendingCCTX returns a list of pending cctxs for a given chain
 //   - The max size of the list is crosschainkeeper.MaxPendingCctxs
 func (c *Clients) ListPendingCCTX(ctx context.Context, chainID int64) ([]*types.CrossChainTx, uint64, error) {
 	in := &types.QueryListPendingCctxRequest{ChainId: chainID}

--- a/zetaclient/chains/bitcoin/bitcoin.go
+++ b/zetaclient/chains/bitcoin/bitcoin.go
@@ -130,10 +130,11 @@ func (b *Bitcoin) scheduleCCTX(ctx context.Context) error {
 
 	// #nosec G115 always in range
 	zetaHeight := uint64(zetaBlock.Block.Height)
-	chainID := b.observer.Chain().ChainId
+	chain := b.observer.Chain()
+	chainID := chain.ChainId
 	lookahead := b.observer.ChainParams().OutboundScheduleLookahead
 
-	cctxList, _, err := b.observer.ZetacoreClient().ListPendingCCTX(ctx, chainID)
+	cctxList, _, err := b.observer.ZetacoreClient().ListPendingCCTX(ctx, chain)
 	if err != nil {
 		return errors.Wrap(err, "unable to list pending cctx")
 	}

--- a/zetaclient/chains/evm/evm.go
+++ b/zetaclient/chains/evm/evm.go
@@ -131,7 +131,8 @@ func (e *EVM) scheduleCCTX(ctx context.Context) error {
 	time.Sleep(delay)
 
 	var (
-		chainID = e.observer.Chain().ChainId
+		chain   = e.observer.Chain()
+		chainID = chain.ChainId
 
 		// #nosec G115 always in range
 		zetaHeight = uint64(zetaBlock.Block.Height)
@@ -151,7 +152,7 @@ func (e *EVM) scheduleCCTX(ctx context.Context) error {
 		outboundScheduleLookBack = uint64(float64(lookahead) * outboundLookBackFactor)
 	)
 
-	cctxList, _, err := e.observer.ZetacoreClient().ListPendingCCTX(ctx, chainID)
+	cctxList, _, err := e.observer.ZetacoreClient().ListPendingCCTX(ctx, chain)
 	if err != nil {
 		return errors.Wrap(err, "unable to list pending cctx")
 	}

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -76,7 +76,7 @@ type ZetacoreClient interface {
 
 	GetBlockHeight(ctx context.Context) (int64, error)
 
-	ListPendingCCTX(ctx context.Context, chainID int64) ([]*crosschaintypes.CrossChainTx, uint64, error)
+	ListPendingCCTX(ctx context.Context, chain chains.Chain) ([]*crosschaintypes.CrossChainTx, uint64, error)
 	ListPendingCCTXWithinRateLimit(
 		ctx context.Context,
 	) (*crosschaintypes.QueryListPendingCctxWithinRateLimitResponse, error)

--- a/zetaclient/chains/solana/solana.go
+++ b/zetaclient/chains/solana/solana.go
@@ -135,7 +135,8 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 	time.Sleep(delay)
 
 	var (
-		chainID = s.observer.Chain().ChainId
+		chain   = s.observer.Chain()
+		chainID = chain.ChainId
 
 		// #nosec G115 positive
 		zetaHeight = uint64(zetaBlock.Block.Height)
@@ -147,7 +148,7 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 		needsProcessingCtr = 0
 	)
 
-	cctxList, _, err := s.observer.ZetacoreClient().ListPendingCCTX(ctx, chainID)
+	cctxList, _, err := s.observer.ZetacoreClient().ListPendingCCTX(ctx, chain)
 	if err != nil {
 		return errors.Wrap(err, "unable to list pending cctx")
 	}

--- a/zetaclient/chains/ton/ton.go
+++ b/zetaclient/chains/ton/ton.go
@@ -130,9 +130,9 @@ func (t *TON) scheduleCCTX(ctx context.Context) error {
 
 	// #nosec G115 always in range
 	zetaHeight := uint64(zetaBlock.Block.Height)
-	chainID := t.observer.Chain().ChainId
+	chain := t.observer.Chain()
 
-	cctxList, _, err := t.observer.ZetacoreClient().ListPendingCCTX(ctx, chainID)
+	cctxList, _, err := t.observer.ZetacoreClient().ListPendingCCTX(ctx, chain)
 	if err != nil {
 		return errors.Wrap(err, "unable to list pending cctx")
 	}

--- a/zetaclient/testutils/mocks/zetacore_client.go
+++ b/zetaclient/testutils/mocks/zetacore_client.go
@@ -650,9 +650,9 @@ func (_m *ZetacoreClient) GetZetaHotKeyBalance(ctx context.Context) (math.Int, e
 	return r0, r1
 }
 
-// ListPendingCCTX provides a mock function with given fields: ctx, chainID
-func (_m *ZetacoreClient) ListPendingCCTX(ctx context.Context, chainID int64) ([]*types.CrossChainTx, uint64, error) {
-	ret := _m.Called(ctx, chainID)
+// ListPendingCCTX provides a mock function with given fields: ctx, chain
+func (_m *ZetacoreClient) ListPendingCCTX(ctx context.Context, chain chains.Chain) ([]*types.CrossChainTx, uint64, error) {
+	ret := _m.Called(ctx, chain)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPendingCCTX")
@@ -661,25 +661,25 @@ func (_m *ZetacoreClient) ListPendingCCTX(ctx context.Context, chainID int64) ([
 	var r0 []*types.CrossChainTx
 	var r1 uint64
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64) ([]*types.CrossChainTx, uint64, error)); ok {
-		return rf(ctx, chainID)
+	if rf, ok := ret.Get(0).(func(context.Context, chains.Chain) ([]*types.CrossChainTx, uint64, error)); ok {
+		return rf(ctx, chain)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64) []*types.CrossChainTx); ok {
-		r0 = rf(ctx, chainID)
+	if rf, ok := ret.Get(0).(func(context.Context, chains.Chain) []*types.CrossChainTx); ok {
+		r0 = rf(ctx, chain)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*types.CrossChainTx)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64) uint64); ok {
-		r1 = rf(ctx, chainID)
+	if rf, ok := ret.Get(1).(func(context.Context, chains.Chain) uint64); ok {
+		r1 = rf(ctx, chain)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, int64) error); ok {
-		r2 = rf(ctx, chainID)
+	if rf, ok := ret.Get(2).(func(context.Context, chains.Chain) error); ok {
+		r2 = rf(ctx, chain)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/zetaclient/zetacore/client_crosschain.go
+++ b/zetaclient/zetacore/client_crosschain.go
@@ -3,25 +3,23 @@ package zetacore
 import (
 	"context"
 	"sort"
-	"strconv"
 
 	"cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 	"github.com/zeta-chain/node/zetaclient/metrics"
 )
 
-func (c *Client) ListPendingCCTX(ctx context.Context, chainID int64) ([]*types.CrossChainTx, uint64, error) {
-	list, total, err := c.Clients.ListPendingCCTX(ctx, chainID)
+func (c *Client) ListPendingCCTX(ctx context.Context, chain chains.Chain) ([]*types.CrossChainTx, uint64, error) {
+	list, total, err := c.Clients.ListPendingCCTX(ctx, chain.ChainId)
 
 	if err == nil {
-		// #nosec G115 always in range
-		label := strconv.Itoa(int(chainID))
 		value := float64(total)
 
-		metrics.PendingTxsPerChain.WithLabelValues(label).Set(value)
+		metrics.PendingTxsPerChain.WithLabelValues(chain.Name).Set(value)
 	}
 
 	return list, total, err


### PR DESCRIPTION
In v27.0.0 the `chain` changed from a string name to the integer ID:

```
root@validator0-us-east-1-testnet:~# zetaclientd version
27.0.1
root@validator0-us-east-1-testncurl -s localhost:8886/metrics | grep zetaclient_pending_txs_total_total
# HELP zetaclient_pending_txs_total Number of pending transactions per chain
# TYPE zetaclient_pending_txs_total gauge
zetaclient_pending_txs_total{chain="11155111"} 0
zetaclient_pending_txs_total{chain="18333"} 0
zetaclient_pending_txs_total{chain="18334"} 0
zetaclient_pending_txs_total{chain="421614"} 0
zetaclient_pending_txs_total{chain="43113"} 1
zetaclient_pending_txs_total{chain="80002"} 0
zetaclient_pending_txs_total{chain="84532"} 0
zetaclient_pending_txs_total{chain="901"} 0
zetaclient_pending_txs_total{chain="97"} 0
```

revert that to the v26 behavior:

```
root@zetaclient0:~# curl -s localhost:8886/metrics | grep zetaclient_pending_txs_total
# HELP zetaclient_pending_txs_total Number of pending transactions per chain
# TYPE zetaclient_pending_txs_total gauge
zetaclient_pending_txs_total{chain="btc_regtest"} 0
zetaclient_pending_txs_total{chain="goerli_localnet"} 0
```

No changelog as it will be released on v27.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Refined method comments to enhance clarity when listing pending cross-chain transactions.
  
- **Refactor**
	- Transitioned from using simple numerical identifiers to a structured chain object across multiple components. This update standardizes the handling of chain data and improves associated metric labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->