### PR TITLE
fix(zetaclient): TON config resolution

### DIFF
--- a/zetaclient/chains/ton/config/config.go
+++ b/zetaclient/chains/ton/config/config.go
@@ -59,11 +59,16 @@ func FromPath(path string) (*GlobalConfigurationFile, error) {
 
 // FromSource returns a parsed configuration file from a URL or a file path.
 func FromSource(ctx context.Context, urlOrPath string) (*GlobalConfigurationFile, error) {
-	if u, err := url.Parse(urlOrPath); err == nil {
-		return FromURL(ctx, u.String())
+	if cfg, err := FromPath(urlOrPath); err == nil {
+		return cfg, nil
 	}
 
-	return FromPath(urlOrPath)
+	u, err := url.Parse(urlOrPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse URL")
+	}
+
+	return FromURL(ctx, u.String())
 }
 
 // FetchGasConfig fetches gas price from the config.

--- a/zetaclient/chains/ton/config/config_test.go
+++ b/zetaclient/chains/ton/config/config_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("FromSource_path", func(t *testing.T) {
+		// ARRANGE
+		tmpDir := t.TempDir()
+		defer os.RemoveAll(tmpDir)
+
+		configPath := filepath.Join(tmpDir, "config.json")
+		require.NoError(t, os.WriteFile(configPath, sampleConfigBytes(t), 0644))
+
+		// ACT
+		cfg, err := FromSource(ctx, configPath)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	})
+
+	t.Run("FromSource_url", func(t *testing.T) {
+		// ARRANGE
+		cfgBytes := sampleConfigBytes(t)
+
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.Write(cfgBytes)
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(handler))
+		defer server.Close()
+
+		url := fmt.Sprintf("%s/config.json", server.URL)
+
+		// ACT
+		cfg, err := FromSource(ctx, url)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	})
+}
+
+func sampleConfigBytes(t *testing.T) []byte {
+	// https://ton.org/testnet-global.config.json
+	const sampleConfig = `{
+		"liteservers": [
+			{
+				"ip": 822907680,
+				"port": 27842,
+				"provided":"Beavis",
+				"id": {
+					"@type": "pub.ed25519",
+					"key": "sU7QavX2F964iI9oToP9gffQpCQIoOLppeqL/pdPvpM="
+				}
+			},
+			{
+				"ip": 1091956407,
+				"port": 16351,
+				"id": {
+					"@type": "pub.ed25519",
+					"key": "Mf/JGvcWAvcrN3oheze8RF/ps6p7oL6ifrIzFmGQFQ8="
+				}
+			}
+		]
+	}`
+
+	return []byte(sampleConfig)
+}


### PR DESCRIPTION
```
 "TONConfig": {
        "liteClientConfigURL": "/home/zetachain/.zetacored/config/ton_config.json"
    },
```

Caused 
```
unable to create TON liteapi: unable to get config: Get "/home/zetachain/.zetacored/config/ton_config.json": unsupported protocol scheme ""
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration loading to first attempt local file retrieval before falling back to remote sources, with clearer error messaging for improved troubleshooting.

- **Tests**
  - Added comprehensive tests to validate configuration loading from both local files and remote endpoints, ensuring robust behavior across scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->