### PR TITLE
fix: cherry pick mainnet bitcoin fix to be able to revert missed inbound w…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,7 @@
 * [3602](https://github.com/zeta-chain/node/pull/3602) - hardcode gas limits to avoid estimate gas calls
 * [3622](https://github.com/zeta-chain/node/pull/3622) - allow object for tracerConfig in `debug_traceTransaction` RPC
 * [3634](https://github.com/zeta-chain/node/pull/3634) - return proper synthetic tx in `eth_getBlockByNumber` RPC
+* [3754](https://github.com/zeta-chain/node/pull/3754) - make the Bitcoin deposit to revert when the memo output is missing
 
 ### Tests
 

--- a/e2e/e2etests/test_bitcoin_deposit_invalid_memo_revert.go
+++ b/e2e/e2etests/test_bitcoin_deposit_invalid_memo_revert.go
@@ -15,17 +15,31 @@ func TestBitcoinDepositInvalidMemoRevert(r *runner.E2ERunner, args []string) {
 	stop := r.MineBlocksIfLocalBitcoin()
 	defer stop()
 
-	// make a deposit with a empty memo
+	// CASE 1
+	// make a deposit without memo output
 	utxos := r.ListDeployerUTXOs()
-	txHash, err := r.SendToTSSFromDeployerWithMemo(0.1, utxos[:1], []byte{})
+	txHash, err := r.SendToTSSFromDeployerWithMemo(0.1, utxos[:1], nil)
 	require.NoError(r, err)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "deposit without memo")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+	require.EqualValues(r, crosschaintypes.InboundStatus_INVALID_MEMO, cctx.InboundParams.Status)
+
+	// CASE 2
+	// make a deposit with a empty memo
+	utxos = r.ListDeployerUTXOs()
+	txHash, err = r.SendToTSSFromDeployerWithMemo(0.1, utxos[:1], []byte{})
+	require.NoError(r, err)
+
+	// wait for the cctx to be mined
+	cctx = utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit empty memo")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 	require.EqualValues(r, crosschaintypes.InboundStatus_INVALID_MEMO, cctx.InboundParams.Status)
 
+	// CASE 3
 	// make a deposit with an invalid memo
 	utxos = r.ListDeployerUTXOs()
 	txHash, err = r.SendToTSSFromDeployerWithMemo(0.1, utxos[:1], []byte("invalid memo"))

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -244,21 +244,29 @@ func (r *E2ERunner) sendToAddrFromDeployerWithMemo(
 	tx, err := btcRPC.CreateRawTransaction(r.Ctx, inputs, amountMap, nil)
 	require.NoError(r, err)
 
-	// this adds a OP_RETURN + single BYTE len prefix to the data
-	nullData, err := txscript.NullDataScript(memo)
-	require.NoError(r, err)
-	r.Logger.Info("nulldata (len %d): %x", len(nullData), nullData)
-	require.NoError(r, err)
-	memoOutput := wire.TxOut{Value: 0, PkScript: nullData}
-	tx.TxOut = append(tx.TxOut, &memoOutput)
-	tx.TxOut[1], tx.TxOut[2] = tx.TxOut[2], tx.TxOut[1]
+	// memo is optional as we also want to test no-memo edge case for revert
+	// this adds an OP_RETURN output with single byte length-delimited data
+	if memo != nil {
+		nullData, err := txscript.NullDataScript(memo)
+		require.NoError(r, err)
+		r.Logger.Info("nulldata (len %d): %x", len(nullData), nullData)
+		require.NoError(r, err)
+		memoOutput := wire.TxOut{Value: 0, PkScript: nullData}
 
-	// make sure that TxOut[0] is sent to "to" address; TxOut[2] is change to oneself. TxOut[1] is memo.
+		// append the memo as the second output
+		tx.TxOut = append(tx.TxOut, &memoOutput)
+		tx.TxOut[1], tx.TxOut[2] = tx.TxOut[2], tx.TxOut[1]
+	}
+
+	// make sure that TxOut[0] is sent to "to" address; last output is change to oneself.
 	if !bytes.Equal(tx.TxOut[0].PkScript[2:], to.ScriptAddress()) {
 		r.Logger.Info("tx.TxOut[0].PkScript: %x", tx.TxOut[0].PkScript)
 		r.Logger.Info("to.ScriptAddress():   %x", to.ScriptAddress())
 		r.Logger.Info("swapping txout[0] with txout[2]")
-		tx.TxOut[0], tx.TxOut[2] = tx.TxOut[2], tx.TxOut[0]
+
+		// swap the TxOut[0] and the last output (change)
+		idxChange := len(tx.TxOut) - 1
+		tx.TxOut[0], tx.TxOut[idxChange] = tx.TxOut[idxChange], tx.TxOut[0]
 	}
 
 	r.Logger.Info("raw transaction: \n")

--- a/zetaclient/chains/bitcoin/observer/event.go
+++ b/zetaclient/chains/bitcoin/observer/event.go
@@ -85,6 +85,12 @@ func (event *BTCInboundEvent) DecodeMemoBytes(chainID int64) error {
 		receiver       ethcommon.Address
 	)
 
+	// skip decoding if no memo is found, returning error to revert the inbound
+	if bytes.Equal(event.MemoBytes, []byte(noMemoFound)) {
+		event.MemoBytes = []byte{}
+		return errors.New("no memo found in inbound")
+	}
+
 	// skip decoding donation tx as it won't go through zetacore
 	if bytes.Equal(event.MemoBytes, []byte(constant.DonationMessage)) {
 		return nil

--- a/zetaclient/chains/bitcoin/observer/event_test.go
+++ b/zetaclient/chains/bitcoin/observer/event_test.go
@@ -169,6 +169,14 @@ func Test_DecodeEventMemoBytes(t *testing.T) {
 			expectedReceiver: common.HexToAddress("0x5A0110032d07A9cbd57dcCa3e2Cf966c88bC8744"),
 		},
 		{
+			name:    "should return error if no memo is found",
+			chainID: chains.BitcoinTestnet.ChainId,
+			event: &observer.BTCInboundEvent{
+				MemoBytes: []byte("no memo found"),
+			},
+			errMsg: "no memo found in inbound",
+		},
+		{
 			name:    "should do nothing for donation message",
 			chainID: chains.BitcoinTestnet.ChainId,
 			event: &observer.BTCInboundEvent{

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -3,15 +3,16 @@ package observer_test
 import (
 	"bytes"
 	"context"
-	cosmosmath "cosmossdk.io/math"
 	"encoding/hex"
-	"github.com/zeta-chain/node/pkg/coin"
-	"github.com/zeta-chain/node/pkg/memo"
 	"math"
 	"math/big"
 	"path"
 	"strings"
 	"testing"
+
+	cosmosmath "cosmossdk.io/math"
+	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/memo"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcjson"
@@ -472,13 +473,25 @@ func TestGetBtcEvent(t *testing.T) {
 		require.Equal(t, eventExpected, event)
 	})
 
-	t.Run("should skip tx if len(tx.Vout) < 2", func(t *testing.T) {
-		// load tx and modify the tx to have only 1 vout
-		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
+	t.Run("it's ok if no memo is provided", func(t *testing.T) {
+		// https://mempool.space/tx/c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697
+		preHash := "c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697"
+		tx.Vin[0].Txid = preHash
+		tx.Vin[0].Vout = 2
+		eventExpected.FromAddress = "bc1q68kxnq52ahz5vd6c8czevsawu0ux9nfrzzrh6e"
+
+		// mock up the output
+		// remove OP_RETURN output to simulate no memo provided
 		tx.Vout = tx.Vout[:1]
 
+		// no memo is found in this case
+		expectedEvent := *eventExpected
+		expectedEvent.MemoBytes = []byte("no memo found")
+
+		// load previous raw tx so so mock rpc client can return it
+		rpcClient := testrpc.CreateBTCRPCAndLoadTx(t, TestDataDir, chain.ChainId, preHash)
+
 		// get BTC event
-		rpcClient := mocks.NewBitcoinClient(t)
 		event, err := observer.GetBtcEvent(
 			ctx,
 			rpcClient,
@@ -490,7 +503,7 @@ func TestGetBtcEvent(t *testing.T) {
 			feeCalculator,
 		)
 		require.NoError(t, err)
-		require.Nil(t, event)
+		require.Equal(t, expectedEvent, *event)
 	})
 
 	t.Run("should skip tx if Vout[0] is not a P2WPKH output", func(t *testing.T) {
@@ -570,13 +583,20 @@ func TestGetBtcEvent(t *testing.T) {
 		require.Nil(t, event)
 	})
 
-	t.Run("should skip tx if 2nd vout is not OP_RETURN", func(t *testing.T) {
+	t.Run("should not skip tx if 2nd vout is not OP_RETURN", func(t *testing.T) {
 		// load tx and modify memo OP_RETURN to OP_1
 		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
 		tx.Vout[1].ScriptPubKey.Hex = strings.Replace(tx.Vout[1].ScriptPubKey.Hex, "6a", "51", 1)
 
+		// https://mempool.space/tx/c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697
+		preHash := "c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697"
+		tx.Vin[0].Txid = preHash
+		tx.Vin[0].Vout = 2
+
+		// load previous raw tx so so mock rpc client can return it
+		rpcClient := testrpc.CreateBTCRPCAndLoadTx(t, TestDataDir, chain.ChainId, preHash)
+
 		// get BTC event
-		rpcClient := mocks.NewBitcoinClient(t)
 		event, err := observer.GetBtcEvent(
 			ctx,
 			rpcClient,
@@ -588,16 +608,23 @@ func TestGetBtcEvent(t *testing.T) {
 			feeCalculator,
 		)
 		require.NoError(t, err)
-		require.Nil(t, event)
+		require.NotNil(t, event)
 	})
 
-	t.Run("should skip tx if memo decoding fails", func(t *testing.T) {
+	t.Run("should not skip tx if memo decoding fails", func(t *testing.T) {
 		// load tx and modify memo length to be 1 byte less than actual
 		tx := testutils.LoadBTCInboundRawResult(t, TestDataDir, chain.ChainId, txHash, false)
 		tx.Vout[1].ScriptPubKey.Hex = strings.Replace(tx.Vout[1].ScriptPubKey.Hex, "6a14", "6a13", 1)
 
+		// https://mempool.space/tx/c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697
+		preHash := "c5d224963832fc0b9a597251c2342a17b25e481a88cc9119008e8f8296652697"
+		tx.Vin[0].Txid = preHash
+		tx.Vin[0].Vout = 2
+
+		// load previous raw tx so so mock rpc client can return it
+		rpcClient := testrpc.CreateBTCRPCAndLoadTx(t, TestDataDir, chain.ChainId, preHash)
+
 		// get BTC event
-		rpcClient := mocks.NewBitcoinClient(t)
 		event, err := observer.GetBtcEvent(
 			ctx,
 			rpcClient,
@@ -609,7 +636,7 @@ func TestGetBtcEvent(t *testing.T) {
 			feeCalculator,
 		)
 		require.NoError(t, err)
-		require.Nil(t, event)
+		require.NotNil(t, event)
 	})
 
 	t.Run("should skip tx if sender address is empty", func(t *testing.T) {


### PR DESCRIPTION
# Description

This PR is to cherry pick the mainnet `v29` fix: https://github.com/zeta-chain/node/pull/3752

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bitcoin deposits that lack a memo now automatically revert, ensuring only complete transactions are processed. This update improves deposit transaction consistency and provides clearer feedback when essential deposit details are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->