### PR TITLE
fix: prevent cctx being set as `abortRefunded` if the abort processing failed before the refund

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@
 * [3850](https://github.com/zeta-chain/node/pull/3850) - broadcast single sui withdraw tx at a time to avoid nonce mismatch failure
 * [3877](https://github.com/zeta-chain/node/pull/3877) - use multiple SUI coin objects to pay PTB transaction gas fee
 * [3890](https://github.com/zeta-chain/node/pull/3890) - solana abort address format
+* [3901](https://github.com/zeta-chain/node/pull/3901) - prevent cctx being set as abortRefunded if the abort processing failed before the refund
 
 ### Tests
 

--- a/x/crosschain/keeper/abort.go
+++ b/x/crosschain/keeper/abort.go
@@ -94,12 +94,14 @@ func (k Keeper) ProcessAbort(
 	if err != nil {
 		messages.ErrorMessageAbort = "failed to process abort: " + err.Error()
 	}
+	// note: we still set this value to true if onAbort reverted because the funds will still be deposited to the abortAddress
+	if err == nil || errors.Is(err, fungibletypes.ErrOnAbortFailed) {
+		cctx.CctxStatus.IsAbortRefunded = true
+	}
 
 	// commit state change from the deposit and eventual cctx events
 	commit()
 
-	// note: we still set this value to true if onAbort reverted because the funds will still be deposited to the abortAddress
-	cctx.CctxStatus.IsAbortRefunded = true
 	cctx.CctxStatus.UpdateStatusAndErrorMessages(types.CctxStatus_Aborted, messages)
 
 	return

--- a/x/fungible/types/evm.go
+++ b/x/fungible/types/evm.go
@@ -1,10 +1,17 @@
 package types
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/core/vm"
 	evmtypes "github.com/zeta-chain/ethermint/x/evm/types"
+)
+
+var (
+	// ErrOnAbortFailed is the error message for failed onAbort
+	// It is used to handle case where abort amount is refunded but onAbort is not implemented
+	ErrOnAbortFailed = errors.New("onAbort failed")
 )
 
 // IsRevertError checks if an error is a evm revert error


### PR DESCRIPTION
# Description

Fixes https://github.com/zeta-chain/protocol-private/issues/244 

Add also some tests that were missing for processAbort


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of cross-chain transaction aborts to ensure transactions are not incorrectly marked as refunded if the abort processing fails before the refund is completed.

- **Tests**
  - Enhanced test coverage for abort processing, including new tests for different error scenarios during aborts.

- **Documentation**
  - Updated changelog to reflect the fix in cross-chain transaction abort handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->