### PR TITLE
fix: set updated zrc20 name and symbol in the foreign coin object

### DIFF
--- a/e2e/e2etests/test_update_zrc20_name.go
+++ b/e2e/e2etests/test_update_zrc20_name.go
@@ -31,6 +31,13 @@ func TestUpdateZRC20Name(r *runner.E2ERunner, _ []string) {
 	require.NoError(r, err)
 	require.Equal(r, "ETH.NEW", newSymbol)
 
+	qRes, err := r.FungibleClient.ForeignCoins(r.Ctx, &fungibletypes.QueryGetForeignCoinsRequest{
+		Index: r.ETHZRC20Addr.Hex(),
+	})
+	require.NoError(r, err)
+	require.EqualValues(r, "New ETH", qRes.ForeignCoins.Name)
+	require.EqualValues(r, "ETH.NEW", qRes.ForeignCoins.Symbol)
+
 	// try another zrc20
 	msg = fungibletypes.NewMsgUpdateZRC20Name(
 		r.ZetaTxServer.MustGetAccountAddressFromName(utils.AdminPolicyName),
@@ -51,4 +58,11 @@ func TestUpdateZRC20Name(r *runner.E2ERunner, _ []string) {
 	newSymbol, err = r.ERC20ZRC20.Symbol(&bind.CallOpts{})
 	require.NoError(r, err)
 	require.Equal(r, "USDT.NEW", newSymbol)
+
+	qRes, err = r.FungibleClient.ForeignCoins(r.Ctx, &fungibletypes.QueryGetForeignCoinsRequest{
+		Index: r.ERC20ZRC20Addr.Hex(),
+	})
+	require.NoError(r, err)
+	require.EqualValues(r, "New USDT", qRes.ForeignCoins.Name)
+	require.EqualValues(r, "USDT.NEW", qRes.ForeignCoins.Symbol)
 }

--- a/x/fungible/keeper/msg_server_update_zrc20_name.go
+++ b/x/fungible/keeper/msg_server_update_zrc20_name.go
@@ -36,7 +36,7 @@ func (k msgServer) UpdateZRC20Name(
 	}
 
 	// check the zrc20 exists
-	_, found := k.GetForeignCoins(ctx, msg.Zrc20Address)
+	fc, found := k.GetForeignCoins(ctx, msg.Zrc20Address)
 	if !found {
 		return nil, cosmoserrors.Wrapf(
 			types.ErrForeignCoinNotFound,
@@ -45,18 +45,23 @@ func (k msgServer) UpdateZRC20Name(
 		)
 	}
 
-	// call the contract methods
+	// call the contract methods and update the object
 	if msg.Name != "" {
 		if err := k.ZRC20SetName(ctx, zrc20Addr, msg.Name); err != nil {
 			return nil, cosmoserrors.Wrapf(types.ErrContractCall, "failed to update zrc20 name (%s)", err.Error())
 		}
+		fc.Name = msg.Name
 	}
 
 	if msg.Symbol != "" {
 		if err = k.ZRC20SetSymbol(ctx, zrc20Addr, msg.Symbol); err != nil {
 			return nil, cosmoserrors.Wrapf(types.ErrContractCall, "failed to update zrc20 symbol (%s)", err.Error())
 		}
+		fc.Symbol = msg.Symbol
 	}
+
+	// save the object
+	k.SetForeignCoins(ctx, fc)
 
 	return &types.MsgUpdateZRC20NameResponse{}, nil
 }

--- a/x/fungible/keeper/msg_server_update_zrc20_name_test.go
+++ b/x/fungible/keeper/msg_server_update_zrc20_name_test.go
@@ -114,6 +114,7 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 	})
 
 	t.Run("can update name and symbol", func(t *testing.T) {
+		// arrange
 		k, ctx, sdkk, _ := keepertest.FungibleKeeperWithMocks(t, keepertest.FungibleMockOptions{
 			UseAuthorityMock: true,
 		})
@@ -137,8 +138,10 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 
 		keepertest.MockCheckAuthorization(&authorityMock.Mock, msg, nil)
 
+		// act
 		_, err := msgServer.UpdateZRC20Name(ctx, msg)
 
+		// assert
 		require.NoError(t, err)
 
 		// check the name and symbol
@@ -150,7 +153,14 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "bar", symbol)
 
+		// check object
+		fc, found := k.GetForeignCoins(ctx, zrc20Address.Hex())
+		require.True(t, found)
+		require.Equal(t, "foo", fc.Name)
+		require.Equal(t, "bar", fc.Symbol)
+
 		// can update name only
+		// arrange
 		msg = types.NewMsgUpdateZRC20Name(
 			admin,
 			zrc20Address.Hex(),
@@ -160,7 +170,10 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 
 		keepertest.MockCheckAuthorization(&authorityMock.Mock, msg, nil)
 
+		// act
 		_, err = msgServer.UpdateZRC20Name(ctx, msg)
+
+		// assert
 		require.NoError(t, err)
 
 		name, err = k.ZRC20Name(ctx, zrc20Address)
@@ -171,7 +184,14 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "bar", symbol)
 
+		// check object
+		fc, found = k.GetForeignCoins(ctx, zrc20Address.Hex())
+		require.True(t, found)
+		require.Equal(t, "foo2", fc.Name)
+		require.Equal(t, "bar", fc.Symbol)
+
 		// can update symbol only
+		// arrange
 		msg = types.NewMsgUpdateZRC20Name(
 			admin,
 			zrc20Address.Hex(),
@@ -181,7 +201,10 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 
 		keepertest.MockCheckAuthorization(&authorityMock.Mock, msg, nil)
 
+		// act
 		_, err = msgServer.UpdateZRC20Name(ctx, msg)
+
+		// assert
 		require.NoError(t, err)
 
 		name, err = k.ZRC20Name(ctx, zrc20Address)
@@ -191,5 +214,11 @@ func TestMsgServer_UpdateZRC20Name(t *testing.T) {
 		symbol, err = k.ZRC20Symbol(ctx, zrc20Address)
 		require.NoError(t, err)
 		require.Equal(t, "bar2", symbol)
+
+		// check object
+		fc, found = k.GetForeignCoins(ctx, zrc20Address.Hex())
+		require.True(t, found)
+		require.Equal(t, "foo2", fc.Name)
+		require.Equal(t, "bar2", fc.Symbol)
 	})
 }


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Token metadata updates now reliably reflect the new names and symbols (e.g., for ETH and USDT tokens), ensuring consistent display across the platform.
- **Tests**
	- Expanded validations have been added to confirm that token detail updates are applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->