### PR TITLE
feat: revert Sui deposit with invalid receiver

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### Features
 
 * [3672](https://github.com/zeta-chain/node/pull/3672) - zetaclient: cache tss signatures for performance.
+* [3698](https://github.com/zeta-chain/node/pull/3698) - revert Sui deposit with invalid receiver
 
 # CHANGELOG
 

--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -462,6 +462,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestSuiTokenDepositName,
 			e2etests.TestSuiTokenDepositAndCallName,
 			e2etests.TestSuiTokenDepositAndCallRevertName,
+			e2etests.TestSuiDepositInvalidReceiverRevertName,
 			e2etests.TestSuiWithdrawName,
 			e2etests.TestSuiTokenWithdrawName,
 		}

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -88,14 +88,15 @@ const (
 	/*
 	 Sui tests
 	*/
-	TestSuiDepositName                   = "sui_deposit"
-	TestSuiDepositAndCallName            = "sui_deposit_and_call"
-	TestSuiDepositAndCallRevertName      = "sui_deposit_and_call_revert"
-	TestSuiTokenDepositName              = "sui_token_deposit"                 // #nosec G101: Potential hardcoded credentials (gosec), not a credential
-	TestSuiTokenDepositAndCallName       = "sui_token_deposit_and_call"        // #nosec G101: Potential hardcoded credentials (gosec), not a credential
-	TestSuiTokenDepositAndCallRevertName = "sui_token_deposit_and_call_revert" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
-	TestSuiWithdrawName                  = "sui_withdraw"
-	TestSuiTokenWithdrawName             = "sui_token_withdraw" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestSuiDepositName                      = "sui_deposit"
+	TestSuiDepositAndCallName               = "sui_deposit_and_call"
+	TestSuiDepositAndCallRevertName         = "sui_deposit_and_call_revert"
+	TestSuiTokenDepositName                 = "sui_token_deposit"                 // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestSuiTokenDepositAndCallName          = "sui_token_deposit_and_call"        // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestSuiTokenDepositAndCallRevertName    = "sui_token_deposit_and_call_revert" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
+	TestSuiDepositInvalidReceiverRevertName = "sui_deposit_invalid_receiver_revert"
+	TestSuiWithdrawName                     = "sui_withdraw"
+	TestSuiTokenWithdrawName                = "sui_token_withdraw" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
 
 	/*
 	 Bitcoin tests
@@ -772,6 +773,15 @@ var AllE2ETests = []runner.E2ETest{
 		},
 		TestSuiTokenDepositAndCallRevert,
 		runner.WithMinimumVersion("v29.0.0"),
+	),
+	runner.NewE2ETest(
+		TestSuiDepositInvalidReceiverRevertName,
+		"deposit fungible token SUI into ZEVM with an invalid receiver; expect revert",
+		[]runner.ArgDefinition{
+			{Description: "amount in base unit", DefaultValue: "10000000000"},
+		},
+		TestSuiDepositInvalidReceiverRevert,
+		runner.WithMinimumVersion("v30.0.0"),
 	),
 	runner.NewE2ETest(
 		TestSuiWithdrawName,

--- a/e2e/e2etests/test_sui_deposit.go
+++ b/e2e/e2etests/test_sui_deposit.go
@@ -20,7 +20,7 @@ func TestSuiDeposit(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 
 	// make the deposit transaction
-	resp := r.SuiDepositSUI(r.EVMAddress(), math.NewUintFromBigInt(amount))
+	resp := r.SuiDepositSUI(r.EVMAddress().Hex(), math.NewUintFromBigInt(amount))
 
 	r.Logger.Info("Sui deposit tx: %s", resp.Digest)
 

--- a/e2e/runner/sui.go
+++ b/e2e/runner/sui.go
@@ -86,8 +86,9 @@ func (r *E2ERunner) SuiWithdrawFungibleToken(
 }
 
 // SuiDepositSUI calls Deposit on Sui
+// This function uses string as receiver to allow testing invalid receiver
 func (r *E2ERunner) SuiDepositSUI(
-	receiver ethcommon.Address,
+	receiver string,
 	amount math.Uint,
 ) models.SuiTransactionBlockResponse {
 	signer, err := r.Account.SuiSigner()
@@ -128,7 +129,7 @@ func (r *E2ERunner) SuiDepositFungibleToken(
 	coinObjectID := r.suiSplitUSDC(signer, amount)
 
 	// create the tx
-	return r.suiExecuteDeposit(signer, "0x"+r.SuiTokenCoinType, coinObjectID, receiver)
+	return r.suiExecuteDeposit(signer, "0x"+r.SuiTokenCoinType, coinObjectID, receiver.Hex())
 }
 
 // SuiFungibleTokenDepositAndCall calls DepositAndCall with fungible token on Sui
@@ -181,7 +182,7 @@ func (r *E2ERunner) suiExecuteDeposit(
 	signer *sui.SignerSecp256k1,
 	coinType string,
 	coinObjectID string,
-	receiver ethcommon.Address,
+	receiver string,
 ) models.SuiTransactionBlockResponse {
 	// create the tx
 	tx, err := r.Clients.Sui.MoveCall(r.Ctx, models.MoveCallRequest{
@@ -190,7 +191,7 @@ func (r *E2ERunner) suiExecuteDeposit(
 		Module:          "gateway",
 		Function:        "deposit",
 		TypeArguments:   []any{coinType},
-		Arguments:       []any{r.SuiGateway.ObjectID(), coinObjectID, receiver.Hex()},
+		Arguments:       []any{r.SuiGateway.ObjectID(), coinObjectID, receiver},
 		GasBudget:       "5000000000",
 	})
 	require.NoError(r, err)

--- a/pkg/contracts/sui/gateway_test.go
+++ b/pkg/contracts/sui/gateway_test.go
@@ -271,6 +271,21 @@ func TestParseEvent(t *testing.T) {
 					"receiver":  "hello",
 				},
 			},
+			assert: func(t *testing.T, raw models.SuiEventResponse, out Event) {
+				assert.Equal(t, txHash, out.TxHash)
+				assert.Equal(t, DepositEvent, out.EventType)
+				assert.Equal(t, uint64(0), out.EventIndex)
+
+				deposit, err := out.Deposit()
+				require.NoError(t, err)
+
+				assert.Equal(t, SUI, deposit.CoinType)
+				assert.True(t, math.NewUint(300).Equal(deposit.Amount))
+				assert.Equal(t, sender, deposit.Sender)
+				assert.False(t, deposit.IsCrossChainCall)
+				assert.True(t, deposit.IsGas())
+				assert.True(t, deposit.IsInvalid())
+			},
 		},
 		{
 			name: "invalid payload",

--- a/pkg/contracts/sui/gateway_test.go
+++ b/pkg/contracts/sui/gateway_test.go
@@ -258,7 +258,7 @@ func TestParseEvent(t *testing.T) {
 			errContains: "invalid sender",
 		},
 		{
-			name: "invalid receiver",
+			name: "invalid receiver can still be parsed",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
 				PackageId: packageID,
@@ -271,7 +271,6 @@ func TestParseEvent(t *testing.T) {
 					"receiver":  "hello",
 				},
 			},
-			errContains: `invalid receiver address "hello"`,
 		},
 		{
 			name: "invalid payload",

--- a/x/crosschain/keeper/cctx_gateway_zevm.go
+++ b/x/crosschain/keeper/cctx_gateway_zevm.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -36,9 +35,14 @@ func (c CCTXGatewayZEVM) InitiateOutbound(
 			StatusMessage:        "inbound observation failed",
 		})
 		return types.CctxStatus_Aborted, nil
-	case types.InboundStatus_INVALID_MEMO:
-		// when invalid memo is reported, the CCTX is reverted to the sender
-		newCCTXStatus = c.crosschainKeeper.ValidateOutboundZEVM(ctx, config.CCTX, errors.New("invalid memo"), true)
+	case types.InboundStatus_INVALID_MEMO, types.InboundStatus_INVALID_RECEIVER_ADDRESS:
+		// invalid observation but can be reverted to the sender
+		newCCTXStatus = c.crosschainKeeper.ValidateOutboundZEVM(
+			ctx,
+			config.CCTX,
+			fmt.Errorf("observation error %s", config.CCTX.InboundParams.Status.String()),
+			true,
+		)
 		return newCCTXStatus, nil
 	case types.InboundStatus_SUCCESS:
 		// process the deposit normally

--- a/zetaclient/chains/sui/observer/inbound.go
+++ b/zetaclient/chains/sui/observer/inbound.go
@@ -182,6 +182,12 @@ func (ob *Observer) constructInboundVote(
 		return nil, errors.Wrap(err, "unable to parse checkpoint")
 	}
 
+	inboundStatus := cctypes.InboundStatus_SUCCESS
+	if deposit.IsInvalid() {
+		// invalid receiver address is currently the only invalid deposit reason
+		inboundStatus = cctypes.InboundStatus_INVALID_RECEIVER_ADDRESS
+	}
+
 	return cctypes.NewMsgVoteInbound(
 		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
 		deposit.Sender,
@@ -199,7 +205,7 @@ func (ob *Observer) constructInboundVote(
 		event.EventIndex,
 		cctypes.ProtocolContractVersion_V2,
 		false,
-		cctypes.InboundStatus_SUCCESS,
+		inboundStatus,
 		cctypes.ConfirmationMode_SAFE,
 		cctypes.WithCrossChainCall(deposit.IsCrossChainCall),
 	), nil


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/3502

Part of https://github.com/zeta-chain/node/issues/3617

So far the deposit would not be observed and deposited funds would be lost,which is problematic as ussers might make mistake.

This PR use a invalid observation and revert the funds to the sender


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated changelog to note the reversion of deposit transactions when an invalid receiver is provided.
- **Bug Fixes**
	- Enhanced deposit processing to revert transactions with invalid receiver addresses and provide clearer error reporting.
- **Tests**
	- Expanded test coverage with new scenarios verifying deposit behavior for invalid receiver cases, ensuring accurate balance handling and appropriate refunds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->