### PR TITLE
fix: add min gas limit for non-gas outbound transactions (v29 backport)

### DIFF
--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -28,7 +28,7 @@ const (
 	PostVoteInboundCallOptionsGasLimit uint64 = 1_500_000
 
 	// AddOutboundTrackerGasLimit is the gas limit for adding tx hash to out tx tracker
-	AddOutboundTrackerGasLimit = 200_000
+	AddOutboundTrackerGasLimit = 400_000
 
 	// PostBlameDataGasLimit is the gas limit for voting on blames
 	PostBlameDataGasLimit = 200_000


### PR DESCRIPTION
# Description

V29 backport for https://github.com/zeta-chain/node/pull/3719