### PR TITLE
fix(e2e): localnet persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ stop-localnet:
 
 # delete any volume ending in persist
 clear-localnet-persistence:
-	docker volume rm $(docker volume ls -qf "label=localnet=true")
+	$(DOCKER) volume rm $$($(DOCKER) volume ls -qf "label=localnet=true")
 
 ###############################################################################
 ###                         E2E tests               						###

--- a/contrib/localnet/docker-compose-persistent.yml
+++ b/contrib/localnet/docker-compose-persistent.yml
@@ -46,6 +46,10 @@ services:
     volumes:
       - eth-data-persist:/root/data
 
+  bitcoin:
+    volumes:
+      - btc-data-persist:/root/.bitcoin
+
   solana:
     volumes:
       - solana-ledger-persist:/data/test-ledger
@@ -107,6 +111,9 @@ volumes:
     labels:
       - "localnet=true"
   eth-data-persist:
+    labels:
+      - "localnet=true"
+  btc-data-persist:
     labels:
       - "localnet=true"
   orchestrator-state-persist:

--- a/contrib/localnet/solana/start-solana.sh
+++ b/contrib/localnet/solana/start-solana.sh
@@ -6,7 +6,7 @@ solana-keygen new -o /root/.config/solana/id.json --no-bip39-passphrase
 
 solana config set --url localhost
 echo "starting solana test validator..."
-solana-test-validator &
+solana-test-validator --limit-ledger-size 50000000 &
 
 sleep 5
 # airdrop to e2e sol account


### PR DESCRIPTION
- fix makefile subshell syntax. `make clear-localnet-persistence` now actually works
- add bitcoin persistence. this is needed now that we only setup the bitcoin wallet once.
- fix solana persistence. we need to prevent immediate pruning of the ledger or transactions will be pruned immediately on restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Bitcoin service with a dedicated data persistence volume for enhanced data management.
  
- **Chores**
  - Refined local environment commands to improve the reliability of persistent volume cleanup.
  - Optimized the blockchain testing setup by adjusting the validator startup to better manage ledger size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->