### PR TITLE
fix: increase evm tx broadcast timeout to 15 seconds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,7 @@
 * [3786](https://github.com/zeta-chain/node/pull/3786) - reorder end block order to allow gov changes to be added before staking.
 * [3821](https://github.com/zeta-chain/node/pull/3821) - set retry gas limit if outbound is successful
 * [3847](https://github.com/zeta-chain/node/pull/3847) - have EVM chain tracker reporter monitor `nonce too low` outbound hashes
+* [3863](https://github.com/zeta-chain/node/pull/3863) - give enough timeout to the EVM chain transaction broadcasting
 
 ### Tests
 

--- a/zetaclient/chains/evm/signer/signer.go
+++ b/zetaclient/chains/evm/signer/signer.go
@@ -36,6 +36,10 @@ const (
 
 	// broadcastRetries is the maximum number of retries for broadcasting a transaction
 	broadcastRetries = 5
+
+	// broadcastTimeout is the timeout for broadcasting a transaction
+	// we should allow enough time for the tx submission and avoid fast timeout
+	broadcastTimeout = time.Second * 15
 )
 
 var (
@@ -226,7 +230,7 @@ func newTx(
 }
 
 func (signer *Signer) broadcast(ctx context.Context, tx *ethtypes.Transaction) error {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, broadcastTimeout)
 	defer cancel()
 
 	return signer.client.SendTransaction(ctx, tx)


### PR DESCRIPTION
# Description

`1 second` timeout is too short for tx broadcasting. Early timeout potentially lead to missed outbound tracker in Arbitrum.

The reasons is:
When the initial tx broadcasting gets timeout, all the subsequent retries will return `nonce too low` in Arbitrum, therefore ignores the outbound tracker posting.


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved transaction broadcasting reliability for EVM chains by increasing the timeout duration, reducing the likelihood of failed broadcasts due to timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->