### PR TITLE
test: update tss address on gateway for TSS migration test

### DIFF
--- a/cmd/zetae2e/local/tss_migration.go
+++ b/cmd/zetae2e/local/tss_migration.go
@@ -92,5 +92,6 @@ func TSSMigration(deployerRunner *runner.E2ERunner, logger *runner.Logger, verbo
 	}
 	deployerRunner.UpdateTSSAddressForConnector()
 	deployerRunner.UpdateTSSAddressForERC20custody()
+	deployerRunner.UpdateTSSAddressForGateway()
 	logger.Print("✅ migration completed in %s ", time.Since(migrationStartTime).String())
 }

--- a/cmd/zetae2e/local/tss_migration.go
+++ b/cmd/zetae2e/local/tss_migration.go
@@ -90,6 +90,10 @@ func TSSMigration(deployerRunner *runner.E2ERunner, logger *runner.Logger, verbo
 		logger.Print("❌ tss migration failed")
 		os.Exit(1)
 	}
+
+	// Update TSS address for contracts in connected chains
+	// TODO : Update TSS address for other chains if necessary
+	// https://github.com/zeta-chain/node/issues/3599
 	deployerRunner.UpdateTSSAddressForConnector()
 	deployerRunner.UpdateTSSAddressForERC20custody()
 	deployerRunner.UpdateTSSAddressForGateway()

--- a/e2e/e2etests/test_migrate_tss.go
+++ b/e2e/e2etests/test_migrate_tss.go
@@ -147,8 +147,8 @@ func TestMigrateTSS(r *runner.E2ERunner, _ []string) {
 		btcTSSBalanceNew += utxo.Amount
 	}
 
-	r.Logger.Info("BTC Balance Old: %f", btcTSSBalanceOld*1e8)
-	r.Logger.Info("BTC Balance New: %f", btcTSSBalanceNew*1e8)
+	r.Logger.Info("BTC TSS Balance Old: %f", btcTSSBalanceOld*1e8)
+	r.Logger.Info("BTC TSS Balance New: %f", btcTSSBalanceNew*1e8)
 	r.Logger.Info("Migrator amount : %s", cctxBTC.GetCurrentOutboundParam().Amount)
 
 	// btcTSSBalanceNew should be less than btcTSSBalanceOld as there is some loss of funds during migration
@@ -165,8 +165,8 @@ func TestMigrateTSS(r *runner.E2ERunner, _ []string) {
 	ethTSSBalanceNew, err := r.EVMClient.BalanceAt(context.Background(), r.TSSAddress, nil)
 	require.NoError(r, err)
 
-	r.Logger.Info("TSS Balance Old: %s", ethTSSBalanceOld.String())
-	r.Logger.Info("TSS Balance New: %s", ethTSSBalanceNew.String())
+	r.Logger.Info("ETH TSS Balance Old: %s", ethTSSBalanceOld.String())
+	r.Logger.Info("ETH TSS Balance New: %s", ethTSSBalanceNew.String())
 	r.Logger.Info("Migrator amount : %s", cctxETH.GetCurrentOutboundParam().Amount.String())
 
 	// ethTSSBalanceNew should be less than ethTSSBalanceOld as there is some loss of funds during migration

--- a/e2e/runner/admin_evm.go
+++ b/e2e/runner/admin_evm.go
@@ -48,7 +48,6 @@ func (r *E2ERunner) UpdateTSSAddressForGateway() {
 	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.EVMClient, tx, r.Logger, r.ReceiptTimeout)
 	utils.RequireTxSuccessful(r, receipt)
 
-	// we have to reference ERC20Custody since it's `TssAddress` on v2 and `TSSAddress` on v1
 	tssAddressOnGateway, err := r.GatewayEVM.TssAddress(&bind.CallOpts{Context: r.Ctx})
 	require.NoError(r, err)
 	require.Equal(r, r.TSSAddress, tssAddressOnGateway)

--- a/e2e/runner/admin_evm.go
+++ b/e2e/runner/admin_evm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zeta-chain/node/e2e/utils"
 )
 
+// UpdateTSSAddressForConnector updates the TSS address for the connector contract
 func (r *E2ERunner) UpdateTSSAddressForConnector() {
 	require.NoError(r, r.SetTSSAddresses())
 
@@ -21,6 +22,7 @@ func (r *E2ERunner) UpdateTSSAddressForConnector() {
 	require.Equal(r, r.TSSAddress, tssAddressOnConnector)
 }
 
+// UpdateTSSAddressForERC20custody updates the TSS address for the ERC20 custody contract
 func (r *E2ERunner) UpdateTSSAddressForERC20custody() {
 	require.NoError(r, r.SetTSSAddresses())
 
@@ -34,4 +36,20 @@ func (r *E2ERunner) UpdateTSSAddressForERC20custody() {
 	tssAddressOnCustody, err := r.ERC20Custody.TssAddress(&bind.CallOpts{Context: r.Ctx})
 	require.NoError(r, err)
 	require.Equal(r, r.TSSAddress, tssAddressOnCustody)
+}
+
+// UpdateTSSAddressForGateway updates the TSS address for the gateway contract
+func (r *E2ERunner) UpdateTSSAddressForGateway() {
+	require.NoError(r, r.SetTSSAddresses())
+
+	tx, err := r.GatewayEVM.UpdateTSSAddress(r.EVMAuth, r.TSSAddress)
+	require.NoError(r, err)
+	r.Logger.Info("TSS Gateway Address Update Tx: %s", tx.Hash().String())
+	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.EVMClient, tx, r.Logger, r.ReceiptTimeout)
+	utils.RequireTxSuccessful(r, receipt)
+
+	// we have to reference ERC20Custody since it's `TssAddress` on v2 and `TSSAddress` on v1
+	tssAddressOnGateway, err := r.GatewayEVM.TssAddress(&bind.CallOpts{Context: r.Ctx})
+	require.NoError(r, err)
+	require.Equal(r, r.TSSAddress, tssAddressOnGateway)
 }

--- a/e2e/runner/setup_zevm.go
+++ b/e2e/runner/setup_zevm.go
@@ -32,8 +32,6 @@ var EmissionsPoolFunding = big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(2e7))
 
 // SetTSSAddresses set TSS addresses from information queried from ZetaChain
 func (r *E2ERunner) SetTSSAddresses() error {
-	r.Logger.Print("⚙️ setting up TSS address")
-
 	btcChainID, err := chains.GetBTCChainIDFromChainParams(r.BitcoinParams)
 	if err != nil {
 		return err

--- a/zetaclient/chains/bitcoin/signer/outbound_data.go
+++ b/zetaclient/chains/bitcoin/signer/outbound_data.go
@@ -58,7 +58,7 @@ func NewOutboundData(
 	params := cctx.GetCurrentOutboundParam()
 
 	// support gas token only for Bitcoin outbound
-	if cctx.InboundParams.CoinType != coin.CoinType_Gas {
+	if cctx.InboundParams.CoinType != coin.CoinType_Gas && cctx.InboundParams.CoinType != coin.CoinType_Cmd {
 		return nil, fmt.Errorf("invalid coin type %s", cctx.InboundParams.CoinType.String())
 	}
 

--- a/zetaclient/chains/bitcoin/signer/outbound_data.go
+++ b/zetaclient/chains/bitcoin/signer/outbound_data.go
@@ -57,7 +57,7 @@ func NewOutboundData(
 	}
 	params := cctx.GetCurrentOutboundParam()
 
-	// support gas token only for Bitcoin outbound
+	// support coin type GAS and CMD only
 	if cctx.InboundParams.CoinType != coin.CoinType_Gas && cctx.InboundParams.CoinType != coin.CoinType_Cmd {
 		return nil, fmt.Errorf("invalid coin type %s", cctx.InboundParams.CoinType.String())
 	}


### PR DESCRIPTION
# Description

THe PR 
- Updates the TSS address on the gatway contract , so that the e2e tests can run post TSS migration with the new TSS addres .
- Updates a check on the Bitcoin outbound , to allow outbounds of cointype CMD to go through , which allows the migration TX to be mined 


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced multi-chain TSS address updates, now including support for gateway contracts.
	- Extended Bitcoin outbound transaction validation to accept an additional coin type.
- **Tests**
	- Updated log messaging for Bitcoin and Ethereum TSS balances to improve clarity.
- **Chores**
	- Removed a redundant log message during the TSS setup process for a cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->