### PR TITLE
fix: backport mainnet hotfix to Bitcoin TSS keysign failure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 * [3501](https://github.com/zeta-chain/node/pull/3501) - fix E2E test failure caused by nil `ConfirmationParams` for Solana and TON
+* [3509](https://github.com/zeta-chain/node/pull/3509) - schedule Bitcoin TSS keysign on interval to avoid TSS keysign spam
 
 ### Tests
 


### PR DESCRIPTION
# Description

Schedule Bitcoin TSS keysign on configured interval in chain parameter. Based on what we observed on mainnet, signing Bitcoin outbound on every ZetaChain block could desync the signers.

The original hotfix: https://github.com/zeta-chain/node/pull/3505

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a scheduled Bitcoin key signing mechanism to limit excessive processing.
  - Updated confirmation management to support multiple counts.
  - Added a new command tool feature and expanded blockchain chain information.
- **Bug Fixes**
  - Resolved timing issues affecting outbound transaction processing and related tests.
- **Refactor**
  - Improved the organization of Bitcoin transaction handling for enhanced performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->