### PR TITLE
feat(sui): custom sui_executeTransactionBlock

### DIFF
--- a/zetaclient/chains/sui/client/client.go
+++ b/zetaclient/chains/sui/client/client.go
@@ -194,7 +194,7 @@ func (c *Client) SuiExecuteTransactionBlock(
 		return models.SuiTransactionBlockResponse{}, errors.New("invalid response type")
 	}
 
-	return parseRPC[models.SuiTransactionBlockResponse]([]byte(resString))
+	return parseRPCResponse[models.SuiTransactionBlockResponse]([]byte(resString))
 }
 
 // EncodeCursor encodes event ID into cursor.
@@ -219,8 +219,8 @@ func DecodeCursor(cursor string) (*models.EventId, error) {
 	}, nil
 }
 
-// parseRPC RPC response into a given type.
-func parseRPC[T any](raw []byte) (T, error) {
+// parseRPCResponse RPC response into a given type.
+func parseRPCResponse[T any](raw []byte) (T, error) {
 	// {
 	//   "jsonrpc": "2.0",
 	//   "id": 1,

--- a/zetaclient/chains/sui/client/client_live_test.go
+++ b/zetaclient/chains/sui/client/client_live_test.go
@@ -118,6 +118,32 @@ func TestClientLive(t *testing.T) {
 	})
 }
 
+func TestParseRPC(t *testing.T) {
+	// ARRANGE
+	const raw = `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"result": {
+			"digest": "8995Wsnjv3udPYGgkfWhfNsu62W2UcT7Zd2tY83MDAyG",
+			"confirmedLocalExecution": false
+		}
+	}`
+
+	// ACT
+	out, err := parseRPC[models.SuiTransactionBlockResponse]([]byte(raw))
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Equal(t,
+		models.SuiTransactionBlockResponse{
+			Digest:                  "8995Wsnjv3udPYGgkfWhfNsu62W2UcT7Zd2tY83MDAyG",
+			ConfirmedLocalExecution: false,
+		},
+		out,
+	)
+
+}
+
 type testSuite struct {
 	t   *testing.T
 	ctx context.Context

--- a/zetaclient/chains/sui/client/client_live_test.go
+++ b/zetaclient/chains/sui/client/client_live_test.go
@@ -118,7 +118,7 @@ func TestClientLive(t *testing.T) {
 	})
 }
 
-func TestParseRPC(t *testing.T) {
+func TestParseRPCResponse(t *testing.T) {
 	// ARRANGE
 	const raw = `{
 		"jsonrpc": "2.0",
@@ -130,7 +130,7 @@ func TestParseRPC(t *testing.T) {
 	}`
 
 	// ACT
-	out, err := parseRPC[models.SuiTransactionBlockResponse]([]byte(raw))
+	out, err := parseRPCResponse[models.SuiTransactionBlockResponse]([]byte(raw))
 
 	// ASSERT
 	require.NoError(t, err)

--- a/zetaclient/chains/sui/signer/signer.go
+++ b/zetaclient/chains/sui/signer/signer.go
@@ -85,6 +85,8 @@ func (s *Signer) ProcessCCTX(ctx context.Context, cctx *cctypes.CrossChainTx, ze
 		return errors.Wrap(err, "unable to broadcast tx")
 	}
 
+	s.Logger().Std.Info().Str(logs.FieldTx, txDigest).Msg("Broadcasted transaction")
+
 	logger := s.Logger().Std.With().
 		Str(logs.FieldMethod, "reportToOutboundTracker").
 		Int64(logs.FieldChain, s.Chain().ChainId).

--- a/zetaclient/chains/sui/signer/signer_tx.go
+++ b/zetaclient/chains/sui/signer/signer_tx.go
@@ -78,9 +78,8 @@ func (s *Signer) broadcast(ctx context.Context, tx models.TxnMetaData, sig [65]b
 	}
 
 	req := models.SuiExecuteTransactionBlockRequest{
-		TxBytes:     tx.TxBytes,
-		Signature:   []string{sigBase64},
-		RequestType: "WaitForLocalExecution",
+		TxBytes:   tx.TxBytes,
+		Signature: []string{sigBase64},
 	}
 
 	res, err := s.client.SuiExecuteTransactionBlock(ctx, req)


### PR DESCRIPTION
Makes SUI signer broadcast tx in a proper way without relying on `WaitForLocalExecution`.

Closes https://github.com/zeta-chain/node/issues/3620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced Sui transaction processing with a new execution method that streamlines transaction broadcasting and improves tracking through detailed logging.
- **Tests**
	- Added tests to ensure the reliability of transaction response parsing from the Sui network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->