### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/app/upgrade_tracker_test.go
+++ b/app/upgrade_tracker_test.go
@@ -17,9 +17,7 @@ import (
 func TestUpgradeTracker(t *testing.T) {
 	r := require.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "storeupgradetracker-*")
-	r.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	allUpgrades := upgradeTracker{
 		upgrades: []upgradeTrackerItem{
@@ -55,7 +53,7 @@ func TestUpgradeTracker(t *testing.T) {
 	r.Len(upgradeHandlers, 2)
 
 	// should return all migrations on first call
-	upgradeHandlers, storeUpgrades, err = allUpgrades.getIncrementalUpgrades()
+	upgradeHandlers, storeUpgrades, err := allUpgrades.getIncrementalUpgrades()
 	r.NoError(err)
 	r.Len(storeUpgrades.Added, 2)
 	r.Len(storeUpgrades.Renamed, 0)
@@ -90,13 +88,11 @@ func TestUpgradeTracker(t *testing.T) {
 func TestUpgradeTrackerBadState(t *testing.T) {
 	r := require.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "storeupgradetracker-*")
-	r.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	stateFilePath := path.Join(tmpdir, incrementalUpgradeTrackerStateFile)
 
-	err = os.WriteFile(stateFilePath, []byte("badstate"), 0o600)
+	err := os.WriteFile(stateFilePath, []byte("badstate"), 0o600)
 	r.NoError(err)
 
 	allUpgrades := upgradeTracker{

--- a/zetaclient/tss/config_test.go
+++ b/zetaclient/tss/config_test.go
@@ -27,8 +27,7 @@ func Test_ParsePubKeysFromPath(t *testing.T) {
 			// ARRANGE
 			logger := zerolog.New(zerolog.NewTestWriter(t))
 
-			dir, err := os.MkdirTemp("", "test-tss")
-			require.NoError(t, err)
+			dir := t.TempDir()
 
 			generateKeyShareFiles(t, tt.n, dir)
 


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir



# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced the test suite by automating temporary directory management, resulting in cleaner setup and implicit cleanup.
  - Simplified error handling and variable assignments to reduce boilerplate and improve overall code readability in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->