### PR TITLE
fix(e2e): cctx list order

### DIFF
--- a/e2e/runner/zevm.go
+++ b/e2e/runner/zevm.go
@@ -415,7 +415,7 @@ func (r *E2ERunner) WaitForSpecificCCTX(
 		ctx      = r.Ctx
 		start    = time.Now()
 		reqQuery = &types.QueryAllCctxRequest{
-			Pagination: &query.PageRequest{Reverse: true},
+			Pagination: &query.PageRequest{Reverse: false},
 		}
 	)
 


### PR DESCRIPTION
This should fix E2E on testnet. reverse=true actually means "ASC" instead of "DESC"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the order in which cross-chain transactions are retrieved during certain automated tests to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->