### PR TITLE
fix: set retry gas limit if outbound is successful

### DIFF
--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -121,7 +121,7 @@ func (ob *Observer) postVoteOutbound(
 
 	const gasLimit = zetacore.PostVoteOutboundGasLimit
 
-	var retryGasLimit uint64
+	retryGasLimit := uint64(1_000_000)
 	if msg.Status == chains.ReceiveStatus_failed {
 		retryGasLimit = zetacore.PostVoteOutboundRevertGasLimit
 	}

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -121,7 +121,7 @@ func (ob *Observer) postVoteOutbound(
 
 	const gasLimit = zetacore.PostVoteOutboundGasLimit
 
-	retryGasLimit := uint64(1_000_000)
+	retryGasLimit := zetacore.PostVoteOutboundRetryGasLimit
 	if msg.Status == chains.ReceiveStatus_failed {
 		retryGasLimit = zetacore.PostVoteOutboundRevertGasLimit
 	}

--- a/zetaclient/chains/solana/observer/outbound.go
+++ b/zetaclient/chains/solana/observer/outbound.go
@@ -151,7 +151,7 @@ func (ob *Observer) PostVoteOutbound(
 		gasLimit = zetacore.PostVoteOutboundGasLimit
 	)
 
-	var retryGasLimit uint64
+	retryGasLimit := zetacore.PostVoteOutboundRetryGasLimit
 	if msg.Status == chains.ReceiveStatus_failed {
 		retryGasLimit = zetacore.PostVoteOutboundRevertGasLimit
 	}

--- a/zetaclient/chains/sui/observer/outbound.go
+++ b/zetaclient/chains/sui/observer/outbound.go
@@ -232,7 +232,7 @@ func (ob *Observer) validateOutbound(cctx *cctypes.CrossChainTx, tx models.SuiTr
 func (ob *Observer) postVoteOutbound(ctx context.Context, msg *cctypes.MsgVoteOutbound) error {
 	const gasLimit = zetacore.PostVoteOutboundGasLimit
 
-	retryGasLimit := uint64(0)
+	retryGasLimit := zetacore.PostVoteOutboundRetryGasLimit
 	if msg.Status == chains.ReceiveStatus_failed {
 		retryGasLimit = zetacore.PostVoteOutboundRevertGasLimit
 	}

--- a/zetaclient/chains/ton/observer/outbound.go
+++ b/zetaclient/chains/ton/observer/outbound.go
@@ -252,7 +252,7 @@ func (ob *Observer) postVoteOutbound(
 
 	const gasLimit = zetacore.PostVoteOutboundGasLimit
 
-	var retryGasLimit uint64
+	retryGasLimit := zetacore.PostVoteOutboundRetryGasLimit
 	if msg.Status == chains.ReceiveStatus_failed {
 		retryGasLimit = zetacore.PostVoteOutboundRevertGasLimit
 	}

--- a/zetaclient/zetacore/constant.go
+++ b/zetaclient/zetacore/constant.go
@@ -39,6 +39,9 @@ const (
 	// PostVoteOutboundRevertGasLimit is the gas limit for voting on observed outbound tx for revert (when outbound fails)
 	// The value is set to 7M because in case of onRevert call, it might consume lot of gas
 	PostVoteOutboundRevertGasLimit = 7_000_000
+
+	// PostVoteOutboundRevertGasLimit is the retry gas limit for voting on observed outbound tx for success outbound
+	PostVoteOutboundRetryGasLimit uint64 = 1_000_000
 )
 
 // constants for monitoring tx results


### PR DESCRIPTION
# Description

Currently if outbound is successful retry gas limit will be 0, meaning there won't be retry for voting if 500k is not enough.
This introduces retry gas limit 1M for all observers.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
