### PR TITLE
chore(zetaclient): reduce default scheduler interval to 10 seconds

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -87,7 +87,7 @@ func (s *Scheduler) Register(ctx context.Context, exec Executable, opts ...Opt) 
 	}
 
 	config := &taskOpts{
-		interval: time.Second,
+		interval: time.Second * 10,
 	}
 
 	for _, opt := range opts {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -36,10 +36,10 @@ func TestScheduler(t *testing.T) {
 		ts.scheduler.Stop()
 
 		// ASSERT
-		// Counter should be 2 because we invoke a task once on a start,
-		// once after 1 second (default interval),
+		// Counter should be 1 because we invoke a task once on a start,
+		// once after 10 second (default interval),
 		// and then at T=1.5s we stop the scheduler.
-		assert.Equal(t, int32(2), counter)
+		assert.Equal(t, int32(1), counter)
 
 		// Check logs
 		assert.Contains(t, ts.logBuffer.String(), "Stopped scheduler task")


### PR DESCRIPTION
Change the default scheduler interval to 10 seconds. This default value is only used by the RPC status check, all other tasks set a value explicitly.

Related to https://github.com/zeta-chain/node/issues/3525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the default timing for scheduled tasks to run at a longer interval (10 seconds), ensuring smoother and more predictable execution.
  
- **Tests**
  - Updated test expectations to align with the new scheduling timing for tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->