### PR TITLE
fix: unblock arb sepolia tx

### DIFF
--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	pkgchains "github.com/zeta-chain/node/pkg/chains"
 
+	pkgchains "github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/x/crosschain/types"
 )
 


### PR DESCRIPTION
# Description

This tx is pending before introducing https://github.com/zeta-chain/node/pull/3680 so it is stuck with old gas limit value in outbound params.
This fix should unblock it, and just set this value manually for arbitrum sepolia. It is a bit too specific and hacky, but it should be a patch just for testnet, then it can be reverted back in next patch we do. Since 100k is minimum for arbitrum sepolia anyways, this should be fine.

Important: majority (6/9) of zetaclients must update for this to work.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
