### PR TITLE
feat: caching TSS signatures for EVM and Bitcoin chain

### DIFF
--- a/zetaclient/chains/base/signer_test.go
+++ b/zetaclient/chains/base/signer_test.go
@@ -18,7 +18,10 @@ func createSigner(t *testing.T) *base.Signer {
 	logger := base.DefaultLogger()
 
 	// create signer
-	return base.NewSigner(chain, tss, logger)
+	signer, err := base.NewSigner(chain, tss, 1, 0, logger)
+	require.NoError(t, err)
+
+	return signer
 }
 
 func TestNewSigner(t *testing.T) {

--- a/zetaclient/chains/base/tss_signature_cache.go
+++ b/zetaclient/chains/base/tss_signature_cache.go
@@ -1,0 +1,134 @@
+package base
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// TSSSignatureEntry represents a single entry in the TSS signature cache.
+type TSSSignatureEntry struct {
+	// signature is the 65-byte ECDSA TSS signature
+	signature [65]byte
+
+	// addedAt is the timestamp when the signature was added to the cache
+	addedAt time.Time
+}
+
+// TSSSignatureCache stores cached TSS signatures
+type TSSSignatureCache struct {
+	// expiration is the expiration time for each cache entry
+	expiration time.Duration
+
+	// digestToSignature maps a digest to a TSS signature
+	digestToSignature *lru.Cache[string, TSSSignatureEntry]
+}
+
+// NewTSSSignatureCache creates a new TSS signature cache
+// Note: passing 0 expiration will effectively disable the cache
+func NewTSSSignatureCache(size int, expiration time.Duration) (*TSSSignatureCache, error) {
+	signatureCache, err := lru.New[string, TSSSignatureEntry](size)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating tss signature cache")
+	}
+
+	return &TSSSignatureCache{
+		expiration:        expiration,
+		digestToSignature: signatureCache,
+	}, nil
+}
+
+// Add adds one TSS signature for given public key and digest to the cache.
+func (c TSSSignatureCache) Add(pkBech32 string, digest []byte, signature [65]byte) {
+	sigKey := signatureKey(pkBech32, digest)
+	c.digestToSignature.Add(sigKey, TSSSignatureEntry{
+		signature: signature,
+		addedAt:   time.Now(),
+	})
+}
+
+// Get fetches a TSS signature for given public key and digest from the cache.
+func (c TSSSignatureCache) Get(pkBech32 string, digest []byte) (signature [65]byte, found bool) {
+	sigKey := signatureKey(pkBech32, digest)
+	entry, ok := c.digestToSignature.Get(sigKey)
+	if !ok {
+		return [65]byte{}, false
+	}
+
+	// early return if expired
+	if c.expire(pkBech32, digest, entry) {
+		return [65]byte{}, false
+	}
+
+	return entry.signature, true
+}
+
+// AddBatch adds multiple TSS signatures for given public key and digests to the cache.
+func (c TSSSignatureCache) AddBatch(pkBech32 string, digests [][]byte, signatures [][65]byte) error {
+	if len(digests) != len(signatures) {
+		return fmt.Errorf("digests and signatures length mismatch: %d != %d", len(digests), len(signatures))
+	}
+
+	now := time.Now()
+	for i, digest := range digests {
+		sigKey := signatureKey(pkBech32, digest)
+		c.digestToSignature.Add(sigKey, TSSSignatureEntry{
+			signature: signatures[i],
+			addedAt:   now,
+		})
+	}
+
+	return nil
+}
+
+// GetBatch fetches TSS signatures for given public key and digests from the cache.
+// Note: it returns true only if
+//   - all the digests have signatures in the cache.
+//   - none of the cached signatures has expired.
+func (c TSSSignatureCache) GetBatch(pkBech32 string, digests [][]byte) (signatures [][65]byte, found bool) {
+	signatures = make([][65]byte, len(digests))
+
+	for i, digest := range digests {
+		sigKey := signatureKey(pkBech32, digest)
+		entry, ok := c.digestToSignature.Get(sigKey)
+		if !ok {
+			return nil, false
+		}
+
+		// early return if expired
+		// if any one of the cached signatures has expired, all digests need a fresh TSS keysign
+		if c.expire(pkBech32, digest, entry) {
+			return nil, false
+		}
+
+		signatures[i] = entry.signature
+	}
+
+	return signatures, true
+}
+
+// expire expires the entry if expiration reached
+func (c TSSSignatureCache) expire(pkBech32 string, digest []byte, entry TSSSignatureEntry) (expired bool) {
+	sigKey := signatureKey(pkBech32, digest)
+	if time.Since(entry.addedAt) >= c.expiration {
+		c.digestToSignature.Remove(sigKey)
+		log.Info().
+			Str("pubkey", pkBech32).
+			Str("digest", hex.EncodeToString(digest)).
+			Str("signature", hex.EncodeToString(entry.signature[:])).
+			Msg("tss signature has expired")
+		return true
+	}
+
+	return false
+}
+
+// signatureKey builds the signature key for given public key and digest.
+func signatureKey(pkBech32 string, digest []byte) string {
+	digestHex := hex.EncodeToString(digest)
+	return fmt.Sprintf("%s-%s", pkBech32, digestHex)
+}

--- a/zetaclient/chains/bitcoin/common/constant.go
+++ b/zetaclient/chains/bitcoin/common/constant.go
@@ -1,0 +1,11 @@
+package common
+
+const (
+	// BlocksPerDay is the average number of Bitcoin blocks produced per day.
+	BlocksPerDay = 144
+
+	// TSSSignatureCacheSize is the size of the TSS signature cache for Bitcoin.
+	// In Bitcoin, each UTXO requires a signature, and TSS may own hundreds of UTXOs,
+	// so we need a bigger cache size than other chains.
+	TSSSignatureCacheSize = 1000
+)

--- a/zetaclient/chains/bitcoin/signer/sign.go
+++ b/zetaclient/chains/bitcoin/signer/sign.go
@@ -219,9 +219,9 @@ func (signer *Signer) SignTx(
 	}
 
 	// sign the tx with TSS
-	sig65Bs, err := signer.TSS().SignBatch(ctx, witnessHashes, height, nonce, signer.Chain().ChainId)
+	sig65Bs, err := signer.TSSSignBatch(ctx, witnessHashes, height, nonce)
 	if err != nil {
-		return errors.Wrap(err, "SignBatch failed")
+		return errors.Wrap(err, "unable to sign Bitcoin transaction")
 	}
 
 	// add witnesses to the tx

--- a/zetaclient/chains/bitcoin/signer/sign_test.go
+++ b/zetaclient/chains/bitcoin/signer/sign_test.go
@@ -201,11 +201,15 @@ func Test_AddTxInputs(t *testing.T) {
 
 func Test_AddWithdrawTxOutputs(t *testing.T) {
 	// Create test signer and receiver address
-	baseSigner := base.NewSigner(
+	baseSigner, err := base.NewSigner(
 		chains.BitcoinMainnet,
 		mocks.NewTSS(t).FakePubKey(testutils.TSSPubKeyMainnet),
+		1,
+		0,
 		base.DefaultLogger(),
 	)
+	require.NoError(t, err)
+
 	signer := signer.New(
 		baseSigner,
 		mocks.NewBitcoinClient(t),

--- a/zetaclient/chains/bitcoin/signer/signer_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_test.go
@@ -67,7 +67,8 @@ func newTestSuite(t *testing.T, chain chains.Chain) *testSuite {
 	baseLogger := base.Logger{Std: logger.Logger, Compliance: logger.Logger}
 
 	// create signer
-	baseSigner := base.NewSigner(chain, tss, baseLogger)
+	baseSigner, err := base.NewSigner(chain, tss, 1, 0, baseLogger)
+	require.NoError(t, err)
 	signer := signer.New(baseSigner, rpcClient)
 
 	// create test suite and observer

--- a/zetaclient/chains/evm/signer/signer_test.go
+++ b/zetaclient/chains/evm/signer/signer_test.go
@@ -56,8 +56,11 @@ func newTestSuite(t *testing.T) *testSuite {
 
 	logger := testlog.New(t)
 
-	baseSigner := base.NewSigner(chain, tss, base.Logger{Std: logger.Logger, Compliance: logger.Logger})
+	// create base signer
+	baseSigner, err := base.NewSigner(chain, tss, 1, 0, base.Logger{Std: logger.Logger, Compliance: logger.Logger})
+	require.NoError(t, err)
 
+	// create evm signer
 	s, err := New(
 		baseSigner,
 		evmClient,

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -179,6 +179,6 @@ type SolanaRPCClient interface {
 // TSSSigner is the interface for TSS signer
 type TSSSigner interface {
 	PubKey() tss.PubKey
-	Sign(ctx context.Context, data []byte, height, nonce uint64, chainID int64) ([65]byte, error)
+	Sign(ctx context.Context, digest []byte, height, nonce uint64, chainID int64) ([65]byte, error)
 	SignBatch(ctx context.Context, digests [][]byte, height, nonce uint64, chainID int64) ([][65]byte, error)
 }

--- a/zetaclient/chains/solana/signer/signer_test.go
+++ b/zetaclient/chains/solana/signer/signer_test.go
@@ -89,7 +89,9 @@ func Test_NewSigner(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			baseSigner := base.NewSigner(tt.chain, tt.tss, tt.logger)
+			baseSigner, err := base.NewSigner(tt.chain, tt.tss, 1, 0, tt.logger)
+			require.NoError(t, err)
+
 			s, err := signer.New(baseSigner, tt.solClient, tt.chainParams.GatewayAddress, tt.relayerKey)
 			if tt.errMessage != "" {
 				require.ErrorContains(t, err, tt.errMessage)
@@ -111,7 +113,9 @@ func Test_SetGatewayAddress(t *testing.T) {
 
 	// helper functor to create signer
 	signerCreator := func() *signer.Signer {
-		baseSigner := base.NewSigner(chain, nil, base.DefaultLogger())
+		baseSigner, err := base.NewSigner(chain, nil, 1, 0, base.DefaultLogger())
+		require.NoError(t, err)
+
 		s, err := signer.New(baseSigner, nil, chainParams.GatewayAddress, nil)
 		require.NoError(t, err)
 
@@ -161,7 +165,8 @@ func Test_SetRelayerBalanceMetrics(t *testing.T) {
 	mckClient := mocks.NewSolanaRPCClient(t)
 	mckClient.On("GetBalance", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
 
-	baseSigner := base.NewSigner(chain, nil, base.DefaultLogger())
+	baseSigner, err := base.NewSigner(chain, nil, 1, 0, base.DefaultLogger())
+	require.NoError(t, err)
 
 	// create signer and set relayer balance metrics
 	s, err := signer.New(baseSigner, mckClient, chainParams.GatewayAddress, relayerKey)
@@ -179,7 +184,8 @@ func Test_SetRelayerBalanceMetrics(t *testing.T) {
 	}, nil)
 
 	// create signer and set relayer balance metrics again
-	baseSigner = base.NewSigner(chain, nil, base.DefaultLogger())
+	baseSigner, err = base.NewSigner(chain, nil, 1, 0, base.DefaultLogger())
+	require.NoError(t, err)
 	s, err = signer.New(baseSigner, mckClient, chainParams.GatewayAddress, relayerKey)
 	require.NoError(t, err)
 	s.SetRelayerBalanceMetrics(ctx)

--- a/zetaclient/chains/sui/signer/signer_test.go
+++ b/zetaclient/chains/sui/signer/signer_test.go
@@ -141,7 +141,9 @@ func newTestSuite(t *testing.T) *testSuite {
 	gw, err := sui.NewGatewayFromPairID(chainParams.GatewayAddress)
 	require.NoError(t, err)
 
-	baseSigner := base.NewSigner(chain, tss, logger)
+	baseSigner, err := base.NewSigner(chain, tss, 1, 0, logger)
+	require.NoError(t, err)
+
 	signer := New(baseSigner, suiMock, gw, zetacore)
 
 	ts := &testSuite{

--- a/zetaclient/chains/ton/signer/signer_test.go
+++ b/zetaclient/chains/ton/signer/signer_test.go
@@ -150,6 +150,10 @@ func newTestSuite(t *testing.T) *testSuite {
 		gwAccountID = ton.MustParseAccountID("0:997d889c815aeac21c47f86ae0e38383efc3c3463067582f6263ad48c5a1485b")
 	)
 
+	// create base signer
+	baseSigner, err := base.NewSigner(chain, tss, 1, 0, logger)
+	require.NoError(t, err)
+
 	ts := &testSuite{
 		ctx: ctx,
 		t:   t,
@@ -163,7 +167,7 @@ func newTestSuite(t *testing.T) *testSuite {
 		tss:      tss,
 
 		gw:         toncontracts.NewGateway(gwAccountID),
-		baseSigner: base.NewSigner(chain, tss, logger),
+		baseSigner: baseSigner,
 	}
 
 	// Setup mocks


### PR DESCRIPTION
# Description

Done: 
- Created a LUR-based `TSSSignatureCache` struct that  allows expiration time.
- The signature cache is specific to a chain.
- Integrate the signature cache into EVM chain and Bitcoin.

In Progress:

- unit test

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
