### PR TITLE
refactor(zetaclient): unexport internal evm observer methods

### DIFF
--- a/zetaclient/chains/evm/observer/inbound_test.go
+++ b/zetaclient/chains/evm/observer/inbound_test.go
@@ -1,4 +1,4 @@
-package observer_test
+package observer
 
 import (
 	"encoding/hex"
@@ -41,7 +41,7 @@ func Test_CheckAndVoteInboundTokenZeta(t *testing.T) {
 
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe())
 
-		ballot, err := ob.CheckAndVoteInboundTokenZeta(ob.ctx, tx, receipt, false)
+		ballot, err := ob.checkAndVoteInboundTokenZeta(ob.ctx, tx, receipt, false)
 		require.NoError(t, err)
 		require.Equal(t, cctx.InboundParams.BallotIndex, ballot)
 	})
@@ -59,7 +59,7 @@ func Test_CheckAndVoteInboundTokenZeta(t *testing.T) {
 
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe() - 2)
 
-		_, err := ob.CheckAndVoteInboundTokenZeta(ob.ctx, tx, receipt, false)
+		_, err := ob.checkAndVoteInboundTokenZeta(ob.ctx, tx, receipt, false)
 		require.ErrorContains(t, err, "not been confirmed")
 	})
 	t.Run("should not act if no ZetaSent event", func(t *testing.T) {
@@ -77,7 +77,7 @@ func Test_CheckAndVoteInboundTokenZeta(t *testing.T) {
 
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe())
 
-		ballot, err := ob.CheckAndVoteInboundTokenZeta(ob.ctx, tx, receipt, true)
+		ballot, err := ob.checkAndVoteInboundTokenZeta(ob.ctx, tx, receipt, true)
 		require.NoError(t, err)
 		require.Equal(t, "", ballot)
 	})
@@ -98,7 +98,7 @@ func Test_CheckAndVoteInboundTokenZeta(t *testing.T) {
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe())
 
 		// ACT
-		_, err := ob.CheckAndVoteInboundTokenZeta(ob.ctx, tx, receipt, true)
+		_, err := ob.checkAndVoteInboundTokenZeta(ob.ctx, tx, receipt, true)
 
 		// ASSERT
 		require.ErrorContains(t, err, "emitter address mismatch")
@@ -126,7 +126,7 @@ func Test_CheckAndVoteInboundTokenERC20(t *testing.T) {
 
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe())
 
-		ballot, err := ob.CheckAndVoteInboundTokenERC20(ob.ctx, tx, receipt, false)
+		ballot, err := ob.checkAndVoteInboundTokenERC20(ob.ctx, tx, receipt, false)
 		require.NoError(t, err)
 		require.Equal(t, cctx.InboundParams.BallotIndex, ballot)
 	})
@@ -144,7 +144,7 @@ func Test_CheckAndVoteInboundTokenERC20(t *testing.T) {
 
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe() - 2)
 
-		_, err := ob.CheckAndVoteInboundTokenERC20(ob.ctx, tx, receipt, false)
+		_, err := ob.checkAndVoteInboundTokenERC20(ob.ctx, tx, receipt, false)
 		require.ErrorContains(t, err, "not been confirmed")
 	})
 	t.Run("should not act if no Deposit event", func(t *testing.T) {
@@ -162,7 +162,7 @@ func Test_CheckAndVoteInboundTokenERC20(t *testing.T) {
 
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe())
 
-		ballot, err := ob.CheckAndVoteInboundTokenERC20(ob.ctx, tx, receipt, true)
+		ballot, err := ob.checkAndVoteInboundTokenERC20(ob.ctx, tx, receipt, true)
 		require.NoError(t, err)
 		require.Equal(t, "", ballot)
 	})
@@ -184,7 +184,7 @@ func Test_CheckAndVoteInboundTokenERC20(t *testing.T) {
 		ob.WithLastBlock(receipt.BlockNumber.Uint64() + ob.chainParams.InboundConfirmationSafe())
 
 		// ACT
-		_, err := ob.CheckAndVoteInboundTokenERC20(ob.ctx, tx, receipt, true)
+		_, err := ob.checkAndVoteInboundTokenERC20(ob.ctx, tx, receipt, true)
 
 		// ASSERT
 		require.ErrorContains(t, err, "emitter address mismatch")
@@ -213,7 +213,7 @@ func Test_CheckAndVoteInboundTokenGas(t *testing.T) {
 		ob := newTestSuite(t)
 		ob.WithLastBlock(lastBlock)
 
-		ballot, err := ob.CheckAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
+		ballot, err := ob.checkAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
 		require.NoError(t, err)
 		require.Equal(t, cctx.InboundParams.BallotIndex, ballot)
 	})
@@ -225,7 +225,7 @@ func Test_CheckAndVoteInboundTokenGas(t *testing.T) {
 		ob := newTestSuite(t)
 		ob.WithLastBlock(lastBlock)
 
-		_, err := ob.CheckAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
+		_, err := ob.checkAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
 		require.ErrorContains(t, err, "not been confirmed")
 	})
 	t.Run("should not act if receiver is not TSS", func(t *testing.T) {
@@ -237,7 +237,7 @@ func Test_CheckAndVoteInboundTokenGas(t *testing.T) {
 		ob := newTestSuite(t)
 		ob.WithLastBlock(lastBlock)
 
-		ballot, err := ob.CheckAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
+		ballot, err := ob.checkAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
 		require.ErrorContains(t, err, "not TSS address")
 		require.Equal(t, "", ballot)
 	})
@@ -250,7 +250,7 @@ func Test_CheckAndVoteInboundTokenGas(t *testing.T) {
 		ob := newTestSuite(t)
 		ob.WithLastBlock(lastBlock)
 
-		ballot, err := ob.CheckAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
+		ballot, err := ob.checkAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
 		require.ErrorContains(t, err, "not a successful tx")
 		require.Equal(t, "", ballot)
 	})
@@ -263,7 +263,7 @@ func Test_CheckAndVoteInboundTokenGas(t *testing.T) {
 		ob := newTestSuite(t)
 		ob.WithLastBlock(lastBlock)
 
-		ballot, err := ob.CheckAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
+		ballot, err := ob.checkAndVoteInboundTokenGas(ob.ctx, tx, receipt, false)
 		require.NoError(t, err)
 		require.Equal(t, "", ballot)
 	})
@@ -289,7 +289,7 @@ func Test_BuildInboundVoteMsgForZetaSentEvent(t *testing.T) {
 	}
 
 	t.Run("should return vote msg for archived ZetaSent event", func(t *testing.T) {
-		msg := ob.BuildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
+		msg := ob.buildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
 		require.NotNil(t, msg)
 		require.Equal(t, cctx.InboundParams.BallotIndex, msg.Digest())
 	})
@@ -297,21 +297,21 @@ func Test_BuildInboundVoteMsgForZetaSentEvent(t *testing.T) {
 		sender := event.ZetaTxSenderAddress.Hex()
 		cfg.ComplianceConfig.RestrictedAddresses = []string{sender}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
+		msg := ob.buildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
 		require.Nil(t, msg)
 	})
 	t.Run("should return nil msg if receiver is restricted", func(t *testing.T) {
 		receiver := clienttypes.BytesToEthHex(event.DestinationAddress)
 		cfg.ComplianceConfig.RestrictedAddresses = []string{receiver}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
+		msg := ob.buildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
 		require.Nil(t, msg)
 	})
 	t.Run("should return nil msg if txOrigin is restricted", func(t *testing.T) {
 		txOrigin := event.SourceTxOriginAddress.Hex()
 		cfg.ComplianceConfig.RestrictedAddresses = []string{txOrigin}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
+		msg := ob.buildInboundVoteMsgForZetaSentEvent(ob.appContext, event)
 		require.Nil(t, msg)
 	})
 }
@@ -337,26 +337,26 @@ func Test_BuildInboundVoteMsgForDepositedEvent(t *testing.T) {
 	}
 
 	t.Run("should return vote msg for archived Deposited event", func(t *testing.T) {
-		msg := ob.BuildInboundVoteMsgForDepositedEvent(event, sender)
+		msg := ob.buildInboundVoteMsgForDepositedEvent(event, sender)
 		require.NotNil(t, msg)
 		require.Equal(t, cctx.InboundParams.BallotIndex, msg.Digest())
 	})
 	t.Run("should return nil msg if sender is restricted", func(t *testing.T) {
 		cfg.ComplianceConfig.RestrictedAddresses = []string{sender.Hex()}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForDepositedEvent(event, sender)
+		msg := ob.buildInboundVoteMsgForDepositedEvent(event, sender)
 		require.Nil(t, msg)
 	})
 	t.Run("should return nil msg if receiver is restricted", func(t *testing.T) {
 		receiver := clienttypes.BytesToEthHex(event.Recipient)
 		cfg.ComplianceConfig.RestrictedAddresses = []string{receiver}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForDepositedEvent(event, sender)
+		msg := ob.buildInboundVoteMsgForDepositedEvent(event, sender)
 		require.Nil(t, msg)
 	})
 	t.Run("should return nil msg on donation transaction", func(t *testing.T) {
 		event.Message = []byte(constant.DonationMessage)
-		msg := ob.BuildInboundVoteMsgForDepositedEvent(event, sender)
+		msg := ob.buildInboundVoteMsgForDepositedEvent(event, sender)
 		require.Nil(t, msg)
 	})
 }
@@ -390,7 +390,7 @@ func Test_BuildInboundVoteMsgForTokenSentToTSS(t *testing.T) {
 	}
 
 	t.Run("should return vote msg for archived gas token transfer to TSS", func(t *testing.T) {
-		msg := ob.BuildInboundVoteMsgForTokenSentToTSS(
+		msg := ob.buildInboundVoteMsgForTokenSentToTSS(
 			tx,
 			ethcommon.HexToAddress(tx.From),
 			receipt.BlockNumber.Uint64(),
@@ -401,7 +401,7 @@ func Test_BuildInboundVoteMsgForTokenSentToTSS(t *testing.T) {
 	t.Run("should return nil msg if sender is restricted", func(t *testing.T) {
 		cfg.ComplianceConfig.RestrictedAddresses = []string{tx.From}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForTokenSentToTSS(
+		msg := ob.buildInboundVoteMsgForTokenSentToTSS(
 			tx,
 			ethcommon.HexToAddress(tx.From),
 			receipt.BlockNumber.Uint64(),
@@ -415,7 +415,7 @@ func Test_BuildInboundVoteMsgForTokenSentToTSS(t *testing.T) {
 		txCopy.Input = message // use other address as receiver
 		cfg.ComplianceConfig.RestrictedAddresses = []string{testutils.OtherAddress1}
 		config.LoadComplianceConfig(cfg)
-		msg := ob.BuildInboundVoteMsgForTokenSentToTSS(
+		msg := ob.buildInboundVoteMsgForTokenSentToTSS(
 			txCopy,
 			ethcommon.HexToAddress(txCopy.From),
 			receipt.BlockNumber.Uint64(),
@@ -423,7 +423,7 @@ func Test_BuildInboundVoteMsgForTokenSentToTSS(t *testing.T) {
 		require.Nil(t, msg)
 	})
 	t.Run("should return nil msg on donation transaction", func(t *testing.T) {
-		msg := ob.BuildInboundVoteMsgForTokenSentToTSS(txDonation,
+		msg := ob.buildInboundVoteMsgForTokenSentToTSS(txDonation,
 			ethcommon.HexToAddress(txDonation.From), receiptDonation.BlockNumber.Uint64())
 		require.Nil(t, msg)
 	})
@@ -492,7 +492,7 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 				tt.mockEVMClient(ob.evmMock)
 			}
 
-			err := ob.ObserveTSSReceiveInBlock(ob.ctx, blockNumber)
+			err := ob.observeTSSReceiveInBlock(ob.ctx, blockNumber)
 			if tt.errMsg != "" {
 				require.ErrorContains(t, err, tt.errMsg)
 				return

--- a/zetaclient/chains/evm/observer/observer.go
+++ b/zetaclient/chains/evm/observer/observer.go
@@ -13,8 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/zeta-chain/protocol-contracts/pkg/erc20custody.sol"
 	"github.com/zeta-chain/protocol-contracts/pkg/gatewayevm.sol"
-	"github.com/zeta-chain/protocol-contracts/pkg/zeta.non-eth.sol"
-	zetaconnectoreth "github.com/zeta-chain/protocol-contracts/pkg/zetaconnector.eth.sol"
 	"github.com/zeta-chain/protocol-contracts/pkg/zetaconnector.non-eth.sol"
 
 	"github.com/zeta-chain/node/zetaclient/chains/base"
@@ -63,79 +61,54 @@ func New(baseObserver *base.Observer, client interfaces.EVMRPCClient) (*Observer
 	}
 
 	// load last block scanned
-	if err := ob.LoadLastBlockScanned(context.Background()); err != nil {
+	if err := ob.loadLastBlockScanned(context.Background()); err != nil {
 		return nil, errors.Wrap(err, "unable to load last block scanned")
 	}
 
 	return ob, nil
 }
 
-// GetConnectorContract returns the non-Eth connector address and binder
-func (ob *Observer) GetConnectorContract() (ethcommon.Address, *zetaconnector.ZetaConnectorNonEth, error) {
+// getConnectorContract returns the non-Eth connector address and binder
+func (ob *Observer) getConnectorContract() (ethcommon.Address, *zetaconnector.ZetaConnectorNonEth, error) {
 	addr := ethcommon.HexToAddress(ob.ChainParams().ConnectorContractAddress)
 	contract, err := zetaconnector.NewZetaConnectorNonEth(addr, ob.evmClient)
 	return addr, contract, err
 }
 
-// GetConnectorContractEth returns the Eth connector address and binder
-func (ob *Observer) GetConnectorContractEth() (ethcommon.Address, *zetaconnectoreth.ZetaConnectorEth, error) {
-	addr := ethcommon.HexToAddress(ob.ChainParams().ConnectorContractAddress)
-	contract, err := FetchConnectorContractEth(addr, ob.evmClient)
-	return addr, contract, err
-}
-
-// GetERC20CustodyContract returns ERC20Custody contract address and binder
-func (ob *Observer) GetERC20CustodyContract() (ethcommon.Address, *erc20custody.ERC20Custody, error) {
+// getERC20CustodyContract returns ERC20Custody contract address and binder
+func (ob *Observer) getERC20CustodyContract() (ethcommon.Address, *erc20custody.ERC20Custody, error) {
 	addr := ethcommon.HexToAddress(ob.ChainParams().Erc20CustodyContractAddress)
 	contract, err := erc20custody.NewERC20Custody(addr, ob.evmClient)
 	return addr, contract, err
 }
 
-// GetERC20CustodyV2Contract returns ERC20Custody contract address and binder
+// getERC20CustodyV2Contract returns ERC20Custody contract address and binder
 // NOTE: we use the same address as gateway v1
 // this simplify the migration process v1 will be completely removed in the future
 // currently the ABI for withdraw is identical, therefore both contract instances can be used
-func (ob *Observer) GetERC20CustodyV2Contract() (ethcommon.Address, *erc20custody.ERC20Custody, error) {
+func (ob *Observer) getERC20CustodyV2Contract() (ethcommon.Address, *erc20custody.ERC20Custody, error) {
 	addr := ethcommon.HexToAddress(ob.ChainParams().Erc20CustodyContractAddress)
 	contract, err := erc20custody.NewERC20Custody(addr, ob.evmClient)
 	return addr, contract, err
 }
 
-// GetGatewayContract returns the gateway contract address and binder
-func (ob *Observer) GetGatewayContract() (ethcommon.Address, *gatewayevm.GatewayEVM, error) {
+// getGatewayContract returns the gateway contract address and binder
+func (ob *Observer) getGatewayContract() (ethcommon.Address, *gatewayevm.GatewayEVM, error) {
 	addr := ethcommon.HexToAddress(ob.ChainParams().GatewayAddress)
 	contract, err := gatewayevm.NewGatewayEVM(addr, ob.evmClient)
 	return addr, contract, err
 }
 
-// FetchConnectorContractEth returns the Eth connector address and binder
-// TODO(revamp): move this to a contract package
-func FetchConnectorContractEth(
-	addr ethcommon.Address,
-	client interfaces.EVMRPCClient,
-) (*zetaconnectoreth.ZetaConnectorEth, error) {
-	return zetaconnectoreth.NewZetaConnectorEth(addr, client)
-}
-
-// FetchZetaTokenContract returns the non-Eth ZETA token binder
-// TODO(revamp): move this to a contract package
-func FetchZetaTokenContract(
-	addr ethcommon.Address,
-	client interfaces.EVMRPCClient,
-) (*zeta.ZetaNonEth, error) {
-	return zeta.NewZetaNonEth(addr, client)
-}
-
-// SetTxNReceipt sets the receipt and transaction in memory
-func (ob *Observer) SetTxNReceipt(nonce uint64, receipt *ethtypes.Receipt, transaction *ethtypes.Transaction) {
+// setTxNReceipt sets the receipt and transaction in memory
+func (ob *Observer) setTxNReceipt(nonce uint64, receipt *ethtypes.Receipt, transaction *ethtypes.Transaction) {
 	ob.Mu().Lock()
 	defer ob.Mu().Unlock()
 	ob.outboundConfirmedReceipts[ob.OutboundID(nonce)] = receipt
 	ob.outboundConfirmedTransactions[ob.OutboundID(nonce)] = transaction
 }
 
-// GetTxNReceipt gets the receipt and transaction from memory
-func (ob *Observer) GetTxNReceipt(nonce uint64) (*ethtypes.Receipt, *ethtypes.Transaction) {
+// getTxNReceipt gets the receipt and transaction from memory
+func (ob *Observer) getTxNReceipt(nonce uint64) (*ethtypes.Receipt, *ethtypes.Transaction) {
 	ob.Mu().Lock()
 	defer ob.Mu().Unlock()
 	receipt := ob.outboundConfirmedReceipts[ob.OutboundID(nonce)]
@@ -143,8 +116,8 @@ func (ob *Observer) GetTxNReceipt(nonce uint64) (*ethtypes.Receipt, *ethtypes.Tr
 	return receipt, transaction
 }
 
-// IsTxConfirmed returns true if there is a confirmed tx for 'nonce'
-func (ob *Observer) IsTxConfirmed(nonce uint64) bool {
+// isTxConfirmed returns true if there is a confirmed tx for 'nonce'
+func (ob *Observer) isTxConfirmed(nonce uint64) bool {
 	ob.Mu().Lock()
 	defer ob.Mu().Unlock()
 	id := ob.OutboundID(nonce)
@@ -152,8 +125,8 @@ func (ob *Observer) IsTxConfirmed(nonce uint64) bool {
 	return ob.outboundConfirmedReceipts[id] != nil && ob.outboundConfirmedTransactions[id] != nil
 }
 
-// CheckTxInclusion returns nil only if tx is included at the position indicated by the receipt ([block, index])
-func (ob *Observer) CheckTxInclusion(ctx context.Context, tx *ethtypes.Transaction, receipt *ethtypes.Receipt) error {
+// checkTxInclusion returns nil only if tx is included at the position indicated by the receipt ([block, index])
+func (ob *Observer) checkTxInclusion(ctx context.Context, tx *ethtypes.Transaction, receipt *ethtypes.Receipt) error {
 	block, err := ob.GetBlockByNumberCached(ctx, receipt.BlockNumber.Uint64())
 	if err != nil {
 		return errors.Wrapf(err, "GetBlockByNumberCached error for block %d txHash %s nonce %d",
@@ -168,7 +141,7 @@ func (ob *Observer) CheckTxInclusion(ctx context.Context, tx *ethtypes.Transacti
 
 	txAtIndex := block.Transactions[receipt.TransactionIndex]
 	if !strings.EqualFold(txAtIndex.Hash, tx.Hash().Hex()) {
-		ob.RemoveCachedBlock(receipt.BlockNumber.Uint64()) // clean stale block from cache
+		ob.removeCachedBlock(receipt.BlockNumber.Uint64()) // clean stale block from cache
 		return fmt.Errorf("transaction at index %d has different hash %s, txHash %s nonce %d block %d",
 			receipt.TransactionIndex, txAtIndex.Hash, tx.Hash(), tx.Nonce(), receipt.BlockNumber.Uint64())
 	}
@@ -176,8 +149,8 @@ func (ob *Observer) CheckTxInclusion(ctx context.Context, tx *ethtypes.Transacti
 	return nil
 }
 
-// TransactionByHash query transaction by hash via JSON-RPC
-func (ob *Observer) TransactionByHash(ctx context.Context, txHash string) (*client.Transaction, bool, error) {
+// transactionByHash query transaction by hash via JSON-RPC
+func (ob *Observer) transactionByHash(ctx context.Context, txHash string) (*client.Transaction, bool, error) {
 	tx, err := ob.evmClient.TransactionByHashCustom(ctx, txHash)
 	if err != nil {
 		return nil, false, err
@@ -187,10 +160,6 @@ func (ob *Observer) TransactionByHash(ctx context.Context, txHash string) (*clie
 		return nil, false, err
 	}
 	return tx, tx.BlockNumber == nil, nil
-}
-
-func (ob *Observer) TransactionReceipt(ctx context.Context, hash ethcommon.Hash) (*ethtypes.Receipt, error) {
-	return ob.evmClient.TransactionReceipt(ctx, hash)
 }
 
 // GetBlockByNumberCached get block by number from cache
@@ -206,7 +175,7 @@ func (ob *Observer) GetBlockByNumberCached(ctx context.Context, blockNumber uint
 		return nil, fmt.Errorf("block number %d is too large", blockNumber)
 	}
 	// #nosec G115 always in range, checked above
-	block, err := ob.BlockByNumber(ctx, int(blockNumber))
+	block, err := ob.blockByNumber(ctx, int(blockNumber))
 	if err != nil {
 		return nil, err
 	}
@@ -214,13 +183,13 @@ func (ob *Observer) GetBlockByNumberCached(ctx context.Context, blockNumber uint
 	return block, nil
 }
 
-// RemoveCachedBlock remove block from cache
-func (ob *Observer) RemoveCachedBlock(blockNumber uint64) {
+// removeCachedBlock remove block from cache
+func (ob *Observer) removeCachedBlock(blockNumber uint64) {
 	ob.BlockCache().Remove(blockNumber)
 }
 
-// BlockByNumber query block by number via JSON-RPC
-func (ob *Observer) BlockByNumber(ctx context.Context, blockNumber int) (*client.Block, error) {
+// blockByNumber query block by number via JSON-RPC
+func (ob *Observer) blockByNumber(ctx context.Context, blockNumber int) (*client.Block, error) {
 	block, err := ob.evmClient.BlockByNumberCustom(ctx, big.NewInt(int64(blockNumber)))
 	if err != nil {
 		return nil, err
@@ -237,9 +206,9 @@ func (ob *Observer) BlockByNumber(ctx context.Context, blockNumber int) (*client
 	return block, nil
 }
 
-// LoadLastBlockScanned loads the last scanned block from the database
+// loadLastBlockScanned loads the last scanned block from the database
 // TODO(revamp): move to a db file
-func (ob *Observer) LoadLastBlockScanned(ctx context.Context) error {
+func (ob *Observer) loadLastBlockScanned(ctx context.Context) error {
 	err := ob.Observer.LoadLastBlockScanned(ob.Logger().Chain)
 	if err != nil {
 		return errors.Wrapf(err, "error LoadLastBlockScanned for chain %d", ob.Chain().ChainId)

--- a/zetaclient/chains/evm/observer/observer_gas_test.go
+++ b/zetaclient/chains/evm/observer/observer_gas_test.go
@@ -1,4 +1,4 @@
-package observer_test
+package observer
 
 import (
 	"context"

--- a/zetaclient/chains/evm/observer/observer_test.go
+++ b/zetaclient/chains/evm/observer/observer_test.go
@@ -1,4 +1,4 @@
-package observer_test
+package observer
 
 import (
 	"context"
@@ -23,7 +23,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
-	"github.com/zeta-chain/node/zetaclient/chains/evm/observer"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/metrics"
@@ -195,7 +194,7 @@ func Test_NewObserver(t *testing.T) {
 				tt.logger,
 			)
 			require.NoError(t, err)
-			ob, err := observer.New(baseObserver, tt.evmClient)
+			ob, err := New(baseObserver, tt.evmClient)
 
 			// check result
 			if tt.fail {
@@ -220,7 +219,7 @@ func Test_LoadLastBlockScanned(t *testing.T) {
 		ob.WriteLastBlockScannedToDB(123)
 
 		// load last block scanned
-		err := ob.LoadLastBlockScanned(ctx)
+		err := ob.loadLastBlockScanned(ctx)
 		require.NoError(t, err)
 		require.EqualValues(t, 123, ob.LastBlockScanned())
 	})
@@ -231,7 +230,7 @@ func Test_LoadLastBlockScanned(t *testing.T) {
 		defer os.Unsetenv(envvar)
 
 		// load last block scanned
-		err := ob.LoadLastBlockScanned(ctx)
+		err := ob.loadLastBlockScanned(ctx)
 		require.ErrorContains(t, err, "error LoadLastBlockScanned")
 	})
 	t.Run("should fail on RPC error", func(t *testing.T) {
@@ -246,7 +245,7 @@ func Test_LoadLastBlockScanned(t *testing.T) {
 		obOther.evmMock.On("BlockNumber", mock.Anything).Return(uint64(0), fmt.Errorf("error RPC"))
 
 		// load last block scanned
-		err := obOther.LoadLastBlockScanned(ctx)
+		err := obOther.loadLastBlockScanned(ctx)
 		require.ErrorContains(t, err, "error RPC")
 	})
 }
@@ -289,7 +288,7 @@ func Test_BlockCache(t *testing.T) {
 
 		// delete non-existing block should not panic
 		blockNumber := uint64(123)
-		ts.RemoveCachedBlock(blockNumber)
+		ts.removeCachedBlock(blockNumber)
 
 		// add a block
 		block := &client.Block{Number: 123}
@@ -301,7 +300,7 @@ func Test_BlockCache(t *testing.T) {
 		require.EqualValues(t, block, result)
 
 		// delete the block should not panic
-		ts.RemoveCachedBlock(blockNumber)
+		ts.removeCachedBlock(blockNumber)
 	})
 }
 
@@ -325,7 +324,7 @@ func Test_CheckTxInclusion(t *testing.T) {
 	ts.BlockCache().Add(blockNumber, block)
 
 	t.Run("should pass for archived outbound", func(t *testing.T) {
-		err := ts.CheckTxInclusion(ts.ctx, tx, receipt)
+		err := ts.checkTxInclusion(ts.ctx, tx, receipt)
 		require.NoError(t, err)
 	})
 	t.Run("should fail on tx index out of range", func(t *testing.T) {
@@ -333,7 +332,7 @@ func Test_CheckTxInclusion(t *testing.T) {
 		copyReceipt := *receipt
 		// #nosec G115 non negative value
 		copyReceipt.TransactionIndex = uint(len(block.Transactions))
-		err := ts.CheckTxInclusion(ts.ctx, tx, &copyReceipt)
+		err := ts.checkTxInclusion(ts.ctx, tx, &copyReceipt)
 		require.ErrorContains(t, err, "out of range")
 	})
 	t.Run("should fail on tx hash mismatch", func(t *testing.T) {
@@ -343,7 +342,7 @@ func Test_CheckTxInclusion(t *testing.T) {
 		ts.BlockCache().Add(blockNumber, block)
 
 		// check inclusion should fail
-		err := ts.CheckTxInclusion(ts.ctx, tx, receipt)
+		err := ts.checkTxInclusion(ts.ctx, tx, receipt)
 		require.ErrorContains(t, err, "has different hash")
 
 		// wrong block should be removed from cache
@@ -384,7 +383,7 @@ func Test_VoteOutboundBallot(t *testing.T) {
 }
 
 type testSuite struct {
-	*observer.Observer
+	*Observer
 	ctx         context.Context
 	appContext  *zctx.AppContext
 	chainParams *observertypes.ChainParams
@@ -433,7 +432,7 @@ func newTestSuite(t *testing.T, opts ...func(*testSuiteConfig)) *testSuite {
 	baseObserver, err := base.NewObserver(chain, chainParams, zetacore, tss, 1000, nil, database, logger)
 	require.NoError(t, err)
 
-	ob, err := observer.New(baseObserver, evmMock)
+	ob, err := New(baseObserver, evmMock)
 	require.NoError(t, err)
 	ob.WithLastBlock(1)
 

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -50,7 +50,7 @@ func (ob *Observer) ProcessOutboundTrackers(ctx context.Context) error {
 	for _, tracker := range trackers {
 		// go to next tracker if this one already has a confirmed tx
 		nonce := tracker.Nonce
-		if ob.IsTxConfirmed(nonce) {
+		if ob.isTxConfirmed(nonce) {
 			continue
 		}
 
@@ -73,7 +73,7 @@ func (ob *Observer) ProcessOutboundTrackers(ctx context.Context) error {
 
 		// should be only one txHash confirmed for each nonce.
 		if txCount == 1 {
-			ob.SetTxNReceipt(nonce, outboundReceipt, outbound)
+			ob.setTxNReceipt(nonce, outboundReceipt, outbound)
 		} else if txCount > 1 {
 			// should not happen. We can't tell which txHash is true. It might happen (e.g. bug, glitchy/hacked endpoint)
 			ob.Logger().Outbound.Error().Msgf("WatchOutbound: confirmed multiple (%d) outbound for chain %d nonce %d", txCount, chainID, nonce)
@@ -87,8 +87,8 @@ func (ob *Observer) ProcessOutboundTrackers(ctx context.Context) error {
 	return nil
 }
 
-// PostVoteOutbound posts vote to zetacore for the confirmed outbound
-func (ob *Observer) PostVoteOutbound(
+// postVoteOutbound posts vote to zetacore for the confirmed outbound
+func (ob *Observer) postVoteOutbound(
 	ctx context.Context,
 	cctxIndex string,
 	receipt *ethtypes.Receipt,
@@ -156,27 +156,27 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 ) (bool, error) {
 	// skip if outbound is not confirmed
 	nonce := cctx.GetCurrentOutboundParam().TssNonce
-	if !ob.IsTxConfirmed(nonce) {
+	if !ob.isTxConfirmed(nonce) {
 		return true, nil
 	}
-	receipt, transaction := ob.GetTxNReceipt(nonce)
+	receipt, transaction := ob.getTxNReceipt(nonce)
 	sendID := fmt.Sprintf("%d-%d", ob.Chain().ChainId, nonce)
 	logger := ob.Logger().Outbound.With().Str("sendID", sendID).Logger()
 
 	// get connector and erc20Custody contracts
-	connectorAddr, connector, err := ob.GetConnectorContract()
+	connectorAddr, connector, err := ob.getConnectorContract()
 	if err != nil {
 		return true, errors.Wrapf(err, "error getting zeta connector for chain %d", ob.Chain().ChainId)
 	}
-	custodyAddr, custody, err := ob.GetERC20CustodyContract()
+	custodyAddr, custody, err := ob.getERC20CustodyContract()
 	if err != nil {
 		return true, errors.Wrapf(err, "error getting erc20 custody for chain %d", ob.Chain().ChainId)
 	}
-	gatewayAddr, gateway, err := ob.GetGatewayContract()
+	gatewayAddr, gateway, err := ob.getGatewayContract()
 	if err != nil {
 		return true, errors.Wrap(err, "error getting gateway for chain")
 	}
-	_, custodyV2, err := ob.GetERC20CustodyV2Contract()
+	_, custodyV2, err := ob.getERC20CustodyV2Contract()
 	if err != nil {
 		return true, errors.Wrapf(err, "error getting erc20 custody v2 for chain %d", ob.Chain().ChainId)
 	}
@@ -194,7 +194,7 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 		if receipt.Status == ethtypes.ReceiptStatusSuccessful {
 			receiveStatus = chains.ReceiveStatus_success
 		}
-		ob.PostVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
+		ob.postVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
 		return false, nil
 	}
 
@@ -220,7 +220,7 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	}
 
 	// post vote to zetacore
-	ob.PostVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
+	ob.postVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
 	return false, nil
 }
 
@@ -260,7 +260,7 @@ func parseOutboundReceivedValue(
 	switch cointype {
 	case coin.CoinType_Zeta:
 		if receipt.Status == ethtypes.ReceiptStatusSuccessful {
-			receivedLog, revertedLog, err := ParseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
+			receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
 			if err != nil {
 				return nil, chains.ReceiveStatus_failed, err
 			}
@@ -273,7 +273,7 @@ func parseOutboundReceivedValue(
 		}
 	case coin.CoinType_ERC20:
 		if receipt.Status == ethtypes.ReceiptStatusSuccessful {
-			withdrawn, err := ParseAndCheckWithdrawnEvent(cctx, receipt, custodyAddress, custody)
+			withdrawn, err := parseAndCheckWithdrawnEvent(cctx, receipt, custodyAddress, custody)
 			if err != nil {
 				return nil, chains.ReceiveStatus_failed, err
 			}
@@ -288,9 +288,9 @@ func parseOutboundReceivedValue(
 	return receiveValue, receiveStatus, nil
 }
 
-// ParseAndCheckZetaEvent parses and checks ZetaReceived/ZetaReverted event from the outbound receipt
+// parseAndCheckZetaEvent parses and checks ZetaReceived/ZetaReverted event from the outbound receipt
 // It either returns an ZetaReceived or an ZetaReverted event, or an error if no event found
-func ParseAndCheckZetaEvent(
+func parseAndCheckZetaEvent(
 	cctx *crosschaintypes.CrossChainTx,
 	receipt *ethtypes.Receipt,
 	connectorAddr ethcommon.Address,
@@ -347,8 +347,8 @@ func ParseAndCheckZetaEvent(
 	return nil, nil, errors.New("no ZetaReceived/ZetaReverted event found")
 }
 
-// ParseAndCheckWithdrawnEvent parses and checks erc20 Withdrawn event from the outbound receipt
-func ParseAndCheckWithdrawnEvent(
+// parseAndCheckWithdrawnEvent parses and checks erc20 Withdrawn event from the outbound receipt
+func parseAndCheckWithdrawnEvent(
 	cctx *crosschaintypes.CrossChainTx,
 	receipt *ethtypes.Receipt,
 	custodyAddr ethcommon.Address,
@@ -380,16 +380,16 @@ func ParseAndCheckWithdrawnEvent(
 	return nil, errors.New("no ERC20 Withdrawn event found")
 }
 
-// FilterTSSOutbound filters the outbounds from TSS address to supplement outbound trackers
-func (ob *Observer) FilterTSSOutbound(ctx context.Context, startBlock, toBlock uint64) {
+// filterTSSOutbound filters the outbounds from TSS address to supplement outbound trackers
+func (ob *Observer) filterTSSOutbound(ctx context.Context, startBlock, toBlock uint64) {
 	// filters the outbounds from TSS address block by block
 	for bn := startBlock; bn <= toBlock; bn++ {
-		ob.FilterTSSOutboundInBlock(ctx, bn)
+		ob.filterTSSOutboundInBlock(ctx, bn)
 	}
 }
 
-// FilterTSSOutboundInBlock filters the outbounds in a single block to supplement outbound trackers
-func (ob *Observer) FilterTSSOutboundInBlock(ctx context.Context, blockNumber uint64) {
+// filterTSSOutboundInBlock filters the outbounds in a single block to supplement outbound trackers
+func (ob *Observer) filterTSSOutboundInBlock(ctx context.Context, blockNumber uint64) {
 	// query block and ignore error (we don't rescan as we are only supplementing outbound trackers)
 	block, err := ob.GetBlockByNumberCached(ctx, blockNumber)
 	if err != nil {
@@ -405,9 +405,9 @@ func (ob *Observer) FilterTSSOutboundInBlock(ctx context.Context, blockNumber ui
 		if ethcommon.HexToAddress(tx.From) == ob.TSS().PubKey().AddressEVM() {
 			// #nosec G115 nonce always positive
 			nonce := uint64(tx.Nonce)
-			if !ob.IsTxConfirmed(nonce) {
+			if !ob.isTxConfirmed(nonce) {
 				if receipt, txx, ok := ob.checkConfirmedTx(ctx, tx.Hash, nonce); ok {
-					ob.SetTxNReceipt(nonce, receipt, txx)
+					ob.setTxNReceipt(nonce, receipt, txx)
 					ob.Logger().
 						Outbound.Info().
 						Msgf("TSS outbound detected on chain %d nonce %d tx %s", ob.Chain().ChainId, nonce, tx.Hash)
@@ -491,7 +491,7 @@ func (ob *Observer) checkConfirmedTx(
 
 	// cross-check tx inclusion against the block
 	// Note: a guard for false BlockNumber in receipt. The blob-carrying tx won't come here
-	err = ob.CheckTxInclusion(ctx, transaction, receipt)
+	err = ob.checkTxInclusion(ctx, transaction, receipt)
 	if err != nil {
 		logger.Error().Err(err).Msg("CheckTxInclusion error")
 		return nil, nil, false

--- a/zetaclient/chains/evm/observer/outbound_test.go
+++ b/zetaclient/chains/evm/observer/outbound_test.go
@@ -1,4 +1,4 @@
-package observer_test
+package observer
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/testutil/sample"
-	"github.com/zeta-chain/node/zetaclient/chains/evm/observer"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
@@ -48,7 +47,7 @@ func Test_IsOutboundProcessed(t *testing.T) {
 	t.Run("should post vote and return true if outbound is processed", func(t *testing.T) {
 		// create evm observer and set outbound and receipt
 		ob := newTestSuite(t)
-		ob.SetTxNReceipt(nonce, receipt, outbound)
+		ob.setTxNReceipt(nonce, receipt, outbound)
 
 		// post outbound vote
 		continueKeysign, err := ob.VoteOutboundIfConfirmed(ctx, cctx)
@@ -64,7 +63,7 @@ func Test_IsOutboundProcessed(t *testing.T) {
 
 		// create evm observer and set outbound and receipt
 		ob := newTestSuite(t)
-		ob.SetTxNReceipt(nonce, receipt, outbound)
+		ob.setTxNReceipt(nonce, receipt, outbound)
 
 		// modify compliance config to restrict sender address
 		cfg := config.Config{
@@ -88,7 +87,7 @@ func Test_IsOutboundProcessed(t *testing.T) {
 	t.Run("should fail if unable to parse ZetaReceived event", func(t *testing.T) {
 		// create evm observer and set outbound and receipt
 		ob := newTestSuite(t)
-		ob.SetTxNReceipt(nonce, receipt, outbound)
+		ob.setTxNReceipt(nonce, receipt, outbound)
 
 		// set connector contract address to an arbitrary address to make event parsing fail
 		chainParamsNew := ob.ChainParams()
@@ -135,7 +134,7 @@ func Test_IsOutboundProcessed_ContractError(t *testing.T) {
 	t.Run("should fail if unable to get connector/custody contract", func(t *testing.T) {
 		// create evm observer and set outbound and receipt
 		ob := newTestSuite(t)
-		ob.SetTxNReceipt(nonce, receipt, outbound)
+		ob.setTxNReceipt(nonce, receipt, outbound)
 		abiConnector := zetaconnector.ZetaConnectorNonEthMetaData.ABI
 		abiCustody := erc20custody.ERC20CustodyMetaData.ABI
 
@@ -179,7 +178,7 @@ func Test_PostVoteOutbound(t *testing.T) {
 
 		// create evm client using mock zetacore client and post outbound vote
 		ob := newTestSuite(t)
-		ob.PostVoteOutbound(
+		ob.postVoteOutbound(
 			ctx,
 			cctx.Index,
 			receipt,
@@ -212,7 +211,7 @@ func Test_ParseZetaReceived(t *testing.T) {
 	)
 
 	t.Run("should parse ZetaReceived event from archived outbound receipt", func(t *testing.T) {
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
 		require.NoError(t, err)
 		require.NotNil(t, receivedLog)
 		require.Nil(t, revertedLog)
@@ -220,7 +219,7 @@ func Test_ParseZetaReceived(t *testing.T) {
 	t.Run("should fail on connector address mismatch", func(t *testing.T) {
 		// use an arbitrary address to make validation fail
 		fakeConnectorAddress := sample.EthAddress()
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, fakeConnectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, fakeConnectorAddress, connector)
 		require.ErrorContains(t, err, "error validating ZetaReceived event")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
@@ -229,7 +228,7 @@ func Test_ParseZetaReceived(t *testing.T) {
 		// load cctx and set receiver address to an arbitrary address
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeCctx.GetCurrentOutboundParam().Receiver = sample.EthAddress().Hex()
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "receiver address mismatch")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
@@ -239,14 +238,14 @@ func Test_ParseZetaReceived(t *testing.T) {
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeAmount := sample.UintInRange(0, fakeCctx.GetCurrentOutboundParam().Amount.Uint64()-1)
 		fakeCctx.GetCurrentOutboundParam().Amount = fakeAmount
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "amount mismatch")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
 	})
 	t.Run("should fail on cctx index mismatch", func(t *testing.T) {
 		cctx.Index = sample.Hash().Hex() // use an arbitrary index
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "cctx index mismatch")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
@@ -262,7 +261,7 @@ func Test_ParseZetaReceived(t *testing.T) {
 			testutils.EventZetaReceived,
 		)
 		receipt.Logs = receipt.Logs[:1] // the 2nd log is ZetaReceived event
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "no ZetaReceived/ZetaReverted event")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
@@ -287,7 +286,7 @@ func Test_ParseZetaReverted(t *testing.T) {
 	)
 
 	t.Run("should parse ZetaReverted event from archived outbound receipt", func(t *testing.T) {
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
 		require.NoError(t, err)
 		require.Nil(t, receivedLog)
 		require.NotNil(t, revertedLog)
@@ -295,7 +294,7 @@ func Test_ParseZetaReverted(t *testing.T) {
 	t.Run("should fail on connector address mismatch", func(t *testing.T) {
 		// use an arbitrary address to make validation fail
 		fakeConnectorAddress := sample.EthAddress()
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, fakeConnectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, fakeConnectorAddress, connector)
 		require.ErrorContains(t, err, "error validating ZetaReverted event")
 		require.Nil(t, receivedLog)
 		require.Nil(t, revertedLog)
@@ -304,7 +303,7 @@ func Test_ParseZetaReverted(t *testing.T) {
 		// load cctx and set receiver address to an arbitrary address
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeCctx.InboundParams.Sender = sample.EthAddress().Hex() // the receiver is the sender for reverted ccxt
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "receiver address mismatch")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
@@ -314,14 +313,14 @@ func Test_ParseZetaReverted(t *testing.T) {
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeAmount := sample.UintInRange(0, fakeCctx.GetCurrentOutboundParam().Amount.Uint64()-1)
 		fakeCctx.GetCurrentOutboundParam().Amount = fakeAmount
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(fakeCctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "amount mismatch")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
 	})
 	t.Run("should fail on cctx index mismatch", func(t *testing.T) {
 		cctx.Index = sample.Hash().Hex() // use an arbitrary index to make validation fail
-		receivedLog, revertedLog, err := observer.ParseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, connectorAddress, connector)
 		require.ErrorContains(t, err, "cctx index mismatch")
 		require.Nil(t, receivedLog)
 		require.Nil(t, revertedLog)
@@ -346,14 +345,14 @@ func Test_ParseERC20WithdrawnEvent(t *testing.T) {
 	)
 
 	t.Run("should parse ERC20 Withdrawn event from archived outbound receipt", func(t *testing.T) {
-		withdrawn, err := observer.ParseAndCheckWithdrawnEvent(cctx, receipt, custodyAddress, custody)
+		withdrawn, err := parseAndCheckWithdrawnEvent(cctx, receipt, custodyAddress, custody)
 		require.NoError(t, err)
 		require.NotNil(t, withdrawn)
 	})
 	t.Run("should fail on erc20 custody address mismatch", func(t *testing.T) {
 		// use an arbitrary address to make validation fail
 		fakeCustodyAddress := sample.EthAddress()
-		withdrawn, err := observer.ParseAndCheckWithdrawnEvent(cctx, receipt, fakeCustodyAddress, custody)
+		withdrawn, err := parseAndCheckWithdrawnEvent(cctx, receipt, fakeCustodyAddress, custody)
 		require.ErrorContains(t, err, "error validating Withdrawn event")
 		require.Nil(t, withdrawn)
 	})
@@ -361,7 +360,7 @@ func Test_ParseERC20WithdrawnEvent(t *testing.T) {
 		// load cctx and set receiver address to an arbitrary address
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeCctx.GetCurrentOutboundParam().Receiver = sample.EthAddress().Hex()
-		withdrawn, err := observer.ParseAndCheckWithdrawnEvent(fakeCctx, receipt, custodyAddress, custody)
+		withdrawn, err := parseAndCheckWithdrawnEvent(fakeCctx, receipt, custodyAddress, custody)
 		require.ErrorContains(t, err, "receiver address mismatch")
 		require.Nil(t, withdrawn)
 	})
@@ -369,7 +368,7 @@ func Test_ParseERC20WithdrawnEvent(t *testing.T) {
 		// load cctx and set asset to an arbitrary address
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeCctx.InboundParams.Asset = sample.EthAddress().Hex()
-		withdrawn, err := observer.ParseAndCheckWithdrawnEvent(fakeCctx, receipt, custodyAddress, custody)
+		withdrawn, err := parseAndCheckWithdrawnEvent(fakeCctx, receipt, custodyAddress, custody)
 		require.ErrorContains(t, err, "asset mismatch")
 		require.Nil(t, withdrawn)
 	})
@@ -378,7 +377,7 @@ func Test_ParseERC20WithdrawnEvent(t *testing.T) {
 		fakeCctx := testutils.LoadCctxByNonce(t, chainID, nonce)
 		fakeAmount := sample.UintInRange(0, fakeCctx.GetCurrentOutboundParam().Amount.Uint64()-1)
 		fakeCctx.GetCurrentOutboundParam().Amount = fakeAmount
-		withdrawn, err := observer.ParseAndCheckWithdrawnEvent(fakeCctx, receipt, custodyAddress, custody)
+		withdrawn, err := parseAndCheckWithdrawnEvent(fakeCctx, receipt, custodyAddress, custody)
 		require.ErrorContains(t, err, "amount mismatch")
 		require.Nil(t, withdrawn)
 	})
@@ -393,7 +392,7 @@ func Test_ParseERC20WithdrawnEvent(t *testing.T) {
 			testutils.EventERC20Withdraw,
 		)
 		receipt.Logs = receipt.Logs[:1] // the 2nd log is Withdrawn event
-		withdrawn, err := observer.ParseAndCheckWithdrawnEvent(cctx, receipt, custodyAddress, custody)
+		withdrawn, err := parseAndCheckWithdrawnEvent(cctx, receipt, custodyAddress, custody)
 		require.ErrorContains(t, err, "no ERC20 Withdrawn event")
 		require.Nil(t, withdrawn)
 	})
@@ -431,14 +430,14 @@ func Test_FilterTSSOutbound(t *testing.T) {
 		ob.WithLastBlock(blockNumber + confirmations - 1)
 
 		// filter TSS outbound
-		ob.FilterTSSOutbound(ctx, blockNumber, blockNumber)
+		ob.filterTSSOutbound(ctx, blockNumber, blockNumber)
 
 		// tx should be confirmed after filtering
-		found := ob.IsTxConfirmed(outboundNonce)
+		found := ob.isTxConfirmed(outboundNonce)
 		require.True(t, found)
 
 		// retrieve tx and receipt
-		receipt, tx = ob.GetTxNReceipt(outboundNonce)
+		receipt, tx = ob.getTxNReceipt(outboundNonce)
 		require.NotNil(t, tx)
 		require.NotNil(t, receipt)
 		require.Equal(t, outboundHash, tx.Hash())
@@ -451,10 +450,10 @@ func Test_FilterTSSOutbound(t *testing.T) {
 		ob.evmMock.On("BlockByNumberCustom", mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
 
 		// filter TSS outbound
-		ob.FilterTSSOutbound(ctx, blockNumber, blockNumber)
+		ob.filterTSSOutbound(ctx, blockNumber, blockNumber)
 
 		// tx should be confirmed after filtering
-		found := ob.IsTxConfirmed(outboundNonce)
+		found := ob.isTxConfirmed(outboundNonce)
 		require.False(t, found)
 	})
 }

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -66,7 +66,7 @@ func (ob *Observer) observeGatewayDeposit(
 	rawLogs []ethtypes.Log,
 ) (uint64, error) {
 	// filter ERC20CustodyDeposited logs
-	gatewayAddr, gatewayContract, err := ob.GetGatewayContract()
+	gatewayAddr, gatewayContract, err := ob.getGatewayContract()
 	if err != nil {
 		// lastScanned is startBlock - 1
 		return startBlock - 1, errors.Wrap(err, "can't get gateway contract")
@@ -209,7 +209,7 @@ func (ob *Observer) observeGatewayCall(
 	startBlock, toBlock uint64,
 	rawLogs []ethtypes.Log,
 ) (uint64, error) {
-	gatewayAddr, gatewayContract, err := ob.GetGatewayContract()
+	gatewayAddr, gatewayContract, err := ob.getGatewayContract()
 	if err != nil {
 		// lastScanned is startBlock - 1
 		return startBlock - 1, errors.Wrap(err, "can't get gateway contract")
@@ -326,7 +326,7 @@ func (ob *Observer) observeGatewayDepositAndCall(
 	startBlock, toBlock uint64,
 	rawLogs []ethtypes.Log,
 ) (uint64, error) {
-	gatewayAddr, gatewayContract, err := ob.GetGatewayContract()
+	gatewayAddr, gatewayContract, err := ob.getGatewayContract()
 	if err != nil {
 		// lastScanned is startBlock - 1
 		return startBlock - 1, errors.Wrap(err, "can't get gateway contract")

--- a/zetaclient/chains/evm/observer/v2_inbound_tracker.go
+++ b/zetaclient/chains/evm/observer/v2_inbound_tracker.go
@@ -24,7 +24,7 @@ func (ob *Observer) ProcessInboundTrackerV2(
 	tx *client.Transaction,
 	receipt *ethtypes.Receipt,
 ) error {
-	gatewayAddr, gateway, err := ob.GetGatewayContract()
+	gatewayAddr, gateway, err := ob.getGatewayContract()
 	if err != nil {
 		ob.Logger().Inbound.Debug().Err(err).Msg("error getting gateway contract for processing inbound tracker")
 		return ErrGatewayNotSet


### PR DESCRIPTION
We should not be exporting functions and methods that are not needed outside of the package. The correct way to test these methods is to have tests be in the same package as the package under test.

Related to https://github.com/zeta-chain/node/pull/3578 as I noticed this as I was trying to add test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal consistency by standardizing naming conventions and method visibility.
  
- **Tests**
  - Updated test structures to seamlessly align with the internal enhancements.

These changes are transparent to end users, ensuring the stability and maintainability of the system without altering its external functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->