### PR TITLE
feat(e2e): add iterations parameter to performance tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -261,10 +261,10 @@ jobs:
             run: ${{ needs.matrix-conditionals.outputs.ADMIN_UPGRADE_TESTS == 'true' }}
             timeout-minutes: 40
           - make-target: "start-e2e-performance-test"
-            runs-on: ubuntu-22.04
+            runs-on: buildjet-8vcpu-ubuntu-2204
             run: ${{ needs.matrix-conditionals.outputs.PERFORMANCE_TESTS == 'true' }}
           - make-target: "start-e2e-performance-test-1k"
-            runs-on: ubuntu-22.04
+            runs-on: buildjet-8vcpu-ubuntu-2204
             run: ${{ needs.matrix-conditionals.outputs.PERFORMANCE_TESTS_1K == 'true' }}
             timeout-minutes: 60
           - make-target: "start-e2e-import-mainnet-test"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,6 +117,7 @@ jobs:
       ADMIN_TESTS: ${{ steps.matrix-conditionals.outputs.ADMIN_TESTS }}
       ADMIN_UPGRADE_TESTS: ${{ steps.matrix-conditionals.outputs.ADMIN_UPGRADE_TESTS }}
       PERFORMANCE_TESTS: ${{ steps.matrix-conditionals.outputs.PERFORMANCE_TESTS }}
+      PERFORMANCE_TESTS_1K: ${{ steps.matrix-conditionals.outputs.PERFORMANCE_TESTS_1K }}
       STATEFUL_DATA_TESTS: ${{ steps.matrix-conditionals.outputs.STATEFUL_DATA_TESTS }}
       TSS_MIGRATION_TESTS: ${{ steps.matrix-conditionals.outputs.TSS_MIGRATION_TESTS }}
       STAKING_TESTS: ${{ steps.matrix-conditionals.outputs.STAKING_TESTS }}
@@ -152,6 +153,7 @@ jobs:
               core.setOutput('ADMIN_TESTS', labels.includes('ADMIN_TESTS'));
               core.setOutput('ADMIN_UPGRADE_TESTS', labels.includes('ADMIN_UPGRADE_TESTS'));
               core.setOutput('PERFORMANCE_TESTS', labels.includes('PERFORMANCE_TESTS'));
+              core.setOutput('PERFORMANCE_TESTS_1K', labels.includes('PERFORMANCE_TESTS_1K'));
               core.setOutput('STATEFUL_DATA_TESTS', labels.includes('STATEFUL_DATA_TESTS'));
               core.setOutput('TSS_MIGRATION_TESTS', labels.includes('TSS_MIGRATION_TESTS'));
               core.setOutput('STAKING_TESTS', labels.includes('STAKING_TESTS'));
@@ -198,7 +200,7 @@ jobs:
               core.setOutput('UPGRADE_IMPORT_MAINNET_TESTS', true);
               core.setOutput('ADMIN_TESTS', true);
               core.setOutput('ADMIN_UPGRADE_TESTS', true);
-              core.setOutput('PERFORMANCE_TESTS', true);
+              core.setOutput('PERFORMANCE_TESTS_1K', true);
               core.setOutput('STATEFUL_DATA_TESTS', true);
               core.setOutput('TSS_MIGRATION_TESTS', true);
               core.setOutput('STAKING_TESTS', true);
@@ -215,6 +217,7 @@ jobs:
               core.setOutput('ADMIN_TESTS', makeTargets.includes('admin-test'));
               core.setOutput('ADMIN_UPGRADE_TESTS', makeTargets.includes('admin-upgrade-test'));
               core.setOutput('PERFORMANCE_TESTS', makeTargets.includes('performance-test'));
+              core.setOutput('PERFORMANCE_TESTS_1K', makeTargets.includes('performance-test-1k'));
               core.setOutput('STATEFUL_DATA_TESTS', makeTargets.includes('import-mainnet-test'));
               core.setOutput('TSS_MIGRATION_TESTS', makeTargets.includes('tss-migration-test'));
               core.setOutput('STAKING_TESTS', makeTargets.includes('staking-test'));
@@ -258,8 +261,12 @@ jobs:
             run: ${{ needs.matrix-conditionals.outputs.ADMIN_UPGRADE_TESTS == 'true' }}
             timeout-minutes: 40
           - make-target: "start-e2e-performance-test"
-            runs-on: buildjet-4vcpu-ubuntu-2204
+            runs-on: ubuntu-22.04
             run: ${{ needs.matrix-conditionals.outputs.PERFORMANCE_TESTS == 'true' }}
+          - make-target: "start-e2e-performance-test-1k"
+            runs-on: ubuntu-22.04
+            run: ${{ needs.matrix-conditionals.outputs.PERFORMANCE_TESTS_1K == 'true' }}
+            timeout-minutes: 60
           - make-target: "start-e2e-import-mainnet-test"
             runs-on: buildjet-16vcpu-ubuntu-2204
             run: ${{ needs.matrix-conditionals.outputs.STATEFUL_DATA_TESTS == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ start-e2e-performance-test: e2e-images solana
 
 start-e2e-performance-test-1k: e2e-images solana
 	@echo "--> Starting e2e performance test"
-	export E2E_ARGS="--test-performance --performance-iterations=1000" && \
+	export E2E_ARGS="--test-performance --iterations=1000" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
 start-e2e-import-mainnet-test: e2e-images

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,11 @@ start-e2e-performance-test: e2e-images solana
 	export E2E_ARGS="${E2E_ARGS} --test-performance" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
+start-e2e-performance-test-1k: e2e-images solana
+	@echo "--> Starting e2e performance test"
+	export E2E_ARGS="--test-performance --performance-iterations=1000" && \
+	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
+
 start-e2e-import-mainnet-test: e2e-images
 	@echo "--> Starting e2e import-data test"
 	export ZETACORED_IMPORT_GENESIS_DATA=true && \

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -29,29 +29,30 @@ import (
 )
 
 const (
-	flagContractsDeployed = "deployed"
-	flagWaitForHeight     = "wait-for"
-	FlagConfigFile        = "config"
-	flagConfigOut         = "config-out"
-	flagVerbose           = "verbose"
-	flagTestAdmin         = "test-admin"
-	flagTestPerformance   = "test-performance"
-	flagTestSolana        = "test-solana"
-	flagTestTON           = "test-ton"
-	flagTestSui           = "test-sui"
-	flagSkipRegular       = "skip-regular"
-	flagLight             = "light"
-	flagSetupOnly         = "setup-only"
-	flagSkipSetup         = "skip-setup"
-	flagTestTSSMigration  = "test-tss-migration"
-	flagSkipBitcoinSetup  = "skip-bitcoin-setup"
-	flagSkipHeaderProof   = "skip-header-proof"
-	flagTestLegacy        = "test-legacy"
-	flagSkipTrackerCheck  = "skip-tracker-check"
-	flagSkipPrecompiles   = "skip-precompiles"
-	flagUpgradeContracts  = "upgrade-contracts"
-	flagTestFilter        = "test-filter"
-	flagTestStaking       = "test-staking"
+	flagContractsDeployed     = "deployed"
+	flagWaitForHeight         = "wait-for"
+	FlagConfigFile            = "config"
+	flagConfigOut             = "config-out"
+	flagVerbose               = "verbose"
+	flagTestAdmin             = "test-admin"
+	flagTestPerformance       = "test-performance"
+	flagPerformanceIterations = "performance-iterations"
+	flagTestSolana            = "test-solana"
+	flagTestTON               = "test-ton"
+	flagTestSui               = "test-sui"
+	flagSkipRegular           = "skip-regular"
+	flagLight                 = "light"
+	flagSetupOnly             = "setup-only"
+	flagSkipSetup             = "skip-setup"
+	flagTestTSSMigration      = "test-tss-migration"
+	flagSkipBitcoinSetup      = "skip-bitcoin-setup"
+	flagSkipHeaderProof       = "skip-header-proof"
+	flagTestLegacy            = "test-legacy"
+	flagSkipTrackerCheck      = "skip-tracker-check"
+	flagSkipPrecompiles       = "skip-precompiles"
+	flagUpgradeContracts      = "upgrade-contracts"
+	flagTestFilter            = "test-filter"
+	flagTestStaking           = "test-staking"
 )
 
 var (
@@ -74,6 +75,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().Bool(flagVerbose, false, "set to true to enable verbose logging")
 	cmd.Flags().Bool(flagTestAdmin, false, "set to true to run admin tests")
 	cmd.Flags().Bool(flagTestPerformance, false, "set to true to run performance tests")
+	cmd.Flags().Int(flagPerformanceIterations, 100, "number of iterations to run each performance test")
 	cmd.Flags().Bool(flagTestSolana, false, "set to true to run solana tests")
 	cmd.Flags().Bool(flagTestTON, false, "set to true to run TON tests")
 	cmd.Flags().Bool(flagTestSui, false, "set to true to run Sui tests")
@@ -103,29 +105,30 @@ func NewLocalCmd() *cobra.Command {
 func localE2ETest(cmd *cobra.Command, _ []string) {
 	// fetch flags
 	var (
-		waitForHeight     = must(cmd.Flags().GetInt64(flagWaitForHeight))
-		contractsDeployed = must(cmd.Flags().GetBool(flagContractsDeployed))
-		verbose           = must(cmd.Flags().GetBool(flagVerbose))
-		configOut         = must(cmd.Flags().GetString(flagConfigOut))
-		testAdmin         = must(cmd.Flags().GetBool(flagTestAdmin))
-		testPerformance   = must(cmd.Flags().GetBool(flagTestPerformance))
-		testSolana        = must(cmd.Flags().GetBool(flagTestSolana))
-		testTON           = must(cmd.Flags().GetBool(flagTestTON))
-		testSui           = must(cmd.Flags().GetBool(flagTestSui))
-		skipRegular       = must(cmd.Flags().GetBool(flagSkipRegular))
-		light             = must(cmd.Flags().GetBool(flagLight))
-		setupOnly         = must(cmd.Flags().GetBool(flagSetupOnly))
-		skipSetup         = must(cmd.Flags().GetBool(flagSkipSetup))
-		skipBitcoinSetup  = must(cmd.Flags().GetBool(flagSkipBitcoinSetup))
-		skipHeaderProof   = must(cmd.Flags().GetBool(flagSkipHeaderProof))
-		skipTrackerCheck  = must(cmd.Flags().GetBool(flagSkipTrackerCheck))
-		testTSSMigration  = must(cmd.Flags().GetBool(flagTestTSSMigration))
-		testLegacy        = must(cmd.Flags().GetBool(flagTestLegacy))
-		skipPrecompiles   = must(cmd.Flags().GetBool(flagSkipPrecompiles))
-		upgradeContracts  = must(cmd.Flags().GetBool(flagUpgradeContracts))
-		setupSolana       = testSolana || testPerformance
-		testFilterStr     = must(cmd.Flags().GetString(flagTestFilter))
-		testStaking       = must(cmd.Flags().GetBool(flagTestStaking))
+		waitForHeight         = must(cmd.Flags().GetInt64(flagWaitForHeight))
+		contractsDeployed     = must(cmd.Flags().GetBool(flagContractsDeployed))
+		verbose               = must(cmd.Flags().GetBool(flagVerbose))
+		configOut             = must(cmd.Flags().GetString(flagConfigOut))
+		testAdmin             = must(cmd.Flags().GetBool(flagTestAdmin))
+		testPerformance       = must(cmd.Flags().GetBool(flagTestPerformance))
+		performanceIterations = must(cmd.Flags().GetInt(flagPerformanceIterations))
+		testSolana            = must(cmd.Flags().GetBool(flagTestSolana))
+		testTON               = must(cmd.Flags().GetBool(flagTestTON))
+		testSui               = must(cmd.Flags().GetBool(flagTestSui))
+		skipRegular           = must(cmd.Flags().GetBool(flagSkipRegular))
+		light                 = must(cmd.Flags().GetBool(flagLight))
+		setupOnly             = must(cmd.Flags().GetBool(flagSetupOnly))
+		skipSetup             = must(cmd.Flags().GetBool(flagSkipSetup))
+		skipBitcoinSetup      = must(cmd.Flags().GetBool(flagSkipBitcoinSetup))
+		skipHeaderProof       = must(cmd.Flags().GetBool(flagSkipHeaderProof))
+		skipTrackerCheck      = must(cmd.Flags().GetBool(flagSkipTrackerCheck))
+		testTSSMigration      = must(cmd.Flags().GetBool(flagTestTSSMigration))
+		testLegacy            = must(cmd.Flags().GetBool(flagTestLegacy))
+		skipPrecompiles       = must(cmd.Flags().GetBool(flagSkipPrecompiles))
+		upgradeContracts      = must(cmd.Flags().GetBool(flagUpgradeContracts))
+		setupSolana           = testSolana || testPerformance
+		testFilterStr         = must(cmd.Flags().GetString(flagTestFilter))
+		testStaking           = must(cmd.Flags().GetBool(flagTestStaking))
 	)
 
 	testFilter := regexp.MustCompile(testFilterStr)
@@ -376,8 +379,24 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	}
 
 	if testPerformance {
-		eg.Go(ethereumDepositPerformanceRoutine(conf, deployerRunner, verbose, e2etests.TestStressEtherDepositName))
-		eg.Go(ethereumWithdrawPerformanceRoutine(conf, deployerRunner, verbose, e2etests.TestStressEtherWithdrawName))
+		eg.Go(
+			ethereumDepositPerformanceRoutine(
+				conf,
+				deployerRunner,
+				verbose,
+				[]string{e2etests.TestStressEtherDepositName},
+				performanceIterations,
+			),
+		)
+		eg.Go(
+			ethereumWithdrawPerformanceRoutine(
+				conf,
+				deployerRunner,
+				verbose,
+				[]string{e2etests.TestStressEtherWithdrawName},
+				performanceIterations,
+			),
+		)
 		eg.Go(
 			solanaDepositPerformanceRoutine(
 				conf,
@@ -385,7 +404,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				deployerRunner,
 				verbose,
 				conf.AdditionalAccounts.UserSolana,
-				e2etests.TestStressSolanaDepositName,
+				[]string{e2etests.TestStressSolanaDepositName},
+				performanceIterations,
 			),
 		)
 		eg.Go(
@@ -395,7 +415,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				deployerRunner,
 				verbose,
 				conf.AdditionalAccounts.UserSPL,
-				e2etests.TestStressSPLDepositName,
+				[]string{e2etests.TestStressSPLDepositName},
+				performanceIterations,
 			),
 		)
 		eg.Go(
@@ -405,7 +426,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				deployerRunner,
 				verbose,
 				conf.AdditionalAccounts.UserSolana,
-				e2etests.TestStressSolanaWithdrawName,
+				[]string{e2etests.TestStressSolanaWithdrawName},
+				performanceIterations,
 			),
 		)
 		eg.Go(
@@ -415,7 +437,8 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				deployerRunner,
 				verbose,
 				conf.AdditionalAccounts.UserSPL,
-				e2etests.TestStressSPLWithdrawName,
+				[]string{e2etests.TestStressSPLWithdrawName},
+				performanceIterations,
 			),
 		)
 	}

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -431,7 +431,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				verbose,
 				conf.AdditionalAccounts.UserSolana,
 				[]string{e2etests.TestStressSolanaWithdrawName},
-				performanceIterations,
 			),
 		)
 		eg.Go(
@@ -442,7 +441,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				verbose,
 				conf.AdditionalAccounts.UserSPL,
 				[]string{e2etests.TestStressSPLWithdrawName},
-				performanceIterations,
 			),
 		)
 	}

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -153,6 +153,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	conf, err := GetConfig(cmd)
 	noError(err)
 
+	if testPerformance && performanceIterations > 100 {
+		TestTimeout = time.Hour
+	}
+
 	// initialize context
 	ctx, timeoutCancel := context.WithTimeoutCause(context.Background(), TestTimeout, ErrTopLevelTimeout)
 	defer timeoutCancel()

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -29,30 +29,30 @@ import (
 )
 
 const (
-	flagContractsDeployed     = "deployed"
-	flagWaitForHeight         = "wait-for"
-	FlagConfigFile            = "config"
-	flagConfigOut             = "config-out"
-	flagVerbose               = "verbose"
-	flagTestAdmin             = "test-admin"
-	flagTestPerformance       = "test-performance"
-	flagPerformanceIterations = "performance-iterations"
-	flagTestSolana            = "test-solana"
-	flagTestTON               = "test-ton"
-	flagTestSui               = "test-sui"
-	flagSkipRegular           = "skip-regular"
-	flagLight                 = "light"
-	flagSetupOnly             = "setup-only"
-	flagSkipSetup             = "skip-setup"
-	flagTestTSSMigration      = "test-tss-migration"
-	flagSkipBitcoinSetup      = "skip-bitcoin-setup"
-	flagSkipHeaderProof       = "skip-header-proof"
-	flagTestLegacy            = "test-legacy"
-	flagSkipTrackerCheck      = "skip-tracker-check"
-	flagSkipPrecompiles       = "skip-precompiles"
-	flagUpgradeContracts      = "upgrade-contracts"
-	flagTestFilter            = "test-filter"
-	flagTestStaking           = "test-staking"
+	flagContractsDeployed = "deployed"
+	flagWaitForHeight     = "wait-for"
+	FlagConfigFile        = "config"
+	flagConfigOut         = "config-out"
+	flagVerbose           = "verbose"
+	flagTestAdmin         = "test-admin"
+	flagTestPerformance   = "test-performance"
+	flagIterations        = "iterations"
+	flagTestSolana        = "test-solana"
+	flagTestTON           = "test-ton"
+	flagTestSui           = "test-sui"
+	flagSkipRegular       = "skip-regular"
+	flagLight             = "light"
+	flagSetupOnly         = "setup-only"
+	flagSkipSetup         = "skip-setup"
+	flagTestTSSMigration  = "test-tss-migration"
+	flagSkipBitcoinSetup  = "skip-bitcoin-setup"
+	flagSkipHeaderProof   = "skip-header-proof"
+	flagTestLegacy        = "test-legacy"
+	flagSkipTrackerCheck  = "skip-tracker-check"
+	flagSkipPrecompiles   = "skip-precompiles"
+	flagUpgradeContracts  = "upgrade-contracts"
+	flagTestFilter        = "test-filter"
+	flagTestStaking       = "test-staking"
 )
 
 var (
@@ -75,7 +75,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().Bool(flagVerbose, false, "set to true to enable verbose logging")
 	cmd.Flags().Bool(flagTestAdmin, false, "set to true to run admin tests")
 	cmd.Flags().Bool(flagTestPerformance, false, "set to true to run performance tests")
-	cmd.Flags().Int(flagPerformanceIterations, 100, "number of iterations to run each performance test")
+	cmd.Flags().Int(flagIterations, 100, "number of iterations to run each performance test")
 	cmd.Flags().Bool(flagTestSolana, false, "set to true to run solana tests")
 	cmd.Flags().Bool(flagTestTON, false, "set to true to run TON tests")
 	cmd.Flags().Bool(flagTestSui, false, "set to true to run Sui tests")
@@ -105,30 +105,30 @@ func NewLocalCmd() *cobra.Command {
 func localE2ETest(cmd *cobra.Command, _ []string) {
 	// fetch flags
 	var (
-		waitForHeight         = must(cmd.Flags().GetInt64(flagWaitForHeight))
-		contractsDeployed     = must(cmd.Flags().GetBool(flagContractsDeployed))
-		verbose               = must(cmd.Flags().GetBool(flagVerbose))
-		configOut             = must(cmd.Flags().GetString(flagConfigOut))
-		testAdmin             = must(cmd.Flags().GetBool(flagTestAdmin))
-		testPerformance       = must(cmd.Flags().GetBool(flagTestPerformance))
-		performanceIterations = must(cmd.Flags().GetInt(flagPerformanceIterations))
-		testSolana            = must(cmd.Flags().GetBool(flagTestSolana))
-		testTON               = must(cmd.Flags().GetBool(flagTestTON))
-		testSui               = must(cmd.Flags().GetBool(flagTestSui))
-		skipRegular           = must(cmd.Flags().GetBool(flagSkipRegular))
-		light                 = must(cmd.Flags().GetBool(flagLight))
-		setupOnly             = must(cmd.Flags().GetBool(flagSetupOnly))
-		skipSetup             = must(cmd.Flags().GetBool(flagSkipSetup))
-		skipBitcoinSetup      = must(cmd.Flags().GetBool(flagSkipBitcoinSetup))
-		skipHeaderProof       = must(cmd.Flags().GetBool(flagSkipHeaderProof))
-		skipTrackerCheck      = must(cmd.Flags().GetBool(flagSkipTrackerCheck))
-		testTSSMigration      = must(cmd.Flags().GetBool(flagTestTSSMigration))
-		testLegacy            = must(cmd.Flags().GetBool(flagTestLegacy))
-		skipPrecompiles       = must(cmd.Flags().GetBool(flagSkipPrecompiles))
-		upgradeContracts      = must(cmd.Flags().GetBool(flagUpgradeContracts))
-		setupSolana           = testSolana || testPerformance
-		testFilterStr         = must(cmd.Flags().GetString(flagTestFilter))
-		testStaking           = must(cmd.Flags().GetBool(flagTestStaking))
+		waitForHeight     = must(cmd.Flags().GetInt64(flagWaitForHeight))
+		contractsDeployed = must(cmd.Flags().GetBool(flagContractsDeployed))
+		verbose           = must(cmd.Flags().GetBool(flagVerbose))
+		configOut         = must(cmd.Flags().GetString(flagConfigOut))
+		testAdmin         = must(cmd.Flags().GetBool(flagTestAdmin))
+		testPerformance   = must(cmd.Flags().GetBool(flagTestPerformance))
+		iterations        = must(cmd.Flags().GetInt(flagIterations))
+		testSolana        = must(cmd.Flags().GetBool(flagTestSolana))
+		testTON           = must(cmd.Flags().GetBool(flagTestTON))
+		testSui           = must(cmd.Flags().GetBool(flagTestSui))
+		skipRegular       = must(cmd.Flags().GetBool(flagSkipRegular))
+		light             = must(cmd.Flags().GetBool(flagLight))
+		setupOnly         = must(cmd.Flags().GetBool(flagSetupOnly))
+		skipSetup         = must(cmd.Flags().GetBool(flagSkipSetup))
+		skipBitcoinSetup  = must(cmd.Flags().GetBool(flagSkipBitcoinSetup))
+		skipHeaderProof   = must(cmd.Flags().GetBool(flagSkipHeaderProof))
+		skipTrackerCheck  = must(cmd.Flags().GetBool(flagSkipTrackerCheck))
+		testTSSMigration  = must(cmd.Flags().GetBool(flagTestTSSMigration))
+		testLegacy        = must(cmd.Flags().GetBool(flagTestLegacy))
+		skipPrecompiles   = must(cmd.Flags().GetBool(flagSkipPrecompiles))
+		upgradeContracts  = must(cmd.Flags().GetBool(flagUpgradeContracts))
+		setupSolana       = testSolana || testPerformance
+		testFilterStr     = must(cmd.Flags().GetString(flagTestFilter))
+		testStaking       = must(cmd.Flags().GetBool(flagTestStaking))
 	)
 
 	testFilter := regexp.MustCompile(testFilterStr)
@@ -153,7 +153,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 	conf, err := GetConfig(cmd)
 	noError(err)
 
-	if testPerformance && performanceIterations > 100 {
+	if testPerformance && iterations > 100 {
 		TestTimeout = time.Hour
 	}
 
@@ -389,7 +389,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				deployerRunner,
 				verbose,
 				[]string{e2etests.TestStressEtherDepositName},
-				performanceIterations,
+				iterations,
 			),
 		)
 		eg.Go(
@@ -398,7 +398,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				deployerRunner,
 				verbose,
 				[]string{e2etests.TestStressEtherWithdrawName},
-				performanceIterations,
+				iterations,
 			),
 		)
 		eg.Go(

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -409,7 +409,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				verbose,
 				conf.AdditionalAccounts.UserSolana,
 				[]string{e2etests.TestStressSolanaDepositName},
-				performanceIterations,
 			),
 		)
 		eg.Go(
@@ -420,7 +419,6 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 				verbose,
 				conf.AdditionalAccounts.UserSPL,
 				[]string{e2etests.TestStressSPLDepositName},
-				performanceIterations,
 			),
 		)
 		eg.Go(

--- a/cmd/zetae2e/local/performance.go
+++ b/cmd/zetae2e/local/performance.go
@@ -21,11 +21,12 @@ import (
 // Update the corresponding argument with the count value
 func updateTestCountArg(tests []runner.E2ETest, count int) {
 	for i := range tests {
+		if len(tests[i].Args) == 0 {
+			tests[i].Args = tests[i].DefaultArgs()
+		}
 		for j, argDef := range tests[i].ArgsDefinition {
-			if argDef.Description == "count" {
-				if len(tests[i].Args) > j {
-					tests[i].Args[j] = fmt.Sprintf("%d", count)
-				}
+			if argDef.Description == e2etests.CountArgDescription {
+				tests[i].Args[j] = fmt.Sprintf("%d", count)
 				break
 			}
 		}

--- a/cmd/zetae2e/local/performance.go
+++ b/cmd/zetae2e/local/performance.go
@@ -138,7 +138,6 @@ func solanaDepositPerformanceRoutine(
 	verbose bool,
 	account config.Account,
 	testNames []string,
-	count int,
 ) func() error {
 	return func() (err error) {
 		// initialize runner for solana test
@@ -171,7 +170,6 @@ func solanaDepositPerformanceRoutine(
 		if err != nil {
 			return fmt.Errorf("solana deposit performance test failed: %v", err)
 		}
-		updateTestCountArg(tests, count)
 
 		if err := r.RunE2ETests(tests); err != nil {
 			return fmt.Errorf("solana deposit performance test failed: %v", err)

--- a/cmd/zetae2e/local/performance.go
+++ b/cmd/zetae2e/local/performance.go
@@ -191,7 +191,6 @@ func solanaWithdrawPerformanceRoutine(
 	verbose bool,
 	account config.Account,
 	testNames []string,
-	count int,
 ) func() error {
 	return func() (err error) {
 		// initialize runner for solana test
@@ -244,7 +243,6 @@ func solanaWithdrawPerformanceRoutine(
 		if err != nil {
 			return fmt.Errorf("solana withdraw performance test failed: %v", err)
 		}
-		updateTestCountArg(tests, count)
 
 		if err := r.RunE2ETests(tests); err != nil {
 			return fmt.Errorf("solana withdraw performance test failed: %v", err)

--- a/cmd/zetae2e/local/performance.go
+++ b/cmd/zetae2e/local/performance.go
@@ -17,12 +17,28 @@ import (
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 
+// Find the index of the count argument in ArgsDefinition.
+// Update the corresponding argument with the count value
+func updateTestCountArg(tests []runner.E2ETest, count int) {
+	for i := range tests {
+		for j, argDef := range tests[i].ArgsDefinition {
+			if argDef.Description == "count" {
+				if len(tests[i].Args) > j {
+					tests[i].Args[j] = fmt.Sprintf("%d", count)
+				}
+				break
+			}
+		}
+	}
+}
+
 // ethereumDepositPerformanceRoutine runs performance tests for Ether deposit
 func ethereumDepositPerformanceRoutine(
 	conf config.Config,
 	deployerRunner *runner.E2ERunner,
 	verbose bool,
-	testNames ...string,
+	testNames []string,
+	count int,
 ) func() error {
 	return func() (err error) {
 		// initialize runner for ether test
@@ -47,6 +63,7 @@ func ethereumDepositPerformanceRoutine(
 		if err != nil {
 			return fmt.Errorf("ethereum deposit performance test failed: %v", err)
 		}
+		updateTestCountArg(tests, count)
 
 		if err := r.RunE2ETests(tests); err != nil {
 			return fmt.Errorf("ethereum deposit performance test failed: %v", err)
@@ -63,7 +80,8 @@ func ethereumWithdrawPerformanceRoutine(
 	conf config.Config,
 	deployerRunner *runner.E2ERunner,
 	verbose bool,
-	testNames ...string,
+	testNames []string,
+	count int,
 ) func() error {
 	return func() (err error) {
 		// initialize runner for ether test
@@ -99,6 +117,7 @@ func ethereumWithdrawPerformanceRoutine(
 		if err != nil {
 			return fmt.Errorf("ethereum withdraw performance test failed: %v", err)
 		}
+		updateTestCountArg(tests, count)
 
 		if err := r.RunE2ETests(tests); err != nil {
 			return fmt.Errorf("ethereum withdraw performance test failed: %v", err)
@@ -117,7 +136,8 @@ func solanaDepositPerformanceRoutine(
 	deployerRunner *runner.E2ERunner,
 	verbose bool,
 	account config.Account,
-	testNames ...string,
+	testNames []string,
+	count int,
 ) func() error {
 	return func() (err error) {
 		// initialize runner for solana test
@@ -150,6 +170,7 @@ func solanaDepositPerformanceRoutine(
 		if err != nil {
 			return fmt.Errorf("solana deposit performance test failed: %v", err)
 		}
+		updateTestCountArg(tests, count)
 
 		if err := r.RunE2ETests(tests); err != nil {
 			return fmt.Errorf("solana deposit performance test failed: %v", err)
@@ -168,7 +189,8 @@ func solanaWithdrawPerformanceRoutine(
 	deployerRunner *runner.E2ERunner,
 	verbose bool,
 	account config.Account,
-	testNames ...string,
+	testNames []string,
+	count int,
 ) func() error {
 	return func() (err error) {
 		// initialize runner for solana test
@@ -221,6 +243,7 @@ func solanaWithdrawPerformanceRoutine(
 		if err != nil {
 			return fmt.Errorf("solana withdraw performance test failed: %v", err)
 		}
+		updateTestCountArg(tests, count)
 
 		if err := r.RunE2ETests(tests); err != nil {
 			return fmt.Errorf("solana withdraw performance test failed: %v", err)

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -245,6 +245,10 @@ const (
 
 )
 
+const (
+	CountArgDescription = "count"
+)
+
 // AllE2ETests is an ordered list of all e2e tests
 var AllE2ETests = []runner.E2ETest{
 	/*
@@ -1050,7 +1054,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test Ether withdrawal",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "100000"},
-			{Description: "count", DefaultValue: "100"},
+			{Description: CountArgDescription, DefaultValue: "100"},
 		},
 		TestStressEtherWithdraw,
 	),
@@ -1059,7 +1063,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test BTC withdrawal",
 		[]runner.ArgDefinition{
 			{Description: "amount in btc", DefaultValue: "0.01"},
-			{Description: "count", DefaultValue: "100"},
+			{Description: CountArgDescription, DefaultValue: "100"},
 		},
 		TestStressBTCWithdraw,
 	),
@@ -1068,7 +1072,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test Ether deposit",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "100000"},
-			{Description: "count", DefaultValue: "100"},
+			{Description: CountArgDescription, DefaultValue: "100"},
 		},
 		TestStressEtherDeposit,
 	),
@@ -1077,7 +1081,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test BTC deposit",
 		[]runner.ArgDefinition{
 			{Description: "amount in btc", DefaultValue: "0.001"},
-			{Description: "count", DefaultValue: "100"},
+			{Description: CountArgDescription, DefaultValue: "100"},
 		},
 		TestStressBTCDeposit,
 	),
@@ -1086,7 +1090,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test SOL deposit",
 		[]runner.ArgDefinition{
 			{Description: "amount in lamports", DefaultValue: "1200000"},
-			{Description: "count of SOL deposits", DefaultValue: "50"},
+			{Description: CountArgDescription, DefaultValue: "50"},
 		},
 		TestStressSolanaDeposit,
 	),
@@ -1095,7 +1099,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test SPL deposit",
 		[]runner.ArgDefinition{
 			{Description: "amount in SPL tokens", DefaultValue: "1200000"},
-			{Description: "count of SPL deposits", DefaultValue: "50"},
+			{Description: CountArgDescription, DefaultValue: "50"},
 		},
 		TestStressSPLDeposit,
 	),
@@ -1104,7 +1108,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test SOL withdrawals",
 		[]runner.ArgDefinition{
 			{Description: "amount in lamports", DefaultValue: "1000000"},
-			{Description: "count of SOL withdrawals", DefaultValue: "50"},
+			{Description: CountArgDescription, DefaultValue: "50"},
 		},
 		TestStressSolanaWithdraw,
 	),
@@ -1113,7 +1117,7 @@ var AllE2ETests = []runner.E2ETest{
 		"stress test SPL withdrawals",
 		[]runner.ArgDefinition{
 			{Description: "amount in SPL tokens", DefaultValue: "1000000"},
-			{Description: "count of SPL withdrawals", DefaultValue: "50"},
+			{Description: CountArgDescription, DefaultValue: "50"},
 		},
 		TestStressSPLWithdraw,
 	),
@@ -1498,7 +1502,7 @@ var AllE2ETests = []runner.E2ETest{
 		"deposit ERC20 into ZEVM in multiple deposits (v1 protocol contracts)",
 		[]runner.ArgDefinition{
 			{Description: "amount", DefaultValue: "1000000000"},
-			{Description: "count", DefaultValue: "3"},
+			{Description: CountArgDescription, DefaultValue: "3"},
 		},
 		legacy.TestMultipleERC20Deposit,
 	),
@@ -1507,7 +1511,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw ERC20 from ZEVM in multiple withdrawals (v1 protocol contracts)",
 		[]runner.ArgDefinition{
 			{Description: "amount", DefaultValue: "100"},
-			{Description: "count", DefaultValue: "3"},
+			{Description: CountArgDescription, DefaultValue: "3"},
 		},
 		legacy.TestMultipleERC20Withdraws,
 	),

--- a/e2e/e2etests/test_eth_deposit.go
+++ b/e2e/e2etests/test_eth_deposit.go
@@ -19,7 +19,7 @@ func TestETHDeposit(r *runner.E2ERunner, args []string) {
 	r.Logger.Info("starting eth deposit test")
 
 	// perform the deposit
-	tx := r.ETHDeposit(r.EVMAddress(), amount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)})
+	tx := r.ETHDeposit(r.EVMAddress(), amount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)}, true)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)

--- a/e2e/e2etests/test_eth_deposit_fast_confirmation.go
+++ b/e2e/e2etests/test_eth_deposit_fast_confirmation.go
@@ -67,6 +67,7 @@ func TestETHDepositFastConfirmation(r *runner.E2ERunner, args []string) {
 		r.EVMAddress(),
 		fastAmountCap.BigInt(),
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		true,
 	)
 	r.Logger.Info("deposited exactly fast amount %d cap tx hash: %s", fastAmountCap, tx.Hash().Hex())
 
@@ -83,7 +84,12 @@ func TestETHDepositFastConfirmation(r *runner.E2ERunner, args []string) {
 	// ACT-2
 	// deposit with amount more than fast amount cap
 	amountMoreThanCap := big.NewInt(0).Add(fastAmountCap.BigInt(), big.NewInt(1))
-	tx = r.ETHDeposit(r.EVMAddress(), amountMoreThanCap, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)})
+	tx = r.ETHDeposit(
+		r.EVMAddress(),
+		amountMoreThanCap,
+		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		true,
+	)
 	r.Logger.Info("deposited more than fast amount cap %d tx hash: %s", amountMoreThanCap, tx.Hash().Hex())
 
 	// ASSERT-2

--- a/e2e/e2etests/test_eth_deposit_liquidity_cap.go
+++ b/e2e/e2etests/test_eth_deposit_liquidity_cap.go
@@ -34,10 +34,8 @@ func TestDepositEtherLiquidityCap(r *runner.E2ERunner, args []string) {
 		r.EVMAddress(),
 		amountMoreThanCap,
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		true,
 	)
-
-	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.EVMClient, signedTx, r.Logger, r.ReceiptTimeout)
-	utils.RequireTxSuccessful(r, receipt)
 
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, signedTx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	utils.RequireCCTXStatus(r, cctx, types.CctxStatus_Reverted)
@@ -52,10 +50,8 @@ func TestDepositEtherLiquidityCap(r *runner.E2ERunner, args []string) {
 		r.EVMAddress(),
 		amountLessThanCap,
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		true,
 	)
-
-	receipt = utils.MustWaitForTxReceipt(r.Ctx, r.EVMClient, signedTx, r.Logger, r.ReceiptTimeout)
-	utils.RequireTxSuccessful(r, receipt)
 
 	cctx = utils.WaitCctxMinedByInboundHash(r.Ctx, signedTx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	utils.RequireCCTXStatus(r, cctx, types.CctxStatus_OutboundMined)
@@ -80,10 +76,8 @@ func TestDepositEtherLiquidityCap(r *runner.E2ERunner, args []string) {
 		r.EVMAddress(),
 		amountMoreThanCap,
 		gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		true,
 	)
-
-	receipt = utils.MustWaitForTxReceipt(r.Ctx, r.EVMClient, signedTx, r.Logger, r.ReceiptTimeout)
-	utils.RequireTxSuccessful(r, receipt)
 
 	utils.WaitCctxMinedByInboundHash(r.Ctx, signedTx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	expectedBalance = big.NewInt(0).Add(initialBal, amountMoreThanCap)

--- a/e2e/e2etests/test_inbound_trackers.go
+++ b/e2e/e2etests/test_inbound_trackers.go
@@ -42,7 +42,7 @@ func TestInboundTrackers(r *runner.E2ERunner, args []string) {
 
 	// send eth deposit
 	r.Logger.Print("🏃test eth deposit")
-	tx := r.ETHDeposit(r.EVMAddress(), amount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)})
+	tx := r.ETHDeposit(r.EVMAddress(), amount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)}, false)
 	addTrackerAndWaitForCCTX(coin.CoinType_Gas, tx.Hash().Hex())
 	r.Logger.Print("🍾 eth deposit observed")
 

--- a/e2e/e2etests/test_stress_eth_deposit.go
+++ b/e2e/e2etests/test_stress_eth_deposit.go
@@ -40,6 +40,11 @@ func TestStressEtherDeposit(r *runner.E2ERunner, args []string) {
 		hash := tx.Hash()
 		r.Logger.Print("index %d: starting deposit, tx hash: %s", i, hash.Hex())
 
+		// slow down submitting transactions a bit.
+		// submitting them as fast as possible does actually work.
+		// but we want to ensure the workload is a bit more representative.
+		time.Sleep(time.Millisecond * 500)
+
 		eg.Go(func() error { return monitorEtherDeposit(r, hash, i, time.Now()) })
 	}
 

--- a/e2e/e2etests/test_stress_eth_deposit.go
+++ b/e2e/e2etests/test_stress_eth_deposit.go
@@ -31,7 +31,12 @@ func TestStressEtherDeposit(r *runner.E2ERunner, args []string) {
 	// send the deposits
 	for i := 0; i < numDeposits; i++ {
 		i := i
-		tx := r.ETHDeposit(r.EVMAddress(), depositAmount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)})
+		tx := r.ETHDeposit(
+			r.EVMAddress(),
+			depositAmount,
+			gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+			false,
+		)
 		hash := tx.Hash()
 		r.Logger.Print("index %d: starting deposit, tx hash: %s", i, hash.Hex())
 

--- a/e2e/e2etests/test_stress_eth_deposit.go
+++ b/e2e/e2etests/test_stress_eth_deposit.go
@@ -28,13 +28,15 @@ func TestStressEtherDeposit(r *runner.E2ERunner, args []string) {
 	// create a wait group to wait for all the deposits to complete
 	var eg errgroup.Group
 
+	revertOptions := gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)}
+
 	// send the deposits
 	for i := 0; i < numDeposits; i++ {
 		i := i
 		tx := r.ETHDeposit(
 			r.EVMAddress(),
 			depositAmount,
-			gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+			revertOptions,
 			false,
 		)
 		hash := tx.Hash()

--- a/e2e/runner/evm.go
+++ b/e2e/runner/evm.go
@@ -21,6 +21,7 @@ func (r *E2ERunner) ETHDeposit(
 	receiver ethcommon.Address,
 	amount *big.Int,
 	revertOptions gatewayevm.RevertOptions,
+	wait bool,
 ) *ethtypes.Transaction {
 	r.Lock()
 	defer r.Unlock()
@@ -35,7 +36,9 @@ func (r *E2ERunner) ETHDeposit(
 	tx, err := r.GatewayEVM.Deposit0(r.EVMAuth, receiver, revertOptions)
 	require.NoError(r, err)
 
-	logDepositInfoAndWaitForTxReceipt(r, tx, "eth_deposit")
+	if wait {
+		logDepositInfoAndWaitForTxReceipt(r, tx, "eth_deposit")
+	}
 
 	return tx
 }
@@ -43,7 +46,7 @@ func (r *E2ERunner) ETHDeposit(
 // DepositEtherDeployer sends Ethers into ZEVM using V2 protocol contracts
 func (r *E2ERunner) DepositEtherDeployer() ethcommon.Hash {
 	amount := big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(100)) // 100 eth
-	tx := r.ETHDeposit(r.EVMAddress(), amount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)})
+	tx := r.ETHDeposit(r.EVMAddress(), amount, gatewayevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)}, true)
 	return tx.Hash()
 }
 


### PR DESCRIPTION
Add `--performance-iterations` parameter to control how many times to run performance tests.

Apply this parameter to eth deposit/withdraw. sol withdraw is excluded as it falls behind very quickly and times out (we still run 50). sol deposit is also excluded hangs after about 300 with this zetaclient error:

```
2025-03-06T18:29:55Z ERR error GetSignaturesForAddressUntil error="error GetTransaction for untilSig 3RFQdt7JmpwLHeHvam5AnBcx1FsdcobnJ4KzDvEvgg9VN5tS9nEWgX6bZwTbPekvpe9KDwvGHs4NTS3kccu66Ee1: not found" chain=902 chain_network=solana module=inbound
```

Add `start-e2e-performance-test-1k` target and run this by default in the nightly tests.

The plan is to get this merged then try to get some solana improvements done

Related to https://github.com/zeta-chain/node/issues/3383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled a dedicated performance testing mode activated via specific labels and a new command targeting high-iteration tests.
  - Extended local test commands to accept a configurable performance iteration count with an extended timeout for larger workloads.

- **Tests**
  - Revised deposit test workflows by adding an extra control parameter for enhanced execution.
  - Introduced a brief delay between deposit submissions in stress tests for a more realistic workload simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->