### PR TITLE
chore: always pass E2E_ARGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,12 +276,12 @@ start-e2e-test: e2e-images
 
 start-e2e-admin-test: e2e-images
 	@echo "--> Starting e2e admin test"
-	export E2E_ARGS="--skip-regular --test-admin" && \
+	export E2E_ARGS="${E2E_ARGS} --skip-regular --test-admin" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile eth2 up -d
 
 start-e2e-performance-test: e2e-images solana
 	@echo "--> Starting e2e performance test"
-	export E2E_ARGS="--test-performance" && \
+	export E2E_ARGS="${E2E_ARGS} --test-performance" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile stress up -d
 
 start-e2e-import-mainnet-test: e2e-images
@@ -303,27 +303,27 @@ start-stress-test: e2e-images
 start-tss-migration-test: e2e-images
 	@echo "--> Starting tss migration test"
 	export LOCALNET_MODE=tss-migrate && \
-	export E2E_ARGS="--test-tss-migration" && \
+	export E2E_ARGS="${E2E_ARGS} --test-tss-migration" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
 
 start-solana-test: e2e-images solana
 	@echo "--> Starting solana test"
-	export E2E_ARGS="--skip-regular --test-solana" && \
+	export E2E_ARGS="${E2E_ARGS} --skip-regular --test-solana" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile solana up -d
 
 start-ton-test: e2e-images
 	@echo "--> Starting TON test"
-	export E2E_ARGS="--skip-regular --test-ton" && \
+	export E2E_ARGS="${E2E_ARGS} --skip-regular --test-ton" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile ton up -d
 
 start-sui-test: e2e-images
 	@echo "--> Starting sui test"
-	export E2E_ARGS="--skip-regular --test-sui" && \
+	export E2E_ARGS="${E2E_ARGS} --skip-regular --test-sui" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile sui up -d
 
 start-legacy-test: e2e-images
 	@echo "--> Starting e2e smart contracts legacy test"
-	export E2E_ARGS="--skip-regular --test-legacy" && \
+	export E2E_ARGS="${E2E_ARGS} --skip-regular --test-legacy" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) up -d
 
 ###############################################################################
@@ -368,7 +368,7 @@ start-upgrade-test-admin: zetanode-upgrade
 	@echo "--> Starting admin upgrade test"
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=90 && \
-	export E2E_ARGS="--skip-regular --test-admin" && \
+	export E2E_ARGS="${E2E_ARGS} --skip-regular --test-admin" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade -f docker-compose-upgrade.yml up -d
 
 start-upgrade-import-mainnet-test: zetanode-upgrade


### PR DESCRIPTION
This enables passing custom `E2E_ARGS` to all the other make targets. This was previously only possible on the main `make start-e2e-test`

```
export E2E_ARGS="--verbose"
make start-solana-test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the test configuration to allow combining multiple testing options, offering enhanced flexibility during end-to-end test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->