### PR TITLE
fix: revert Bitcoin inbound if there no memo provided by user

### DIFF
--- a/zetaclient/chains/bitcoin/observer/event.go
+++ b/zetaclient/chains/bitcoin/observer/event.go
@@ -85,6 +85,12 @@ func (event *BTCInboundEvent) DecodeMemoBytes(chainID int64) error {
 		receiver       ethcommon.Address
 	)
 
+	// skip decoding if no memo is found, returning error to revert the inbound
+	if bytes.Equal(event.MemoBytes, []byte(noMemoFound)) {
+		event.MemoBytes = []byte{}
+		return errors.New("no memo found in inbound")
+	}
+
 	// skip decoding donation tx as it won't go through zetacore
 	if bytes.Equal(event.MemoBytes, []byte(constant.DonationMessage)) {
 		return nil

--- a/zetaclient/chains/bitcoin/observer/event_test.go
+++ b/zetaclient/chains/bitcoin/observer/event_test.go
@@ -169,6 +169,14 @@ func Test_DecodeEventMemoBytes(t *testing.T) {
 			expectedReceiver: common.HexToAddress("0x5A0110032d07A9cbd57dcCa3e2Cf966c88bC8744"),
 		},
 		{
+			name:    "should return error if no memo is found",
+			chainID: chains.BitcoinTestnet.ChainId,
+			event: &observer.BTCInboundEvent{
+				MemoBytes: []byte("no memo found"),
+			},
+			errMsg: "no memo found in inbound",
+		},
+		{
 			name:    "should do nothing for donation message",
 			chainID: chains.BitcoinTestnet.ChainId,
 			event: &observer.BTCInboundEvent{

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -3,15 +3,16 @@ package observer_test
 import (
 	"bytes"
 	"context"
-	cosmosmath "cosmossdk.io/math"
 	"encoding/hex"
-	"github.com/zeta-chain/node/pkg/coin"
-	"github.com/zeta-chain/node/pkg/memo"
 	"math"
 	"math/big"
 	"path"
 	"strings"
 	"testing"
+
+	cosmosmath "cosmossdk.io/math"
+	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/memo"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcjson"
@@ -472,13 +473,25 @@ func TestGetBtcEvent(t *testing.T) {
 		require.Equal(t, eventExpected, event)
 	})
 
-	t.Run("should skip tx if len(tx.Vout) < 2", func(t *testing.T) {
-		// load tx and modify the tx to have only 1 vout
-		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
+	t.Run("it's ok if no memo is provided", func(t *testing.T) {
+		// https://mempool.space/tx/c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697
+		preHash := "c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697"
+		tx.Vin[0].Txid = preHash
+		tx.Vin[0].Vout = 2
+		eventExpected.FromAddress = "bc1q68kxnq52ahz5vd6c8czevsawu0ux9nfrzzrh6e"
+
+		// mock up the output
+		// remove OP_RETURN output to simulate no memo provided
 		tx.Vout = tx.Vout[:1]
 
+		// no memo is found in this case
+		expectedEvent := *eventExpected
+		expectedEvent.MemoBytes = []byte("no memo found")
+
+		// load previous raw tx so so mock rpc client can return it
+		rpcClient := testrpc.CreateBTCRPCAndLoadTx(t, TestDataDir, chain.ChainId, preHash)
+
 		// get BTC event
-		rpcClient := mocks.NewBitcoinClient(t)
 		event, err := observer.GetBtcEvent(
 			ctx,
 			rpcClient,
@@ -490,7 +503,7 @@ func TestGetBtcEvent(t *testing.T) {
 			feeCalculator,
 		)
 		require.NoError(t, err)
-		require.Nil(t, event)
+		require.Equal(t, expectedEvent, *event)
 	})
 
 	t.Run("should skip tx if Vout[0] is not a P2WPKH output", func(t *testing.T) {
@@ -570,13 +583,20 @@ func TestGetBtcEvent(t *testing.T) {
 		require.Nil(t, event)
 	})
 
-	t.Run("should skip tx if 2nd vout is not OP_RETURN", func(t *testing.T) {
+	t.Run("should not skip tx if 2nd vout is not OP_RETURN", func(t *testing.T) {
 		// load tx and modify memo OP_RETURN to OP_1
 		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
 		tx.Vout[1].ScriptPubKey.Hex = strings.Replace(tx.Vout[1].ScriptPubKey.Hex, "6a", "51", 1)
 
+		// https://mempool.space/tx/c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697
+		preHash := "c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697"
+		tx.Vin[0].Txid = preHash
+		tx.Vin[0].Vout = 2
+
+		// load previous raw tx so so mock rpc client can return it
+		rpcClient := testrpc.CreateBTCRPCAndLoadTx(t, TestDataDir, chain.ChainId, preHash)
+
 		// get BTC event
-		rpcClient := mocks.NewBitcoinClient(t)
 		event, err := observer.GetBtcEvent(
 			ctx,
 			rpcClient,
@@ -588,16 +608,23 @@ func TestGetBtcEvent(t *testing.T) {
 			feeCalculator,
 		)
 		require.NoError(t, err)
-		require.Nil(t, event)
+		require.NotNil(t, event)
 	})
 
-	t.Run("should skip tx if memo decoding fails", func(t *testing.T) {
+	t.Run("should not skip tx if memo decoding fails", func(t *testing.T) {
 		// load tx and modify memo length to be 1 byte less than actual
 		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
 		tx.Vout[1].ScriptPubKey.Hex = strings.Replace(tx.Vout[1].ScriptPubKey.Hex, "6a14", "6a13", 1)
 
+		// https://mempool.space/tx/c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697
+		preHash := "c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697"
+		tx.Vin[0].Txid = preHash
+		tx.Vin[0].Vout = 2
+
+		// load previous raw tx so so mock rpc client can return it
+		rpcClient := testrpc.CreateBTCRPCAndLoadTx(t, TestDataDir, chain.ChainId, preHash)
+
 		// get BTC event
-		rpcClient := mocks.NewBitcoinClient(t)
 		event, err := observer.GetBtcEvent(
 			ctx,
 			rpcClient,
@@ -609,7 +636,7 @@ func TestGetBtcEvent(t *testing.T) {
 			feeCalculator,
 		)
 		require.NoError(t, err)
-		require.Nil(t, event)
+		require.NotNil(t, event)
 	})
 
 	t.Run("should skip tx if sender address is empty", func(t *testing.T) {


### PR DESCRIPTION
# Description

The v29 is able to revert Bitcoin deposits that carry incorrectly formatted memo (e.g., invalid receiver address), but it cannot properly revert deposits that carry no memo at all, which are supposed be reverted.

This fix will allow no-memo deposits to be able to go through ZetaChain and get funds reverted.



# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
