### PR TITLE
feat: support Bitcoin for onAbort and add e2e test cases for no asset calls

### DIFF
--- a/cmd/zetae2e/local/bitcoin.go
+++ b/cmd/zetae2e/local/bitcoin.go
@@ -32,6 +32,7 @@ func startBitcoinTests(
 		e2etests.TestBitcoinStdMemoDepositName,
 		e2etests.TestBitcoinStdMemoDepositAndCallName,
 		e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
+		e2etests.TestBitcoinStdMemoDepositAndCallRevertAndAbortName,
 		e2etests.TestBitcoinStdMemoInscribedDepositAndCallName,
 		e2etests.TestBitcoinDepositAndAbortWithLowDepositFeeName,
 		e2etests.TestCrosschainSwapName,

--- a/cmd/zetae2e/local/evm.go
+++ b/cmd/zetae2e/local/evm.go
@@ -26,6 +26,7 @@ func startEVMTests(eg *errgroup.Group, conf config.Config, deployerRunner *runne
 		e2etests.TestZEVMToEVMCallName,
 		e2etests.TestZEVMToEVMCallThroughContractName,
 		e2etests.TestEVMToZEVMCallName,
+		e2etests.TestEVMToZEVMCallAbortName,
 		e2etests.TestETHDepositAndCallNoMessageName,
 		e2etests.TestETHWithdrawAndCallNoMessageName,
 		e2etests.TestEtherWithdrawRestrictedName,

--- a/cmd/zetae2e/local/evm.go
+++ b/cmd/zetae2e/local/evm.go
@@ -26,7 +26,6 @@ func startEVMTests(eg *errgroup.Group, conf config.Config, deployerRunner *runne
 		e2etests.TestZEVMToEVMCallName,
 		e2etests.TestZEVMToEVMCallThroughContractName,
 		e2etests.TestEVMToZEVMCallName,
-		e2etests.TestEVMToZEVMCallAbortName,
 		e2etests.TestETHDepositAndCallNoMessageName,
 		e2etests.TestETHWithdrawAndCallNoMessageName,
 		e2etests.TestEtherWithdrawRestrictedName,
@@ -64,6 +63,9 @@ func startEVMTests(eg *errgroup.Group, conf config.Config, deployerRunner *runne
 			e2etests.TestETHWithdrawRevertAndAbortName,
 			e2etests.TestETHWithdrawAndCallRevertWithWithdrawName,
 			e2etests.TestDepositAndCallOutOfGasName,
+			e2etests.TestZEVMToEVMCallRevertName,
+			e2etests.TestZEVMToEVMCallRevertAndAbortName,
+			e2etests.TestEVMToZEVMCallAbortName,
 		),
 	)
 

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -96,6 +96,7 @@ const (
 	TestBitcoinStdMemoDepositAndCallName                   = "bitcoin_std_memo_deposit_and_call"
 	TestBitcoinStdMemoDepositAndCallRevertName             = "bitcoin_std_memo_deposit_and_call_revert"
 	TestBitcoinStdMemoDepositAndCallRevertOtherAddressName = "bitcoin_std_memo_deposit_and_call_revert_other_address"
+	TestBitcoinStdMemoDepositAndCallRevertAndAbortName     = "bitcoin_std_memo_deposit_and_call_revert_and_abort"
 	TestBitcoinStdMemoInscribedDepositAndCallName          = "bitcoin_std_memo_inscribed_deposit_and_call"
 	TestBitcoinDepositAndAbortWithLowDepositFeeName        = "bitcoin_deposit_and_abort_with_low_deposit_fee"
 	TestBitcoinWithdrawSegWitName                          = "bitcoin_withdraw_segwit"
@@ -735,6 +736,12 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in btc", DefaultValue: "0.1"},
 		},
 		TestBitcoinStdMemoDepositAndCallRevertOtherAddress,
+	),
+	runner.NewE2ETest(
+		TestBitcoinStdMemoDepositAndCallRevertAndAbortName,
+		"deposit Bitcoin into ZEVM and call a contract with standard memo; revert and abort with onAbort",
+		[]runner.ArgDefinition{},
+		TestBitcoinStdMemoDepositAndCallRevertAndAbort,
 	),
 	runner.NewE2ETest(
 		TestBitcoinStdMemoInscribedDepositAndCallName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -48,6 +48,7 @@ const (
 	TestZEVMToEVMCallName                = "zevm_to_evm_call"
 	TestZEVMToEVMCallThroughContractName = "zevm_to_evm_call_through_contract"
 	TestEVMToZEVMCallName                = "evm_to_zevm_call"
+	TestEVMToZEVMCallAbortName           = "evm_to_zevm_abort_call"
 
 	TestDepositAndCallSwapName      = "deposit_and_call_swap"
 	TestEtherWithdrawRestrictedName = "eth_withdraw_restricted"
@@ -475,6 +476,12 @@ var AllE2ETests = []runner.E2ETest{
 		"evm -> zevm call",
 		[]runner.ArgDefinition{},
 		TestEVMToZEVMCall,
+	),
+	runner.NewE2ETest(
+		TestEVMToZEVMCallAbortName,
+		"evm -> zevm call fails and abort with onAbort",
+		[]runner.ArgDefinition{},
+		TestEVMToZEVMCallAbort,
 	),
 	runner.NewE2ETest(
 		TestDepositAndCallSwapName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -46,6 +46,8 @@ const (
 
 	TestZEVMToEVMArbitraryCallName       = "zevm_to_evm_arbitrary_call"
 	TestZEVMToEVMCallName                = "zevm_to_evm_call"
+	TestZEVMToEVMCallRevertName          = "zevm_to_evm_call_revert"
+	TestZEVMToEVMCallRevertAndAbortName  = "zevm_to_evm_call_revert_and_abort"
 	TestZEVMToEVMCallThroughContractName = "zevm_to_evm_call_through_contract"
 	TestEVMToZEVMCallName                = "evm_to_zevm_call"
 	TestEVMToZEVMCallAbortName           = "evm_to_zevm_abort_call"
@@ -464,6 +466,18 @@ var AllE2ETests = []runner.E2ETest{
 		"zevm -> evm call",
 		[]runner.ArgDefinition{},
 		TestZEVMToEVMCall,
+	),
+	runner.NewE2ETest(
+		TestZEVMToEVMCallRevertName,
+		"zevm -> evm call that reverts and call onRevert",
+		[]runner.ArgDefinition{},
+		TestZEVMToEVMCallRevert,
+	),
+	runner.NewE2ETest(
+		TestZEVMToEVMCallRevertAndAbortName,
+		"zevm -> evm call that reverts and abort with onAbort",
+		[]runner.ArgDefinition{},
+		TestZEVMToEVMCallRevertAndAbort,
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallThroughContractName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -473,12 +473,14 @@ var AllE2ETests = []runner.E2ETest{
 		"zevm -> evm call that reverts and call onRevert",
 		[]runner.ArgDefinition{},
 		TestZEVMToEVMCallRevert,
+		runner.WithMinimumVersion("v28.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallRevertAndAbortName,
 		"zevm -> evm call that reverts and abort with onAbort",
 		[]runner.ArgDefinition{},
 		TestZEVMToEVMCallRevertAndAbort,
+		runner.WithMinimumVersion("v28.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallThroughContractName,
@@ -497,6 +499,7 @@ var AllE2ETests = []runner.E2ETest{
 		"evm -> zevm call fails and abort with onAbort",
 		[]runner.ArgDefinition{},
 		TestEVMToZEVMCallAbort,
+		runner.WithMinimumVersion("v28.0.0"),
 	),
 	runner.NewE2ETest(
 		TestDepositAndCallSwapName,
@@ -742,6 +745,7 @@ var AllE2ETests = []runner.E2ETest{
 		"deposit Bitcoin into ZEVM and call a contract with standard memo; revert and abort with onAbort",
 		[]runner.ArgDefinition{},
 		TestBitcoinStdMemoDepositAndCallRevertAndAbort,
+		runner.WithMinimumVersion("v28.0.0"),
 	),
 	runner.NewE2ETest(
 		TestBitcoinStdMemoInscribedDepositAndCallName,

--- a/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
+++ b/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
@@ -1,0 +1,68 @@
+package e2etests
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/e2e/contracts/testabort"
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/pkg/memo"
+	"github.com/zeta-chain/node/testutil/sample"
+	"github.com/zeta-chain/node/x/crosschain/types"
+)
+
+func TestBitcoinStdMemoDepositAndCallRevertAndAbort(r *runner.E2ERunner, args []string) {
+	// Start mining blocks
+	stop := r.MineBlocksIfLocalBitcoin()
+	defer stop()
+
+	require.Len(r, args, 0)
+	amount := 0.00000001 // 1 satoshi so revert fails because of insufficient gas
+
+	// deploy testabort contract
+	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	require.NoError(r, err)
+
+	// Create a memo to call non-existing contract
+	inboundMemo := &memo.InboundMemo{
+		Header: memo.Header{
+			Version:     0,
+			EncodingFmt: memo.EncodingFmtCompactShort,
+			OpCode:      memo.OpCodeDepositAndCall,
+		},
+		FieldsV0: memo.FieldsV0{
+			Receiver: sample.EthAddress(), // non-existing contract
+			Payload:  []byte("a payload"),
+			RevertOptions: types.RevertOptions{
+				RevertMessage: []byte("revert"),
+				AbortAddress:  testAbortAddr.Hex(),
+			},
+		},
+	}
+
+	// ACT
+	// Deposit
+	txHash := r.DepositBTCWithExactAmount(amount, inboundMemo)
+
+	// ASSERT
+	// Now we want to make sure revert TX is completed.
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "bitcoin_std_memo_deposit")
+	utils.RequireCCTXStatus(r, cctx, types.CctxStatus_Aborted)
+
+	// check onAbort was called
+	aborted, err := testAbort.IsAborted(&bind.CallOpts{})
+	require.NoError(r, err)
+	require.True(r, aborted)
+
+	// check abort context was passed
+	abortContext, err := testAbort.GetAbortedWithMessage(&bind.CallOpts{}, "revert")
+	require.NoError(r, err)
+	require.EqualValues(r, r.BTCZRC20Addr.Hex(), abortContext.Asset.Hex())
+
+	// check abort contract received the tokens
+	balance, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, testAbortAddr)
+	require.NoError(r, err)
+	require.True(r, balance.Uint64() > 0)
+}

--- a/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
+++ b/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
@@ -55,11 +55,6 @@ func TestBitcoinStdMemoDepositAndCallRevertAndAbort(r *runner.E2ERunner, args []
 	require.NoError(r, err)
 	require.True(r, aborted)
 
-	// check abort context was passed
-	abortContext, err := testAbort.GetAbortedWithMessage(&bind.CallOpts{}, "revert")
-	require.NoError(r, err)
-	require.EqualValues(r, r.BTCZRC20Addr.Hex(), abortContext.Asset.Hex())
-
 	// check abort contract received the tokens
 	balance, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, testAbortAddr)
 	require.NoError(r, err)

--- a/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
+++ b/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
@@ -35,8 +35,7 @@ func TestBitcoinStdMemoDepositAndCallRevertAndAbort(r *runner.E2ERunner, args []
 			Receiver: sample.EthAddress(), // non-existing contract
 			Payload:  []byte("a payload"),
 			RevertOptions: types.RevertOptions{
-				RevertMessage: []byte("revert"),
-				AbortAddress:  testAbortAddr.Hex(),
+				AbortAddress: testAbortAddr.Hex(),
 			},
 		},
 	}

--- a/e2e/e2etests/test_evm_to_zevm_call_abort.go
+++ b/e2e/e2etests/test_evm_to_zevm_call_abort.go
@@ -1,0 +1,43 @@
+package e2etests
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayevm.sol"
+
+	"github.com/zeta-chain/node/e2e/contracts/testabort"
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+func TestEVMToZEVMCallAbort(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 0)
+
+	// deploy testabort contract
+	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	require.NoError(r, err)
+
+	// perform the withdraw
+	tx := r.EVMToZEMVCall(
+		sample.EthAddress(), // non-existing address
+		[]byte("revert"),
+		gatewayevm.RevertOptions{
+			CallOnRevert:  false, // revert not supported
+			RevertMessage: []byte("revert"),
+			AbortAddress:  testAbortAddr,
+		},
+	)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "call")
+	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+
+	// check abort context was passed
+	abortContext, err := testAbort.GetAbortedWithMessage(&bind.CallOpts{}, "revert")
+	require.NoError(r, err)
+	require.EqualValues(r, r.ERC20ZRC20Addr.Hex(), abortContext.Asset.Hex())
+	require.EqualValues(r, int64(0), abortContext.Amount.Int64())
+}

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -1,0 +1,48 @@
+package e2etests
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
+
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 0)
+
+	payload := randomPayload(r)
+
+	r.ApproveETHZRC20(r.GatewayZEVMAddr)
+
+	// perform the withdraw
+	tx := r.ZEVMToEMVCall(
+		r.TestDAppV2EVMAddr,
+		[]byte("revert"),
+		gatewayzevm.RevertOptions{
+			RevertAddress:    r.TestDAppV2ZEVMAddr,
+			CallOnRevert:     true,
+			RevertMessage:    []byte(payload),
+			OnRevertGasLimit: big.NewInt(200000),
+		},
+	)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "call")
+	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+
+	// check expected sender was used
+	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(
+		&bind.CallOpts{},
+		[]byte(payload),
+	)
+	require.NoError(r, err)
+	require.Equal(r, r.ZEVMAuth.From, senderForMsg)
+}

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -1,6 +1,7 @@
 package e2etests
 
 import (
+	"github.com/zeta-chain/node/testutil/sample"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -21,7 +22,7 @@ func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
 
 	// perform the withdraw
 	tx := r.ZEVMToEMVCall(
-		r.TestDAppV2EVMAddr,
+		sample.EthAddress(), // non-existing address
 		[]byte("revert"),
 		gatewayzevm.RevertOptions{
 			RevertAddress:    r.TestDAppV2ZEVMAddr,

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -1,7 +1,6 @@
 package e2etests
 
 import (
-	"github.com/zeta-chain/node/testutil/sample"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/testutil/sample"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 

--- a/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
@@ -27,7 +27,7 @@ func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
 
 	// perform the withdraw
 	tx := r.ZEVMToEMVCall(
-		r.TestDAppV2EVMAddr,
+		sample.EthAddress(), // non-existing address
 		[]byte("revert"),
 		gatewayzevm.RevertOptions{
 			RevertAddress:    sample.EthAddress(), // non-existing address

--- a/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
@@ -1,0 +1,58 @@
+package e2etests
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
+
+	"github.com/zeta-chain/node/e2e/contracts/testabort"
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 0)
+
+	payload := randomPayload(r)
+
+	r.ApproveETHZRC20(r.GatewayZEVMAddr)
+
+	// deploy testabort contract
+	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	require.NoError(r, err)
+
+	// perform the withdraw
+	tx := r.ZEVMToEMVCall(
+		r.TestDAppV2EVMAddr,
+		[]byte("revert"),
+		gatewayzevm.RevertOptions{
+			RevertAddress:    sample.EthAddress(), // non-existing address
+			CallOnRevert:     true,
+			RevertMessage:    []byte("revert"),
+			OnRevertGasLimit: big.NewInt(200000),
+			AbortAddress:     testAbortAddr,
+		},
+	)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "call")
+	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+
+	// check onAbort was called
+	aborted, err := testAbort.IsAborted(&bind.CallOpts{})
+	require.NoError(r, err)
+	require.True(r, aborted)
+
+	// check abort context was passed
+	abortContext, err := testAbort.GetAbortedWithMessage(&bind.CallOpts{}, "revert")
+	require.NoError(r, err)
+	require.EqualValues(r, r.ETHZRC20Addr.Hex(), abortContext.Asset.Hex())
+	require.EqualValues(r, int64(0), abortContext.Amount.Int64())
+}

--- a/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
@@ -17,8 +17,6 @@ import (
 func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	payload := randomPayload(r)
-
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
 	// deploy testabort contract
@@ -42,8 +40,6 @@ func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
 	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
-
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/zetaclient/chains/bitcoin/observer/event.go
+++ b/zetaclient/chains/bitcoin/observer/event.go
@@ -217,6 +217,7 @@ func (ob *Observer) NewInboundVoteFromStdMemo(
 	// zetacore will create a revert outbound that points to the custom revert address.
 	revertOptions := crosschaintypes.RevertOptions{
 		RevertAddress: event.MemoStd.RevertOptions.RevertAddress,
+		AbortAddress:  event.MemoStd.RevertOptions.AbortAddress,
 	}
 
 	// check if the memo is a cross-chain call, or simple token deposit


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/3530 https://github.com/zeta-chain/node/issues/3532

Finally seems it's already supported so this PR just add the test
no asset call evm -> zevm aborts
no asset call zevm -> evm reverts (was actually missing in the first place)
no asset call zevm -> evm aborts



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for cross-chain transactions, improving reliability for deposit and call operations.
- **Tests**
  - Expanded end-to-end test coverage to simulate and verify revert and abort scenarios in Bitcoin and Ethereum interactions.
- **Chores**
  - Refined transaction messaging to better incorporate abort context, ensuring improved clarity during error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->