### PR TITLE
feat(e2e): add MERGE_FAILED label and comment if mergequeue CI fails

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -337,6 +337,33 @@ jobs:
               body: JSON.stringify({text: msg}),
             });
 
+      - name: Add MERGE_FAILED label if merge queue failed
+        uses: actions/github-script@v7
+        if: ${{ github.event_name == 'merge_group' && needs.e2e.result == 'failure' }}
+        with:
+          script: |
+            const commit_message = context.payload.merge_group.head_commit.message;
+            const pr_match = commit_message.split('\n')[0].match(/\(#(\d+)\)$/);
+            if (!pr_match) {
+              console.error("unable to extract PR number from mergequeue commit message");
+              return;
+            }
+            const pr_number = pr_match[1];
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              labels: ['MERGE_FAILED']
+            });
+
+            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              body: `[Merge queue e2e run failed](${workflowRunUrl})`
+            });
 
       - run: |
           result="${{ needs.build-zetanode.result }}"


### PR DESCRIPTION
This will help us quickly identify PRs which need to be fixed or requeued.