### PR TITLE
chore: add triage comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- Please apply the 'triage' label if you would like a prioritised response from the team -->
+
 **Describe the Bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- Please apply the 'triage' label if you would like a prioritised response from the team -->
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is.
 

--- a/.github/ISSUE_TEMPLATE/syncing.yaml
+++ b/.github/ISSUE_TEMPLATE/syncing.yaml
@@ -1,6 +1,6 @@
 name: Having difficulties setting up or syncing a node
 description: Please fill out the following form to help us understand and resolve your issue with setting up or syncing a node. Provide as much detail as possible to ensure a quick and accurate resolution.
-labels: ["infra"]
+labels: ["infra", "triage"]
 body:
   - type: dropdown
     attributes:


### PR DESCRIPTION
Add comment in templates asking user to assign triage label if they want response from the team. This label should generate an internal slack notification.

Also move syncing template to https://github.com/zeta-chain/issues/blob/main/.github/ISSUE_TEMPLATE/3-syncing.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced issue reporting forms with guidance to apply a priority label for expedited handling.
	- Expanded categorization options and refined formatting for improved clarity in issue submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->