### PR TITLE
fix: prevent invalid Sui withdraw address from blocking the outbound

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
-## v29.2.0
+## v29.1.6
+
+* [3801](https://github.com/zeta-chain/node/pull/3801) - prevent invalid Sui withdraw address from blocking the outbound
+
+## v29.1.5
+
+* [3785](https://github.com/zeta-chain/node/pull/3785) - add btc inbound logs to find root cause of Testnet4 missed txs
+
+## v29.1.4
 
 * [3780](https://github.com/zeta-chain/node/pull/3780) - patch maxValidator param decrease bug
 

--- a/e2e/e2etests/test_sui_withdraw.go
+++ b/e2e/e2etests/test_sui_withdraw.go
@@ -38,4 +38,22 @@ func TestSuiWithdraw(r *runner.E2ERunner, args []string) {
 	// reason is that the max budget is refunded to the TSS
 	tssBalanceAfter := r.SuiGetSUIBalance(r.SuiTSSAddress)
 	require.GreaterOrEqual(r, tssBalanceAfter, tssBalanceBefore)
+
+	// PATCH: v29
+
+	tssBalanceBefore = tssBalanceAfter
+
+	// Check that an invalid withdraw doesn't block the outbound
+	// Use the same address as in the current incident
+	tx = r.SuiWithdrawSUI("0x307832356462313663336361353535663637303263303738363035303331303762623733636365396636633164366466303034363435323964623135643561356162", amount)
+	r.Logger.EVMTransaction(*tx, "invalid_withdraw")
+
+	// wait for the cctx to be mined
+	cctx = utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+
+	// check the TSS receive the amount
+	tssBalanceAfter = r.SuiGetSUIBalance(r.SuiTSSAddress)
+	require.GreaterOrEqual(r, tssBalanceAfter, tssBalanceBefore+amount.Uint64())
 }

--- a/e2e/e2etests/test_sui_withdraw.go
+++ b/e2e/e2etests/test_sui_withdraw.go
@@ -45,7 +45,10 @@ func TestSuiWithdraw(r *runner.E2ERunner, args []string) {
 
 	// Check that an invalid withdraw doesn't block the outbound
 	// Use the same address as in the current incident
-	tx = r.SuiWithdrawSUI("0x307832356462313663336361353535663637303263303738363035303331303762623733636365396636633164366466303034363435323964623135643561356162", amount)
+	tx = r.SuiWithdrawSUI(
+		"0x307832356462313663336361353535663637303263303738363035303331303762623733636365396636633164366466303034363435323964623135643561356162",
+		amount,
+	)
 	r.Logger.EVMTransaction(*tx, "invalid_withdraw")
 
 	// wait for the cctx to be mined

--- a/pkg/contracts/sui/crypto.go
+++ b/pkg/contracts/sui/crypto.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
+	"strings"
 
 	"github.com/block-vision/sui-go-sdk/models"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -162,4 +164,23 @@ func (s *SignerSecp256k1) SignTxBlock(tx models.TxnMetaData) (string, error) {
 	sigReordered[64] = sig[0]             // Move V[1] to the end
 
 	return SerializeSignatureECDSA(sigReordered, &s.pk.ToECDSA().PublicKey)
+}
+
+// CheckValidSuiAddress checks whether the input string is a valid Sui address.
+func CheckValidSuiAddress(addr string) error {
+	if !strings.HasPrefix(addr, "0x") {
+		return errors.New("address must start with 0x")
+	}
+	hexPart := addr[2:]
+
+	if len(hexPart) == 0 {
+		return errors.New("address must not be empty")
+	}
+
+	if len(hexPart) > 64 {
+		return errors.New("address must be 64 characters or less")
+	}
+
+	_, err := hex.DecodeString(fmt.Sprintf("%064s", hexPart))
+	return errors.Wrapf(err, "address %s is not valid hex", addr)
 }

--- a/pkg/contracts/sui/crypto.go
+++ b/pkg/contracts/sui/crypto.go
@@ -166,8 +166,8 @@ func (s *SignerSecp256k1) SignTxBlock(tx models.TxnMetaData) (string, error) {
 	return SerializeSignatureECDSA(sigReordered, &s.pk.ToECDSA().PublicKey)
 }
 
-// CheckValidSuiAddress checks whether the input string is a valid Sui address.
-func CheckValidSuiAddress(addr string) error {
+// ValidAddress checks whether the input string is a valid Sui address.
+func ValidAddress(addr string) error {
 	if !strings.HasPrefix(addr, "0x") {
 		return errors.New("address must start with 0x")
 	}

--- a/pkg/contracts/sui/crypto_test.go
+++ b/pkg/contracts/sui/crypto_test.go
@@ -209,7 +209,7 @@ func TestCheckValidSuiAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := CheckValidSuiAddress(tt.address)
+			err := ValidAddress(tt.address)
 			if tt.wantErr {
 				require.Error(t, err, "expected error for address: %s", tt.address)
 			} else {

--- a/pkg/contracts/sui/crypto_test.go
+++ b/pkg/contracts/sui/crypto_test.go
@@ -158,3 +158,63 @@ func TestCrypto(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckValidSuiAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{
+			name:    "Valid full-length address",
+			address: "0x2a4c5a97b561ac5b38edc4b4e9b2c183c57b56df5b1ea2f1c6f2e4a44b92d59f",
+			wantErr: false,
+		},
+		{
+			name:    "Valid short address",
+			address: "0x1a",
+			wantErr: false,
+		},
+		{
+			name:    "Missing 0x prefix",
+			address: "2a4c5a97b561ac5b38edc4b4e9b2c183c57b56df5b1ea2f1c6f2e4a44b92d59f",
+			wantErr: true,
+		},
+		{
+			name:    "Too long address",
+			address: "0x" + "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899a1",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid hex characters",
+			address: "0xZZZZZZ",
+			wantErr: true,
+		},
+		{
+			name:    "Empty string",
+			address: "",
+			wantErr: true,
+		},
+		{
+			name:    "Only 0x",
+			address: "0x",
+			wantErr: true,
+		},
+		{
+			name:    "Minimal valid single-byte address",
+			address: "0x0",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckValidSuiAddress(tt.address)
+			if tt.wantErr {
+				require.Error(t, err, "expected error for address: %s", tt.address)
+			} else {
+				require.NoError(t, err, "unexpected error for address: %s", tt.address)
+			}
+		})
+	}
+}

--- a/zetaclient/chains/sui/signer/signer_tx.go
+++ b/zetaclient/chains/sui/signer/signer_tx.go
@@ -63,7 +63,7 @@ func (s *Signer) buildWithdrawal(ctx context.Context, cctx *cctypes.CrossChainTx
 	// TODO: add validation of the withdraw address to prevent this issue
 	// https://github.com/zeta-chain/node/issues/3798
 	// https://github.com/zeta-chain/node/issues/3799
-	if sui.CheckValidSuiAddress(recipient) != nil {
+	if sui.ValidAddress(recipient) != nil {
 		s.Logger().Std.Warn().Str("recipient", recipient).Msg("Invalid recipient address, redirecting to TSS")
 		recipient = s.TSS().PubKey().AddressSui()
 	}


### PR DESCRIPTION
# Description

If the withdraw address is invalid, the ZetaClient sign the tx to the TSS, this is like a donation to the TSS.

A fix in the main branch will make the withdraw revert instead
