### PR TITLE
refactor(zetaclient): make EVM getLogs call once

### DIFF
--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"math/big"
 	"sort"
 
 	"cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
-	"github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/zeta-chain/protocol-contracts/pkg/gatewayevm.sol"
@@ -22,7 +20,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/compliance"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/logs"
-	"github.com/zeta-chain/node/zetaclient/metrics"
 	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
 
@@ -59,27 +56,6 @@ func (ob *Observer) isEventProcessable(
 	}
 
 	return true
-}
-
-func (ob *Observer) fetchGatewayLogs(ctx context.Context, startBlock, toBlock uint64) ([]ethtypes.Log, error) {
-	gatewayAddr, _, err := ob.GetGatewayContract()
-	if err != nil {
-		return nil, errors.Wrap(err, "can't get gateway contract")
-	}
-
-	logs, err := ob.evmClient.FilterLogs(ctx, ethereum.FilterQuery{
-		FromBlock: new(big.Int).SetUint64(startBlock),
-		ToBlock:   new(big.Int).SetUint64(toBlock),
-		Addresses: []ethcommon.Address{gatewayAddr},
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "filter logs")
-	}
-
-	// increment prom counter
-	metrics.GetFilterLogsPerChain.WithLabelValues(ob.Chain().Name).Inc()
-
-	return logs, nil
 }
 
 // observeGatewayDeposit queries the gateway contract for deposit events

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"math/big"
 	"sort"
 
 	"cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/zeta-chain/protocol-contracts/pkg/gatewayevm.sol"
 
 	"github.com/zeta-chain/node/pkg/coin"
@@ -59,9 +61,34 @@ func (ob *Observer) isEventProcessable(
 	return true
 }
 
-// ObserveGatewayDeposit queries the gateway contract for deposit events
+func (ob *Observer) fetchGatewayLogs(ctx context.Context, startBlock, toBlock uint64) ([]ethtypes.Log, error) {
+	gatewayAddr, _, err := ob.GetGatewayContract()
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get gateway contract")
+	}
+
+	logs, err := ob.evmClient.FilterLogs(ctx, ethereum.FilterQuery{
+		FromBlock: new(big.Int).SetUint64(startBlock),
+		ToBlock:   new(big.Int).SetUint64(toBlock),
+		Addresses: []ethcommon.Address{gatewayAddr},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "filter logs")
+	}
+
+	// increment prom counter
+	metrics.GetFilterLogsPerChain.WithLabelValues(ob.Chain().Name).Inc()
+
+	return logs, nil
+}
+
+// observeGatewayDeposit queries the gateway contract for deposit events
 // returns the last block successfully scanned
-func (ob *Observer) ObserveGatewayDeposit(ctx context.Context, startBlock, toBlock uint64) (uint64, error) {
+func (ob *Observer) observeGatewayDeposit(
+	ctx context.Context,
+	startBlock, toBlock uint64,
+	rawLogs []ethtypes.Log,
+) (uint64, error) {
 	// filter ERC20CustodyDeposited logs
 	gatewayAddr, gatewayContract, err := ob.GetGatewayContract()
 	if err != nil {
@@ -69,27 +96,8 @@ func (ob *Observer) ObserveGatewayDeposit(ctx context.Context, startBlock, toBlo
 		return startBlock - 1, errors.Wrap(err, "can't get gateway contract")
 	}
 
-	// get iterator for the events for the block range
-	eventIterator, err := gatewayContract.FilterDeposited(&bind.FilterOpts{
-		Start:   startBlock,
-		End:     &toBlock,
-		Context: ctx,
-	}, []ethcommon.Address{}, []ethcommon.Address{})
-	if err != nil {
-		return startBlock - 1, errors.Wrapf(
-			err,
-			"error filtering deposits from block %d to %d for chain %d",
-			startBlock,
-			toBlock,
-			ob.Chain().ChainId,
-		)
-	}
-
 	// parse and validate events
-	events := ob.parseAndValidateDepositEvents(eventIterator, gatewayAddr)
-
-	// increment prom counter
-	metrics.GetFilterLogsPerChain.WithLabelValues(ob.Chain().Name).Inc()
+	events := ob.parseAndValidateDepositEvents(rawLogs, gatewayAddr, gatewayContract)
 
 	// post to zetacore
 	lastScanned := uint64(0)
@@ -124,22 +132,26 @@ func (ob *Observer) ObserveGatewayDeposit(ctx context.Context, startBlock, toBlo
 
 // parseAndValidateDepositEvents collects and sorts events by block number, tx index, and log index
 func (ob *Observer) parseAndValidateDepositEvents(
-	iterator *gatewayevm.GatewayEVMDepositedIterator,
+	rawLogs []ethtypes.Log,
 	gatewayAddr ethcommon.Address,
+	gatewayContract *gatewayevm.GatewayEVM,
 ) []*gatewayevm.GatewayEVMDeposited {
-	// collect and sort validEvents by block number, then tx index, then log index (ascending)
 	validEvents := make([]*gatewayevm.GatewayEVMDeposited, 0)
-	for iterator.Next() {
-		err := common.ValidateEvmTxLog(&iterator.Event.Raw, gatewayAddr, "", common.TopicsGatewayDeposit)
-		if err == nil {
-			validEvents = append(validEvents, iterator.Event)
+	for _, log := range rawLogs {
+		err := common.ValidateEvmTxLog(&log, gatewayAddr, "", common.TopicsGatewayDeposit)
+		if err != nil {
 			continue
 		}
-		ob.Logger().
-			Inbound.Warn().
-			Stringer(logs.FieldTx, iterator.Event.Raw.TxHash).
-			Uint64(logs.FieldBlock, iterator.Event.Raw.BlockNumber).
-			Msg("invalid Deposited event")
+		depositedEvent, err := gatewayContract.ParseDeposited(log)
+		if err != nil {
+			ob.Logger().
+				Inbound.Warn().
+				Stringer(logs.FieldTx, log.TxHash).
+				Uint64(logs.FieldBlock, log.BlockNumber).
+				Msg("invalid Deposited event")
+			continue
+		}
+		validEvents = append(validEvents, depositedEvent)
 	}
 
 	// order events by height, tx index and event index (ascending)
@@ -211,50 +223,29 @@ func (ob *Observer) newDepositInboundVote(event *gatewayevm.GatewayEVMDeposited)
 	)
 }
 
-// ObserveGatewayCall queries the gateway contract for call events
+// observeGatewayCall queries the gateway contract for call events
 // returns the last block successfully scanned
 // TODO: there are lot of similarities between this function and ObserveGatewayDeposit
 // logic should be factorized using interfaces and generics
 // https://github.com/zeta-chain/node/issues/2493
-func (ob *Observer) ObserveGatewayCall(ctx context.Context, startBlock, toBlock uint64) (uint64, error) {
-	// filter ERC20CustodyDeposited logs
+func (ob *Observer) observeGatewayCall(
+	ctx context.Context,
+	startBlock, toBlock uint64,
+	rawLogs []ethtypes.Log,
+) (uint64, error) {
 	gatewayAddr, gatewayContract, err := ob.GetGatewayContract()
 	if err != nil {
 		// lastScanned is startBlock - 1
 		return startBlock - 1, errors.Wrap(err, "can't get gateway contract")
 	}
 
-	// get iterator for the events for the block range
-	eventIterator, err := gatewayContract.FilterCalled(&bind.FilterOpts{
-		Start:   startBlock,
-		End:     &toBlock,
-		Context: ctx,
-	}, []ethcommon.Address{}, []ethcommon.Address{})
-	if err != nil {
-		return startBlock - 1, errors.Wrapf(
-			err,
-			"error filtering calls from block %d to %d for chain %d",
-			startBlock,
-			toBlock,
-			ob.Chain().ChainId,
-		)
-	}
-
-	// parse and validate events
-	events := ob.parseAndValidateCallEvents(eventIterator, gatewayAddr)
-
-	// increment prom counter
-	metrics.GetFilterLogsPerChain.WithLabelValues(ob.Chain().Name).Inc()
-
-	// post to zetacore
+	events := ob.parseAndValidateCallEvents(rawLogs, gatewayAddr, gatewayContract)
 	lastScanned := uint64(0)
 	for _, event := range events {
-		// remember which block we are scanning (there could be multiple events in the same block)
 		if event.Raw.BlockNumber > lastScanned {
 			lastScanned = event.Raw.BlockNumber
 		}
 
-		// check if the event is processable
 		if !ob.isEventProcessable(event.Sender, event.Receiver, event.Raw.TxHash, event.Payload) {
 			continue
 		}
@@ -268,33 +259,35 @@ func (ob *Observer) ObserveGatewayCall(ctx context.Context, startBlock, toBlock 
 
 		_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
 		if err != nil {
-			// decrement the last scanned block so we have to re-scan from this block next time
 			return lastScanned - 1, errors.Wrap(err, "error posting vote inbound")
 		}
 	}
 
-	// successfully processed all events in [startBlock, toBlock]
 	return toBlock, nil
 }
 
 // parseAndValidateCallEvents collects and sorts events by block number, tx index, and log index
 func (ob *Observer) parseAndValidateCallEvents(
-	iterator *gatewayevm.GatewayEVMCalledIterator,
+	rawLogs []ethtypes.Log,
 	gatewayAddr ethcommon.Address,
+	gatewayContract *gatewayevm.GatewayEVM,
 ) []*gatewayevm.GatewayEVMCalled {
-	// collect and sort validEvents by block number, then tx index, then log index (ascending)
 	validEvents := make([]*gatewayevm.GatewayEVMCalled, 0)
-	for iterator.Next() {
-		err := common.ValidateEvmTxLog(&iterator.Event.Raw, gatewayAddr, "", common.TopicsGatewayCall)
-		if err == nil {
-			validEvents = append(validEvents, iterator.Event)
+	for _, log := range rawLogs {
+		err := common.ValidateEvmTxLog(&log, gatewayAddr, "", common.TopicsGatewayCall)
+		if err != nil {
 			continue
 		}
-		ob.Logger().
-			Inbound.Warn().
-			Stringer(logs.FieldTx, iterator.Event.Raw.TxHash).
-			Uint64(logs.FieldBlock, iterator.Event.Raw.BlockNumber).
-			Msg("invalid Called event")
+		calledEvent, err := gatewayContract.ParseCalled(log)
+		if err != nil {
+			ob.Logger().
+				Inbound.Warn().
+				Stringer(logs.FieldTx, log.TxHash).
+				Uint64(logs.FieldBlock, log.BlockNumber).
+				Msg("invalid Called event")
+			continue
+		}
+		validEvents = append(validEvents, calledEvent)
 	}
 
 	// order events by height, tx index and event index (ascending)
@@ -350,38 +343,21 @@ func (ob *Observer) newCallInboundVote(event *gatewayevm.GatewayEVMCalled) types
 	)
 }
 
-// ObserveGatewayDepositAndCall queries the gateway contract for deposit and call events
+// observeGatewayDepositAndCall queries the gateway contract for deposit and call events
 // returns the last block successfully scanned
-func (ob *Observer) ObserveGatewayDepositAndCall(ctx context.Context, startBlock, toBlock uint64) (uint64, error) {
+func (ob *Observer) observeGatewayDepositAndCall(
+	ctx context.Context,
+	startBlock, toBlock uint64,
+	rawLogs []ethtypes.Log,
+) (uint64, error) {
 	gatewayAddr, gatewayContract, err := ob.GetGatewayContract()
 	if err != nil {
 		// lastScanned is startBlock - 1
 		return startBlock - 1, errors.Wrap(err, "can't get gateway contract")
 	}
 
-	// get iterator for the events for the block range
-	eventIterator, err := gatewayContract.FilterDepositedAndCalled(&bind.FilterOpts{
-		Start:   startBlock,
-		End:     &toBlock,
-		Context: ctx,
-	}, []ethcommon.Address{}, []ethcommon.Address{})
-	if err != nil {
-		return startBlock - 1, errors.Wrapf(
-			err,
-			"error filtering deposits from block %d to %d for chain %d",
-			startBlock,
-			toBlock,
-			ob.Chain().ChainId,
-		)
-	}
+	events := ob.parseAndValidateDepositAndCallEvents(rawLogs, gatewayAddr, gatewayContract)
 
-	// parse and validate events
-	events := ob.parseAndValidateDepositAndCallEvents(eventIterator, gatewayAddr)
-
-	// increment prom counter
-	metrics.GetFilterLogsPerChain.WithLabelValues(ob.Chain().Name).Inc()
-
-	// post to zetacore
 	lastScanned := uint64(0)
 	for _, event := range events {
 		// remember which block we are scanning (there could be multiple events in the same block)
@@ -414,22 +390,27 @@ func (ob *Observer) ObserveGatewayDepositAndCall(ctx context.Context, startBlock
 
 // parseAndValidateDepositAndCallEvents collects and sorts events by block number, tx index, and log index
 func (ob *Observer) parseAndValidateDepositAndCallEvents(
-	iterator *gatewayevm.GatewayEVMDepositedAndCalledIterator,
+	rawLogs []ethtypes.Log,
 	gatewayAddr ethcommon.Address,
+	gatewayContract *gatewayevm.GatewayEVM,
 ) []*gatewayevm.GatewayEVMDepositedAndCalled {
 	// collect and sort validEvents by block number, then tx index, then log index (ascending)
 	validEvents := make([]*gatewayevm.GatewayEVMDepositedAndCalled, 0)
-	for iterator.Next() {
-		err := common.ValidateEvmTxLog(&iterator.Event.Raw, gatewayAddr, "", common.TopicsGatewayDepositAndCall)
-		if err == nil {
-			validEvents = append(validEvents, iterator.Event)
+	for _, log := range rawLogs {
+		err := common.ValidateEvmTxLog(&log, gatewayAddr, "", common.TopicsGatewayDepositAndCall)
+		if err != nil {
 			continue
 		}
-		ob.Logger().
-			Inbound.Warn().
-			Stringer(logs.FieldTx, iterator.Event.Raw.TxHash).
-			Uint64(logs.FieldBlock, iterator.Event.Raw.BlockNumber).
-			Msg("invalid DepositedAndCalled event")
+		depositAndCallEvent, err := gatewayContract.ParseDepositedAndCalled(log)
+		if err != nil {
+			ob.Logger().
+				Inbound.Warn().
+				Stringer(logs.FieldTx, log.TxHash).
+				Uint64(logs.FieldBlock, log.BlockNumber).
+				Msg("invalid DepositedAndCalled event")
+			continue
+		}
+		validEvents = append(validEvents, depositAndCallEvent)
 	}
 
 	// order events by height, tx index and event index (ascending)


### PR DESCRIPTION
Make the `getLogs` call once then filter the results for each event type. Now instead of making 3 `getLogs` calls we only make 1!

Update: also combine the v1 `getLogs` calls. Is it possible to deploy on a chain without zeta connector having a valid address?

Related to https://github.com/zeta-chain/node/issues/3549 https://github.com/zeta-chain/node/issues/2493 https://github.com/zeta-chain/node/issues/3525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated multiple steps in event log retrieval into a single, streamlined process for enhanced efficiency.
  - Updated the processing of deposit and call events with improved error handling and more reliable validation.
  - Adjusted the initialization workflow to better support unified log management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->