### PR TITLE
chore: Update go version on README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ smart contracts and messaging between any blockchain.
 
 ## Prerequisites
 
-- [Go](https://golang.org/doc/install) 1.22
+- [Go](https://golang.org/doc/install) 1.23
 - [Docker](https://docs.docker.com/install/) and
   [Docker Compose](https://docs.docker.com/compose/install/) (optional, for
   running tests locally)


### PR DESCRIPTION
# Description
Update README with go 1.23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated prerequisites information to require Go 1.23 instead of Go 1.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->