### PR TITLE
refactor(e2e): allow using all UTXOs for deposits

### DIFF
--- a/e2e/e2etests/test_bitcoin_deposit.go
+++ b/e2e/e2etests/test_bitcoin_deposit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
 )
 
 func TestBitcoinDeposit(r *runner.E2ERunner, args []string) {
@@ -20,19 +21,30 @@ func TestBitcoinDeposit(r *runner.E2ERunner, args []string) {
 	startingBalance, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, r.ZEVMAuth.From)
 	require.NoError(r, err)
 
-	txHash := r.DepositBTCWithExactAmount(depositAmount, nil)
+	txHash := r.DepositBTCWithAmount(depositAmount, nil)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
+	// calculate fee
+	tx, err := r.BtcRPCClient.GetTransaction(r.Ctx, txHash)
+	require.NoError(r, err)
+	rawTx, err := r.BtcRPCClient.GetRawTransactionResult(r.Ctx, txHash, tx)
+	require.NoError(r, err)
+	fee, err := common.CalcDepositorFee(r.Ctx, r.BtcRPCClient, &rawTx, r.BitcoinParams)
+	require.NoError(r, err)
+	feeSatoshis := uint64(fee * btcutil.SatoshiPerBitcoin)
+
+	expectedAmount := depositAmountZRC20 - feeSatoshis
+
 	// assert that the inbound amount is expected
-	require.InDelta(r, depositAmountZRC20, cctx.InboundParams.Amount.Uint64(), 100)
+	require.InDelta(r, expectedAmount, cctx.InboundParams.Amount.Uint64(), 100)
 
 	// assert that the balance increases by the expected amount
 	endingBalance, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, r.ZEVMAuth.From)
 	require.NoError(r, err)
 	balanceDiff := bigSub(endingBalance, startingBalance)
-	require.InDelta(r, depositAmountZRC20, balanceDiff.Uint64(), 100)
+	require.InDelta(r, expectedAmount, balanceDiff.Uint64(), 100)
 }

--- a/e2e/e2etests/test_bitcoin_deposit.go
+++ b/e2e/e2etests/test_bitcoin_deposit.go
@@ -1,6 +1,7 @@
 package e2etests
 
 import (
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 
@@ -14,7 +15,7 @@ func TestBitcoinDeposit(r *runner.E2ERunner, args []string) {
 
 	depositAmount := utils.ParseFloat(r, args[0])
 	// ZRC20 BTC amounts have 8 decimals
-	depositAmountZRC20 := uint64(depositAmount * 1e8)
+	depositAmountZRC20 := uint64(depositAmount * btcutil.SatoshiPerBitcoin)
 
 	startingBalance, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, r.ZEVMAuth.From)
 	require.NoError(r, err)

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert.go
@@ -19,15 +19,12 @@ func TestBitcoinDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseFloat(r, args[0])
 	amount += zetabitcoin.DefaultDepositorFee
 
-	// Given a list of UTXOs
-	utxos := r.ListUTXOs()
-
 	// ACT
 	// Send BTC to TSS address with a dummy memo
 	// zetacore should revert cctx if call is made on a non-existing address
 	nonExistReceiver := sample.EthAddress()
 	badMemo := append(nonExistReceiver.Bytes(), []byte("gibberish-memo")...)
-	txHash, err := r.SendToTSSWithMemo(amount, utxos[:1], badMemo)
+	txHash, err := r.SendToTSSWithMemo(amount, badMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
 

--- a/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_call_revert_with_dust.go
@@ -27,9 +27,6 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	)
 	amount := depositAmount + zetabitcoin.DefaultDepositorFee
 
-	// Given a list of UTXOs
-	utxos := r.ListUTXOs()
-
 	// ACT
 	// Send BTC to TSS address with a dummy memo
 	// zetacore should revert cctx if call is made on a non-existing address
@@ -37,7 +34,7 @@ func TestBitcoinDepositAndCallRevertWithDust(r *runner.E2ERunner, args []string)
 	anyMemo := append(nonExistReceiver.Bytes(), []byte("gibberish-memo")...)
 
 	// One UTXO is enough to cover the deposit amount
-	txHash, err := r.SendToTSSWithMemo(amount, utxos[:1], anyMemo)
+	txHash, err := r.SendToTSSWithMemo(amount, anyMemo)
 	require.NoError(r, err)
 	require.NotEmpty(r, txHash)
 

--- a/e2e/e2etests/test_bitcoin_deposit_and_withdraw_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_withdraw_with_dust.go
@@ -31,14 +31,10 @@ func TestBitcoinDepositAndWithdrawWithDust(r *runner.E2ERunner, args []string) {
 	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 	require.Equal(r, receipt.Status, uint64(1))
 
-	// Given a list of UTXOs
-	utxos := r.ListUTXOs()
-
 	// ACT
 	// Deposit 0.01 BTC to withdrawer, this is an arbitrary amount, must be greater than dust amount
 	txHash, err := r.SendToTSSWithMemo(
 		0.01,
-		utxos[:1],
 		append(withdrawerAddr.Bytes(), []byte("payload")...),
 	)
 	require.NoError(r, err)

--- a/e2e/e2etests/test_bitcoin_deposit_call.go
+++ b/e2e/e2etests/test_bitcoin_deposit_call.go
@@ -18,9 +18,6 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseFloat(r, args[0])
 	amountTotal := amount + common.DefaultDepositorFee
 
-	// Given a list of UTXOs
-	utxos := r.ListUTXOs()
-
 	// deploy an example contract in ZEVM
 	contractAddr, _, contract, err := testcontract.DeployExample(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
@@ -30,7 +27,7 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	// Send BTC to TSS address with a dummy memo
 	data := []byte("hello satoshi")
 	memo := append(contractAddr.Bytes(), data...)
-	txHash, err := r.SendToTSSWithMemo(amountTotal, utxos[:1], memo)
+	txHash, err := r.SendToTSSWithMemo(amountTotal, memo)
 	require.NoError(r, err)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_bitcoin_deposit_invalid_memo_revert.go
+++ b/e2e/e2etests/test_bitcoin_deposit_invalid_memo_revert.go
@@ -17,8 +17,7 @@ func TestBitcoinDepositInvalidMemoRevert(r *runner.E2ERunner, args []string) {
 
 	// CASE 1
 	// make a deposit without memo output
-	utxos := r.ListUTXOs()
-	txHash, err := r.SendToTSSWithMemo(0.1, utxos[:1], nil)
+	txHash, err := r.SendToTSSWithMemo(0.1, nil)
 	require.NoError(r, err)
 
 	// wait for the cctx to be mined
@@ -29,8 +28,7 @@ func TestBitcoinDepositInvalidMemoRevert(r *runner.E2ERunner, args []string) {
 
 	// CASE 2
 	// make a deposit with a empty memo
-	utxos = r.ListUTXOs()
-	txHash, err = r.SendToTSSWithMemo(0.1, utxos[:1], []byte{})
+	txHash, err = r.SendToTSSWithMemo(0.1, []byte{})
 	require.NoError(r, err)
 
 	// wait for the cctx to be mined
@@ -41,8 +39,7 @@ func TestBitcoinDepositInvalidMemoRevert(r *runner.E2ERunner, args []string) {
 
 	// CASE 3
 	// make a deposit with an invalid memo
-	utxos = r.ListUTXOs()
-	txHash, err = r.SendToTSSWithMemo(0.1, utxos[:1], []byte("invalid memo"))
+	txHash, err = r.SendToTSSWithMemo(0.1, []byte("invalid memo"))
 	require.NoError(r, err)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_bitcoin_donation.go
+++ b/e2e/e2etests/test_bitcoin_donation.go
@@ -18,13 +18,10 @@ func TestBitcoinDonation(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseFloat(r, args[0])
 	amountTotal := amount + zetabitcoin.DefaultDepositorFee
 
-	// Given a list of UTXOs
-	utxos := r.ListUTXOs()
-
 	// ACT
 	// Send BTC to TSS address with donation message
 	memo := []byte(constant.DonationMessage)
-	txHash, err := r.SendToTSSWithMemo(amountTotal, utxos[:1], memo)
+	txHash, err := r.SendToTSSWithMemo(amountTotal, memo)
 	require.NoError(r, err)
 
 	// ASSERT after 4 Zeta blocks

--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -109,7 +109,7 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 	memo = append(r.ZEVMSwapAppAddr.Bytes(), memo...)
 	r.Logger.Info("memo length %d", len(memo))
 
-	txID, err := r.SendToTSSWithMemo(0.01, utxos[0:1], memo)
+	txID, err := r.SendToTSSWithMemo(0.01, memo)
 	require.NoError(r, err)
 
 	cctx3 := utils.WaitCctxMinedByInboundHash(r.Ctx, txID.String(), r.CctxClient, r.Logger, r.CctxTimeout)
@@ -139,7 +139,7 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 
 		amount := 0.1
 		utxos = r.ListUTXOs()
-		txid, err := r.SendToTSSWithMemo(amount, utxos[0:1], memo)
+		txid, err := r.SendToTSSWithMemo(amount, memo)
 		require.NoError(r, err)
 
 		cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txid.String(), r.CctxClient, r.Logger, r.CctxTimeout)

--- a/e2e/e2etests/test_crosschain_swap.go
+++ b/e2e/e2etests/test_crosschain_swap.go
@@ -138,7 +138,6 @@ func TestCrosschainSwap(r *runner.E2ERunner, _ []string) {
 		r.Logger.Info("memo length %d", len(memo))
 
 		amount := 0.1
-		utxos = r.ListUTXOs()
 		txid, err := r.SendToTSSWithMemo(amount, memo)
 		require.NoError(r, err)
 

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -239,11 +239,6 @@ func (r *E2ERunner) sendToAddrWithMemo(
 	require.NoError(r, err)
 	tx.AddTxOut(wire.NewTxOut(int64(amountSats), pkScript))
 
-	// Add change output
-	changePkScript, err := txscript.PayToAddrScript(address)
-	require.NoError(r, err)
-	tx.AddTxOut(wire.NewTxOut(int64(change), changePkScript))
-
 	// Add memo output if provided
 	if memo != nil {
 		nullData, err := txscript.NullDataScript(memo)
@@ -251,10 +246,12 @@ func (r *E2ERunner) sendToAddrWithMemo(
 		r.Logger.Info("nulldata (len %d): %x", len(nullData), nullData)
 		memoOutput := wire.NewTxOut(0, nullData)
 		tx.AddTxOut(memoOutput)
-
-		// Move memo output to second position
-		tx.TxOut[1], tx.TxOut[2] = tx.TxOut[2], tx.TxOut[1]
 	}
+
+	// Add change output
+	changePkScript, err := txscript.PayToAddrScript(address)
+	require.NoError(r, err)
+	tx.AddTxOut(wire.NewTxOut(int64(change), changePkScript))
 
 	r.Logger.Info("raw transaction: \n")
 	for idx, txout := range tx.TxOut {

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -198,25 +198,8 @@ func (r *E2ERunner) sendToAddrWithMemo(
 
 	allUTXOs := r.ListUTXOs()
 
-	// Estimate fee using bitcoind's fee estimation
-	// This gets fee rate in BTC/KB for targeting confirmation within 6 blocks
-	feeRate, err := btcRPC.GetEstimatedFeeRate(r.Ctx, 6)
-	require.NoError(r, err)
-
-	// very rough estimate of transaction size
-	estimatedTxSizeBytes := 200 + int64(len(memo))
-
-	// Calculate fee based on estimated size
-	feeSats := btcutil.Amount(feeRate * estimatedTxSizeBytes)
-
-	// Minimum fee threshold
-	minFeeSats := btcutil.Amount(0.0005 * btcutil.SatoshiPerBitcoin)
-	if feeSats < minFeeSats {
-		feeSats = minFeeSats
-	}
-
-	r.Logger.Info("Using fee of %d satoshis (rate: %d)", feeSats, feeRate)
-
+	// Calculate required amount including fee
+	feeSats := btcutil.Amount(0.0005 * btcutil.SatoshiPerBitcoin)
 	amountInt, err := zetabtc.GetSatoshis(amount)
 	require.NoError(r, err)
 	amountSats := btcutil.Amount(amountInt)


### PR DESCRIPTION
Allow using all UTXOs for inputs on deposits. Just call `ListUTXOs()` inside the deposit function.

Also add some retries to gettransaction and getrawtransaction.

Also assemble outputs in correct order rather than swapping them later.

Also fix a rounding error that would occasionally cause signing failures on inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved Bitcoin deposit conversions by switching to a dynamic conversion factor for greater accuracy.
  - Simplified transaction submissions by removing redundant steps to streamline processing.

- **Tests**
  - Updated end-to-end validations for deposit, withdrawal, donation, and swap flows.
  - Enhanced error resilience and verification in transaction handling for a more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->