### PR TITLE
feat(e2e): add --test-filter parameter

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"syscall"
 	"time"
 
@@ -49,6 +50,7 @@ const (
 	flagSkipTrackerCheck  = "skip-tracker-check"
 	flagSkipPrecompiles   = "skip-precompiles"
 	flagUpgradeContracts  = "upgrade-contracts"
+	flagTestFilter        = "test-filter"
 )
 
 var (
@@ -87,6 +89,7 @@ func NewLocalCmd() *cobra.Command {
 	cmd.Flags().Bool(flagSkipPrecompiles, true, "set to true to skip stateful precompiled contracts test")
 	cmd.Flags().
 		Bool(flagUpgradeContracts, false, "set to true to upgrade Gateways and ERC20Custody contracts during setup for ZEVM and EVM")
+	cmd.Flags().String(flagTestFilter, "", "regexp filter to limit which test to run")
 
 	cmd.AddCommand(NewGetZetaclientBootstrap())
 
@@ -119,7 +122,10 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		skipPrecompiles   = must(cmd.Flags().GetBool(flagSkipPrecompiles))
 		upgradeContracts  = must(cmd.Flags().GetBool(flagUpgradeContracts))
 		setupSolana       = testSolana || testPerformance
+		testFilterStr     = must(cmd.Flags().GetString(flagTestFilter))
 	)
+
+	testFilter := regexp.MustCompile(testFilterStr)
 
 	logger := runner.NewLogger(verbose, color.FgWhite, "setup")
 
@@ -191,6 +197,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 		conf.DefaultAccount,
 		logger,
 		runner.WithZetaTxServer(zetaTxServer),
+		runner.WithTestFilter(testFilter),
 	)
 	noError(err)
 

--- a/cmd/zetae2e/local/test_runner.go
+++ b/cmd/zetae2e/local/test_runner.go
@@ -33,6 +33,7 @@ func initTestRunner(
 	// copy timeouts from deployer runner
 	testRunner.CctxTimeout = deployerRunner.ReceiptTimeout
 	testRunner.ReceiptTimeout = deployerRunner.ReceiptTimeout
+	testRunner.TestFilter = deployerRunner.TestFilter
 
 	// copy contracts from deployer runner
 	if err := testRunner.CopyAddressesFrom(deployerRunner); err != nil {

--- a/docs/development/LOCAL_TESTING.md
+++ b/docs/development/LOCAL_TESTING.md
@@ -34,9 +34,24 @@ This uses `docker compose` to start the localnet and run standard e2e tests insi
 	- `upgrade`: run the upgrade tests
 	- unset: run the e2e tests
 - `E2E_ARGS`: arguments to provide to the `zetae2e local` command
+    - `--verbose` will give you verbose logs
+	- `--test-filter` allows you to filter which tests to run by regular expression
 - `UPGRADE_HEIGHT`: block height to upgrade at when `LOCALNET_MODE=upgrade`
 - `ZETACORED_IMPORT_GENESIS_DATA`: path to genesis data to import before starting zetacored
 - `ZETACORED_START_PERIOD`: duration to tolerate `zetacored` health check failures during startup
+
+Here is an example of using `E2E_ARGS`:
+
+```
+export E2E_ARGS='--verbose --test-filter eth_deposit|eth_withdraw'
+make start-e2e-test
+```
+
+This will execute `zetae2e local` as:
+
+```
+zetae2e local --verbose --test-filter eth_deposit|eth_withdraw --config config.yml
+```
 
 More options directly to `docker compose` via the `NODE_COMPOSE_ARGS` variable. This allows setting additional profiles or configuring an overlay. Example:
 

--- a/e2e/runner/e2etest.go
+++ b/e2e/runner/e2etest.go
@@ -103,6 +103,9 @@ func (r *E2ERunner) GetE2ETestsToRunByConfig(
 		if !found {
 			return nil, fmt.Errorf("e2e test %s not found", testSpec.Name)
 		}
+		if r.TestFilter != nil && !r.TestFilter.MatchString(e2eTest.Name) {
+			continue
+		}
 		e2eTestToRun := E2ETest{
 			Name:           e2eTest.Name,
 			Description:    e2eTest.Description,

--- a/e2e/runner/runner.go
+++ b/e2e/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 
@@ -64,6 +65,12 @@ const (
 func WithZetaTxServer(txServer *txserver.ZetaTxServer) E2ERunnerOption {
 	return func(r *E2ERunner) {
 		r.ZetaTxServer = txServer
+	}
+}
+
+func WithTestFilter(testFilter *regexp.Regexp) E2ERunnerOption {
+	return func(r *E2ERunner) {
+		r.TestFilter = testFilter
 	}
 }
 
@@ -192,6 +199,7 @@ type E2ERunner struct {
 	CtxCancel        context.CancelCauseFunc
 	Logger           *Logger
 	BitcoinParams    *chaincfg.Params
+	TestFilter       *regexp.Regexp
 	mutex            sync.Mutex
 	zetacoredVersion string
 }


### PR DESCRIPTION
Now you can do this to focus on the one test you're working on rather than having to comment and uncomment code to control which tests to run.

```
export E2E_ARGS="--test-filter stress_solana_withdraw"
make start-e2e-performance-test
```

The other test routines will still be started but none of the tests will actually run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line option that accepts a regular expression filter, allowing users to run only tests matching specific patterns.
  - Improved test execution by integrating targeted filtering throughout the testing process for enhanced efficiency.
  - This update empowers users to precisely control which tests run, streamlining test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->