### PR TITLE
chore: update protocol contract version

### DIFF
--- a/e2e/runner/setup_sui.go
+++ b/e2e/runner/setup_sui.go
@@ -46,7 +46,9 @@ func (r *E2ERunner) SetupSui(faucetURL string) {
 	r.RequestSuiFromFaucet(faucetURL, deployerAddress)
 
 	// fund the TSS
+	// request twice from the faucet to ensure TSS has enough funds for the first withdraw
 	// TODO: this step might no longer necessary if a custom solution is implemented for the TSS funding
+	r.RequestSuiFromFaucet(faucetURL, r.SuiTSSAddress)
 	r.RequestSuiFromFaucet(faucetURL, r.SuiTSSAddress)
 
 	// deploy gateway package

--- a/e2e/runner/sui.go
+++ b/e2e/runner/sui.go
@@ -88,7 +88,7 @@ func (r *E2ERunner) SuiWithdrawAndCallSUI(
 		payloadBytes,
 		gatewayzevm.CallOptions{
 			IsArbitraryCall: false,
-			GasLimit:        big.NewInt(20000),
+			GasLimit:        big.NewInt(100000),
 		},
 		revertOptions,
 	)
@@ -138,7 +138,7 @@ func (r *E2ERunner) SuiWithdrawAndCallFungibleToken(
 		payloadBytes,
 		gatewayzevm.CallOptions{
 			IsArbitraryCall: false,
-			GasLimit:        big.NewInt(20000),
+			GasLimit:        big.NewInt(100000),
 		},
 		revertOptions,
 	)

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zeta-chain/ethermint v0.0.0-20250211180824-ea52413a15f3
-	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc
+	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250505190744-1b0bce7ec4da
 	go.nhat.io/grpcmock v0.25.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56

--- a/go.sum
+++ b/go.sum
@@ -1416,6 +1416,8 @@ github.com/zeta-chain/go-tss v0.5.0 h1:vXFEXPC5fSDhlcsU515/vUYGKQWAFj4PfwjrZnbtA
 github.com/zeta-chain/go-tss v0.5.0/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc h1:oXw/b55v4KbX5KV7CELt5IRNDwu6w6g/P6jY2ARYzUQ=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
+github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250505190744-1b0bce7ec4da h1:QxpqQTfFPloM8wlr59TIHA1wI9SpCvFNJ4b7PQGXucE=
+github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250505190744-1b0bce7ec4da/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46 h1:xbgrVDXWkZaWhMAuD3Q5A13jmRKYQbjZMPBaCkv3cns=
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46/go.mod h1:DcDY828o773soiU/h0XpC+naxitrIMFVZqEvq/EJxMA=
 github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901 h1:9whtN5fjYHfk4yXIuAsYP2EHxImwDWDVUOnZJ2pfL3w=


### PR DESCRIPTION
Use contract that includes changes from https://github.com/zeta-chain/protocol-contracts/pull/497 to check E2E tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased gas limit for certain Sui withdrawal operations to improve reliability.
  - Enhanced Sui setup process to ensure sufficient funds are available for initial withdrawals.

- **Chores**
  - Updated a protocol contracts dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->