### PR TITLE
fix: add min gas limit for non-gas outbound transactions (develop rebase)

### DIFF
--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -15,7 +15,7 @@ import (
 const maxGasLimit = 2_500_000
 
 const gasTransferGasLimit = 21_000
-const nonGasMinGasLimit = 100_000
+const contractCallMinGasLimit = 100_000
 
 // Gas represents gas parameters for EVM transactions.
 //
@@ -77,15 +77,17 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 			Uint64("cctx.initial_gas_limit", params.CallOptions.GasLimit).
 			Uint64("cctx.gas_limit", limit).
 			Msgf("Gas limit is too high; Setting to the maximum (%d)", maxGasLimit)
-	} else if limit == gasTransferGasLimit && params.CoinType != coin.CoinType_Gas {
-		// some erc20 reverts currently use 21k, this check add a minimum gas limit
-		// TODO: fix the gas limit used for gas revert outbounds
+	} else if limit == gasTransferGasLimit && (params.CoinType != coin.CoinType_Gas || (cctx.IsCurrentOutboundRevert() && cctx.RevertOptions.CallOnRevert)) {
+		// in some context, 21k might currently be used for an outbound that involves a contract call
+		// this includes erc20 withdraw and onRevert calls whe gas deposit revert
+		// we fix this minimum to ensure the transaction has the minimum required gas limit
+		// TODO: fix the gas limit used for these cctx outbound gas limit
 		// https://github.com/zeta-chain/node/issues/3723
-		limit = nonGasMinGasLimit
+		limit = contractCallMinGasLimit
 		logger.Warn().
 			Uint64("cctx.initial_gas_limit", params.CallOptions.GasLimit).
 			Uint64("cctx.gas_limit", limit).
-			Msgf("Gas limit is too low; Setting to the minimum (%d)", nonGasMinGasLimit)
+			Msgf("Gas limit is too low for contract call; Setting to the minimum (%d)", contractCallMinGasLimit)
 	}
 
 	gasPrice, err := bigIntFromString(params.GasPrice)

--- a/zetaclient/chains/evm/signer/gas.go
+++ b/zetaclient/chains/evm/signer/gas.go
@@ -78,7 +78,9 @@ func gasFromCCTX(cctx *types.CrossChainTx, logger zerolog.Logger) (Gas, error) {
 			Uint64("cctx.gas_limit", limit).
 			Msgf("Gas limit is too high; Setting to the maximum (%d)", maxGasLimit)
 	} else if limit == gasTransferGasLimit && params.CoinType != coin.CoinType_Gas {
-		// some erc20 reverts currently use 21k, this check add a minimum gas limitm
+		// some erc20 reverts currently use 21k, this check add a minimum gas limit
+		// TODO: fix the gas limit used for gas revert outbounds
+		// https://github.com/zeta-chain/node/issues/3723
 		limit = nonGasMinGasLimit
 		logger.Warn().
 			Uint64("cctx.initial_gas_limit", params.CallOptions.GasLimit).


### PR DESCRIPTION
# Description

Add to upstream backported fix: https://github.com/zeta-chain/node/pull/3719 

Add a TODO to address the underlying issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction reliability by auto-adjusting gas limits when they fall below a minimum threshold. This change ensures smoother transaction processing and provides a warning when the gas limit is too low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->