### PR TITLE
chore: remove mergequeue failed comment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -357,14 +357,6 @@ jobs:
               labels: ['MERGE_FAILED']
             });
 
-            const workflowRunUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr_number,
-              body: `[Merge queue e2e run failed](${workflowRunUrl})`
-            });
-
       - run: |
           result="${{ needs.build-zetanode.result }}"
           if [[ $result == "failed" ]]; then


### PR DESCRIPTION
This comment is not actually needed since github natively show which status check failed:

<img width="924" alt="image" src="https://github.com/user-attachments/assets/d17d401c-4035-49e2-99d4-4fd0a7902004" />

I had removed this locally but forgot to push the change.

Related to https://github.com/zeta-chain/node/pull/3611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined automated notifications by removing the automatic comment on pull requests after test failures.
  - Continued to use labels to indicate the outcome of end-to-end tests, ensuring clarity without extra commentary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->