### PR TITLE
chore: upload zetae2e build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           GOOS: linux
           GOARCH: ${{ env.CPU_ARCH }}
         run: |
-          make install
+          make install install-zetae2e
           cp "$HOME"/go/bin/* ./
           chmod a+x ./zetacored
           ./zetacored version
@@ -88,6 +88,13 @@ jobs:
           name: zetaclientd
           path: ~/go/bin/zetaclientd
           retention-days: 30
+
+      - name: Upload zetae2e
+        uses: actions/upload-artifact@v4
+        with:
+          name: zetae2e
+          path: ~/go/bin/zetae2e
+          retention-days: 90
       
       - name: Clean Up Workspace
         if: always()


### PR DESCRIPTION
Let's just upload `zetae2e` rather than having to build it in other places in our CI workflows.

Example download:
```
RUN_ID=$(gh run list --repo zeta-chain/node --branch zetae2e-artifacts --workflow ci.yml --limit 1 --json databaseId --jq '.[0].databaseId')
gh run download --repo zeta-chain/node --name zetae2e $RUN_ID
```

Related to https://github.com/zeta-chain/infrastructure/issues/1788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to integrate an extra installation step for a new component.
  - Added an automated step to preserve a build artifact for 90 days, enhancing overall build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->