### PR TITLE
feat(zetaclient): solana lead relayer

### DIFF
--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -145,10 +145,11 @@ func Start(_ *cobra.Command, _ []string) error {
 	// It also handles background configuration updates from zetacore
 	taskScheduler := scheduler.New(logger.Std, 0)
 	maestroDeps := &orchestrator.Dependencies{
-		Zetacore:  zetacoreClient,
-		TSS:       tss,
-		DBPath:    dbPath,
-		Telemetry: telemetry,
+		Zetacore:            zetacoreClient,
+		TSS:                 tss,
+		DBPath:              dbPath,
+		Telemetry:           telemetry,
+		IsLeadSolanaRelayer: cfg.IsLeadSolanaRelayer,
 	}
 
 	maestro, err := orchestrator.NewV2(taskScheduler, maestroDeps, logger)

--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -85,6 +85,9 @@ then
     # import relayer private key for zetaclient0
     import_relayer_key 0
 
+    # zetaclient0 is the lead relayer
+    jq '.IsLeadSolanaRelayer = true' /root/.zetacored/config/zetaclient_config.json > tmp.json && mv tmp.json /root/.zetacored/config/zetaclient_config.json
+
     # if eth2 is enabled, set the endpoint in the zetaclient_config.json
     # in this case, the additional evm is represented with the sepolia chain, we set manually the eth2 endpoint to the sepolia chain (11155111 -> http://eth2:8545)
     # in /root/.zetacored/config/zetaclient_config.json

--- a/e2e/runner/setup_solana.go
+++ b/e2e/runner/setup_solana.go
@@ -169,7 +169,7 @@ func (r *E2ERunner) ensureSolanaChainParams() error {
 		InboundTicker:               2,
 		OutboundTicker:              2,
 		OutboundScheduleInterval:    2,
-		OutboundScheduleLookahead:   5,
+		OutboundScheduleLookahead:   20,
 		BallotThreshold:             observertypes.DefaultBallotThreshold,
 		MinObserverDelegation:       observertypes.DefaultMinObserverDelegation,
 		IsSupported:                 true,

--- a/zetaclient/chains/solana/signer/signer_test.go
+++ b/zetaclient/chains/solana/signer/signer_test.go
@@ -90,7 +90,7 @@ func Test_NewSigner(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			baseSigner := base.NewSigner(tt.chain, tt.tss, tt.logger)
-			s, err := signer.New(baseSigner, tt.solClient, tt.chainParams.GatewayAddress, tt.relayerKey)
+			s, err := signer.New(baseSigner, tt.solClient, tt.chainParams.GatewayAddress, tt.relayerKey, true)
 			if tt.errMessage != "" {
 				require.ErrorContains(t, err, tt.errMessage)
 				require.Nil(t, s)
@@ -112,7 +112,7 @@ func Test_SetGatewayAddress(t *testing.T) {
 	// helper functor to create signer
 	signerCreator := func() *signer.Signer {
 		baseSigner := base.NewSigner(chain, nil, base.DefaultLogger())
-		s, err := signer.New(baseSigner, nil, chainParams.GatewayAddress, nil)
+		s, err := signer.New(baseSigner, nil, chainParams.GatewayAddress, nil, true)
 		require.NoError(t, err)
 
 		return s
@@ -164,7 +164,7 @@ func Test_SetRelayerBalanceMetrics(t *testing.T) {
 	baseSigner := base.NewSigner(chain, nil, base.DefaultLogger())
 
 	// create signer and set relayer balance metrics
-	s, err := signer.New(baseSigner, mckClient, chainParams.GatewayAddress, relayerKey)
+	s, err := signer.New(baseSigner, mckClient, chainParams.GatewayAddress, relayerKey, true)
 	require.NoError(t, err)
 	s.SetRelayerBalanceMetrics(ctx)
 
@@ -180,7 +180,7 @@ func Test_SetRelayerBalanceMetrics(t *testing.T) {
 
 	// create signer and set relayer balance metrics again
 	baseSigner = base.NewSigner(chain, nil, base.DefaultLogger())
-	s, err = signer.New(baseSigner, mckClient, chainParams.GatewayAddress, relayerKey)
+	s, err = signer.New(baseSigner, mckClient, chainParams.GatewayAddress, relayerKey, true)
 	require.NoError(t, err)
 	s.SetRelayerBalanceMetrics(ctx)
 

--- a/zetaclient/chains/solana/solana.go
+++ b/zetaclient/chains/solana/solana.go
@@ -179,7 +179,7 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 		// 1. schedule the very first cctx (there can be multiple) created in the last Zeta block.
 		// 2. schedule new cctx only when there is no other older cctx to process
 		isCCTXNewlyCreated := inboundParams.ObservedExternalHeight == zetaHeight
-		shouldProcessCCTXImmedately := isCCTXNewlyCreated && needsProcessingCtr == 0
+		shouldProcessCCTXImmedately := isCCTXNewlyCreated
 
 		// even if the outbound is currently active, we should increment this counter
 		// to avoid immediate processing logic

--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -95,6 +95,7 @@ type Config struct {
 	TestTssKeysign      bool           `json:"TestTssKeysign"`
 	KeyringBackend      KeyringBackend `json:"KeyringBackend"`
 	RelayerKeyPath      string         `json:"RelayerKeyPath"`
+	IsLeadSolanaRelayer bool           `json:"IsLeadSolanaRelayer"`
 
 	// chain configs
 	EVMChainConfigs map[int64]EVMConfig `json:"EVMChainConfigs"`

--- a/zetaclient/orchestrator/v2_bootstrap.go
+++ b/zetaclient/orchestrator/v2_bootstrap.go
@@ -132,7 +132,7 @@ func (oc *V2) bootstrapEVM(ctx context.Context, chain zctx.Chain) (*evm.EVM, err
 	return evm.New(oc.scheduler, observer, signer), nil
 }
 
-func (oc *V2) bootstrapSolana(ctx context.Context, chain zctx.Chain) (*solana.Solana, error) {
+func (oc *V2) bootstrapSolana(ctx context.Context, chain zctx.Chain, isLeadRelayer bool) (*solana.Solana, error) {
 	// should not happen
 	if !chain.IsSolana() {
 		return nil, errors.New("chain is not Solana")
@@ -176,7 +176,7 @@ func (oc *V2) bootstrapSolana(ctx context.Context, chain zctx.Chain) (*solana.So
 	baseSigner := oc.newBaseSigner(chain)
 
 	// create Solana signer
-	signer, err := solanasigner.New(baseSigner, rpcClient, gwAddress, relayerKey)
+	signer, err := solanasigner.New(baseSigner, rpcClient, gwAddress, relayerKey, isLeadRelayer)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create signer")
 	}

--- a/zetaclient/orchestrator/v2_orchestrator.go
+++ b/zetaclient/orchestrator/v2_orchestrator.go
@@ -50,10 +50,11 @@ type ObserverSigner interface {
 }
 
 type Dependencies struct {
-	Zetacore  interfaces.ZetacoreClient
-	TSS       interfaces.TSSSigner
-	DBPath    string
-	Telemetry *metrics.TelemetryServer
+	Zetacore            interfaces.ZetacoreClient
+	TSS                 interfaces.TSSSigner
+	DBPath              string
+	Telemetry           *metrics.TelemetryServer
+	IsLeadSolanaRelayer bool
 }
 
 func NewV2(scheduler *scheduler.Scheduler, deps *Dependencies, logger base.Logger) (*V2, error) {
@@ -168,7 +169,7 @@ func (oc *V2) SyncChains(ctx context.Context) error {
 		case chain.IsEVM():
 			observerSigner, err = oc.bootstrapEVM(ctx, chain)
 		case chain.IsSolana():
-			observerSigner, err = oc.bootstrapSolana(ctx, chain)
+			observerSigner, err = oc.bootstrapSolana(ctx, chain, oc.deps.IsLeadSolanaRelayer)
 		case chain.IsSui():
 			observerSigner, err = oc.bootstrapSui(ctx, chain)
 		case chain.IsTON():


### PR DESCRIPTION
Allow a solana relayer to designate itself the lead relayer. The lead relayer will skip all preflight checks when submitting transactions and assume it's transactions will always succeed. So long as you are submitting your transactions to the same RPC server, it should be safe to submit them as fast as possible so long as they are in order. This is a simple demo for CI and feedback but it will require a few things:

- [x] lead relayer must submit transactions serially.
    - [ ] do not increment backoff counter while waiting for next transaction
    - [ ] mod nonce scheduling leads to higher nonce getting scheduled before lower nonce
- [ ] lead relayer should configure small priority fee. [ref](https://docs.helius.dev/guides/sending-transactions-on-solana#setting-the-right-priority-fee)
- [x] non-lead relayer should ideally avoid submitting the transaction the first time to allow lead relayer to take priority and avoid conflicts
    - [ ] replace static 2 second wait in current implementation. we should be able to determine if this is the first try based on observed block number and current block number.
- [ ] the lead relayer solana RPC must provide sticky load balancing and should only switch nodes on a failover
- [ ] the api call to load the pda nonce should be deduplicated
- [ ] connect a localnet to a live network to validate this actually works

[Initial performance tests](https://github.com/zeta-chain/node/actions/runs/13840342673/job/38726156880?pr=3708) show 15-20% performance gain even without these checks.

Note: when you disable preflight checks some relayer funds will be burned if your transaction fails. This is why it's important that the preflight checks are normally enabled.

With most requirements minimally satisfied, we see a 50-60% [performance increase](https://github.com/zeta-chain/node/actions/runs/13844320397/job/38739256146) which makes solana withdrawals as fast as ethereum 🎉 

```
perf_sol_wit | Latency report:
perf_sol_wit | min:  18.70
perf_sol_wit | max:  23.11
perf_sol_wit | mean: 20.42
perf_sol_wit | std:  0.95
perf_sol_wit | p50:  20.18
perf_sol_wit | p75:  20.86
perf_sol_wit | p90:  21.79
perf_sol_wit | p95:  22.44
perf_sol_wit | all SOL withdrawals completed
perf_sol_wit | ✅ completed - stress_solana_withdraw (2m29.606121s)
perf_sol_wit | 🍾 solana withdraw performance test completed in 3m1.240450272s
```

Note: we can increase the schedule lookahead because we have signature caching now so TSS won't be spammed.


Related to https://github.com/zeta-chain/node/pull/3633