### PR TITLE
fix: avoid false positive on multiple events in same tx

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 
 * [3501](https://github.com/zeta-chain/node/pull/3501) - fix E2E test failure caused by nil `ConfirmationParams` for Solana and TON
 * [3509](https://github.com/zeta-chain/node/pull/3509) - schedule Bitcoin TSS keysign on interval to avoid TSS keysign spam
+* [3517](https://github.com/zeta-chain/node/pull/3517) - remove duplicate gateway event appending to fix false positive on multiple events in same tx
 
 ### Tests
 

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -141,6 +141,9 @@ func (ob *Observer) parseAndValidateDepositEvents(
 			Uint64(logs.FieldBlock, iterator.Event.Raw.BlockNumber).
 			Msg("invalid Deposited event")
 	}
+
+	// order events by height, tx index and event index (ascending)
+	// this ensures the first event is observed if there are multiple in the same tx
 	sort.SliceStable(events, func(i, j int) bool {
 		if events[i].Raw.BlockNumber == events[j].Raw.BlockNumber {
 			if events[i].Raw.TxIndex == events[j].Raw.TxIndex {
@@ -292,6 +295,9 @@ func (ob *Observer) parseAndValidateCallEvents(
 			Uint64(logs.FieldBlock, iterator.Event.Raw.BlockNumber).
 			Msg("invalid Called event")
 	}
+
+	// order events by height, tx index and event index (ascending)
+	// this ensures the first event is observed if there are multiple in the same tx
 	sort.SliceStable(events, func(i, j int) bool {
 		if events[i].Raw.BlockNumber == events[j].Raw.BlockNumber {
 			if events[i].Raw.TxIndex == events[j].Raw.TxIndex {
@@ -423,6 +429,9 @@ func (ob *Observer) parseAndValidateDepositAndCallEvents(
 			Uint64(logs.FieldBlock, iterator.Event.Raw.BlockNumber).
 			Msg("invalid DepositedAndCalled event")
 	}
+
+	// order events by height, tx index and event index (ascending)
+	// this ensures the first event is observed if there are multiple in the same tx
 	sort.SliceStable(events, func(i, j int) bool {
 		if events[i].Raw.BlockNumber == events[j].Raw.BlockNumber {
 			if events[i].Raw.TxIndex == events[j].Raw.TxIndex {

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -127,12 +127,12 @@ func (ob *Observer) parseAndValidateDepositEvents(
 	iterator *gatewayevm.GatewayEVMDepositedIterator,
 	gatewayAddr ethcommon.Address,
 ) []*gatewayevm.GatewayEVMDeposited {
-	// collect and sort events by block number, then tx index, then log index (ascending)
-	events := make([]*gatewayevm.GatewayEVMDeposited, 0)
+	// collect and sort validEvents by block number, then tx index, then log index (ascending)
+	validEvents := make([]*gatewayevm.GatewayEVMDeposited, 0)
 	for iterator.Next() {
 		err := common.ValidateEvmTxLog(&iterator.Event.Raw, gatewayAddr, "", common.TopicsGatewayDeposit)
 		if err == nil {
-			events = append(events, iterator.Event)
+			validEvents = append(validEvents, iterator.Event)
 			continue
 		}
 		ob.Logger().
@@ -144,20 +144,20 @@ func (ob *Observer) parseAndValidateDepositEvents(
 
 	// order events by height, tx index and event index (ascending)
 	// this ensures the first event is observed if there are multiple in the same tx
-	sort.SliceStable(events, func(i, j int) bool {
-		if events[i].Raw.BlockNumber == events[j].Raw.BlockNumber {
-			if events[i].Raw.TxIndex == events[j].Raw.TxIndex {
-				return events[i].Raw.Index < events[j].Raw.Index
+	sort.SliceStable(validEvents, func(i, j int) bool {
+		if validEvents[i].Raw.BlockNumber == validEvents[j].Raw.BlockNumber {
+			if validEvents[i].Raw.TxIndex == validEvents[j].Raw.TxIndex {
+				return validEvents[i].Raw.Index < validEvents[j].Raw.Index
 			}
-			return events[i].Raw.TxIndex < events[j].Raw.TxIndex
+			return validEvents[i].Raw.TxIndex < validEvents[j].Raw.TxIndex
 		}
-		return events[i].Raw.BlockNumber < events[j].Raw.BlockNumber
+		return validEvents[i].Raw.BlockNumber < validEvents[j].Raw.BlockNumber
 	})
 
 	// filter events from same tx
 	filtered := make([]*gatewayevm.GatewayEVMDeposited, 0)
 	guard := make(map[string]bool)
-	for _, event := range events {
+	for _, event := range validEvents {
 		// guard against multiple events in the same tx
 		if guard[event.Raw.TxHash.Hex()] {
 			ob.Logger().
@@ -281,12 +281,12 @@ func (ob *Observer) parseAndValidateCallEvents(
 	iterator *gatewayevm.GatewayEVMCalledIterator,
 	gatewayAddr ethcommon.Address,
 ) []*gatewayevm.GatewayEVMCalled {
-	// collect and sort events by block number, then tx index, then log index (ascending)
-	events := make([]*gatewayevm.GatewayEVMCalled, 0)
+	// collect and sort validEvents by block number, then tx index, then log index (ascending)
+	validEvents := make([]*gatewayevm.GatewayEVMCalled, 0)
 	for iterator.Next() {
 		err := common.ValidateEvmTxLog(&iterator.Event.Raw, gatewayAddr, "", common.TopicsGatewayCall)
 		if err == nil {
-			events = append(events, iterator.Event)
+			validEvents = append(validEvents, iterator.Event)
 			continue
 		}
 		ob.Logger().
@@ -298,20 +298,20 @@ func (ob *Observer) parseAndValidateCallEvents(
 
 	// order events by height, tx index and event index (ascending)
 	// this ensures the first event is observed if there are multiple in the same tx
-	sort.SliceStable(events, func(i, j int) bool {
-		if events[i].Raw.BlockNumber == events[j].Raw.BlockNumber {
-			if events[i].Raw.TxIndex == events[j].Raw.TxIndex {
-				return events[i].Raw.Index < events[j].Raw.Index
+	sort.SliceStable(validEvents, func(i, j int) bool {
+		if validEvents[i].Raw.BlockNumber == validEvents[j].Raw.BlockNumber {
+			if validEvents[i].Raw.TxIndex == validEvents[j].Raw.TxIndex {
+				return validEvents[i].Raw.Index < validEvents[j].Raw.Index
 			}
-			return events[i].Raw.TxIndex < events[j].Raw.TxIndex
+			return validEvents[i].Raw.TxIndex < validEvents[j].Raw.TxIndex
 		}
-		return events[i].Raw.BlockNumber < events[j].Raw.BlockNumber
+		return validEvents[i].Raw.BlockNumber < validEvents[j].Raw.BlockNumber
 	})
 
 	// filter events from same tx
 	filtered := make([]*gatewayevm.GatewayEVMCalled, 0)
 	guard := make(map[string]bool)
-	for _, event := range events {
+	for _, event := range validEvents {
 		// guard against multiple events in the same tx
 		if guard[event.Raw.TxHash.Hex()] {
 			ob.Logger().Inbound.Warn().Stringer(logs.FieldTx, event.Raw.TxHash).Msg("multiple Called events in same tx")
@@ -415,12 +415,12 @@ func (ob *Observer) parseAndValidateDepositAndCallEvents(
 	iterator *gatewayevm.GatewayEVMDepositedAndCalledIterator,
 	gatewayAddr ethcommon.Address,
 ) []*gatewayevm.GatewayEVMDepositedAndCalled {
-	// collect and sort events by block number, then tx index, then log index (ascending)
-	events := make([]*gatewayevm.GatewayEVMDepositedAndCalled, 0)
+	// collect and sort validEvents by block number, then tx index, then log index (ascending)
+	validEvents := make([]*gatewayevm.GatewayEVMDepositedAndCalled, 0)
 	for iterator.Next() {
 		err := common.ValidateEvmTxLog(&iterator.Event.Raw, gatewayAddr, "", common.TopicsGatewayDepositAndCall)
 		if err == nil {
-			events = append(events, iterator.Event)
+			validEvents = append(validEvents, iterator.Event)
 			continue
 		}
 		ob.Logger().
@@ -432,20 +432,20 @@ func (ob *Observer) parseAndValidateDepositAndCallEvents(
 
 	// order events by height, tx index and event index (ascending)
 	// this ensures the first event is observed if there are multiple in the same tx
-	sort.SliceStable(events, func(i, j int) bool {
-		if events[i].Raw.BlockNumber == events[j].Raw.BlockNumber {
-			if events[i].Raw.TxIndex == events[j].Raw.TxIndex {
-				return events[i].Raw.Index < events[j].Raw.Index
+	sort.SliceStable(validEvents, func(i, j int) bool {
+		if validEvents[i].Raw.BlockNumber == validEvents[j].Raw.BlockNumber {
+			if validEvents[i].Raw.TxIndex == validEvents[j].Raw.TxIndex {
+				return validEvents[i].Raw.Index < validEvents[j].Raw.Index
 			}
-			return events[i].Raw.TxIndex < events[j].Raw.TxIndex
+			return validEvents[i].Raw.TxIndex < validEvents[j].Raw.TxIndex
 		}
-		return events[i].Raw.BlockNumber < events[j].Raw.BlockNumber
+		return validEvents[i].Raw.BlockNumber < validEvents[j].Raw.BlockNumber
 	})
 
 	// filter events from same tx
 	filtered := make([]*gatewayevm.GatewayEVMDepositedAndCalled, 0)
 	guard := make(map[string]bool)
-	for _, event := range events {
+	for _, event := range validEvents {
 		// guard against multiple events in the same tx
 		if guard[event.Raw.TxHash.Hex()] {
 			ob.Logger().

--- a/zetaclient/logs/fields.go
+++ b/zetaclient/logs/fields.go
@@ -10,6 +10,7 @@ const (
 	FieldNonce        = "nonce"
 	FieldTx           = "tx"
 	FieldOutboundID   = "outbound_id"
+	FieldBlock        = "block"
 	FieldCctx         = "cctx"
 	FieldZetaTx       = "zeta_tx"
 	FieldBallot       = "ballot"


### PR DESCRIPTION
# Description

Same event is appended twice to the event array and it results in false positive in the log print. The error message appears in local E2E tests and goes away after fix.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced chain confirmation settings to support multiple confirmation counts.
- **Bug Fixes**
	- Resolved issues with duplicate event reporting and test failures across multiple blockchain operations.
	- Adjusted key operation scheduling to reduce spam.
- **Refactor**
	- Reorganized core components and improved logging for clearer event tracking.
- **Tests**
	- Added simulation tests to validate withdrawal operations and ballot consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->