### PR TITLE
test: add gaslimit as a argument for withdrawAndCall e2e test

### DIFF
--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -342,6 +342,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw Ether from ZEVM call a contract",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "100000"},
+			{Description: "gas limit for withdraw", DefaultValue: "250000"},
 		},
 		TestETHWithdrawAndCall,
 	),
@@ -350,6 +351,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw Ether from ZEVM call a contract with no message content",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "100000"},
+			{Description: "gas limit for withdraw", DefaultValue: "250000"},
 		},
 		TestETHWithdrawAndCallNoMessage,
 	),
@@ -382,6 +384,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw Ether from ZEVM, revert, then abort with onAbort, check onAbort can created cctx",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "1000000000000000000"},
+			{Description: "gas limit for withdraw", DefaultValue: "250000"},
 		},
 		TestETHWithdrawRevertAndAbort,
 		runner.WithMinimumVersion("v29.0.0"),

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -342,7 +342,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw Ether from ZEVM call a contract",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "100000"},
-			{Description: "gas limit for withdraw", DefaultValue: "250000"},
+			{Description: "gas limit for withdraw", DefaultValue: "14000"},
 		},
 		TestETHWithdrawAndCall,
 	),

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -342,7 +342,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw Ether from ZEVM call a contract",
 		[]runner.ArgDefinition{
 			{Description: "amount in wei", DefaultValue: "100000"},
-			{Description: "gas limit for withdraw", DefaultValue: "14000"},
+			{Description: "gas limit for withdraw", DefaultValue: "250000"},
 		},
 		TestETHWithdrawAndCall,
 	),

--- a/e2e/e2etests/test_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000
@@ -22,6 +22,7 @@ func TestETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	}()
 
 	amount := utils.ParseBigInt(r, args[0])
+	gasLimit := utils.ParseBigInt(r, args[1])
 
 	payload := randomPayload(r)
 
@@ -35,6 +36,7 @@ func TestETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 		amount,
 		[]byte(payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_eth_withdraw_and_call_no_message.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_no_message.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestETHWithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000
@@ -22,6 +22,7 @@ func TestETHWithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	}()
 
 	amount := utils.ParseBigInt(r, args[0])
+	gasLimit := utils.ParseBigInt(r, args[1])
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -31,6 +32,7 @@ func TestETHWithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
 		amount,
 		[]byte{},
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_eth_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_eth_withdraw_revert_and_abort.go
@@ -15,9 +15,10 @@ import (
 )
 
 func TestETHWithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	amount := utils.ParseBigInt(r, args[0])
+	gasLimit := utils.ParseBigInt(r, args[1])
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -39,6 +40,7 @@ func TestETHWithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 			OnRevertGasLimit: big.NewInt(200000),
 			AbortAddress:     testAbortAddr,
 		},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/runner/zevm.go
+++ b/e2e/runner/zevm.go
@@ -128,6 +128,7 @@ func (r *E2ERunner) ETHWithdrawAndCall(
 	amount *big.Int,
 	payload []byte,
 	revertOptions gatewayzevm.RevertOptions,
+	gasLimit *big.Int,
 ) *ethtypes.Transaction {
 	tx, err := r.GatewayZEVM.WithdrawAndCall0(
 		r.ZEVMAuth,


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a gas limit when running Ether withdrawal tests involving contract calls.

- **Tests**
  - Updated Ether withdrawal end-to-end tests to accept a gas limit parameter, allowing more control over test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->