### PR TITLE
fix: add non-nil confirmation params in solana/ton E2E test to avoid chain param update error

### DIFF
--- a/e2e/runner/setup_solana.go
+++ b/e2e/runner/setup_solana.go
@@ -120,6 +120,10 @@ func (r *E2ERunner) ensureSolanaChainParams() error {
 		MinObserverDelegation:       observertypes.DefaultMinObserverDelegation,
 		IsSupported:                 true,
 		GatewayAddress:              r.GatewayProgram.String(),
+		ConfirmationParams: &observertypes.ConfirmationParams{
+			SafeInboundCount:  32,
+			SafeOutboundCount: 32,
+		},
 	}
 
 	updateMsg := observertypes.NewMsgUpdateChainParams(creator, chainParams)

--- a/e2e/runner/setup_ton.go
+++ b/e2e/runner/setup_ton.go
@@ -110,6 +110,10 @@ func (r *E2ERunner) ensureTONChainParams(gw *ton.AccountInit) error {
 		MinObserverDelegation:       observertypes.DefaultMinObserverDelegation,
 		IsSupported:                 true,
 		GatewayAddress:              gw.ID.ToRaw(),
+		ConfirmationParams: &observertypes.ConfirmationParams{
+			SafeInboundCount:  1,
+			SafeOutboundCount: 1,
+		},
 	}
 
 	msg := observertypes.NewMsgUpdateChainParams(creator, chainParams)


### PR DESCRIPTION
# Description

The Solana and TON E2E tests are failing due to nil `ConfirmationParams` field when updating chain params.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
