### PR TITLE
feat(e2e): add populate-addresses command

### DIFF
--- a/cmd/zetae2e/balances.go
+++ b/cmd/zetae2e/balances.go
@@ -34,7 +34,7 @@ func NewBalancesCmd() *cobra.Command {
 
 func runBalances(cmd *cobra.Command, args []string) error {
 	// read the config file
-	conf, err := config.ReadConfig(args[0])
+	conf, err := config.ReadConfig(args[0], true)
 	if err != nil {
 		return err
 	}

--- a/cmd/zetae2e/bitcoin_address.go
+++ b/cmd/zetae2e/bitcoin_address.go
@@ -37,7 +37,7 @@ func runBitcoinAddress(cmd *cobra.Command, args []string) error {
 	}
 
 	// read the config file
-	conf, err := config.ReadConfig(args[0])
+	conf, err := config.ReadConfig(args[0], true)
 	if err != nil {
 		return err
 	}

--- a/cmd/zetae2e/config/config_test.go
+++ b/cmd/zetae2e/config/config_test.go
@@ -31,7 +31,7 @@ func TestReadConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf, err := config.ReadConfig(tt.filePath)
+			conf, err := config.ReadConfig(tt.filePath, true)
 			require.NoError(t, err)
 			require.NotEmpty(t, conf.DefaultAccount.RawEVMAddress)
 			require.NotEmpty(t, conf.DefaultAccount.RawPrivateKey)

--- a/cmd/zetae2e/local/config.go
+++ b/cmd/zetae2e/local/config.go
@@ -21,5 +21,5 @@ func GetConfig(cmd *cobra.Command) (config.Config, error) {
 		return config.Config{}, err
 	}
 
-	return config.ReadConfig(configFile)
+	return config.ReadConfig(configFile, true)
 }

--- a/cmd/zetae2e/populate_addresses.go
+++ b/cmd/zetae2e/populate_addresses.go
@@ -42,7 +42,10 @@ func runPopulateAddresses(_ *cobra.Command, args []string) error {
 
 	// solana address
 	if conf.DefaultAccount.SolanaPrivateKey != "" {
-		sPrivKey := solana.MustPrivateKeyFromBase58(conf.DefaultAccount.SolanaPrivateKey.String())
+		sPrivKey, err := solana.PrivateKeyFromBase58(conf.DefaultAccount.SolanaPrivateKey.String())
+		if err != nil {
+			return fmt.Errorf("decoding Solana private key: %w", err)
+		}
 		sAddress := sPrivKey.PublicKey().String()
 		conf.DefaultAccount.SolanaAddress = config.DoubleQuotedString(sAddress)
 	}

--- a/cmd/zetae2e/populate_addresses.go
+++ b/cmd/zetae2e/populate_addresses.go
@@ -22,6 +22,7 @@ func NewPopulateAddressesCmd() *cobra.Command {
 }
 
 func runPopulateAddresses(_ *cobra.Command, args []string) error {
+	// do not validate the config on load as it will not have addresses populated yet
 	conf, err := config.ReadConfig(args[0], false)
 	if err != nil {
 		return err

--- a/cmd/zetae2e/populate_addresses.go
+++ b/cmd/zetae2e/populate_addresses.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gagliardetto/solana-go"
 	"github.com/spf13/cobra"
+
 	"github.com/zeta-chain/node/e2e/config"
 )
 
@@ -19,12 +21,13 @@ func NewPopulateAddressesCmd() *cobra.Command {
 	return cmd
 }
 
-func runPopulateAddresses(cmd *cobra.Command, args []string) error {
+func runPopulateAddresses(_ *cobra.Command, args []string) error {
 	conf, err := config.ReadConfig(args[0])
 	if err != nil {
 		return err
 	}
 
+	// evm address
 	privKey, err := conf.DefaultAccount.PrivateKey()
 	if err != nil {
 		return fmt.Errorf("decoding private key: %w", err)
@@ -36,6 +39,13 @@ func runPopulateAddresses(cmd *cobra.Command, args []string) error {
 	}
 	conf.DefaultAccount.RawEVMAddress = config.DoubleQuotedString(evmAddress.String())
 	conf.DefaultAccount.RawBech32Address = config.DoubleQuotedString(bech32Address)
+
+	// solana address
+	if conf.DefaultAccount.SolanaPrivateKey != "" {
+		sPrivKey := solana.MustPrivateKeyFromBase58(conf.DefaultAccount.SolanaPrivateKey.String())
+		sAddress := sPrivKey.PublicKey().String()
+		conf.DefaultAccount.SolanaAddress = config.DoubleQuotedString(sAddress)
+	}
 
 	err = config.WriteConfig(args[0], conf)
 	if err != nil {

--- a/cmd/zetae2e/populate_addresses.go
+++ b/cmd/zetae2e/populate_addresses.go
@@ -22,7 +22,7 @@ func NewPopulateAddressesCmd() *cobra.Command {
 }
 
 func runPopulateAddresses(_ *cobra.Command, args []string) error {
-	conf, err := config.ReadConfig(args[0])
+	conf, err := config.ReadConfig(args[0], false)
 	if err != nil {
 		return err
 	}

--- a/cmd/zetae2e/root.go
+++ b/cmd/zetae2e/root.go
@@ -29,6 +29,7 @@ func NewRootCmd() *cobra.Command {
 		NewStressTestCmd(),
 		NewInitCmd(),
 		NewSetupBitcoinCmd(),
+		NewPopulateAddressesCmd(),
 	)
 
 	return cmd

--- a/cmd/zetae2e/run.go
+++ b/cmd/zetae2e/run.go
@@ -63,7 +63,7 @@ func runE2ETest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	conf, err := config.ReadConfig(configPath)
+	conf, err := config.ReadConfig(configPath, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/zetae2e/setup_bitcoin.go
+++ b/cmd/zetae2e/setup_bitcoin.go
@@ -25,7 +25,7 @@ func NewSetupBitcoinCmd() *cobra.Command {
 
 func runSetupBitcoin(_ *cobra.Command, args []string) error {
 	// read the config file
-	conf, err := config.ReadConfig(args[0])
+	conf, err := config.ReadConfig(args[0], true)
 	if err != nil {
 		return err
 	}

--- a/cmd/zetae2e/show_tss.go
+++ b/cmd/zetae2e/show_tss.go
@@ -25,7 +25,7 @@ func NewShowTSSCmd() *cobra.Command {
 
 func runShowTSS(_ *cobra.Command, args []string) error {
 	// read the config file
-	conf, err := config.ReadConfig(args[0])
+	conf, err := config.ReadConfig(args[0], true)
 	if err != nil {
 		return err
 	}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -213,7 +213,7 @@ func DefaultConfig() Config {
 }
 
 // ReadConfig reads the config file
-func ReadConfig(file string) (config Config, err error) {
+func ReadConfig(file string, validate bool) (config Config, err error) {
 	if file == "" {
 		return Config{}, errors.New("file name cannot be empty")
 	}
@@ -227,8 +227,10 @@ func ReadConfig(file string) (config Config, err error) {
 	if err != nil {
 		return Config{}, err
 	}
-	if err := config.Validate(); err != nil {
-		return Config{}, err
+	if validate {
+		if err := config.Validate(); err != nil {
+			return Config{}, err
+		}
 	}
 
 	return

--- a/e2e/runner/legacy_setup_evm.go
+++ b/e2e/runner/legacy_setup_evm.go
@@ -24,7 +24,7 @@ const (
 
 // LegacySetEVMContractsFromConfig set legacy EVM contracts for e2e test from the config
 func (r *E2ERunner) LegacySetEVMContractsFromConfig() {
-	conf, err := config.ReadConfig(ContractsConfigFile)
+	conf, err := config.ReadConfig(ContractsConfigFile, true)
 	require.NoError(r, err)
 
 	// Set ZetaEthAddr


### PR DESCRIPTION
When running e2e tests with many wallets, I only want to have to set the private key. Introduce

```
zetae2e populate-addresses config.yml
```

Which will automatically derive the addresses from the private keys and set them in the config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line tool to automatically derive and populate blockchain addresses (EVM and Solana) in the configuration file.

- **Bug Fixes**
  - Improved configuration validation by updating how configuration files are loaded and validated across multiple commands.

- **Tests**
  - Updated test coverage to reflect changes in configuration loading behavior.

- **Documentation**
  - Enhanced inline documentation for new and updated command-line features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->