### PR TITLE
refactor: set zeta protocol fee to zero

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
 
 * [3709](https://github.com/zeta-chain/node/pull/3709) - improve cctx error message for out of gas errors when creating outbound
 * [3777](https://github.com/zeta-chain/node/pull/3777) - use SignBatch keysign for solana outbound tx and fallback tx
+* [3813](https://github.com/zeta-chain/node/pull/3813) - set ZETA protocol fee to 0
 
 ### Fixes
 * [3711](https://github.com/zeta-chain/node/pull/3711) - fix TON call_data parsing

--- a/x/crosschain/keeper/evm_hooks.go
+++ b/x/crosschain/keeper/evm_hooks.go
@@ -260,7 +260,8 @@ func (k Keeper) ProcessZetaSentEvent(
 		return observertypes.ErrChainParamsNotFound
 	}
 
-	if receiverChain.IsExternalChain() && chainParams.ZetaTokenContractAddress == "" {
+	if receiverChain.IsExternalChain() &&
+		(chainParams.ZetaTokenContractAddress == "" || chainParams.ZetaTokenContractAddress == constant.EVMZeroAddress) {
 		return types.ErrUnableToSendCoinType
 	}
 

--- a/x/crosschain/types/keys.go
+++ b/x/crosschain/types/keys.go
@@ -23,15 +23,15 @@ const (
 	// we keep the current value for backward compatibility
 	MemStoreKey = "mem_metacore"
 
-	ProtocolFee = 250000000000000000
-
 	// CCTXIndexLength is the length of a crosschain transaction index
 	CCTXIndexLength          = 66
 	MaxOutboundTrackerHashes = 5
 )
 
+// GetProtocolFee returns the protocol fee for the cross chain transaction
+// It is no longer used, but the function is kept for backward compatibility with the Zeta Conversion Rate query
 func GetProtocolFee() math.Uint {
-	return math.NewUint(ProtocolFee)
+	return math.ZeroUint()
 }
 
 func KeyPrefix(p string) []byte {


### PR DESCRIPTION
# Description

- Set ZETA additional protocol fee to zero as this fee is no longer relevant
- Fix a invalid check for ZETA withdraw to the bitcoin chain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Protocol fee for ZETA transactions has been set to zero. This change is reflected in the system and will affect any operations or queries involving the protocol fee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->