### PR TITLE
fix(e2e): ensure ton deposits to self

### DIFF
--- a/e2e/e2etests/test_ton_deposit.go
+++ b/e2e/e2etests/test_ton_deposit.go
@@ -13,6 +13,12 @@ func TestTONDeposit(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
 	ctx := r.Ctx
+	recipient := r.Account.EVMAddress()
+
+	// Get TON ZRC20 balance before deposit
+	balanceBefore, err := r.TONZRC20.BalanceOf(&bind.CallOpts{}, recipient)
+	require.NoError(r, err)
+	r.Logger.Info("Recipient's zEVM TON balance before deposit: %d", balanceBefore.Uint64())
 
 	// Given gateway
 	gw := toncontracts.NewGateway(r.TONGateway)
@@ -28,25 +34,22 @@ func TestTONDeposit(r *runner.E2ERunner, args []string) {
 	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
 
-	recipient := r.Account.EVMAddress()
-
 	// ACT
 	cctx, err := r.TONDeposit(gw, sender, amount, recipient)
-
-	// ASSERT
 	require.NoError(r, err)
 
+	// ASSERT
 	// Check CCTX
 	expectedDeposit := amount.Sub(depositFee)
-
 	require.Equal(r, sender.GetAddress().ToRaw(), cctx.InboundParams.Sender)
 	require.Equal(r, expectedDeposit.Uint64(), cctx.InboundParams.Amount.Uint64())
 
-	// Check receiver's balance
-	balance, err := r.TONZRC20.BalanceOf(&bind.CallOpts{}, recipient)
+	// Check receiver's balance after deposit
+	balanceAfter, err := r.TONZRC20.BalanceOf(&bind.CallOpts{}, recipient)
 	require.NoError(r, err)
+	r.Logger.Info("Recipient's zEVM TON balance after deposit: %d", balanceAfter.Uint64())
 
-	r.Logger.Info("Recipient's zEVM TON balance after deposit: %d", balance.Uint64())
-
-	require.Equal(r, expectedDeposit.Uint64(), balance.Uint64())
+	// The recipient balance should be increased by the expected deposit amount
+	amountIncreased := bigSub(balanceAfter, balanceBefore)
+	require.Equal(r, expectedDeposit.Uint64(), amountIncreased.Uint64())
 }

--- a/e2e/e2etests/test_ton_deposit.go
+++ b/e2e/e2etests/test_ton_deposit.go
@@ -7,7 +7,6 @@ import (
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
-	"github.com/zeta-chain/node/testutil/sample"
 )
 
 func TestTONDeposit(r *runner.E2ERunner, args []string) {
@@ -29,8 +28,7 @@ func TestTONDeposit(r *runner.E2ERunner, args []string) {
 	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
 
-	// Given sample EVM address
-	recipient := sample.EthAddress()
+	recipient := r.Account.EVMAddress()
 
 	// ACT
 	cctx, err := r.TONDeposit(gw, sender, amount, recipient)


### PR DESCRIPTION
We should be depositing to a real address so that when running live networks we preserve our limited testnet funds.

Also tolerate existence of current balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved deposit test to dynamically use the test runner's account address and verify balance changes before and after deposit, ensuring more accurate validation of deposit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->