### PR TITLE
chore: use v28 as upgrade test base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ ifdef UPGRADE_TEST_FROM_SOURCE
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from source"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime-source \
-		--build-arg OLD_VERSION='release/v26' \
+		--build-arg OLD_VERSION='release/v28' \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg NODE_COMMIT=$(NODE_COMMIT)
 		.
@@ -345,7 +345,7 @@ else
 zetanode-upgrade: e2e-images
 	@echo "Building zetanode-upgrade from binaries"
 	$(DOCKER) build -t zetanode:old -f Dockerfile-localnet --target old-runtime \
-	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v26.0.0' \
+	--build-arg OLD_VERSION='https://github.com/zeta-chain/node/releases/download/v28.0.0' \
 	--build-arg NODE_VERSION=$(NODE_VERSION) \
 	--build-arg NODE_COMMIT=$(NODE_COMMIT) \
 	.

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,23 @@
 * [3430](https://github.com/zeta-chain/node/pull/3430) - add simulation test for MsgWithDrawEmission
 * [3503](https://github.com/zeta-chain/node/pull/3503) - add check in e2e test to ensure deletion of stale ballots
 
+## v28.0.0
+
+v28 is based on the release/v27 branch rather than develop
+
+### Fixes
+* [3563](https://github.com/zeta-chain/node/pull/3563) - upgrade cosmos-sdk to v0.50.12 to resolve GHSA-x5vx-95h7-rv4p
+
+## v27.0.5
+
+### Fixes
+* [3554](https://github.com/zeta-chain/node/pull/3554) - disable observation of direct to TSS Address deposits on Arbitrum and Avalanch networks
+
+## v27.0.4
+
+### Fixes
+* [3508](https://github.com/zeta-chain/node/pull/3508) - fix empty from field in eth receipt rpc method
+
 ## v27.0.1
 
 ### Fixes

--- a/contrib/localnet/docker-compose-upgrade.yml
+++ b/contrib/localnet/docker-compose-upgrade.yml
@@ -1,4 +1,3 @@
-version: "3"
 # This docker-compose updates the services to use the old version of the zetanode image
 
 services:

--- a/contrib/localnet/scripts/start-upgrade-orchestrator.sh
+++ b/contrib/localnet/scripts/start-upgrade-orchestrator.sh
@@ -92,18 +92,13 @@ cat upgrade.json | jq --arg info "$(cat upgrade_plan_info.json)" '.messages[0].p
 
 echo "Submitting upgrade proposal"
 
-zetacored tx gov submit-proposal upgrade_full.json --from operator --keyring-backend test --chain-id $CHAINID --yes --fees 2000000000000000azeta -o json | tee proposal.json
+zetacored tx gov submit-proposal upgrade_full.json --from operator --keyring-backend test --chain-id $CHAINID --yes --gas 300000 --fees 3000000000000000azeta -o json | tee proposal.json
 PROPOSAL_TX_HASH=$(jq -r .txhash proposal.json)
 PROPOSAL_ID=""
-# WARN: this seems to be unstable
 while [[ -z $PROPOSAL_ID ]]; do
     echo "waiting to get proposal_id"
     sleep 1
-    # v0.47 version
-    # proposal_id=$(zetacored query tx $PROPOSAL_TX_HASH -o json | jq -r '.events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value')
-    
-    # v0.46 version
-    PROPOSAL_ID=$(zetacored query tx --type=hash $PROPOSAL_TX_HASH -o json | jq -r '.logs[0].events[] | select(.type == "proposal_deposit") | .attributes[] | select(.key == "proposal_id") | .value')
+    PROPOSAL_ID=$(zetacored query tx $PROPOSAL_TX_HASH -o json | jq -r '.events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value')
 done
 echo "proposal id is ${PROPOSAL_ID}"
 

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -9,65 +9,6 @@
 
 /usr/sbin/sshd
 
-# This function add authz observer authorizations for inbound/outbound votes and tracker messages
-# These messages have been renamed for v17: https://github.com/zeta-chain/node/blob/refactor/rename-outbound-inbound/docs/releases/v17_breaking_changes.md#inbound-and-outtx-renaming
-# There if the genesis is generated with a v16 binary for the upgrade tests, it will not contains authorizations for new messages
-# This function will add the missing authorizations to the genesis file
-# TODO: Remove this function when v17 is released
-# https://github.com/zeta-chain/node/issues/2196
-add_v17_message_authorizations() {
-    # Path to the JSON file
-    json_file="/root/.zetacored/config/genesis.json"
-
-    # Using jq to parse JSON, create new entries, and append them to the authorization array
-    jq '
-        # Store the nodeAccountList array
-        .app_state.observer.nodeAccountList as $list |
-
-        # Iterate over the stored list to construct new objects and append to the authorization array
-        .app_state.authz.authorization += [
-            $list[] |
-            {
-                "granter": .operator,
-                "grantee": .granteeAddress,
-                "authorization": {
-                    "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-                    "msg": "/zetachain.zetacore.crosschain.MsgVoteInbound"
-                },
-                "expiration": null
-            },
-            {
-                "granter": .operator,
-                "grantee": .granteeAddress,
-                "authorization": {
-                    "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-                    "msg": "/zetachain.zetacore.crosschain.MsgVoteOutbound"
-                },
-                "expiration": null
-            },
-            {
-                "granter": .operator,
-                "grantee": .granteeAddress,
-                "authorization": {
-                    "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-                    "msg": "/zetachain.zetacore.crosschain.MsgAddOutboundTracker"
-                },
-                "expiration": null
-            },
-            {
-                "granter": .operator,
-                "grantee": .granteeAddress,
-                "authorization": {
-                    "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-                    "msg": "/zetachain.zetacore.crosschain.MsgAddInboundTracker"
-                },
-                "expiration": null
-            }
-        ]
-    ' $json_file > temp.json && mv temp.json $json_file
-}
-
-
 add_emissions_withdraw_authorizations() {
 
     config_file="/root/config.yml"
@@ -161,7 +102,7 @@ then
   # Init a new node to generate genesis file .
   # Copy config files from existing folders which get copied via Docker Copy when building images
   mkdir -p ~/.backup/config
-  zetacored init Zetanode-Localnet --chain-id=$CHAINID
+  zetacored init Zetanode-Localnet --chain-id=$CHAINID --default-denom azeta
   rm -rf ~/.zetacored/config/app.toml
   rm -rf ~/.zetacored/config/client.toml
   rm -rf ~/.zetacored/config/config.toml
@@ -246,40 +187,22 @@ then
       exit 1
   fi
 
-  # Check for the existence of "AddToOutTxTracker" string in the genesis file
-  # If this message is found in the genesis, it means add-observer-list has been run with the v16 binary for upgrade tests
-  # In this case, we need to add authorizations for the new v17 messages to the genesis file
-  # TODO: Remove this function when v17 is released
-  # https://github.com/zeta-chain/node/issues/2196
-  if jq -e 'tostring | contains("AddToOutTxTracker")' "/root/.zetacored/config/genesis.json" > /dev/null; then
-    add_v17_message_authorizations
-  fi
-
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["staking"]["params"]["bond_denom"]="azeta"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom"]="azeta"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="azeta"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]="azeta"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["evm"]["params"]["evm_denom"]="azeta"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.consensus["params"]["block"]["max_gas"]="500000000"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq '.app_state["feemarket"]["params"]["min_gas_price"]="10000000000.0000"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-
-  # TODO: remove and move gov params change below after v50 upgrade
-  cat $HOME/.zetacored/config/genesis.json | jq '
-    if .consensus_params == null then
-      .app_state.gov.params.expedited_voting_period = "50s"
-    else
-      .consensus_params.block.max_gas = "500000000"
-    end
-  ' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-
-  # set governance parameters in new params module for sdk v0.47+
-  # these parameters will normally be migrated but is needed for localnet genesis
-  # set the parameters only if params field is defined in gov
-  # in the case of sdk v0.46 during upgrade test, the params field is not defined
-  if jq -e '.app_state.gov | has("params")' "$HOME/.zetacored/config/genesis.json" > /dev/null; then
-    cat $HOME/.zetacored/config/genesis.json | jq '.app_state["gov"]["params"]["min_deposit"][0]["denom"]="azeta"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-    cat $HOME/.zetacored/config/genesis.json | jq '.app_state["gov"]["params"]["voting_period"]="100s"' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  fi
+  # Update governance and other chain parameters for localnet
+  jq '
+    .app_state.gov.params.voting_period="100s" |
+    .app_state.gov.params.quorum="0.1" |
+    .app_state.gov.params.threshold="0.1" |
+    .app_state.gov.params.expedited_voting_period = "50s" |
+    .app_state.gov.deposit_params.min_deposit[0].denom = "azeta" |
+    .app_state.gov.params.min_deposit[0].denom = "azeta" |
+    .app_state.staking.params.bond_denom = "azeta" |
+    .app_state.crisis.constant_fee.denom = "azeta" |
+    .app_state.mint.params.mint_denom = "azeta" |
+    .app_state.evm.params.evm_denom = "azeta" |
+    .app_state.feemarket.params.min_gas_price = "10000000000.0000" |
+    .consensus.params.block.max_gas = "500000000"
+  ' "$HOME/.zetacored/config/genesis.json" > "$HOME/.zetacored/config/tmp_genesis.json" \
+    && mv "$HOME/.zetacored/config/tmp_genesis.json" "$HOME/.zetacored/config/genesis.json"
 
 # set admin account
   zetacored add-genesis-account zeta1n0rn6sne54hv7w2uu93fl48ncyqz97d3kty6sh 100000000000000000000000000azeta # Funds the localnet_gov_admin account
@@ -292,9 +215,14 @@ then
   zetacored add-genesis-account "$admin_policy" 100000000000000000000000000azeta
   zetacored add-genesis-account "$operational_policy" 100000000000000000000000000azeta
 
-  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$emergency_policy" '.app_state["authority"]["policies"]["items"][0]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$operational_policy" '.app_state["authority"]["policies"]["items"][1]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
-  cat $HOME/.zetacored/config/genesis.json | jq --arg address "$admin_policy" '.app_state["authority"]["policies"]["items"][2]["address"] = $address' > $HOME/.zetacored/config/tmp_genesis.json && mv $HOME/.zetacored/config/tmp_genesis.json $HOME/.zetacored/config/genesis.json
+  jq --arg emergency "$emergency_policy" \
+    --arg operational "$operational_policy" \
+    --arg admin "$admin_policy" '
+      .app_state.authority.policies.items[0].address = $emergency |
+      .app_state.authority.policies.items[1].address = $operational |
+      .app_state.authority.policies.items[2].address = $admin
+  ' "$HOME/.zetacored/config/genesis.json" > "$HOME/.zetacored/config/tmp_genesis.json" \
+    && mv "$HOME/.zetacored/config/tmp_genesis.json" "$HOME/.zetacored/config/genesis.json"
 
 # give balance to runner accounts to deploy contracts directly on zEVM
 # default account
@@ -362,13 +290,6 @@ then
     echo "Importing data"
     zetacored parse-genesis-file /root/genesis_data/exported-genesis.json
   fi
-
-# Update governance voting parameters for localnet
-# this allows for quick upgrades and using more than two nodes
-  jq '.app_state["gov"]["params"]["voting_period"]="100s" |
-    .app_state["gov"]["params"]["quorum"]="0.1" |
-    .app_state["gov"]["params"]["threshold"]="0.1"' \
-  $HOME/.zetacored/config/genesis.json > tmp.json && mv tmp.json $HOME/.zetacored/config/genesis.json
 
 # 4. Collect all the gentx files in zetacore0 and create the final genesis.json
   zetacored collect-gentxs

--- a/contrib/localnet/ssh_config
+++ b/contrib/localnet/ssh_config
@@ -1,2 +1,3 @@
 Host *
     StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -266,7 +266,7 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in wei", DefaultValue: "10000000000000000"},
 		},
 		TestETHDepositRevertAndAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestETHWithdrawName,
@@ -331,7 +331,7 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in wei", DefaultValue: "1000000000000000000"},
 		},
 		TestETHWithdrawRevertAndAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestETHWithdrawAndCallRevertWithWithdrawName,
@@ -395,7 +395,7 @@ var AllE2ETests = []runner.E2ETest{
 		"deposit ERC20 into ZEVM, revert, then abort with onAbort because revert fee cannot be paid",
 		[]runner.ArgDefinition{},
 		TestERC20DepositRevertAndAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestERC20WithdrawName,
@@ -452,7 +452,7 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount", DefaultValue: "1000"},
 		},
 		TestERC20WithdrawRevertAndAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMArbitraryCallName,
@@ -471,14 +471,14 @@ var AllE2ETests = []runner.E2ETest{
 		"zevm -> evm call that reverts and call onRevert",
 		[]runner.ArgDefinition{},
 		TestZEVMToEVMCallRevert,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallRevertAndAbortName,
 		"zevm -> evm call that reverts and abort with onAbort",
 		[]runner.ArgDefinition{},
 		TestZEVMToEVMCallRevertAndAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallThroughContractName,
@@ -497,7 +497,7 @@ var AllE2ETests = []runner.E2ETest{
 		"evm -> zevm call fails and abort with onAbort",
 		[]runner.ArgDefinition{},
 		TestEVMToZEVMCallAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestDepositAndCallSwapName,
@@ -743,7 +743,7 @@ var AllE2ETests = []runner.E2ETest{
 		"deposit Bitcoin into ZEVM and call a contract with standard memo; revert and abort with onAbort",
 		[]runner.ArgDefinition{},
 		TestBitcoinStdMemoDepositAndCallRevertAndAbort,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestBitcoinStdMemoInscribedDepositAndCallName,
@@ -1008,7 +1008,7 @@ var AllE2ETests = []runner.E2ETest{
 		"update ZRC20 name and symbol",
 		[]runner.ArgDefinition{},
 		TestUpdateZRC20Name,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZetaclientRestartHeightName,
@@ -1027,7 +1027,7 @@ var AllE2ETests = []runner.E2ETest{
 		"update operational chain params",
 		[]runner.ArgDefinition{},
 		TestUpdateOperationalChainParams,
-		runner.WithMinimumVersion("v28.0.0"),
+		runner.WithMinimumVersion("v29.0.0"),
 	),
 	/*
 	 Special tests


### PR DESCRIPTION
Also:

- port https://github.com/zeta-chain/node/pull/3564
- sync changelog
- bump minimum version in upgrade tests where needed
- cleanup genesis logic

Closes https://github.com/zeta-chain/node/issues/2196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the release version to v28.0.0 and refined the upgrade process for smoother operations.
- **Bug Fixes**
  - Addressed issues impacting deposit handling and transaction details for improved consistency.
- **Documentation**
  - Updated public release notes with the latest version details and fixes.
- **Tests**
  - Revised version requirements in end-to-end tests to ensure compatibility with upcoming v29.0.0 features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->