### PR TITLE
chore: tune zetae2e run

### DIFF
--- a/cmd/zetae2e/main.go
+++ b/cmd/zetae2e/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -16,7 +15,6 @@ func main() {
 	// initialize root command
 	rootCmd := NewRootCmd()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(-1)
 	}
 }

--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -21,6 +21,7 @@ import (
 
 const flagVerbose = "verbose"
 const flagConfig = "config"
+const flagFailFast = "fail-fast"
 
 // NewRunCmd returns the run command
 // which runs the E2E from a config file describing the tests, networks, and accounts
@@ -32,8 +33,9 @@ func NewRunCmd() *cobra.Command {
 		Short: "Run one or more E2E tests with optional arguments",
 		Long: `Run one or more E2E tests specified by their names and optional arguments.
 For example: zetae2e run deposit:1000 withdraw: --config config.yml`,
-		RunE: runE2ETest,
-		Args: cobra.MinimumNArgs(1), // Ensures at least one test is provided
+		RunE:         runE2ETest,
+		Args:         cobra.MinimumNArgs(1), // Ensures at least one test is provided
+		SilenceUsage: true,
 	}
 
 	cmd.Flags().StringVarP(&configFile, flagConfig, "c", "", "path to the configuration file")
@@ -46,6 +48,8 @@ For example: zetae2e run deposit:1000 withdraw: --config config.yml`,
 
 	// Retain the verbose flag
 	cmd.Flags().Bool(flagVerbose, false, "set to true to enable verbose logging")
+
+	cmd.Flags().Bool(flagFailFast, false, "should a failure in one test cause an immediate halt")
 
 	return cmd
 }
@@ -67,6 +71,11 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	failFast, err := cmd.Flags().GetBool(flagFailFast)
+	if err != nil {
+		return err
+	}
+
 	// initialize logger
 	logger := runner.NewLogger(verbose, color.FgHiCyan, "e2e")
 
@@ -78,6 +87,11 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 	// initialize context
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(nil)
+	// if failFast option is not specified, overwrite context cancellation function
+	// so that it is a no-op
+	if !failFast {
+		cancel = func(cause error) {}
+	}
 
 	var runnerOpts []runner.E2ERunnerOption
 


### PR DESCRIPTION
Tune `zetae2e run` so that the live network ci results are a bit cleaner. Output looks like this before:

```
e2e          | starting tests
e2e          | ❓ balance of zeta eth: no contract code at given address
e2e          | ⏳ running   - eth_deposit
e2e          | [INFO] starting eth deposit test 
Error: 6me2e          | [ERROR]
	Error Trace:	/home/runner/work/node/node/e2e/runner/evm.go:36
	            				/home/runner/work/node/node/e2e/e2etests/test_eth_deposit.go:22
	Error:      	Received unexpected error:
	            	Connection prematurely closed BEFORE response

Error: 6me2e          | [ERROR]Failure: (*E2ERunner).FailNow for runner "e2e". Exiting
e2e          | test eth_deposit failed: context cancelled in eth_deposit after 1.288465[53](https://github.com/zeta-chain/infrastructure/actions/runs/13933180377/job/38996467762#step:11:54)3s
Error: get zeta balance: Post "https://zetachain-athens-evm.blockpi.network/v1/rpc/public": context canceled
Usage:
  zetae2e run [testname1]:[arg1],[arg2] [testname2]:[arg1],[arg2]... [flags]

Flags:
  -c, --config string          path to the configuration file
  -h, --help                   help for run
      --verbose                set to true to enable verbose logging
      --zrc20-network string   network from /zeta-chain/observer/supportedChains
      --zrc20-symbol string    symbol from /zeta-chain/fungible/foreign_coins

get zeta balance: Post "https://zetachain-athens-evm.blockpi.network/v1/rpc/public": context canceled
```

- remove double error print
- suppress pointless usage print on error
- add `fail-fast` option defaulting to false which will prevent an immediate halt if one test fails.