### PR TITLE
fix(e2e): only write address book once

### DIFF
--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -69,7 +69,10 @@ RELAYER_KEY_PATH="$HOME/.zetacored/relayer-keys"
 mkdir -p "${RELAYER_KEY_PATH}"
 
 mkdir -p "$HOME/.tss/"
-zetae2e local get-zetaclient-bootstrap > "$HOME/.tss/address_book.seed"
+address_book_path="$HOME/.tss/address_book.seed"
+if [[ ! -f "$address_book_path" ]]; then
+    zetae2e local get-zetaclient-bootstrap > $address_book_path
+fi
 
 MYIP=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
 


### PR DESCRIPTION
When running in persistent mode, we shouldn't try to write out the address book file a second time. When you restart the container, the other zetaclient containers may not be up yet and the dns resolution performed by this command may fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the startup process by adding a safety check to ensure critical initialization data isn’t overwritten unnecessarily, enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->