### PR TITLE
fix(zetacore): allow object for tracerConfig

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@
 * [3509](https://github.com/zeta-chain/node/pull/3509) - schedule Bitcoin TSS keysign on interval to avoid TSS keysign spam
 * [3517](https://github.com/zeta-chain/node/pull/3517) - remove duplicate gateway event appending to fix false positive on multiple events in same tx
 * [3602](https://github.com/zeta-chain/node/pull/3602) - hardcode gas limits to avoid estimate gas calls
+* [3622](https://github.com/zeta-chain/node/pull/3622) - allow object for tracerConfig in `debug_traceTransaction` RPC
 
 ### Tests
 

--- a/rpc/backend/backend.go
+++ b/rpc/backend/backend.go
@@ -165,10 +165,10 @@ type EVMBackend interface {
 	BloomStatus() (uint64, uint64)
 
 	// Tracing
-	TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (interface{}, error)
+	TraceTransaction(hash common.Hash, config *rpctypes.TraceConfig) (interface{}, error)
 	TraceBlock(
 		height rpctypes.BlockNumber,
-		config *evmtypes.TraceConfig,
+		config *rpctypes.TraceConfig,
 		block *tmrpctypes.ResultBlock,
 	) ([]*evmtypes.TxTraceResult, error)
 }

--- a/rpc/backend/tracing_convert_test.go
+++ b/rpc/backend/tracing_convert_test.go
@@ -24,20 +24,34 @@ const compliantStyleRaw = `
 }
 `
 
-// TestConvertConfig ensures that both the old broken style and the new compliant style
-// serialize to the same value
+const emptyStyleRaw = `
+{
+    "tracer": "callTracer"
+}
+`
+
 func TestConvertConfig(t *testing.T) {
-	brokenStyle := &rpctypes.TraceConfig{}
-	err := json.Unmarshal([]byte(brokenStyleRaw), brokenStyle)
-	require.NoError(t, err)
+	t.Run("broken style", func(t *testing.T) {
+		brokenStyle := &rpctypes.TraceConfig{}
+		err := json.Unmarshal([]byte(brokenStyleRaw), brokenStyle)
+		require.NoError(t, err)
+		brokenStyleConverted := convertConfig(brokenStyle)
+		require.Equal(t, expectedConvertedValue, brokenStyleConverted.TracerJsonConfig)
+	})
 
-	brokenStyleConverted := convertConfig(brokenStyle)
-	require.Equal(t, expectedConvertedValue, brokenStyleConverted.TracerJsonConfig)
+	t.Run("compliant style", func(t *testing.T) {
+		compliantStyle := &rpctypes.TraceConfig{}
+		err := json.Unmarshal([]byte(compliantStyleRaw), compliantStyle)
+		require.NoError(t, err)
+		compliantStyleConverted := convertConfig(compliantStyle)
+		require.Equal(t, expectedConvertedValue, compliantStyleConverted.TracerJsonConfig)
+	})
 
-	compliantStyle := &rpctypes.TraceConfig{}
-	err = json.Unmarshal([]byte(compliantStyleRaw), compliantStyle)
-	require.NoError(t, err)
-
-	compliantStyleConverted := convertConfig(compliantStyle)
-	require.Equal(t, expectedConvertedValue, compliantStyleConverted.TracerJsonConfig)
+	t.Run("empty style", func(t *testing.T) {
+		emptyStyle := &rpctypes.TraceConfig{}
+		err := json.Unmarshal([]byte(emptyStyleRaw), emptyStyle)
+		require.NoError(t, err)
+		emptyStyleConverted := convertConfig(emptyStyle)
+		require.Equal(t, "", emptyStyleConverted.TracerJsonConfig)
+	})
 }

--- a/rpc/backend/tracing_convert_test.go
+++ b/rpc/backend/tracing_convert_test.go
@@ -30,28 +30,59 @@ const emptyStyleRaw = `
 }
 `
 
+const invalidStyleRaw = `
+{
+    "tracer": "callTracer",
+	"tracerConfig": []
+}
+`
+
 func TestConvertConfig(t *testing.T) {
-	t.Run("broken style", func(t *testing.T) {
-		brokenStyle := &rpctypes.TraceConfig{}
-		err := json.Unmarshal([]byte(brokenStyleRaw), brokenStyle)
-		require.NoError(t, err)
-		brokenStyleConverted := convertConfig(brokenStyle)
-		require.Equal(t, expectedConvertedValue, brokenStyleConverted.TracerJsonConfig)
-	})
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+		expected    string
+	}{
+		{
+			name:        "broken style",
+			input:       brokenStyleRaw,
+			expectError: false,
+			expected:    expectedConvertedValue,
+		},
+		{
+			name:        "compliant style",
+			input:       compliantStyleRaw,
+			expectError: false,
+			expected:    expectedConvertedValue,
+		},
+		{
+			name:        "empty style",
+			input:       emptyStyleRaw,
+			expectError: false,
+			expected:    "",
+		},
+		{
+			name:        "invalid style",
+			input:       invalidStyleRaw,
+			expectError: true,
+			expected:    "",
+		},
+	}
 
-	t.Run("compliant style", func(t *testing.T) {
-		compliantStyle := &rpctypes.TraceConfig{}
-		err := json.Unmarshal([]byte(compliantStyleRaw), compliantStyle)
-		require.NoError(t, err)
-		compliantStyleConverted := convertConfig(compliantStyle)
-		require.Equal(t, expectedConvertedValue, compliantStyleConverted.TracerJsonConfig)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpcConfig := &rpctypes.TraceConfig{}
+			err := json.Unmarshal([]byte(tt.input), rpcConfig)
+			require.NoError(t, err)
 
-	t.Run("empty style", func(t *testing.T) {
-		emptyStyle := &rpctypes.TraceConfig{}
-		err := json.Unmarshal([]byte(emptyStyleRaw), emptyStyle)
-		require.NoError(t, err)
-		emptyStyleConverted := convertConfig(emptyStyle)
-		require.Equal(t, "", emptyStyleConverted.TracerJsonConfig)
-	})
+			ethermintConfig, err := convertConfig(rpcConfig)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, ethermintConfig.TracerJsonConfig)
+		})
+	}
 }

--- a/rpc/backend/tracing_convert_test.go
+++ b/rpc/backend/tracing_convert_test.go
@@ -1,0 +1,43 @@
+package backend
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rpctypes "github.com/zeta-chain/node/rpc/types"
+)
+
+const expectedConvertedValue = `{"onlyTopCall":false}`
+
+const brokenStyleRaw = `
+{
+    "tracer": "callTracer",
+    "tracerConfig": "{\"onlyTopCall\":false}"
+}
+`
+
+const compliantStyleRaw = `
+{
+    "tracer": "callTracer",
+    "tracerConfig": {"onlyTopCall":false}
+}
+`
+
+// TestConvertConfig ensures that both the old broken style and the new compliant style
+// serialize to the same value
+func TestConvertConfig(t *testing.T) {
+	brokenStyle := &rpctypes.TraceConfig{}
+	err := json.Unmarshal([]byte(brokenStyleRaw), brokenStyle)
+	require.NoError(t, err)
+
+	brokenStyleConverted := convertConfig(brokenStyle)
+	require.Equal(t, expectedConvertedValue, brokenStyleConverted.TracerJsonConfig)
+
+	compliantStyle := &rpctypes.TraceConfig{}
+	err = json.Unmarshal([]byte(compliantStyleRaw), compliantStyle)
+	require.NoError(t, err)
+
+	compliantStyleConverted := convertConfig(compliantStyle)
+	require.Equal(t, expectedConvertedValue, compliantStyleConverted.TracerJsonConfig)
+}

--- a/rpc/backend/tracing_test.go
+++ b/rpc/backend/tracing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zeta-chain/ethermint/crypto/ethsecp256k1"
 	"github.com/zeta-chain/ethermint/indexer"
 	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
+	rpctypes "github.com/zeta-chain/node/rpc/types"
 
 	"github.com/zeta-chain/node/rpc/backend/mocks"
 )
@@ -272,7 +273,7 @@ func (suite *BackendTestSuite) TestTraceBlock() {
 		registerMock    func()
 		expTraceResults []*evmtypes.TxTraceResult
 		resBlock        *tmrpctypes.ResultBlock
-		config          *evmtypes.TraceConfig
+		config          *rpctypes.TraceConfig
 		expPass         bool
 	}{
 		{
@@ -280,7 +281,7 @@ func (suite *BackendTestSuite) TestTraceBlock() {
 			func() {},
 			[]*evmtypes.TxTraceResult{},
 			&resBlockEmpty,
-			&evmtypes.TraceConfig{},
+			&rpctypes.TraceConfig{},
 			true,
 		},
 		{
@@ -293,7 +294,7 @@ func (suite *BackendTestSuite) TestTraceBlock() {
 			},
 			[]*evmtypes.TxTraceResult{},
 			&resBlockFilled,
-			&evmtypes.TraceConfig{},
+			&rpctypes.TraceConfig{},
 			false,
 		},
 	}

--- a/rpc/namespaces/ethereum/debug/api.go
+++ b/rpc/namespaces/ethereum/debug/api.go
@@ -72,7 +72,7 @@ func NewAPI(
 
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
-func (a *API) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (interface{}, error) {
+func (a *API) TraceTransaction(hash common.Hash, config *rpctypes.TraceConfig) (interface{}, error) {
 	a.logger.Debug("debug_traceTransaction", "hash", hash)
 	return a.backend.TraceTransaction(hash, config)
 }
@@ -81,7 +81,7 @@ func (a *API) TraceTransaction(hash common.Hash, config *evmtypes.TraceConfig) (
 // EVM and returns them as a JSON object.
 func (a *API) TraceBlockByNumber(
 	height rpctypes.BlockNumber,
-	config *evmtypes.TraceConfig,
+	config *rpctypes.TraceConfig,
 ) ([]*evmtypes.TxTraceResult, error) {
 	a.logger.Debug("debug_traceBlockByNumber", "height", height)
 	if height == 0 {
@@ -99,7 +99,7 @@ func (a *API) TraceBlockByNumber(
 
 // TraceBlockByHash returns the structured logs created during the execution of
 // EVM and returns them as a JSON object.
-func (a *API) TraceBlockByHash(hash common.Hash, config *evmtypes.TraceConfig) ([]*evmtypes.TxTraceResult, error) {
+func (a *API) TraceBlockByHash(hash common.Hash, config *rpctypes.TraceConfig) ([]*evmtypes.TxTraceResult, error) {
 	a.logger.Debug("debug_traceBlockByHash", "hash", hash)
 	// Get Tendermint Block
 	resBlock, err := a.backend.TendermintBlockByHash(hash)

--- a/rpc/types/types.go
+++ b/rpc/types/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
 )
 
 // Copied the Account and StorageResult types since they are registered under an
@@ -114,4 +115,9 @@ type OneFeeHistory struct {
 	BaseFee, NextBaseFee *big.Int   // base fee for each block
 	Reward               []*big.Int // each element of the array will have the tip provided to miners for the percentile given
 	GasUsedRatio         float64    // the ratio of gas used to the gas limit for each block
+}
+
+type TraceConfig struct {
+	evmtypes.TraceConfig
+	TracerConfig interface{} `json:"tracerConfig"`
 }


### PR DESCRIPTION
Closes https://github.com/zeta-chain/node/issues/3391

Inspired by https://github.com/crypto-org-chain/ethermint/commit/ccb83e2e068878551bc7bd704617bdaba72f1358 but I took a slightly different approach so that this is not a breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced tracing configuration that includes additional options for improved tracer support.
  
- **Refactor**
	- Updated the tracing operations in transaction and block processing to utilize the new configuration, ensuring greater flexibility and consistency.
	- Implemented a conversion helper to seamlessly process diverse configuration formats.
  
- **Tests**
	- Added comprehensive tests to verify the accuracy of configuration conversion and overall tracing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->