### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/rpc/namespaces/ethereum/eth/filters/api.go
+++ b/rpc/namespaces/ethereum/eth/filters/api.go
@@ -611,7 +611,7 @@ func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit filters.FilterCrit
 		return nil, err
 	}
 
-	return returnLogs(logs), err
+	return returnLogs(logs), nil
 }
 
 // UninstallFilter removes the filter with the given filter id.

--- a/server/util.go
+++ b/server/util.go
@@ -135,5 +135,5 @@ func Listen(addr string, config *config.Config) (net.Listener, error) {
 	if config.JSONRPC.MaxOpenConnections > 0 {
 		ln = netutil.LimitListener(ln, config.JSONRPC.MaxOpenConnections)
 	}
-	return ln, err
+	return ln, nil
 }


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The logic of err not being nil has been processed and returned before, so err must be nil here.



# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted log retrieval responses to consistently indicate successful outcomes when no issues occur.
  - Updated the listener initialization process to reliably communicate successful connection creation without error signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->