### PR TITLE
fix: port the v28 Arbitrum withdraw fix to v29

### DIFF
--- a/zetaclient/chains/evm/common/constant.go
+++ b/zetaclient/chains/evm/common/constant.go
@@ -14,7 +14,9 @@ const (
 	OutboundTrackerReportTimeout = 10 * time.Minute
 
 	// EthTransferGasLimit is the gas limit for a standard ETH transfer
-	EthTransferGasLimit = 21000
+	// Not all EVM chains use the same 21000 gas limit for gas token transfers, e.g. Arbitrum uses more than 21000.
+	// We choose a slightly higher number (25000) to make it compatible with all EVM chains.
+	EthTransferGasLimit = 25000
 
 	// TopicsZetaSent is the number of topics for a Zeta sent event
 	// [signature, zetaTxSenderAddress, destinationChainId]


### PR DESCRIPTION
# Description

This PR ports this v28 [Arbitrum withdraw fix](https://github.com/zeta-chain/node/pull/3667) to v29 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
