### PR TITLE
fix(e2e): use latest buildkit-cache-dance

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,7 @@ jobs:
           key: cache-${{ hashFiles('go.sum') }}
 
       - name: Inject go cache into docker
-        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+        uses: reproducible-containers/buildkit-cache-dance@61bd187f75f25d38e056fdd48506fac777c6ebec
         with:
           cache-map: |
             {


### PR DESCRIPTION
```
#3 [internal] load metadata for docker.io/library/busybox:1
#3 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/busybox/blobs/sha256:af47096251092caf59498806ab8d58e8173ecf5a182f024ce9d635b5b4a55d66: 500 Internal Server Error
------
```

Upgrade to latest version which uses ghcr.io which should be more stable. Ref: https://github.com/reproducible-containers/buildkit-cache-dance/pull/44