### PR TITLE
refactor(zetaclient): wait for expected nonce and defer relayer signing

### DIFF
--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -144,6 +144,11 @@ type SolanaRPCClient interface {
 	GetSlot(ctx context.Context, commitment solrpc.CommitmentType) (uint64, error)
 	GetBlockTime(ctx context.Context, block uint64) (*solana.UnixTimeSeconds, error)
 	GetAccountInfo(ctx context.Context, account solana.PublicKey) (*solrpc.GetAccountInfoResult, error)
+	GetAccountInfoWithOpts(
+		ctx context.Context,
+		account solana.PublicKey,
+		opts *solrpc.GetAccountInfoOpts,
+	) (*solrpc.GetAccountInfoResult, error)
 	GetBalance(
 		ctx context.Context,
 		account solana.PublicKey,

--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -42,6 +42,8 @@ const (
 	SolanaMaxComputeBudget = 1_400_000
 )
 
+type txGetterT func() (*solana.Transaction, error)
+
 // Signer deals with signing Solana transactions and implements the ChainSigner interface
 type Signer struct {
 	*base.Signer
@@ -135,68 +137,68 @@ func (signer *Signer) TryProcessOutbound(
 	nonce := params.TssNonce
 	coinType := cctx.InboundParams.CoinType
 
-	var tx *solana.Transaction
-	var fallbackTx *solana.Transaction
+	var txGetter txGetterT
+	var fallbackTxGetter txGetterT
 
 	switch coinType {
 	case coin.CoinType_Cmd:
-		whitelistTx, err := signer.prepareWhitelistTx(ctx, cctx, height)
+		whitelistTxGetter, err := signer.prepareWhitelistTx(ctx, cctx, height)
 		if err != nil {
 			logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign whitelist outbound")
 			return
 		}
 
-		tx = whitelistTx
+		txGetter = whitelistTxGetter
 
 	case coin.CoinType_Gas:
 		if cctx.IsWithdrawAndCall() {
-			executeTx, err := signer.prepareExecuteTx(ctx, cctx, height, logger)
+			executeTxGetter, err := signer.prepareExecuteTx(ctx, cctx, height, logger)
 			if err != nil {
 				logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign execute outbound")
 				return
 			}
-			incrementNonceTx, err := signer.prepareIncrementNonceTx(ctx, cctx, height, logger)
+			incrementNonceTxGetter, err := signer.prepareIncrementNonceTx(ctx, cctx, height, logger)
 			if err != nil {
 				logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign increment_nonce outbound")
 				return
 			}
 
-			tx = executeTx
-			fallbackTx = incrementNonceTx
+			txGetter = executeTxGetter
+			fallbackTxGetter = incrementNonceTxGetter
 		} else {
-			withdrawTx, err := signer.prepareWithdrawTx(ctx, cctx, height, logger)
+			withdrawTxGetter, err := signer.prepareWithdrawTx(ctx, cctx, height, logger)
 			if err != nil {
 				logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign withdraw outbound")
 				return
 			}
 
-			tx = withdrawTx
+			txGetter = withdrawTxGetter
 		}
 
 	case coin.CoinType_ERC20:
 		if cctx.IsWithdrawAndCall() {
-			executeSPLTx, err := signer.prepareExecuteSPLTx(ctx, cctx, height, logger)
+			executeSPLTxGetter, err := signer.prepareExecuteSPLTx(ctx, cctx, height, logger)
 			if err != nil {
 				logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign execute spl outbound")
 				return
 			}
 
-			incrementNonceTx, err := signer.prepareIncrementNonceTx(ctx, cctx, height, logger)
+			incrementNonceTxGetter, err := signer.prepareIncrementNonceTx(ctx, cctx, height, logger)
 			if err != nil {
 				logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign increment_nonce outbound")
 				return
 			}
 
-			tx = executeSPLTx
-			fallbackTx = incrementNonceTx
+			txGetter = executeSPLTxGetter
+			fallbackTxGetter = incrementNonceTxGetter
 		} else {
-			withdrawSPLTx, err := signer.prepareWithdrawSPLTx(ctx, cctx, height, logger)
+			withdrawSPLTxGetter, err := signer.prepareWithdrawSPLTx(ctx, cctx, height, logger)
 			if err != nil {
 				logger.Error().Err(err).Msgf("TryProcessOutbound: Fail to sign withdraw spl outbound")
 				return
 			}
 
-			tx = withdrawSPLTx
+			txGetter = withdrawSPLTxGetter
 		}
 	default:
 		logger.Error().
@@ -212,6 +214,27 @@ func (signer *Signer) TryProcessOutbound(
 
 	// set relayer balance metrics
 	signer.SetRelayerBalanceMetrics(ctx)
+
+	isNonceRelayable := signer.waitNonceRelayable(ctx, nonce, logger)
+	if !isNonceRelayable {
+		return
+	}
+	// Get transactions from getters
+	// This is when the recent block hash timer starts
+	tx, err := txGetter()
+	if err != nil {
+		logger.Error().Err(err).Msgf("TryProcessOutbound: Failed to get transaction")
+		return
+	}
+
+	var fallbackTx *solana.Transaction
+	if fallbackTxGetter != nil {
+		fallbackTx, err = fallbackTxGetter()
+		if err != nil {
+			logger.Error().Err(err).Msgf("TryProcessOutbound: Failed to get fallback transaction")
+			return
+		}
+	}
 
 	// broadcast the signed tx to the Solana network
 	signer.broadcastOutbound(ctx, tx, fallbackTx, chainID, nonce, logger, zetacoreClient)
@@ -334,12 +357,60 @@ func (signer *Signer) broadcastOutbound(
 	}
 }
 
+// waitNonceRelayable will wait until the given nonce is relayable.
+// so long as we wait for this condition before actually sending the
+// transaction the RPC should accept it immediately.
+func (signer *Signer) waitNonceRelayable(
+	ctx context.Context,
+	nonce uint64,
+	logger zerolog.Logger,
+) bool {
+	for range 30 {
+		if ctx.Err() != nil {
+			return false
+		}
+		sleepDuration := time.Second
+		pdaInfo, err := signer.client.GetAccountInfoWithOpts(
+			ctx,
+			signer.pda,
+			&rpc.GetAccountInfoOpts{Commitment: rpc.CommitmentProcessed},
+		)
+		if err != nil {
+			logger.Error().Err(err).Msgf("unable to get PDA account info")
+		} else {
+			pda, err := contracts.DeserializePdaInfo(pdaInfo)
+			if err != nil {
+				// this will happen when contracts are first deployed
+				logger.Error().Err(err).Msgf("unable to deserialize PDA info")
+				return true
+			} else if pda.Nonce > nonce {
+				logger.Info().Msgf("PDA nonce %d is greater than outbound nonce, do not attempt relay", pda.Nonce)
+				return false
+			} else if pda.Nonce == nonce {
+				return true
+			}
+
+			// Calculate how far behind the nonce is
+			nonceDiff := nonce - pda.Nonce
+			// Scale sleep duration: longer wait for bigger differences
+			// Base sleep time of 1 second, multiplied by the difference
+			// Lookahead parameter should keep this from getting too out of control
+			sleepDuration = time.Second * time.Duration(nonceDiff)
+
+			logger.Info().
+				Msgf("waiting for pda nonce (%d) to match current nonce, sleeping for %s", pda.Nonce, sleepDuration)
+		}
+		time.Sleep(sleepDuration)
+	}
+	return false
+}
+
 func (signer *Signer) prepareIncrementNonceTx(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
 	height uint64,
 	logger zerolog.Logger,
-) (*solana.Transaction, error) {
+) (txGetterT, error) {
 	params := cctx.GetCurrentOutboundParam()
 	// compliance check
 	cancelTx := compliance.IsCctxRestricted(cctx)
@@ -362,13 +433,15 @@ func (signer *Signer) prepareIncrementNonceTx(
 		return nil, err
 	}
 
-	// sign the increment_nonce transaction by relayer key
-	inst, err := signer.createIncrementNonceInstruction(*msg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating increment nonce instruction")
-	}
+	return func() (*solana.Transaction, error) {
+		// sign the increment_nonce transaction by relayer key
+		inst, err := signer.createIncrementNonceInstruction(*msg)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating increment nonce instruction")
+		}
 
-	return signer.signTx(ctx, inst, 0)
+		return signer.signTx(ctx, inst, 0)
+	}, nil
 }
 
 func (signer *Signer) prepareWithdrawTx(
@@ -376,7 +449,7 @@ func (signer *Signer) prepareWithdrawTx(
 	cctx *types.CrossChainTx,
 	height uint64,
 	logger zerolog.Logger,
-) (*solana.Transaction, error) {
+) (txGetterT, error) {
 	params := cctx.GetCurrentOutboundParam()
 	// compliance check
 	cancelTx := compliance.IsCctxRestricted(cctx)
@@ -399,13 +472,15 @@ func (signer *Signer) prepareWithdrawTx(
 		return nil, errors.Wrap(err, "createAndSignMsgWithdraw error")
 	}
 
-	// sign the withdraw transaction by relayer key
-	inst, err := signer.createWithdrawInstruction(*msg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating withdraw instruction")
-	}
+	return func() (*solana.Transaction, error) {
+		// sign the withdraw transaction by relayer key
+		inst, err := signer.createWithdrawInstruction(*msg)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating withdraw instruction")
+		}
 
-	return signer.signTx(ctx, inst, 0)
+		return signer.signTx(ctx, inst, 0)
+	}, nil
 }
 
 func (signer *Signer) prepareExecuteTx(
@@ -413,7 +488,7 @@ func (signer *Signer) prepareExecuteTx(
 	cctx *types.CrossChainTx,
 	height uint64,
 	logger zerolog.Logger,
-) (*solana.Transaction, error) {
+) (txGetterT, error) {
 	params := cctx.GetCurrentOutboundParam()
 	// compliance check
 	cancelTx := compliance.IsCctxRestricted(cctx)
@@ -462,13 +537,15 @@ func (signer *Signer) prepareExecuteTx(
 		return nil, errors.Wrap(err, "createAndSignMsgExecute error")
 	}
 
-	// sign the execute transaction by relayer key
-	inst, err := signer.createExecuteInstruction(*msgExecute)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating execute instruction")
-	}
+	return func() (*solana.Transaction, error) {
+		// sign the execute transaction by relayer key
+		inst, err := signer.createExecuteInstruction(*msgExecute)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating execute instruction")
+		}
 
-	return signer.signTx(ctx, inst, params.CallOptions.GasLimit)
+		return signer.signTx(ctx, inst, params.CallOptions.GasLimit)
+	}, nil
 }
 
 func (signer *Signer) prepareWithdrawSPLTx(
@@ -476,7 +553,7 @@ func (signer *Signer) prepareWithdrawSPLTx(
 	cctx *types.CrossChainTx,
 	height uint64,
 	logger zerolog.Logger,
-) (*solana.Transaction, error) {
+) (txGetterT, error) {
 	params := cctx.GetCurrentOutboundParam()
 	// compliance check
 	cancelTx := compliance.IsCctxRestricted(cctx)
@@ -512,13 +589,15 @@ func (signer *Signer) prepareWithdrawSPLTx(
 		return nil, errors.Wrap(err, "createAndSignMsgWithdrawSPL error")
 	}
 
-	// sign the withdraw transaction by relayer key
-	inst, err := signer.createWithdrawSPLInstruction(*msg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating withdraw SPL instruction")
-	}
+	return func() (*solana.Transaction, error) {
+		// sign the withdraw transaction by relayer key
+		inst, err := signer.createWithdrawSPLInstruction(*msg)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating withdraw SPL instruction")
+		}
 
-	return signer.signTx(ctx, inst, 0)
+		return signer.signTx(ctx, inst, 0)
+	}, nil
 }
 
 func (signer *Signer) prepareExecuteSPLTx(
@@ -526,7 +605,7 @@ func (signer *Signer) prepareExecuteSPLTx(
 	cctx *types.CrossChainTx,
 	height uint64,
 	logger zerolog.Logger,
-) (*solana.Transaction, error) {
+) (txGetterT, error) {
 	params := cctx.GetCurrentOutboundParam()
 	// compliance check
 	cancelTx := compliance.IsCctxRestricted(cctx)
@@ -584,20 +663,22 @@ func (signer *Signer) prepareExecuteSPLTx(
 		return nil, err
 	}
 
-	// sign the execute spl transaction by relayer key
-	inst, err := signer.createExecuteSPLInstruction(*msgExecuteSpl)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating execute SPL instruction")
-	}
+	return func() (*solana.Transaction, error) {
+		// sign the execute spl transaction by relayer key
+		inst, err := signer.createExecuteSPLInstruction(*msgExecuteSpl)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating execute SPL instruction")
+		}
 
-	return signer.signTx(ctx, inst, params.CallOptions.GasLimit)
+		return signer.signTx(ctx, inst, params.CallOptions.GasLimit)
+	}, nil
 }
 
 func (signer *Signer) prepareWhitelistTx(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
 	height uint64,
-) (*solana.Transaction, error) {
+) (txGetterT, error) {
 	params := cctx.GetCurrentOutboundParam()
 	relayedMsg := strings.Split(cctx.RelayedMessage, ":")
 	if len(relayedMsg) != 2 {
@@ -621,13 +702,15 @@ func (signer *Signer) prepareWhitelistTx(
 		return nil, errors.Wrap(err, "createAndSignMsgWhitelist error")
 	}
 
-	// sign the whitelist transaction by relayer key
-	inst, err := signer.createWhitelistInstruction(msg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating whitelist instruction")
-	}
+	return func() (*solana.Transaction, error) {
+		// sign the whitelist transaction by relayer key
+		inst, err := signer.createWhitelistInstruction(msg)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating whitelist instruction")
+		}
 
-	return signer.signTx(ctx, inst, 0)
+		return signer.signTx(ctx, inst, 0)
+	}, nil
 }
 
 func (signer *Signer) decodeMintAccountDetails(ctx context.Context, asset string) (token.Mint, error) {

--- a/zetaclient/testutils/mocks/solana_rpc.go
+++ b/zetaclient/testutils/mocks/solana_rpc.go
@@ -47,6 +47,33 @@ func (_m *SolanaRPCClient) GetAccountInfo(ctx context.Context, account solana.Pu
 	return r0, r1
 }
 
+// GetAccountInfoWithOpts provides a mock function with given fields: ctx, account, opts
+func (_m *SolanaRPCClient) GetAccountInfoWithOpts(ctx context.Context, account solana.PublicKey, opts *rpc.GetAccountInfoOpts) (*rpc.GetAccountInfoResult, error) {
+	ret := _m.Called(ctx, account, opts)
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountInfoWithOpts")
+	}
+	var r0 *rpc.GetAccountInfoResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, solana.PublicKey, *rpc.GetAccountInfoOpts) (*rpc.GetAccountInfoResult, error)); ok {
+		return rf(ctx, account, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, solana.PublicKey, *rpc.GetAccountInfoOpts) *rpc.GetAccountInfoResult); ok {
+		r0 = rf(ctx, account, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*rpc.GetAccountInfoResult)
+		}
+	}
+	if rf, ok := ret.Get(1).(func(context.Context, solana.PublicKey, *rpc.GetAccountInfoOpts) error); ok {
+		r1 = rf(ctx, account, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetBalance provides a mock function with given fields: ctx, account, commitment
 func (_m *SolanaRPCClient) GetBalance(ctx context.Context, account solana.PublicKey, commitment rpc.CommitmentType) (*rpc.GetBalanceResult, error) {
 	ret := _m.Called(ctx, account, commitment)


### PR DESCRIPTION
There is no reason to even try to submit the transaction until the nonce is in the expected range. Update: that would not be true if we enabled skipping the preflight checks (which may be a better solution than this).

If we defer relayer transaction signing until we're closer to actually being able to relay the transaction, we can avoid starting the two minute `recentBlockhash` timer ([ref](https://solana.com/docs/core/transactions#recent-blockhash)).

We need to continue doing TSS signing immediately to avoid desynchronization.

TODO:
- [ ] deduplicate `signer.client.GetAccountInfoWithOpts` calls. We should only make 1 call even if we have N pending transactions
- [ ] inject the fallbackTx as `txGetterT` and resolve it only when actually needed. Although I don't exactly understand why we actually would want to do this. Testing for the `NonceMismatch` will have a lot of false positives since we see it during normal operations.

Note, I have another older version of this logic that make the relayer more like a queue. But that has a bunch of concurrency overhead that could be a bit of maintenance burden.

Related to https://github.com/zeta-chain/node/issues/3383

### Performance Test Comparison

We see 10-20% reductions in latency since we are spending less time in the relayer backoff loop

#### [Before](https://github.com/zeta-chain/node/actions/runs/13647314383/job/38148522148) (nightly run)

```
perf_sol_wit | Latency report:
perf_sol_wit | min:  42.59
perf_sol_wit | max:  649.80
perf_sol_wit | mean: 330.21
perf_sol_wit | std:  182.90
perf_sol_wit | p50:  314.24
perf_sol_wit | p75:  480.37
perf_sol_wit | p90:  576.56
perf_sol_wit | p95:  616.17
```

#### [After](https://github.com/zeta-chain/node/actions/runs/13664327834/job/38202479261?pr=3633) (this PR)

```
perf_sol_wit | Latency report:
perf_sol_wit | min:  26.58
perf_sol_wit | max:  568.70
perf_sol_wit | mean: 296.78
perf_sol_wit | std:  159.03
perf_sol_wit | p50:  296.59
perf_sol_wit | p75:  425.42
perf_sol_wit | p90:  512.57
perf_sol_wit | p95:  531.25
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced retrieval of account details by allowing additional query options.
  
- **Refactor**
  - Improved outbound transaction handling by deferring transaction creation, which streamlines error management and processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->