### PR TITLE
feat(tss): bump go-tss & logging improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -313,7 +313,7 @@ require (
 	github.com/pattonkan/sui-go v0.1.0
 	github.com/showa-93/go-mask v0.6.2
 	github.com/tonkeeper/tongo v1.14.8
-	github.com/zeta-chain/go-tss v0.6.1
+	github.com/zeta-chain/go-tss v0.6.2
 	github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46
 )
 

--- a/go.mod
+++ b/go.mod
@@ -313,7 +313,7 @@ require (
 	github.com/pattonkan/sui-go v0.1.0
 	github.com/showa-93/go-mask v0.6.2
 	github.com/tonkeeper/tongo v1.14.8
-	github.com/zeta-chain/go-tss v0.6.0
+	github.com/zeta-chain/go-tss v0.6.1
 	github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1420,6 +1420,8 @@ github.com/zeta-chain/go-tss v0.6.0 h1:kxIBsqaq24qNJ36h6HR/rEEY84xjN2tE03KbJykoo
 github.com/zeta-chain/go-tss v0.6.0/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
 github.com/zeta-chain/go-tss v0.6.1 h1:MRELa9A9ANHjLfX1AhjHp8aqciUZRjW/NLj4jYW2Ark=
 github.com/zeta-chain/go-tss v0.6.1/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
+github.com/zeta-chain/go-tss v0.6.2 h1:cFXKVd+mSHr8Sc5xheARIBUwK2N4Fx/Qr/hIhb0Ce5E=
+github.com/zeta-chain/go-tss v0.6.2/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc h1:oXw/b55v4KbX5KV7CELt5IRNDwu6w6g/P6jY2ARYzUQ=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250505190744-1b0bce7ec4da h1:QxpqQTfFPloM8wlr59TIHA1wI9SpCvFNJ4b7PQGXucE=

--- a/go.sum
+++ b/go.sum
@@ -1418,6 +1418,8 @@ github.com/zeta-chain/go-tss v0.5.1-0.20250501131202-70bd876407f5 h1:jCaxpa5+M/2
 github.com/zeta-chain/go-tss v0.5.1-0.20250501131202-70bd876407f5/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
 github.com/zeta-chain/go-tss v0.6.0 h1:kxIBsqaq24qNJ36h6HR/rEEY84xjN2tE03KbJykooJA=
 github.com/zeta-chain/go-tss v0.6.0/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
+github.com/zeta-chain/go-tss v0.6.1 h1:MRELa9A9ANHjLfX1AhjHp8aqciUZRjW/NLj4jYW2Ark=
+github.com/zeta-chain/go-tss v0.6.1/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc h1:oXw/b55v4KbX5KV7CELt5IRNDwu6w6g/P6jY2ARYzUQ=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250318094825-429d8390b7fc/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250505190744-1b0bce7ec4da h1:QxpqQTfFPloM8wlr59TIHA1wI9SpCvFNJ4b7PQGXucE=

--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-docker run -it --rm -w /node -v "$(pwd):/node" ghcr.io/zeta-chain/gosec:2.21.4-zeta2 -exclude-generated -exclude-dir testutil ./...
+image=ghcr.io/zeta-chain/gosec:2.21.4-zeta2
+
+docker run -it --rm -w /node -v "$(pwd):/node" \
+  -e GO111MODULE=on -e GOTOOLCHAIN=auto \
+  $image -exclude-generated -exclude-dir testutil ./...
+


### PR DESCRIPTION
- [x] Bump go-tss
- [x] Fix `make lint-gosec`
- [x] Streamline & unify tss logging fields across zetaclient and go-tss
- [x] Reuse tss messageId from go-tss
- [x] Add message id to `"TSS keysign response"`


```sh
 ▸ ~/Code/zeta/node ▸ git:feat/bump-go-tss-4 ▸ docker logs -f zetaclient0 | grep "d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e"

2025-05-16T11:38:09Z INF Keysign request module=tss msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e request.block_height=177 request.messages=["lX01/RYxXFBVS3DhpVqi08dR4IMLH6KRshYMmZ9KzTc="] tss.block_height=177 tss.chain_id=1337 tss.nonce=32
2025-05-16T11:38:10Z INF Joined party for keysign latency=0.505971723 module=tss msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e p2p_leader=16Uiu2HAmNXQwweGUukZHmrrVi5Xc5ZBaLuciYaWQWWWevocmm63u
2025-05-16T11:38:10Z INF Keysign parties component=keysign module=tss msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e parties=["zetapub1addwnpepq0dvyaxef5z7grm9as4ecparst20sy478vg9z8t7lxqjtcfs7pv5jvn74sx","zetapub1addwnpepqwf2gzg9yaz874dpt7d0hyu7atnzv2zqr0tryngr0mvrkynuuspaczhjjd2"]
2025-05-16T11:38:10Z INF Successfully signed the message component=keysign p2p_host=16Uiu2HAmTNwCxcE5onWxKsCdgSqs6jtVRvfw5aWA3ojUYw1aKgNk module=tss msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e
2025-05-16T11:38:10Z INF TSS keysign response module=tss_service msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e tss.block_height=177 tss.chain_id=1337 tss.latency=0.85 tss.nonce=32 tss.success=true
2025-05-16T11:38:12Z INF Signature cache hit module=tss_service msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e tss.block_height=178 tss.chain_id=1337 tss.nonce=32
2025-05-16T11:38:14Z INF Signature cache hit module=tss_service msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e tss.block_height=179 tss.chain_id=1337 tss.nonce=32
2025-05-16T11:38:16Z INF Signature cache hit module=tss_service msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e tss.block_height=180 tss.chain_id=1337 tss.nonce=32
2025-05-16T11:38:19Z INF Signature cache hit module=tss_service msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e tss.block_height=181 tss.chain_id=1337 tss.nonce=32
2025-05-16T11:38:21Z INF Signature cache hit module=tss_service msg_id=d280de72b3991f1f64139519bc6e54f4d3d0178d76ffd30bd255e808264db59e tss.block_height=182 tss.chain_id=1337 tss.nonce=32
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated a dependency to a newer version for improved stability.
	- Enhanced the Go security scanning script for better readability and environment consistency.
- **Refactor**
	- Simplified and unified logging and cache key generation in the TSS service.
	- Standardized log field names for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->