### PR TITLE
fix(ci): only run sec checks once on PRs

### DIFF
--- a/.github/workflows/zetachain-sec-checks.yml
+++ b/.github/workflows/zetachain-sec-checks.yml
@@ -1,6 +1,11 @@
 name: "CodeQL - ZetaChain Custom checks "
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - release/*
+  pull_request:
 
 jobs:
   analyze:


### PR DESCRIPTION
Should only run on push to main branches.

<img width="762" alt="image" src="https://github.com/user-attachments/assets/10fe8c8c-7bf1-49f7-a89f-e9e67a2a25eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Optimized automated security checks by adjusting commit triggers to run only on designated development and release branches, while maintaining validations for all pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->