### PR TITLE
refactor(e2e): use alternative errgroup to catch panics

### DIFF
--- a/cmd/zetae2e/local/bitcoin.go
+++ b/cmd/zetae2e/local/bitcoin.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/zeta-chain/node/e2e/config"
 	"github.com/zeta-chain/node/e2e/e2etests"
 	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/pkg/errgroup"
 	"github.com/zeta-chain/node/testutil"
 )
 

--- a/cmd/zetae2e/local/evm.go
+++ b/cmd/zetae2e/local/evm.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/zeta-chain/node/e2e/config"
 	"github.com/zeta-chain/node/e2e/e2etests"
 	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/pkg/errgroup"
 )
 
 // startEVMTests starts EVM chains related tests in parallel

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 
 	zetae2econfig "github.com/zeta-chain/node/cmd/zetae2e/config"
 	"github.com/zeta-chain/node/e2e/config"
@@ -22,6 +21,7 @@ import (
 	"github.com/zeta-chain/node/e2e/txserver"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/errgroup"
 	"github.com/zeta-chain/node/testutil"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"

--- a/pkg/errgroup/errgroup.go
+++ b/pkg/errgroup/errgroup.go
@@ -1,0 +1,125 @@
+// Package errgroup provides synchronization, error propagation, and Context
+// cancellation for groups of goroutines working on subtasks of a common task.
+//
+// It wraps, and exposes a similar API to, the upstream package
+// golang.org/x/sync/errgroup.  Our version additionally recovers from panics,
+// converting them into errors.
+//
+// Copyright 2009 The Go Authors and 2021 Steve Coffman
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// fromPanicValue takes a value recovered from a panic and converts it into an
+// error, for logging purposes.  If the value is nil, it returns nil instead of
+// an error.
+//
+// Use like:
+//
+//	 defer func() {
+//			err := fromPanicValue(recover())
+//			// log or otheriwse use err
+//		}()
+func fromPanicValue(i interface{}) error {
+	switch value := i.(type) {
+	case nil:
+		return nil
+	case string:
+		return fmt.Errorf("panic: %v\n%s", value, collectStack())
+	case error:
+		return fmt.Errorf("panic in errgroup goroutine %w\n%s", value, collectStack())
+	default:
+		return fmt.Errorf("unknown panic: %+v\n%s", value, collectStack())
+	}
+}
+
+func collectStack() []byte {
+	buf := make([]byte, 64<<10)
+	buf = buf[:runtime.Stack(buf, false)]
+	return buf
+}
+
+func catchPanics(f func() error) func() error {
+	return func() (err error) {
+		defer func() {
+			// modified from log.PanicHandler, except instead of log.Panic we
+			// set `err`, which is the named-return from our closure to
+			// `g.Group.Go`, to an error based on the panic value.
+			// We do not log here -- we are effectively returning the (panic)
+			// error to our caller which suffices.
+			if r := recover(); r != nil {
+				err = fromPanicValue(r)
+			}
+		}()
+
+		return f()
+	}
+}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	// Sadly, we have to copy the whole implementation, because:
+	// - we want a zero errgroup to work, which means we'd need to embed the
+	//   upstream errgroup by value
+	// - we can't copy an errgroup, which means we can't embed by value
+	// (We could get around this with our own initialization-Once, but that
+	// seems even more convoluted.)  So we just copy -- it's not that much
+	// code.  The only change below is to add catchPanics(), in Go().
+	cancel  func()
+	wg      sync.WaitGroup
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or panics, or the first time Wait returns,
+// whichever occurs first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will
+// be returned by Wait.
+//
+// If the function panics, this is treated as if it returned an error.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		// here's the only change from upstream: this was
+		//  err := f(); ...
+		if err := catchPanics(f)(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/pkg/errgroup/errgroup_test.go
+++ b/pkg/errgroup/errgroup_test.go
@@ -1,0 +1,166 @@
+package errgroup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPanicWithString(t *testing.T) {
+	g, ctx := WithContext(context.Background())
+	g.Go(func() error { panic("oh noes") })
+	// this function ensures that the panic in fact cancels the context, by not
+	// returning until it's been cancelled; it should return context.Canceled
+	g.Go(func() error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	// Wait() will finish only once all goroutines do, but returns the first
+	// error
+	err := g.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oh noes")
+
+	// ctx should now be canceled.
+	require.Error(t, ctx.Err())
+}
+
+func TestPanicWithError(t *testing.T) {
+	g, ctx := WithContext(context.Background())
+
+	panicErr := errors.New("oh noes")
+	g.Go(func() error { panic(panicErr) })
+	// this function ensures that the panic in fact cancels the context, by not
+	// returning until it's been cancelled; it should return context.Canceled
+	g.Go(func() error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	// Wait() will finish only once all goroutines do, but returns the first
+	// error
+	err := g.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oh noes")
+	require.True(t, errors.Is(err, panicErr))
+
+	// ctx should now be canceled.
+	require.Error(t, ctx.Err())
+}
+
+func TestPanicWithOtherValue(t *testing.T) {
+	g, ctx := WithContext(context.Background())
+
+	panicVal := struct {
+		int
+		string
+	}{1234567890, "oh noes"}
+	g.Go(func() error { panic(panicVal) })
+	// this function ensures that the panic in fact cancels the context, by not
+	// returning until it's been cancelled; it should return context.Canceled
+	g.Go(func() error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	// Wait() will finish only once all goroutines do, but returns the first
+	// error
+	err := g.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oh noes")
+	require.Contains(t, err.Error(), "1234567890")
+
+	// ctx should now be canceled.
+	require.Error(t, ctx.Err())
+}
+
+func TestError(t *testing.T) {
+	g, ctx := WithContext(context.Background())
+
+	goroutineErr := errors.New("oh noes")
+	g.Go(func() error { return goroutineErr })
+	// this function ensures that the panic in fact cancels the context, by not
+	// returning until it's been cancelled; it should return context.Canceled
+	g.Go(func() error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	// Wait() will finish only once all goroutines do, but returns the first
+	// error
+	err := g.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oh noes")
+	require.True(t, errors.Is(err, goroutineErr))
+
+	// ctx should now be canceled.
+	require.Error(t, ctx.Err())
+}
+
+func TestSuccess(t *testing.T) {
+	g, ctx := WithContext(context.Background())
+
+	g.Go(func() error { return nil })
+	// since no goroutine errored, ctx.Err() should be nil
+	// (until all goroutines are done)
+	g.Go(ctx.Err)
+
+	err := g.Wait()
+	require.NoError(t, err)
+
+	// ctx should now still be canceled.
+	require.Error(t, ctx.Err())
+}
+
+func TestManyGoroutines(t *testing.T) {
+	n := 100
+	g, ctx := WithContext(context.Background())
+
+	for i := 0; i < n; i++ {
+		// put in a bunch of goroutines that just return right away
+		g.Go(func() error { return nil })
+		// and also a bunch that wait for the error
+		g.Go(func() error {
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}
+
+	// finally, put in a panic
+	g.Go(func() error { panic("oh noes") })
+
+	// as before, Wait() will finish only once all goroutines do, but returns
+	// the first error (namely the panic)
+	err := g.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oh noes")
+
+	// ctx should now be canceled.
+	require.Error(t, ctx.Err())
+}
+
+func TestZeroGroupPanic(t *testing.T) {
+	var g Group
+
+	// either of these could happen first, since a zero group does not cancel
+	g.Go(func() error { panic("oh noes") })
+	g.Go(func() error { return nil })
+
+	// Wait() still returns the error.
+	err := g.Wait()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oh noes")
+}
+
+func TestZeroGroupSuccess(t *testing.T) {
+	var g Group
+
+	g.Go(func() error { return nil })
+	g.Go(func() error { return nil })
+
+	err := g.Wait()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Use an errgroup implementation based on https://github.com/StevenACoffman/errgroup so that panics in the test routines are caught. This will reduce the amount of log spam when you have a test failure in one routine before another routine has even started running.

I just vendored the library to avoid external dependencies. The tests are rewritten to just use `require` rather than `suite`.

Closes https://github.com/zeta-chain/node/issues/3613

Related to #3578 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced error handling module that improves recovery from unexpected issues during concurrent operations.
- **Tests**
	- Added comprehensive tests to validate robust error propagation and system reliability.
- **Refactor**
	- Updated dependency references to leverage a localized error handling solution for improved maintainability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->