### PR TITLE
chore: increase solana_deposit and solana_withdraw suggested amounts

### DIFF
--- a/e2e/TESTING_GUIDE.md
+++ b/e2e/TESTING_GUIDE.md
@@ -38,7 +38,7 @@ eth_deposit_and_call:1000 eth_withdraw_and_call:1000 erc20_deposit_and_call:1000
 When it is necessary to test the Solana workflows, SOL and SPL tokens.
 
 ```
-solana_deposit:1000 solana_withdraw:1000 solana_deposit_and_call:1000 spl_deposit:1000 spl_withdraw:1000 spl_deposit_and_call:1000 solana_deposit_and_call_revert:20000
+solana_deposit:10000000 solana_withdraw:10000000 solana_deposit_and_call:1000 spl_deposit:1000 spl_withdraw:1000 spl_deposit_and_call:1000 solana_deposit_and_call_revert:20000
 ```
 
 ## Gateway revert workflow

--- a/e2e/TESTING_GUIDE.md
+++ b/e2e/TESTING_GUIDE.md
@@ -38,7 +38,7 @@ eth_deposit_and_call:1000 eth_withdraw_and_call:1000 erc20_deposit_and_call:1000
 When it is necessary to test the Solana workflows, SOL and SPL tokens.
 
 ```
-solana_deposit:10000000 solana_withdraw:10000000 solana_deposit_and_call:1000 spl_deposit:1000 spl_withdraw:1000 spl_deposit_and_call:1000 solana_deposit_and_call_revert:20000
+solana_deposit:10000000 solana_withdraw:10000000 solana_deposit_and_call:1000 spl_deposit:1000 spl_withdraw:1000 spl_deposit_and_call:1000 solana_deposit_and_call_revert:10000000
 ```
 
 ## Gateway revert workflow


### PR DESCRIPTION
# Description

For Solana, there is minimum amount set in protocol code to ensure rent. This new value is larger than that.

solana_deposit value is also increased, not for its own sake but to ensure that we don't end up with an E2E wallet imbalance from one side moving drastically more than the other.

# How Has This Been Tested?

Changed values work in e2e tests. https://github.com/zeta-chain/e2e/actions/runs/14959281793/job/42019112905

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the E2E testing guide to reflect increased test amounts for Solana deposit and withdraw workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->