### PR TITLE
chore(e2e): ensure tests exit if any error

### DIFF
--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	zetae2econfig "github.com/zeta-chain/node/cmd/zetae2e/config"
@@ -158,10 +159,15 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print tests completion info
-	logger.Print("tests finished successfully in %s", time.Since(testStartTime).String())
+	logger.Print("tests finished in %s", time.Since(testStartTime).String())
 	testRunner.Logger.SetColor(color.FgHiRed)
 	testRunner.Logger.SetColor(color.FgHiGreen)
 	testRunner.PrintTestReports(reports)
+
+	anyTestFailed := lo.ContainsBy(reports, func(r runner.TestReport) bool { return !r.Success })
+	if anyTestFailed {
+		return errors.New("tests failed")
+	}
 
 	return nil
 }


### PR DESCRIPTION
I removed the hard exit in https://github.com/zeta-chain/node/pull/3737 but now the overall test run doesn't return an error. We want the process to return an error and exit if any test had an error.

Current state:

<img width="1265" alt="image" src="https://github.com/user-attachments/assets/814b5db0-6eaf-4d45-8b22-de5e3abd3802" />

The bsc check should have failed since one of the tests failed.

New state:

https://github.com/zeta-chain/e2e/actions/runs/13954918491/job/39063619621

<img width="2032" alt="image" src="https://github.com/user-attachments/assets/d1e28161-2d6a-497c-81d3-a3d7f5bfca53" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced error reporting during test execution.
	- Refined messaging to clearly indicate when tests complete with failures rather than implying success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->