### PR TITLE
refactor(crosschain): set outbound hash in cctx when adding outbound tracker

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 
 * [3381](https://github.com/zeta-chain/node/pull/3381) - split Bitcoin observer and signer into small files and organize outbound logic into reusable/testable functions; renaming, type unification, etc.
 * [3496](https://github.com/zeta-chain/node/pull/3496) - zetaclient uses `ConfirmationParams` instead of old `ConfirmationCount`; use block ranged based observation for btc and evm chain.
+* [3594](https://github.com/zeta-chain/node/pull/3594) - set outbound hash in cctx when adding outbound tracker
 
 ### Fixes
 

--- a/testutil/keeper/crosschain.go
+++ b/testutil/keeper/crosschain.go
@@ -486,11 +486,11 @@ func MockCctxByNonce(
 	observerKeeper *crosschainmocks.CrosschainObserverKeeper,
 	cctxStatus types.CctxStatus,
 	isErr bool,
-) {
+) string {
 	if isErr {
 		// return error on GetTSS to make CctxByNonce return error
 		observerKeeper.On("GetTSS", mock.Anything).Return(observertypes.TSS{}, false).Once()
-		return
+		return ""
 	}
 
 	cctx := sample.CrossChainTx(t, sample.StringRandom(sample.Rand(), 10))
@@ -505,4 +505,6 @@ func MockCctxByNonce(
 			CctxIndex: cctx.Index,
 		}, true).
 		Once()
+
+	return cctx.Index
 }

--- a/x/crosschain/keeper/msg_server_add_outbound_tracker.go
+++ b/x/crosschain/keeper/msg_server_add_outbound_tracker.go
@@ -63,6 +63,12 @@ func (k msgServer) AddOutboundTracker(
 		return nil, cosmoserrors.Wrapf(authoritytypes.ErrUnauthorized, "Creator %s", msg.Creator)
 	}
 
+	// set the outbound hash from the last tracker and save it in the store
+	// this value is helpful for explorer or front-end application to find the outbound hash, it has no on-chain utility
+	// the hash will be replaced with the actual hash, if different, when the outbound transaction is observed and voted
+	cctx.CrossChainTx.GetCurrentOutboundParam().Hash = msg.TxHash
+	k.SetCrossChainTx(ctx, *cctx.CrossChainTx)
+
 	// fetch the tracker
 	// if the tracker does not exist, initialize a new one
 	tracker, found := k.GetOutboundTracker(ctx, msg.ChainId, msg.Nonce)


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/3490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Outbound transaction tracking now captures and records an additional hash for cross-chain transactions. This enhancement improves the way explorers and front-end applications locate and verify outbound transactions, providing more transparent tracking data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->