### PR TITLE
chore: upgrade cosmovisor

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     make install install-zetae2e
 
 FROM ghcr.io/zeta-chain/golang:1.23.3-bookworm AS cosmovisor-build
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.0
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.1
 
 FROM ghcr.io/zeta-chain/golang:1.23.3-bookworm AS base-runtime
 


### PR DESCRIPTION
https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.7.1

We already use this version internally: https://github.com/zeta-chain/zetacored-docker/pull/13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded a core dependency to its latest version, enhancing system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->