### PR TITLE
fix: skip block scanning actions on Arbitrum and Avalanch networks (v27)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v27.0.5
+* [3554](https://github.com/zeta-chain/node/pull/3554) - disable observation of direct to TSS Address deposits on Arbitrum and Avalanch networks
+
 ## v27.0.4
 
 ### Fixes

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -188,13 +188,10 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 					Msgf("ObserveInbound: error observe TSSReceive")
 			}
 		}
-	}()
-
-	// task 4: filter the outbounds from TSS address to supplement outbound trackers
-	// TODO: make this a separate go routine in outbound.go after switching to smart contract V2
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+		// task 4: filter the outbounds from TSS address to supplement outbound trackers
+		// TODO: make this a separate go routine in outbound.go after switching to smart contract V2
+		//
+		// this is a slow task and should be skipped for ARB, AVAX, and their testnets
 		ob.FilterTSSOutbound(ctx, startBlock, toBlock)
 	}()
 

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -19,6 +20,7 @@ import (
 	"github.com/zeta-chain/protocol-contracts/pkg/erc20custody.sol"
 	"github.com/zeta-chain/protocol-contracts/pkg/zetaconnector.non-eth.sol"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/pkg/memo"
@@ -131,59 +133,108 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		return nil
 	}
 
-	// get last scanned block height (we simply use same height for all 3 events ZetaSent, Deposited, TssRecvd)
+	var (
+		lastScannedZetaSent              uint64
+		lastScannedDeposited             uint64
+		lastScannedGatewayDeposit        uint64
+		lastScannedGatewayCall           uint64
+		lastScannedGatewayDepositAndCall uint64
+		lastScannedTssRecvd              uint64
+	)
 	// Note: using different heights for each event incurs more complexity (metrics, db, etc) and not worth it
 	startBlock, toBlock := ob.calcBlockRangeToScan(confirmedBlockNum, lastScanned, config.MaxBlocksPerPeriod)
 
+	wg := sync.WaitGroup{}
+
 	// task 1:  query evm chain for zeta sent logs (read at most 100 blocks in one go)
-	lastScannedZetaSent, err := ob.ObserveZetaSent(ctx, startBlock, toBlock)
-	if err != nil {
-		return errors.Wrap(err, "unable to observe ZetaSent")
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		lastScannedZetaSent, err = ob.ObserveZetaSent(ctx, startBlock, toBlock)
+		if err != nil {
+			ob.Logger().Inbound.Error().
+				Err(err).
+				Msgf("ObserveInbound: error observing zeta sent")
+		}
+	}()
 
 	// task 2: query evm chain for deposited logs (read at most 100 blocks in one go)
-	lastScannedDeposited := ob.ObserveERC20Deposited(ctx, startBlock, toBlock)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		lastScannedDeposited = ob.ObserveERC20Deposited(ctx, startBlock, toBlock)
+	}()
 
 	// task 3: query the incoming tx to TSS address (read at most 100 blocks in one go)
 	// only do this for ARB, AVAX, and their testnets
 	//
 	// initialize lastScannedTssRecvd to a known "unset" value
-	var lastScannedTssRecvd uint64
 	chainID := ob.Chain().ChainId
-	if chainID != 421614 && chainID != 42161 && chainID != 43113 && chainID != 43114 {
-		var err error
-		lastScannedTssRecvd, err = ob.ObserverTSSReceive(ctx, startBlock, toBlock)
-		if err != nil {
-			return errors.Wrap(err, "unable to observe TSSReceive")
+	shouldScanTSSRecieve := chainID != chains.ArbitrumMainnet.ChainId &&
+		chainID != chains.ArbitrumSepolia.ChainId &&
+		chainID != chains.AvalancheMainnet.ChainId &&
+		chainID != chains.AvalancheTestnet.ChainId
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if shouldScanTSSRecieve {
+			var err error
+			lastScannedTssRecvd, err = ob.ObserverTSSReceive(ctx, startBlock, toBlock)
+			if err != nil {
+				ob.Logger().Inbound.Error().
+					Err(err).
+					Msgf("ObserveInbound: error observe TSSReceive")
+			}
 		}
-	}
+	}()
 
 	// task 4: filter the outbounds from TSS address to supplement outbound trackers
 	// TODO: make this a separate go routine in outbound.go after switching to smart contract V2
-	//
-	ob.FilterTSSOutbound(ctx, startBlock, toBlock)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ob.FilterTSSOutbound(ctx, startBlock, toBlock)
+	}()
 
 	// query the gateway logs
 	// TODO: refactor in a more declarative design. Example: storing the list of contract and events to listen in an array
 	// https://github.com/zeta-chain/node/issues/2493
-	lastScannedGatewayDeposit, err := ob.ObserveGatewayDeposit(ctx, startBlock, toBlock)
-	if err != nil {
-		ob.Logger().Inbound.Error().
-			Err(err).
-			Msgf("ObserveInbound: error observing deposit events from Gateway contract")
-	}
-	lastScannedGatewayCall, err := ob.ObserveGatewayCall(ctx, startBlock, toBlock)
-	if err != nil {
-		ob.Logger().Inbound.Error().
-			Err(err).
-			Msgf("ObserveInbound: error observing call events from Gateway contract")
-	}
-	lastScannedGatewayDepositAndCall, err := ob.ObserveGatewayDepositAndCall(ctx, startBlock, toBlock)
-	if err != nil {
-		ob.Logger().Inbound.Error().
-			Err(err).
-			Msgf("ObserveInbound: error observing depositAndCall events from Gateway contract")
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		lastScannedGatewayDeposit, err = ob.ObserveGatewayDeposit(ctx, startBlock, toBlock)
+		if err != nil {
+			ob.Logger().Inbound.Error().
+				Err(err).
+				Msgf("ObserveInbound: error observing deposit events from Gateway contract")
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		lastScannedGatewayCall, err = ob.ObserveGatewayCall(ctx, startBlock, toBlock)
+		if err != nil {
+			ob.Logger().Inbound.Error().
+				Err(err).
+				Msgf("ObserveInbound: error observing call events from Gateway contract")
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		lastScannedGatewayDepositAndCall, err = ob.ObserveGatewayDepositAndCall(ctx, startBlock, toBlock)
+		if err != nil {
+			ob.Logger().Inbound.Error().
+				Err(err).
+				Msgf("ObserveInbound: error observing depositAndCall events from Gateway contract")
+		}
+	}()
+	wg.Wait()
 
 	// note: using the lowest height for all events is not perfect,
 	// but it's simple and good enough
@@ -195,11 +246,19 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		lastScannedGatewayDepositAndCall,
 	}
 	// only include lastScannedTssRecvd if it was set
-	if lastScannedTssRecvd != 0 {
+	if shouldScanTSSRecieve {
 		scannedBlocks = append(scannedBlocks, lastScannedTssRecvd)
 	}
 	// calculate the lowest last scanned block
 	lowestLastScannedBlock := slices.Min(scannedBlocks)
+
+	highestLastScannedBlock := slices.Max(scannedBlocks)
+	if highestLastScannedBlock-lowestLastScannedBlock > 10 {
+		ob.Logger().Inbound.Warn().
+			Uint64("observer.last_scanned_lowest", lowestLastScannedBlock).
+			Uint64("observer.highest_scanned_lowest", highestLastScannedBlock).
+			Msg("ObserveInbound: high scanned block delta")
+	}
 
 	// update last scanned block height for all 3 events (ZetaSent, Deposited, TssRecvd), ignore db error
 	if lowestLastScannedBlock > lastScanned {

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -148,7 +148,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// only do this for ARB, AVAX, and their testnets
 	//
 	// initialize lastScannedTssRecvd to a known "unset" value
-	var lastScannedTssRecvd uint64 = 0 // Assuming 0 is an appropriate "unset" value
+	var lastScannedTssRecvd uint64
 	chainID := ob.Chain().ChainId
 	if chainID != 421614 && chainID != 42161 && chainID != 43113 && chainID != 43114 {
 		var err error
@@ -194,7 +194,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		lastScannedGatewayCall,
 		lastScannedGatewayDepositAndCall,
 	}
-	// only include lastScannedTssRecvd if it was set (non-zero)
+	// only include lastScannedTssRecvd if it was set
 	if lastScannedTssRecvd != 0 {
 		scannedBlocks = append(scannedBlocks, lastScannedTssRecvd)
 	}

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -146,7 +146,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 
 	// task 3: query the incoming tx to TSS address (read at most 100 blocks in one go)
 	// only do this for ARB, AVAX, and their testnets
-        //
+	//
 	// initialize lastScannedTssRecvd to a known "unset" value
 	var lastScannedTssRecvd uint64 = 0 // Assuming 0 is an appropriate "unset" value
 	chainID := ob.Chain().ChainId

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -155,7 +155,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 			logger.Error().Err(err).Msg("error observing TSS received gas asset")
 		}
 	}
-	
+
 	// task 4: filter the outbounds from TSS address to supplement outbound trackers
 	// TODO: make this a separate go routine in outbound.go after switching to smart contract V2
 	//

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -154,7 +154,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
                 var err error
 		lastScannedTssRecvd, err = ob.ObserveTSSReceive(ctx, startBlock, toBlock)
 		if err != nil {
-			logger.Error().Err(err).Msg("error observing TSS received gas asset")
+			return errors.Wrap(err, "unable to observe TSSReceive")
 		}
 	}
 

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -152,7 +152,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	chainID := ob.Chain().ChainId
         if chainID != 421614 && chainID != 42161 && chainID != 43113 && chainID != 43114 {
                 var err error
-		lastScannedTssRecvd, err = ob.ObserveTSSReceive(ctx, startBlock, toBlock)
+		lastScannedTssRecvd, err = ob.ObserverTSSReceive(ctx, startBlock, toBlock)
 		if err != nil {
 			return errors.Wrap(err, "unable to observe TSSReceive")
 		}

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -168,8 +168,6 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 
 	// task 3: query the incoming tx to TSS address (read at most 100 blocks in one go)
 	// only do this for ARB, AVAX, and their testnets
-	//
-	// initialize lastScannedTssRecvd to a known "unset" value
 	chainID := ob.Chain().ChainId
 	shouldScanTSSRecieve := chainID != chains.ArbitrumMainnet.ChainId &&
 		chainID != chains.ArbitrumSepolia.ChainId &&

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -149,7 +149,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	
 	// Initialize lastScannedTssRecvd to a known "unset" value
 	var lastScannedTssRecvd uint64 = 0 // Assuming 0 is an appropriate "unset" value
-	if ob.Chain().ChainId != 421614 && ob.Chain().ChainId != 42161 && ob.Chain().ChainId != 43113 && ob.Chain().ChainId != 43114  {
+	if chainID == 1 || chainID == 11155111 || chainID == 1337 {
 		lastScannedTssRecvd, err := ob.ObserveTSSReceive(ctx, startBlock, toBlock)
 		if err != nil {
 			logger.Error().Err(err).Msg("error observing TSS received gas asset")

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -149,7 +149,8 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	
 	// Initialize lastScannedTssRecvd to a known "unset" value
 	var lastScannedTssRecvd uint64 = 0 // Assuming 0 is an appropriate "unset" value
-	if chainID == 1 || chainID == 11155111 || chainID == 1337 {
+	chainID := ob.Chain().ChainId
+	if chainID == 1 || chainID == 11155111 || chainID == 1337 || chainID == 137 || chainID == 80002 {
 		lastScannedTssRecvd, err := ob.ObserveTSSReceive(ctx, startBlock, toBlock)
 		if err != nil {
 			logger.Error().Err(err).Msg("error observing TSS received gas asset")

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -150,8 +150,9 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// Initialize lastScannedTssRecvd to a known "unset" value
 	var lastScannedTssRecvd uint64 = 0 // Assuming 0 is an appropriate "unset" value
 	chainID := ob.Chain().ChainId
-	if chainID == 1 || chainID == 11155111 || chainID == 1337 || chainID == 137 || chainID == 80002 {
-		lastScannedTssRecvd, err := ob.ObserveTSSReceive(ctx, startBlock, toBlock)
+        if chainID != 421614 && chainID != 42161 && chainID != 43113 && chainID != 43114 {
+                var err error
+		lastScannedTssRecvd, err = ob.ObserveTSSReceive(ctx, startBlock, toBlock)
 		if err != nil {
 			logger.Error().Err(err).Msg("error observing TSS received gas asset")
 		}

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -187,12 +187,12 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 					Err(err).
 					Msgf("ObserveInbound: error observe TSSReceive")
 			}
+			// task 4: filter the outbounds from TSS address to supplement outbound trackers
+			// TODO: make this a separate go routine in outbound.go after switching to smart contract V2
+			//
+			// this is a slow task and should be skipped for ARB, AVAX, and their testnets
+			ob.FilterTSSOutbound(ctx, startBlock, toBlock)
 		}
-		// task 4: filter the outbounds from TSS address to supplement outbound trackers
-		// TODO: make this a separate go routine in outbound.go after switching to smart contract V2
-		//
-		// this is a slow task and should be skipped for ARB, AVAX, and their testnets
-		ob.FilterTSSOutbound(ctx, startBlock, toBlock)
 	}()
 
 	// query the gateway logs

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -145,13 +145,13 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	lastScannedDeposited := ob.ObserveERC20Deposited(ctx, startBlock, toBlock)
 
 	// task 3: query the incoming tx to TSS address (read at most 100 blocks in one go)
-	// Only do this for ARB, AVAX, and their testnets
-	
-	// Initialize lastScannedTssRecvd to a known "unset" value
+	// only do this for ARB, AVAX, and their testnets
+        //
+	// initialize lastScannedTssRecvd to a known "unset" value
 	var lastScannedTssRecvd uint64 = 0 // Assuming 0 is an appropriate "unset" value
 	chainID := ob.Chain().ChainId
-        if chainID != 421614 && chainID != 42161 && chainID != 43113 && chainID != 43114 {
-                var err error
+	if chainID != 421614 && chainID != 42161 && chainID != 43113 && chainID != 43114 {
+		var err error
 		lastScannedTssRecvd, err = ob.ObserverTSSReceive(ctx, startBlock, toBlock)
 		if err != nil {
 			return errors.Wrap(err, "unable to observe TSSReceive")
@@ -194,13 +194,13 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		lastScannedGatewayCall,
 		lastScannedGatewayDepositAndCall,
 	}
-	// Only include lastScannedTssRecvd if it was set (non-zero)
+	// only include lastScannedTssRecvd if it was set (non-zero)
 	if lastScannedTssRecvd != 0 {
 		scannedBlocks = append(scannedBlocks, lastScannedTssRecvd)
 	}
-	// Calculate the lowest last scanned block
+	// calculate the lowest last scanned block
 	lowestLastScannedBlock := slices.Min(scannedBlocks)
-	
+
 	// update last scanned block height for all 3 events (ZetaSent, Deposited, TssRecvd), ignore db error
 	if lowestLastScannedBlock > lastScanned {
 		if err = ob.SaveLastBlockScanned(lowestLastScannedBlock); err != nil {


### PR DESCRIPTION
# Description

This PR takes a hatchet to zetaclient/chains/evm/observer/inbound.go to validate the expected gains from not observing TSS direct transfers on Arbitrum and Avalanche.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
