### PR TITLE
chore: cleanup unused ibc ante handler

### DIFF
--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -27,8 +27,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	ibcante "github.com/cosmos/ibc-go/v8/modules/core/ante"
-	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	ethante "github.com/zeta-chain/ethermint/app/ante"
 	ethermint "github.com/zeta-chain/ethermint/types"
 	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
@@ -37,9 +35,10 @@ import (
 )
 
 type HandlerOptions struct {
-	AccountKeeper          evmtypes.AccountKeeper
-	BankKeeper             evmtypes.BankKeeper
-	IBCKeeper              *ibckeeper.Keeper
+	AccountKeeper evmtypes.AccountKeeper
+	BankKeeper    evmtypes.BankKeeper
+	// TODO: enable back IBC
+	// IBCKeeper              *ibckeeper.Keeper
 	FeeMarketKeeper        FeeMarketKeeper
 	EvmKeeper              EVMKeeper
 	FeegrantKeeper         ante.FeegrantKeeper
@@ -76,7 +75,9 @@ func NewLegacyCosmosAnteHandlerEip712(options HandlerOptions) sdk.AnteHandler {
 		// Note: signature verification uses EIP instead of the cosmos signature validator
 		ethante.NewLegacyEip712SigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
-		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
+		// TODO: enable back IBC
+		// check if this ante handler is needed in non legacy cosmos ante handlers
+		// ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
 		ethante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
 	)
 }


### PR DESCRIPTION
# Description

we dont use ibc, so this is not used in ante handlers

commenting out with todo to add back when we use ibc, same as other places where ibc is commented

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed legacy multi-chain communication references to streamline internal operations (no visible changes for end‐users).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->