### PR TITLE
refactor(e2e): setup btc wallet earlier

### DIFF
--- a/cmd/zetae2e/local/bitcoin.go
+++ b/cmd/zetae2e/local/bitcoin.go
@@ -95,7 +95,6 @@ func bitcoinTestRoutines(
 		color.FgYellow,
 		verbose,
 		initNetwork,
-		true,
 	)
 
 	// initialize runner for withdraw tests
@@ -109,7 +108,6 @@ func bitcoinTestRoutines(
 		color.FgHiYellow,
 		verbose,
 		initNetwork,
-		false,
 	)
 
 	// initialize funds
@@ -140,7 +138,7 @@ func initBitcoinRunner(
 	conf config.Config,
 	deployerRunner *runner.E2ERunner,
 	printColor color.Attribute,
-	verbose, initNetwork, createWallet bool,
+	verbose, initNetwork bool,
 ) *runner.E2ERunner {
 	// initialize runner for bitcoin test
 	runner, err := initTestRunner(

--- a/cmd/zetae2e/local/bitcoin.go
+++ b/cmd/zetae2e/local/bitcoin.go
@@ -153,8 +153,7 @@ func initBitcoinRunner(
 	)
 	testutil.NoError(err)
 
-	// setup TSS address and setup deployer wallet
-	runner.SetupBitcoinAccounts(createWallet)
+	runner.BTCDeployerAddress, _ = deployerRunner.GetBtcAddress()
 
 	// initialize funds
 	if initNetwork {

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -229,6 +229,9 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		logger.Print("⚙️ setting up networks")
 		startTime := time.Now()
 
+		// setup TSS address and setup deployer wallet
+		deployerRunner.SetupBitcoinAccounts(true)
+
 		//setup protocol contracts v1 as they are still supported for now
 		deployerRunner.LegacySetupEVM(contractsDeployed, testLegacy)
 


### PR DESCRIPTION
Setup btc wallet earlier (during setup section) to avoid this logspam early in the tests and when not running any bitcoin tests (performance, admin, etc):

```
2025-03-06T16:16:49Z ERR task failed error="unable to list unspent: \"listunspent\" failed: unexpected status code 500 ({\"result\":null,\"error\":{\"code\":-18,\"message\":\"No wallet is loaded. Load a wallet using loadwallet or create a new one with createwallet. (Note: A default wallet is no longer automatically created)\"},\"id\":1}\n)" module=scheduler task.group=btc:18444 task.name=fetch_utxos task.type=interval_ticker
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined Bitcoin account initialization by removing redundant parameters and simplifying the setup logic for deposit and withdrawal operations.
- **New Features**
  - Enhanced the local network configuration by adding an explicit step to configure Bitcoin accounts, ensuring a smoother setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->