### PR TITLE
fix: add DisableTssBlockScan to the chain params equality check function

### DIFF
--- a/x/observer/types/chain_params.go
+++ b/x/observer/types/chain_params.go
@@ -466,7 +466,8 @@ func ChainParamsEqual(params1, params2 ChainParams) bool {
 		params1.MinObserverDelegation.Equal(params2.MinObserverDelegation) &&
 		params1.IsSupported == params2.IsSupported &&
 		params1.GatewayAddress == params2.GatewayAddress &&
-		confirmationParamsEqual(params1.ConfirmationParams, params2.ConfirmationParams)
+		confirmationParamsEqual(params1.ConfirmationParams, params2.ConfirmationParams) &&
+		params1.DisableTssBlockScan == params2.DisableTssBlockScan
 }
 
 // confirmationParamsEqual returns true if two confirmation params are equal

--- a/x/observer/types/chain_params_test.go
+++ b/x/observer/types/chain_params_test.go
@@ -216,6 +216,11 @@ func TestChainParamsEqual(t *testing.T) {
 	cp = copyParams(params)
 	cp.ConfirmationParams.FastOutboundCount = params.ConfirmationParams.FastOutboundCount + 1
 	require.False(t, types.ChainParamsEqual(*params, *cp))
+
+	// DisableTSSBlockScan matters
+	cp = copyParams(params)
+	cp.DisableTssBlockScan = !params.DisableTssBlockScan
+	require.False(t, types.ChainParamsEqual(*params, *cp))
 }
 
 func (s *UpdateChainParamsSuite) SetupTest() {


### PR DESCRIPTION
# Description

This PR is a partial cherry pick of https://github.com/zeta-chain/node/pull/3682:

Add `DisableTssBlockScan` to the chain params equality check function `ChainParamsEqual`. This allows the `zetaclientd` to disable scanning individual blocks without restart.


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the chain configuration comparison logic to ensure all relevant options are consistently evaluated.
  
- **Tests**
  - Introduced additional tests to verify that modifications to configuration options are accurately detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->