### PR TITLE
feat(e2e): add more details sol withdrawal latency breakdown

### DIFF
--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -3,7 +3,9 @@ package e2etests
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
@@ -83,4 +85,10 @@ func bigAdd(x *big.Int, y *big.Int) *big.Int {
 // bigSub is shorthand for new(big.Int).Sub(x, y)
 func bigSub(x *big.Int, y *big.Int) *big.Int {
 	return new(big.Int).Sub(x, y)
+}
+
+func formatDuration(d time.Duration) string {
+	minutes := int(d.Minutes())
+	seconds := d.Seconds() - float64(minutes*60)
+	return fmt.Sprintf("%dm%.1fs", minutes, seconds)
 }

--- a/e2e/e2etests/test_stress_solana_withdraw.go
+++ b/e2e/e2etests/test_stress_solana_withdraw.go
@@ -75,11 +75,13 @@ func TestStressSolanaWithdraw(r *runner.E2ERunner, args []string) {
 					cctx.Index,
 				)
 			}
+			onChainDuration := time.Second * time.Duration(cctx.CctxStatus.LastUpdateTimestamp-cctx.CctxStatus.CreatedTimestamp)
 			timeToFinalized := time.Since(segmentStartTime)
 			totalTime := timeToOutboundHash + timeToFinalized
-			r.Logger.Print("index %d: withdraw SOL cctx success in %s (outbound hash: %s + finalized: %s)",
+			r.Logger.Print("index %d: withdraw SOL cctx success in %s (on chain %s) (outbound hash: %s + finalized: %s)",
 				i,
 				formatDuration(totalTime),
+				formatDuration(onChainDuration),
 				formatDuration(timeToOutboundHash),
 				formatDuration(timeToFinalized),
 			)

--- a/e2e/e2etests/test_stress_solana_withdraw.go
+++ b/e2e/e2etests/test_stress_solana_withdraw.go
@@ -44,7 +44,7 @@ func TestStressSolanaWithdraw(r *runner.E2ERunner, args []string) {
 		i := i
 
 		// execute the withdraw SOL transaction
-		tx, err = r.SOLZRC20.Withdraw(r.ZEVMAuth, []byte(privKey.PublicKey().String()), withdrawSOLAmount)
+		tx, err := r.SOLZRC20.Withdraw(r.ZEVMAuth, []byte(privKey.PublicKey().String()), withdrawSOLAmount)
 		require.NoError(r, err)
 
 		receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
@@ -75,13 +75,12 @@ func TestStressSolanaWithdraw(r *runner.E2ERunner, args []string) {
 					cctx.Index,
 				)
 			}
-			onChainDuration := time.Second * time.Duration(cctx.CctxStatus.LastUpdateTimestamp-cctx.CctxStatus.CreatedTimestamp)
 			timeToFinalized := time.Since(segmentStartTime)
 			totalTime := timeToOutboundHash + timeToFinalized
-			r.Logger.Print("index %d: withdraw SOL cctx success in %s (on chain %s) (outbound hash: %s + finalized: %s)",
+			r.Logger.Print(
+				"index %d: withdraw SOL cctx success in %s (outbound hash: %s + finalized: %s)",
 				i,
 				formatDuration(totalTime),
-				formatDuration(onChainDuration),
 				formatDuration(timeToOutboundHash),
 				formatDuration(timeToFinalized),
 			)

--- a/e2e/e2etests/test_stress_spl_withdraw.go
+++ b/e2e/e2etests/test_stress_spl_withdraw.go
@@ -54,7 +54,7 @@ func TestStressSPLWithdraw(r *runner.E2ERunner, args []string) {
 		i := i
 
 		// execute the withdraw SPL transaction
-		tx, err = r.SPLZRC20.Withdraw(r.ZEVMAuth, []byte(privKey.PublicKey().String()), withdrawSPLAmount)
+		tx, err := r.SPLZRC20.Withdraw(r.ZEVMAuth, []byte(privKey.PublicKey().String()), withdrawSPLAmount)
 		require.NoError(r, err)
 
 		receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)

--- a/e2e/e2etests/test_stress_spl_withdraw.go
+++ b/e2e/e2etests/test_stress_spl_withdraw.go
@@ -63,7 +63,18 @@ func TestStressSPLWithdraw(r *runner.E2ERunner, args []string) {
 		r.Logger.Print("index %d: starting SPL withdraw, tx hash: %s", i, tx.Hash().Hex())
 
 		eg.Go(func() error {
-			startTime := time.Now()
+			segmentStartTime := time.Now()
+			cctxFirstHash := utils.WaitCctxByInboundHash(
+				r.Ctx,
+				r,
+				tx.Hash().Hex(),
+				r.CctxClient,
+				utils.HasOutboundTxHash(),
+			)
+			r.Logger.Info("index %d: got first outbound hash: %s", i, cctxFirstHash.OutboundParams[0].Hash)
+			timeToOutboundHash := time.Since(segmentStartTime)
+
+			segmentStartTime = time.Now()
 			cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.ReceiptTimeout)
 			if cctx.CctxStatus.Status != crosschaintypes.CctxStatus_OutboundMined {
 				return fmt.Errorf(
@@ -74,11 +85,17 @@ func TestStressSPLWithdraw(r *runner.E2ERunner, args []string) {
 					cctx.Index,
 				)
 			}
-			timeToComplete := time.Since(startTime)
-			r.Logger.Print("index %d: withdraw SPL cctx success in %s", i, timeToComplete.String())
+			timeToFinalized := time.Since(segmentStartTime)
+			totalTime := timeToOutboundHash + timeToFinalized
+			r.Logger.Print("index %d: withdraw SPL cctx success in %s (outbound hash: %s + finalized: %s)",
+				i,
+				formatDuration(totalTime),
+				formatDuration(timeToOutboundHash),
+				formatDuration(timeToFinalized),
+			)
 
 			withdrawDurationsLock.Lock()
-			withdrawDurations = append(withdrawDurations, timeToComplete.Seconds())
+			withdrawDurations = append(withdrawDurations, totalTime.Seconds())
 			withdrawDurationsLock.Unlock()
 
 			return nil

--- a/e2e/runner/solana.go
+++ b/e2e/runner/solana.go
@@ -403,6 +403,7 @@ func (r *E2ERunner) BroadcastTxSync(tx *solana.Transaction) (solana.Signature, *
 
 		if isConfirmed {
 			r.Logger.Info("Tx broadcasted and confirmed")
+			require.Nil(r, out.Meta.Err, out.Meta.LogMessages)
 			return sig, out
 		}
 


### PR DESCRIPTION
This helps demonstrate where the latency is actually coming from.

Related to https://github.com/zeta-chain/node/pull/3633 and https://github.com/zeta-chain/node/issues/3383

```
perf_sol_wit | index 34: withdraw SOL cctx success in 7m47.7s (outbound hash: 7m14.1s + finalized: 0m33.6s)
perf_sol_wit | index 35: withdraw SOL cctx success in 7m44.8s (outbound hash: 7m16.2s + finalized: 0m28.6s)
perf_sol_wit | index 36: withdraw SOL cctx success in 7m43.0s (outbound hash: 7m21.9s + finalized: 0m21.1s)
perf_spl_wit | index 33: withdraw SPL cctx success in 7m47.1s (outbound hash: 7m19.0s + finalized: 0m28.1s)
perf_spl_wit | index 34: withdraw SPL cctx success in 8m0.9s (outbound hash: 7m26.8s + finalized: 0m34.1s)
perf_spl_wit | index 35: withdraw SPL cctx success in 8m24.2s (outbound hash: 7m56.2s + finalized: 0m28.1s)
perf_sol_wit | index 37: withdraw SOL cctx success in 8m26.6s (outbound hash: 7m53.5s + finalized: 0m33.1s)
perf_sol_wit | index 38: withdraw SOL cctx success in 8m23.8s (outbound hash: 7m55.7s + finalized: 0m28.1s)
perf_spl_wit | index 36: withdraw SPL cctx success in 8m28.7s (outbound hash: 7m58.1s + finalized: 0m30.6s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced duration formatting and precise timing measurements for withdrawal operations.
  - Added functionality to verify outbound transaction information.
  
- **Bug Fixes**
  - Strengthened error validation during transaction processing to improve reliability.

- **Refactor**
  - Streamlined withdrawal handling for clearer, consistent performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->