### PR TITLE
fix(zetaclient): ensure fallbackTx is not nil

### DIFF
--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -317,7 +317,9 @@ func (signer *Signer) broadcastOutbound(
 		if err != nil {
 			// in case it is not failure due to nonce mismatch, replace tx with fallback tx
 			// probably need a better way to do this, but currently this is the only error to tolerate like this
-			if !strings.Contains(err.Error(), "NonceMismatch") && fallbackTx != nil {
+			errStr := err.Error()
+			if strings.Contains(errStr, "Error processing Instruction") && !strings.Contains(errStr, "NonceMismatch") &&
+				fallbackTx != nil {
 				tx = fallbackTx
 			}
 			logger.Warn().Err(err).Fields(lf).Msgf("SendTransactionWithOpts failed")

--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -317,7 +317,7 @@ func (signer *Signer) broadcastOutbound(
 		if err != nil {
 			// in case it is not failure due to nonce mismatch, replace tx with fallback tx
 			// probably need a better way to do this, but currently this is the only error to tolerate like this
-			if !strings.Contains(err.Error(), "NonceMismatch") {
+			if !strings.Contains(err.Error(), "NonceMismatch") && fallbackTx != nil {
 				tx = fallbackTx
 			}
 			logger.Warn().Err(err).Fields(lf).Msgf("SendTransactionWithOpts failed")


### PR DESCRIPTION
`fallbackTx` is only not nil on withdraw and call paths.

Related to https://github.com/zeta-chain/node/issues/3527

Example of revert log:

```
2025-03-05T20:09:22Z WRN SendTransactionWithOpts failed error="(*jsonrpc.RPCError)(0x40010c0f00)({\n Code: (int) -32002,\n Message: (string) (len=91) \"Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1771\",\n Data: (map[string]interface {}) (len=7) {\n  (string) (len=8) \"accounts\": (interface {}) <nil>,\n  (string) (len=3) \"err\": (map[string]interface {}) (len=1) {\n   (string) (len=16) \"InstructionError\": ([]interface {}) (len=2 cap=2) {\n    (json.Number) (len=1) \"0\",\n    (map[string]interface {}) (len=1) {\n     (string) (len=6) \"Custom\": (json.Number) (len=4) \"6001\"\n    }\n   }\n  },\n  (string) (len=17) \"innerInstructions\": (interface {}) <nil>,\n  (string) (len=4) \"logs\": ([]interface {}) (len=12 cap=16) {\n   (string) (len=63) \"Program 94U5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d invoke [1]\",\n   (string) (len=33) \"Program log: Instruction: Execute\",\n   (string) (len=183) \"Program log: Computed message hash: [25, 163, 172, 233, 104, 70, 114, 159, 122, 93, 100, 65, 228, 131, 220, 31, 197, 246, 205, 217, 9, 124, 4, 248, 192, 63, 222, 8, 48, 251, 127, 235]\",\n   (string) (len=122) \"Program log: Recovered address [190, 82, 189, 13, 153, 158, 16, 249, 78, 71, 248, 215, 117, 47, 58, 114, 164, 25, 236, 18]\",\n   (string) (len=63) \"Program 4xEw862A2SEwMjofPkUyd4NEekmVJKJsdHkK3UkAtDrc invoke [2]\",\n   (string) (len=32) \"Program log: Instruction: OnCall\",\n   (string) (len=59) \"Program log: Reverting transaction due to 'revert' message.\",\n   (string) (len=152) \"Program log: AnchorError occurred. Error Code: RevertMessage. Error Number: 6001. Error Message: Revert message detected. Transaction execution halted..\",\n   (string) (len=90) \"Program 4xEw862A2SEwMjofPkUyd4NEekmVJKJsdHkK3UkAtDrc consumed 7254 of 150151 compute units\",\n   (string) (len=89) \"Program 4xEw862A2SEwMjofPkUyd4NEekmVJKJsdHkK3UkAtDrc failed: custom program error: 0x1771\",\n   (string) (len=91) \"Program 94U5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d consumed 57103 of 200000 compute units\",\n   (string) (len=89) \"Program 94U5AHQMKkV5txNJ17QPXWoh474PheGou6cNP2FEuL1d failed: custom program error: 0x1771\"\n  },\n  (string) (len=20) \"replacementBlockhash\": (interface {}) <nil>,\n  (string) (len=10) \"returnData\": (interface {}) <nil>,\n  (string) (len=13) \"unitsConsumed\": (json.Number) (len=5) \"57103\"\n }\n})\n" cctx=0xc45986890f5049b2105b278928c2e9f5beff9eb3428df4384e449074328d7128 chain=902 method=broadcastOutbound module=signer nonce=2 tx=2HcrhXugrgFQbuhwaRxwxMJwxHyuVMqCoVuagMnjHjDvPtZDfcCigJofYBkuAnaFwfSCC9SB8dfEQhqPjZrSS5e6
```

note that `Error Code: RevertMessage` comes from the connected contract.

Here's another error that's not a revert:

```
(*jsonrpc.RPCError)(0x408bb0cd80)({
 Code: (int) -32002,
 Message: (string) (len=74) "Transaction simulation failed: This transaction has already been processed",
 Data: (map[string]interface {}) (len=7) {
  (string) (len=8) "accounts": (interface {}) <nil>,
  (string) (len=3) "err": (string) (len=16) "AlreadyProcessed",
  (string) (len=17) "innerInstructions": (interface {}) <nil>,
  (string) (len=4) "logs": ([]interface {}) {
  },
  (string) (len=20) "replacementBlockhash": (interface {}) <nil>,
  (string) (len=10) "returnData": (interface {}) <nil>,
  (string) (len=13) "unitsConsumed": (json.Number) (len=1) "0"
 }
})
```

So `Error processing Instruction` seems to be what could indicate a revert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fallback transaction handling during errors to ensure that fallback actions occur only when a valid fallback option is available, thereby enhancing system reliability during transaction broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->