### PR TITLE
fix(zetacore): use query context rather than tx

### DIFF
--- a/x/crosschain/client/cli/cli_zeta_height.go
+++ b/x/crosschain/client/cli/cli_zeta_height.go
@@ -14,7 +14,7 @@ func CmdLastZetaHeight() *cobra.Command {
 		Short: "Query last Zeta Height",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/emissions/client/cli/query_list_balances.go
+++ b/x/emissions/client/cli/query_list_balances.go
@@ -14,7 +14,7 @@ func CmdListPoolAddresses() *cobra.Command {
 		Short: "Query list-pool-addresses",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/emissions/client/cli/query_show_available_emissions.go
+++ b/x/emissions/client/cli/query_show_available_emissions.go
@@ -16,7 +16,7 @@ func CmdShowAvailableEmissions() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqAddress := args[0]
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/lightclient/client/cli/query_block_header.go
+++ b/x/lightclient/client/cli/query_block_header.go
@@ -14,7 +14,7 @@ func CmdListBlockHeader() *cobra.Command {
 		Short: "List all the block headers",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -52,7 +52,7 @@ func CmdShowBlockHeader() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			blockHash := args[0]
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/lightclient/client/cli/query_chain_state.go
+++ b/x/lightclient/client/cli/query_chain_state.go
@@ -16,7 +16,7 @@ func CmdListChainState() *cobra.Command {
 		Short: "List all the chain states",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -57,7 +57,7 @@ func CmdShowChainState() *cobra.Command {
 				return err
 			}
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/lightclient/client/cli/query_verification_flags.go
+++ b/x/lightclient/client/cli/query_verification_flags.go
@@ -14,7 +14,7 @@ func CmdShowHeaderHeaderSupportedChains() *cobra.Command {
 		Short: "Show the verification flags",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/observer/client/cli/query_ballot.go
+++ b/x/observer/client/cli/query_ballot.go
@@ -17,7 +17,7 @@ func CmdBallotByIdentifier() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			reqVoteIdentifier := args[0]
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -48,7 +48,7 @@ func CmdAllBallots() *cobra.Command {
 		Short: "Query all ballots",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/observer/client/cli/query_blame.go
+++ b/x/observer/client/cli/query_blame.go
@@ -18,7 +18,7 @@ func CmdBlameByIdentifier() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			Identifier := args[0]
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -49,7 +49,7 @@ func CmdGetAllBlameRecords() *cobra.Command {
 		Short: "Query AllBlameRecords",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -81,7 +81,7 @@ func CmdGetBlameByChainAndNonce() *cobra.Command {
 			chainID := args[0]
 			nonce := args[1]
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/observer/client/cli/query_chain_params.go
+++ b/x/observer/client/cli/query_chain_params.go
@@ -20,7 +20,7 @@ func CmdGetChainParamsForChain() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -48,7 +48,7 @@ func CmdGetChainParams() *cobra.Command {
 		Short: "Query GetChainParams",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/observer/client/cli/query_get_tss_address.go
+++ b/x/observer/client/cli/query_get_tss_address.go
@@ -16,7 +16,7 @@ func CmdGetTssAddress() *cobra.Command {
 		Short: "Query current tss address",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -50,7 +50,7 @@ func CmdGetTssAddressByFinalizedZetaHeight() *cobra.Command {
 		Short: "Query tss address by finalized zeta height (for historical tss addresses)",
 		Args:  cobra.MaximumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/observer/client/cli/query_show_observer_count.go
+++ b/x/observer/client/cli/query_show_observer_count.go
@@ -14,7 +14,7 @@ func CmdShowObserverCount() *cobra.Command {
 		Short: "Query show-observer-count",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) (err error) {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Always use the `client.GetClientQueryContext(cmd)` rather than `client.GetClientTxContext(cmd)` for all queries otherwise the `--height` parameter will not work.

```
func GetClientQueryContext(cmd *cobra.Command) (Context, error) {
	ctx := GetClientContextFromCmd(cmd)
	return readQueryCommandFlags(ctx, cmd.Flags())
}
```


```
func readQueryCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Context, error) {
	if clientCtx.Height == 0 || flagSet.Changed(flags.FlagHeight) {
		height, _ := flagSet.GetInt64(flags.FlagHeight)
		clientCtx = clientCtx.WithHeight(height)
	}

	if !clientCtx.UseLedger || flagSet.Changed(flags.FlagUseLedger) {
		useLedger, _ := flagSet.GetBool(flags.FlagUseLedger)
		clientCtx = clientCtx.WithUseLedger(useLedger)
	}

	return ReadPersistentCommandFlags(clientCtx, flagSet)
}
```