### PR TITLE
fix: check if cctx has already been created before casting inbound vote

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+* [3636](https://github.com/zeta-chain/node/pull/3636) - add a check to stop posting inbound votes if the cctx has already been created
+
 ## v28.1.0
 
 This is a zetaclient only release.

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -414,15 +414,14 @@ func (ob *Observer) PostVoteInbound(
 	// 2. if the cctx exists but the ballot does not exist, we do not need to vote
 	_, err := ob.ZetacoreClient().GetCctxByHash(ctx, cctxIndex)
 	if err == nil {
-			// The cctx exists we should still vote if the ballot is present
-			_, err = ob.ZetacoreClient().GetBallotByID(ctx, cctxIndex)
-			if err != nil {
-				// Verify ballot is not found
-				if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
-					// Query for ballot failed, the ballot does not exist we can return
-					ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
-					return cctxIndex, nil
-				}
+		// The cctx exists we should still vote if the ballot is present
+		_, ballotErr := ob.ZetacoreClient().GetBallotByID(ctx, cctxIndex)
+		if ballotErr != nil {
+			// Verify ballot is not found
+			if st, ok := status.FromError(ballotErr); ok && st.Code() == codes.NotFound {
+				// Query for ballot failed, the ballot does not exist we can return
+				ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
+				return cctxIndex, nil
 			}
 		}
 	}

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -12,7 +12,6 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-
 	"github.com/zeta-chain/node/pkg/chains"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
@@ -22,6 +21,8 @@ import (
 	"github.com/zeta-chain/node/zetaclient/metrics"
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 	"github.com/zeta-chain/node/zetaclient/zetacore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -413,12 +414,15 @@ func (ob *Observer) PostVoteInbound(
 	// 2. if the cctx exists but the ballot does not exist, we do not need to vote
 	_, err := ob.ZetacoreClient().GetCctxByHash(ctx, cctxIndex)
 	if err == nil {
-		// The cctx exists we should still vote if the ballot is present
-		_, err = ob.ZetacoreClient().GetBallotByID(ctx, cctxIndex)
-		if err != nil {
-			// Query for ballot failed, the ballot does not exist we can return
-			ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
-			return cctxIndex, nil
+		// Verify ballot is not found
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			// The cctx exists we should still vote if the ballot is present
+			_, err = ob.ZetacoreClient().GetBallotByID(ctx, cctxIndex)
+			if err != nil {
+				// Query for ballot failed, the ballot does not exist we can return
+				ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
+				return cctxIndex, nil
+			}
 		}
 	}
 

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -417,8 +417,8 @@ func (ob *Observer) PostVoteInbound(
 		_, err = ob.ZetacoreClient().GetBallotByID(ctx, cctxIndex)
 		if err != nil {
 			// Query for ballot failed, the ballot does not exist we can return
-			ob.logger.Inbound.Warn().Err(err).Fields(lf).Msg("inbound detected: cctx exists but no ballot")
-			return "", nil
+			ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
+			return cctxIndex, nil
 		}
 	}
 

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -409,8 +409,8 @@ func (ob *Observer) PostVoteInbound(
 	cctxIndex := msg.Digest()
 
 	// The cctx is created after the inbound ballot is finalized
-	// if the cctx already exists, we should still vote if the ballot is present
-	// if the cctx exists but the ballot does not exist, we can still try voting if the ballot is present
+	// 1. if the cctx already exists, we could try voting if the ballot is present
+	// 2. if the cctx exists but the ballot does not exist, we do not need to vote
 	_, err := ob.ZetacoreClient().GetCctxByHash(ctx, cctxIndex)
 	if err == nil {
 		// The cctx exists we should still vote if the ballot is present

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -12,6 +12,9 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/zeta-chain/node/pkg/chains"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
@@ -21,8 +24,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/metrics"
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 	"github.com/zeta-chain/node/zetaclient/zetacore"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -414,14 +414,15 @@ func (ob *Observer) PostVoteInbound(
 	// 2. if the cctx exists but the ballot does not exist, we do not need to vote
 	_, err := ob.ZetacoreClient().GetCctxByHash(ctx, cctxIndex)
 	if err == nil {
-		// Verify ballot is not found
-		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 			// The cctx exists we should still vote if the ballot is present
 			_, err = ob.ZetacoreClient().GetBallotByID(ctx, cctxIndex)
 			if err != nil {
-				// Query for ballot failed, the ballot does not exist we can return
-				ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
-				return cctxIndex, nil
+				// Verify ballot is not found
+				if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+					// Query for ballot failed, the ballot does not exist we can return
+					ob.logger.Inbound.Info().Fields(lf).Msg("inbound detected: cctx exists but the ballot does not")
+					return cctxIndex, nil
+				}
 			}
 		}
 	}

--- a/zetaclient/chains/base/observer_test.go
+++ b/zetaclient/chains/base/observer_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,8 @@ import (
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -538,9 +541,10 @@ func TestPostVoteInbound(t *testing.T) {
 		ob := newTestSuite(t, chains.Ethereum)
 
 		ob.zetacore.WithPostVoteInbound("", "sampleBallotIndex")
-
 		// post vote inbound
 		msg := sample.InboundVote(coin.CoinType_Gas, chains.Ethereum.ChainId, chains.ZetaChainMainnet.ChainId)
+		ob.zetacore.MockGetCctxByHash(msg.Digest(), errors.New("not found"))
+
 		ballot, err := ob.PostVoteInbound(context.TODO(), &msg, 100000)
 		require.NoError(t, err)
 		require.Equal(t, "sampleBallotIndex", ballot)
@@ -553,11 +557,28 @@ func TestPostVoteInbound(t *testing.T) {
 		// create sample message with long Message
 		msg := sample.InboundVote(coin.CoinType_Gas, chains.Ethereum.ChainId, chains.ZetaChainMainnet.ChainId)
 		msg.Message = strings.Repeat("1", crosschaintypes.MaxMessageLength+1)
+		ob.zetacore.MockGetCctxByHash(msg.Digest(), errors.New("not found"))
 
 		// post vote inbound
 		ballot, err := ob.PostVoteInbound(context.TODO(), &msg, 100000)
 		require.NoError(t, err)
 		require.Empty(t, ballot)
+	})
+
+	t.Run("should not post vote cctx already exists and ballot is not found", func(t *testing.T) {
+		//Arrange
+		// create observer
+		ob := newTestSuite(t, chains.Ethereum)
+		// create sample message with long Message
+		msg := sample.InboundVote(coin.CoinType_Gas, chains.Ethereum.ChainId, chains.ZetaChainMainnet.ChainId)
+		msg.Message = strings.Repeat("1", crosschaintypes.MaxMessageLength+1)
+		ob.zetacore.MockGetCctxByHash(msg.Digest(), nil)
+		ob.zetacore.MockGetBallotByID(msg.Digest(), status.Error(codes.NotFound, "not found ballot"))
+		// Act
+		ballot, err := ob.PostVoteInbound(context.TODO(), &msg, 100000)
+		// Assert
+		require.NoError(t, err)
+		require.Equal(t, ballot, msg.Digest())
 	})
 }
 

--- a/zetaclient/chains/evm/observer/inbound_test.go
+++ b/zetaclient/chains/evm/observer/inbound_test.go
@@ -446,9 +446,10 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 
 	// test cases
 	tests := []struct {
-		name          string
-		mockEVMClient func(m *mocks.EVMRPCClient)
-		errMsg        string
+		name               string
+		mockEVMClient      func(m *mocks.EVMRPCClient)
+		mockZetacoreClient func(m *mocks.ZetacoreClient)
+		errMsg             string
 	}{
 		{
 			name: "should observe TSS receive in block",
@@ -457,6 +458,9 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 				m.On("BlockNumber", mock.Anything).Return(uint64(1000), nil)
 				m.On("TransactionReceipt", mock.Anything, mock.Anything).Return(receipt, nil)
 				m.On("BlockByNumberCustom", mock.Anything, mock.Anything).Return(block, nil)
+			},
+			mockZetacoreClient: func(m *mocks.ZetacoreClient) {
+				m.On("GetCctxByHash", mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
 			},
 			errMsg: "",
 		},
@@ -469,7 +473,8 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 				m.On("BlockNumber", mock.Anything).Return(uint64(0), errors.New("RPC error"))
 				m.On("BlockByNumberCustom", mock.Anything, mock.Anything).Return(nil, errors.New("RPC error"))
 			},
-			errMsg: "error getting block",
+			mockZetacoreClient: nil,
+			errMsg:             "error getting block",
 		},
 		{
 			name: "should not observe on error getting receipt",
@@ -479,7 +484,8 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 				m.On("TransactionReceipt", mock.Anything, mock.Anything).Return(nil, errors.New("RPC error"))
 				m.On("BlockByNumberCustom", mock.Anything, mock.Anything).Return(block, nil)
 			},
-			errMsg: "error getting receipt",
+			mockZetacoreClient: nil,
+			errMsg:             "error getting receipt",
 		},
 	}
 
@@ -490,6 +496,9 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 
 			if tt.mockEVMClient != nil {
 				tt.mockEVMClient(ob.evmMock)
+			}
+			if tt.mockZetacoreClient != nil {
+				tt.mockZetacoreClient(ob.zetacore)
 			}
 
 			err := ob.ObserveTSSReceiveInBlock(ob.ctx, blockNumber)

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -85,6 +85,7 @@ type ZetacoreClient interface {
 	GetPendingNoncesByChain(ctx context.Context, chainID int64) (observertypes.PendingNonces, error)
 
 	GetCctxByNonce(ctx context.Context, chainID int64, nonce uint64) (*crosschaintypes.CrossChainTx, error)
+	GetCctxByHash(ctx context.Context, sendHash string) (*crosschaintypes.CrossChainTx, error)
 	GetOutboundTracker(ctx context.Context, chain chains.Chain, nonce uint64) (*crosschaintypes.OutboundTracker, error)
 	GetAllOutboundTrackerByChain(
 		ctx context.Context,
@@ -98,6 +99,7 @@ type ZetacoreClient interface {
 	GetBTCTSSAddress(ctx context.Context, chainID int64) (string, error)
 	GetZetaHotKeyBalance(ctx context.Context) (sdkmath.Int, error)
 	GetInboundTrackersForChain(ctx context.Context, chainID int64) ([]crosschaintypes.InboundTracker, error)
+	GetBallotByID(ctx context.Context, id string) (*observertypes.QueryBallotByIdentifierResponse, error)
 
 	GetUpgradePlan(ctx context.Context) (*upgradetypes.Plan, error)
 

--- a/zetaclient/chains/ton/observer/inbound_test.go
+++ b/zetaclient/chains/ton/observer/inbound_test.go
@@ -142,6 +142,7 @@ func TestInbound(t *testing.T) {
 			Once()
 
 		ts.MockGetBlockHeader(depositTX.BlockID)
+		ts.MockGetCctxByHash()
 
 		// ACT
 		// Observe inbounds once
@@ -204,6 +205,7 @@ func TestInbound(t *testing.T) {
 			Once()
 
 		ts.MockGetBlockHeader(depositAndCallTX.BlockID)
+		ts.MockGetCctxByHash()
 
 		// ACT
 		// Observe inbounds once
@@ -350,6 +352,7 @@ func TestInbound(t *testing.T) {
 		for _, tx := range txs {
 			ts.MockGetBlockHeader(tx.BlockID)
 		}
+		ts.MockGetCctxByHash()
 
 		// ACT
 		// Observe inbounds once
@@ -417,6 +420,7 @@ func TestInboundTracker(t *testing.T) {
 	})
 	ts.MockGetTransaction(ts.gateway.AccountID(), txWithdrawal)
 	ts.MockGetBlockHeader(txWithdrawal.BlockID)
+	ts.MockGetCctxByHash()
 
 	// Given inbound trackers from zetacore
 	trackers := []cc.InboundTracker{

--- a/zetaclient/chains/ton/observer/observer_test.go
+++ b/zetaclient/chains/ton/observer/observer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/math"
 	eth "github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -173,6 +174,11 @@ func (ts *testSuite) MockGetBlockHeader(id ton.BlockIDExt) *mock.Call {
 	return ts.liteClient.
 		On("GetBlockHeader", mock.Anything, id, uint32(0)).
 		Return(blockInfo, nil)
+}
+
+func (ts *testSuite) MockGetCctxByHash() *mock.Call {
+	return ts.zetacore.
+		On("GetCctxByHash", mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
 }
 
 func (ts *testSuite) OnGetInboundTrackersForChain(trackers []cc.InboundTracker) *mock.Call {

--- a/zetaclient/testutils/mocks/zetacore_client.go
+++ b/zetaclient/testutils/mocks/zetacore_client.go
@@ -136,6 +136,36 @@ func (_m *ZetacoreClient) GetBTCTSSAddress(ctx context.Context, chainID int64) (
 	return r0, r1
 }
 
+// GetBallotByID provides a mock function with given fields: ctx, id
+func (_m *ZetacoreClient) GetBallotByID(ctx context.Context, id string) (*observertypes.QueryBallotByIdentifierResponse, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBallotByID")
+	}
+
+	var r0 *observertypes.QueryBallotByIdentifierResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*observertypes.QueryBallotByIdentifierResponse, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *observertypes.QueryBallotByIdentifierResponse); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*observertypes.QueryBallotByIdentifierResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetBlockHeight provides a mock function with given fields: ctx
 func (_m *ZetacoreClient) GetBlockHeight(ctx context.Context) (int64, error) {
 	ret := _m.Called(ctx)
@@ -157,6 +187,36 @@ func (_m *ZetacoreClient) GetBlockHeight(ctx context.Context) (int64, error) {
 
 	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
 		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCctxByHash provides a mock function with given fields: ctx, sendHash
+func (_m *ZetacoreClient) GetCctxByHash(ctx context.Context, sendHash string) (*types.CrossChainTx, error) {
+	ret := _m.Called(ctx, sendHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCctxByHash")
+	}
+
+	var r0 *types.CrossChainTx
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*types.CrossChainTx, error)); ok {
+		return rf(ctx, sendHash)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *types.CrossChainTx); ok {
+		r0 = rf(ctx, sendHash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.CrossChainTx)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, sendHash)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/zetaclient/testutils/mocks/zetacore_client_opts.go
+++ b/zetaclient/testutils/mocks/zetacore_client_opts.go
@@ -38,7 +38,16 @@ func (_m *ZetacoreClient) WithPostVoteInbound(zetaTxHash string, ballotIndex str
 	_m.On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Return(zetaTxHash, ballotIndex, nil)
+	return _m
+}
 
+func (_m *ZetacoreClient) MockGetCctxByHash(cctxIndex string, err error) *ZetacoreClient {
+	_m.On("GetCctxByHash", mock.Anything, cctxIndex).Return(nil, err)
+	return _m
+}
+
+func (_m *ZetacoreClient) MockGetBallotByID(ballotIndex string, err error) *ZetacoreClient {
+	_m.On("GetBallotByID", mock.Anything, ballotIndex).Return(nil, err)
 	return _m
 }
 


### PR DESCRIPTION
# Description
Closes : https://github.com/zeta-chain/node/issues/3635

The pr adds a check to stop zetaclient from voting on unnecessary ballots.

For e2e testing, its not straightforward to add a test , as we only print to logs when not casting votes.This has been tested manually by creating a tracker with the details from a confirmed CCTX and checking zetalient logs.


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
