### PR TITLE
test: fix sim tests

### DIFF
--- a/x/crosschain/simulation/operation_vote_outbound.go
+++ b/x/crosschain/simulation/operation_vote_outbound.go
@@ -92,7 +92,7 @@ func SimulateVoteOutbound(k keeper.Keeper) simtypes.Operation {
 			return simtypes.NoOpMsg(types.ModuleName, TypeMsgVoteOutbound, "tss not found"), nil, nil
 		}
 
-		asset, err := zetasimulation.GetAsset(ctx, k.GetFungibleKeeper(), from)
+		asset, err := zetasimulation.GetAsset(ctx, k.GetFungibleKeeper(), to)
 		if err != nil {
 			return simtypes.NoOpMsg(types.ModuleName, TypeMsgVoteOutbound, "unable to get asset"), nil, err
 		}


### PR DESCRIPTION
# Description

failing for couple of days on develop branch due to asset missing on receiver chain after this change https://github.com/zeta-chain/node/pull/3869/files#diff-6c6b704f695ab2e9a14e02b6250c74d01482566e72f7afaf1c25bfecda5bbda6R209

fixing simulation outbounds to set asset belonging to receiver chain, not sender, to align with this
 
# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected asset retrieval in outbound vote simulations to ensure the appropriate asset is selected for the destination chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->