### PR TITLE
feat: revert restricted cctx for evm chain, bitcoin and solana

### DIFF
--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -751,6 +751,7 @@ var AllE2ETests = []runner.E2ETest{
 		[]runner.ArgDefinition{
 			{Description: "receiver", DefaultValue: sample.RestrictedSolAddressTest},
 			{Description: "amount in lamport", DefaultValue: "1000000"},
+			{Description: "revert address", DefaultValue: sample.RevertAddressZEVM},
 		},
 		TestSolanaWithdrawRestricted,
 		runner.WithMinimumVersion("v29.0.0"),
@@ -988,7 +989,9 @@ var AllE2ETests = []runner.E2ETest{
 		TestSuiWithdrawRestrictedName,
 		"withdraw SUI from ZEVM to restricted address",
 		[]runner.ArgDefinition{
+			{Description: "receiver", DefaultValue: sample.RestrictedSuiAddressTest},
 			{Description: "amount in mist", DefaultValue: "1000000"},
+			{Description: "revert address", DefaultValue: sample.RevertAddressZEVM},
 		},
 		TestSuiWithdrawRestrictedAddress,
 	),
@@ -1169,7 +1172,9 @@ var AllE2ETests = []runner.E2ETest{
 		TestBitcoinWithdrawRestrictedName,
 		"withdraw Bitcoin from ZEVM to restricted address",
 		[]runner.ArgDefinition{
+			{Description: "receiver", DefaultValue: sample.RestrictedBtcAddressTest},
 			{Description: "amount in btc", DefaultValue: "0.001"},
+			{Description: "revert address", DefaultValue: sample.RevertAddressZEVM},
 		},
 		TestBitcoinWithdrawRestricted,
 	),
@@ -1630,7 +1635,9 @@ var AllE2ETests = []runner.E2ETest{
 		TestEtherWithdrawRestrictedName,
 		"withdraw Ether from ZEVM to restricted address (v1 protocol contracts)",
 		[]runner.ArgDefinition{
+			{Description: "receiver", DefaultValue: sample.RestrictedEVMAddressTest},
 			{Description: "amount in wei", DefaultValue: "100000"},
+			{Description: "revert address", DefaultValue: sample.RevertAddressZEVM},
 		},
 		TestEtherWithdrawRestricted,
 	),

--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -7,14 +7,9 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/btcsuite/btcd/btcjson"
-	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zeta-chain/node/e2e/runner"
-	"github.com/zeta-chain/node/e2e/utils"
-	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 // randomPayload generates a random payload to be used in gateway calls for testing purposes
@@ -24,43 +19,6 @@ func randomPayload(r *runner.E2ERunner) string {
 	require.NoError(r, err)
 
 	return hex.EncodeToString(bytes)
-}
-
-func withdrawBTCZRC20(r *runner.E2ERunner, to btcutil.Address, amount *big.Int) *btcjson.TxRawResult {
-	// approve and withdraw on ZRC20 contract
-	receipt := r.WithdrawBTC(to, amount, true)
-
-	// mine blocks if testing on regnet
-	stop := r.MineBlocksIfLocalBitcoin()
-	defer stop()
-
-	// get cctx and check status
-	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, receipt.TxHash.Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
-
-	// get bitcoin tx according to the outTxHash in cctx
-	outTxHash := cctx.GetCurrentOutboundParam().Hash
-	hash, err := chainhash.NewHashFromStr(outTxHash)
-	require.NoError(r, err)
-
-	rawTx, err := r.BtcRPCClient.GetRawTransactionVerbose(r.Ctx, hash)
-	require.NoError(r, err)
-
-	r.Logger.Info("raw tx:")
-	r.Logger.Info("  TxIn: %d", len(rawTx.Vin))
-	for idx, txIn := range rawTx.Vin {
-		r.Logger.Info("  TxIn %d:", idx)
-		r.Logger.Info("    TxID:Vout:  %s:%d", txIn.Txid, txIn.Vout)
-		r.Logger.Info("    ScriptSig: %s", txIn.ScriptSig.Hex)
-	}
-	r.Logger.Info("  TxOut: %d", len(rawTx.Vout))
-	for _, txOut := range rawTx.Vout {
-		r.Logger.Info("  TxOut %d:", txOut.N)
-		r.Logger.Info("    Value: %.8f", txOut.Value)
-		r.Logger.Info("    ScriptPubKey: %s", txOut.ScriptPubKey.Hex)
-	}
-
-	return rawTx
 }
 
 // bigAdd is shorthand for new(big.Int).Add(x, y)

--- a/e2e/e2etests/legacy/test_erc20_multiple_withdraws.go
+++ b/e2e/e2etests/legacy/test_erc20_multiple_withdraws.go
@@ -84,6 +84,6 @@ func TestMultipleERC20Withdraws(r *runner.E2ERunner, args []string) {
 
 	// verify the withdraw value
 	for _, cctx := range cctxs {
-		r.VerifyTransferAmountFromCCTX(cctx, withdrawalAmount.Int64())
+		r.EVMVerifyOutboundTransferAmount(cctx.GetCurrentOutboundParam().Hash, withdrawalAmount.Int64())
 	}
 }

--- a/e2e/e2etests/legacy/test_erc20_withdraw.go
+++ b/e2e/e2etests/legacy/test_erc20_withdraw.go
@@ -29,5 +29,5 @@ func TestERC20Withdraw(r *runner.E2ERunner, args []string) {
 	// verify the withdraw value
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 
-	r.VerifyTransferAmountFromCCTX(cctx, withdrawalAmount.Int64())
+	r.EVMVerifyOutboundTransferAmount(cctx.GetCurrentOutboundParam().Hash, withdrawalAmount.Int64())
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_legacy.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_legacy.go
@@ -1,11 +1,15 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestBitcoinWithdrawLegacy(r *runner.E2ERunner, args []string) {
@@ -18,5 +22,10 @@ func TestBitcoinWithdrawLegacy(r *runner.E2ERunner, args []string) {
 	_, ok := receiver.(*btcutil.AddressPubKeyHash)
 	require.True(r, ok, "Invalid receiver address specified for TestBitcoinWithdrawLegacy.")
 
-	withdrawBTCZRC20(r, receiver, amount)
+	r.WithdrawBTCAndWaitCCTX(
+		receiver,
+		amount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		crosschaintypes.CctxStatus_OutboundMined,
+	)
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_multiple.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_multiple.go
@@ -1,11 +1,15 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/chains"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 const defaultReceiver = "mxpYha3UJKUgSwsAz2qYRqaDSwAkKZ3YEY"
@@ -25,6 +29,11 @@ func WithdrawBitcoinMultipleTimes(r *runner.E2ERunner, args []string) {
 
 	// ACT
 	for i := 0; i < times; i++ {
-		withdrawBTCZRC20(r, receiver, amount)
+		r.WithdrawBTCAndWaitCCTX(
+			receiver,
+			amount,
+			gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+			crosschaintypes.CctxStatus_OutboundMined,
+		)
 	}
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_p2sh.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_p2sh.go
@@ -1,11 +1,15 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestBitcoinWithdrawP2SH(r *runner.E2ERunner, args []string) {
@@ -18,5 +22,10 @@ func TestBitcoinWithdrawP2SH(r *runner.E2ERunner, args []string) {
 	_, ok := receiver.(*btcutil.AddressScriptHash)
 	require.True(r, ok, "Invalid receiver address specified for TestBitcoinWithdrawP2SH.")
 
-	withdrawBTCZRC20(r, receiver, amount)
+	r.WithdrawBTCAndWaitCCTX(
+		receiver,
+		amount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		crosschaintypes.CctxStatus_OutboundMined,
+	)
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_p2wsh.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_p2wsh.go
@@ -1,11 +1,15 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestBitcoinWithdrawP2WSH(r *runner.E2ERunner, args []string) {
@@ -17,5 +21,10 @@ func TestBitcoinWithdrawP2WSH(r *runner.E2ERunner, args []string) {
 	_, ok := receiver.(*btcutil.AddressWitnessScriptHash)
 	require.True(r, ok, "Invalid receiver address specified for TestBitcoinWithdrawP2WSH.")
 
-	withdrawBTCZRC20(r, receiver, amount)
+	r.WithdrawBTCAndWaitCCTX(
+		receiver,
+		amount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		crosschaintypes.CctxStatus_OutboundMined,
+	)
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_restricted_address.go
@@ -3,32 +3,56 @@ package e2etests
 import (
 	"math/big"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestBitcoinWithdrawRestricted(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 3)
 
-	withdrawalAmount := utils.ParseFloat(r, args[0])
-	amount := utils.BTCAmountFromFloat64(r, withdrawalAmount)
+	// ARRANGE
+	// Given amount, restricted BTC P2WPKH address, revert address
+	addressRestricted, err := chains.DecodeBtcAddress(args[0], chains.BitcoinRegtest.ChainId)
+	require.NoError(r, err)
+	amountStr := utils.ParseFloat(r, args[1])
+	amount := utils.BTCAmountFromFloat64(r, amountStr)
+	revertAddress := ethcommon.HexToAddress(args[2])
 
-	withdrawBitcoinRestricted(r, amount)
-}
-
-func withdrawBitcoinRestricted(r *runner.E2ERunner, amount *big.Int) {
-	// use restricted BTC P2WPKH address
-	addressRestricted, err := chains.DecodeBtcAddress(
-		sample.RestrictedBtcAddressTest,
-		chains.BitcoinRegtest.ChainId,
-	)
+	// balance before
+	revertBalanceBefore, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
 	require.NoError(r, err)
 
-	// the cctx should be cancelled
-	rawTx := withdrawBTCZRC20(r, addressRestricted, amount)
-	require.Len(r, rawTx.Vout, 2, "BTC cancelled outtx rawTx.Vout should have 2 outputs")
+	// ACT
+	// the cctx should be reverted
+	rawTx := r.WithdrawBTCAndWaitCCTX(
+		addressRestricted,
+		amount,
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
+		crosschaintypes.CctxStatus_Reverted,
+	)
+
+	// ASSERT
+	// normal withdraw tx has 3 outputs: [nonce, payment, change], but a cancel tx should have only 2 outputs: [nonce, change]
+	require.Len(r, rawTx.Vout, 2, "BTC cancelled tx should have 2 outputs")
+
+	// receiver balance should not change
+	unspent, err := r.BtcRPCClient.ListUnspentMinMaxAddresses(r.Ctx, 1, 9999999, []btcutil.Address{addressRestricted})
+	require.NoError(r, err)
+	require.Empty(r, unspent)
+
+	// revert address should receive the amount
+	revertBalanceAfter, err := r.BTCZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_segwit.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_segwit.go
@@ -1,11 +1,15 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestBitcoinWithdrawSegWit(r *runner.E2ERunner, args []string) {
@@ -17,5 +21,10 @@ func TestBitcoinWithdrawSegWit(r *runner.E2ERunner, args []string) {
 	_, ok := receiver.(*btcutil.AddressWitnessPubKeyHash)
 	require.True(r, ok, "Invalid receiver address specified for TestBitcoinWithdrawSegWit.")
 
-	withdrawBTCZRC20(r, receiver, amount)
+	r.WithdrawBTCAndWaitCCTX(
+		receiver,
+		amount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		crosschaintypes.CctxStatus_OutboundMined,
+	)
 }

--- a/e2e/e2etests/test_bitcoin_withdraw_taproot.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_taproot.go
@@ -1,11 +1,15 @@
 package e2etests
 
 import (
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 func TestBitcoinWithdrawTaproot(r *runner.E2ERunner, args []string) {
@@ -17,5 +21,10 @@ func TestBitcoinWithdrawTaproot(r *runner.E2ERunner, args []string) {
 	_, ok := receiver.(*btcutil.AddressTaproot)
 	require.True(r, ok, "Invalid receiver address specified for TestBitcoinWithdrawTaproot.")
 
-	withdrawBTCZRC20(r, receiver, amount)
+	r.WithdrawBTCAndWaitCCTX(
+		receiver,
+		amount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		crosschaintypes.CctxStatus_OutboundMined,
+	)
 }

--- a/e2e/e2etests/test_eth_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_eth_withdraw_restricted_address.go
@@ -3,28 +3,44 @@ package e2etests
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
-	"github.com/zeta-chain/node/testutil/sample"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 // TestEtherWithdrawRestricted tests the withdrawal to a restricted receiver address
 func TestEtherWithdrawRestricted(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 3)
 
-	amount := utils.ParseBigInt(r, args[0])
+	// ARRANGE
+	// Given amount, receiver, revert address
+	receiver := ethcommon.HexToAddress(args[0])
+	amount := utils.ParseBigInt(r, args[1])
+	revertAddress := ethcommon.HexToAddress(args[2])
+
+	// balances before
+	receiverBalanceBefore, err := r.EVMClient.BalanceAt(r.Ctx, receiver, nil)
+	require.NoError(r, err)
+	revertBalanceBefore, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+
+	// approve the ZRC20
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
+	// ACT
 	// perform the withdraw on restricted address
 	tx := r.ETHWithdraw(
-		ethcommon.HexToAddress(sample.RestrictedEVMAddressTest),
+		receiver,
 		amount,
-		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
 	)
 
 	r.Logger.EVMTransaction(*tx, "withdraw to restricted address")
@@ -35,12 +51,23 @@ func TestEtherWithdrawRestricted(r *runner.E2ERunner, args []string) {
 	r.Logger.EVMReceipt(*receipt, "withdraw")
 	r.Logger.ZRC20Withdrawal(r.ETHZRC20, *receipt, "withdraw")
 
-	// verify the withdrawal value
+	// ASSERT
+	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, receipt.TxHash.Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// the cctx should be cancelled with zero value
-	r.VerifyTransferAmountFromCCTX(cctx, 0)
+	// note: the first outbound param is the cancel transaction
+	r.EVMVerifyOutboundTransferAmount(cctx.OutboundParams[0].Hash, 0)
+
+	// receiver balance should not change
+	receiverBalanceAfter, err := r.EVMClient.BalanceAt(r.Ctx, receiver, nil)
+	require.NoError(r, err)
+	require.EqualValues(r, receiverBalanceBefore, receiverBalanceAfter)
+
+	// revert address should receive the amount
+	revertBalanceAfter, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 }

--- a/e2e/e2etests/test_solana_withdraw.go
+++ b/e2e/e2etests/test_solana_withdraw.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
@@ -38,7 +39,12 @@ func TestSolanaWithdraw(r *runner.E2ERunner, args []string) {
 	privkey := r.GetSolanaPrivKey()
 
 	// withdraw
-	tx := r.WithdrawSOLZRC20(privkey.PublicKey(), withdrawAmount, approvedAmount)
+	tx := r.WithdrawSOLZRC20(
+		privkey.PublicKey(),
+		withdrawAmount,
+		approvedAmount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+	)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)

--- a/e2e/e2etests/test_solana_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_solana_withdraw_restricted_address.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
@@ -14,9 +18,10 @@ import (
 )
 
 func TestSolanaWithdrawRestricted(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 2)
+	require.Len(r, args, 3)
 
-	// parse restricted address
+	// ARRANGE
+	// Given amount, receiver, revert address
 	receiverRestricted, err := chains.DecodeSolanaWalletAddress(args[0])
 	require.NoError(r, err, fmt.Sprintf("unable to decode solana wallet address: %s", args[0]))
 
@@ -29,14 +34,42 @@ func TestSolanaWithdrawRestricted(r *runner.E2ERunner, args []string) {
 		withdrawAmount.Cmp(approvedAmount),
 		"Withdrawal amount must be less than the approved amount (1e9).",
 	)
+	revertAddress := ethcommon.HexToAddress(args[2])
+
+	// balances before
+	result, err := r.SolanaClient.GetBalance(r.Ctx, receiverRestricted, rpc.CommitmentFinalized)
+	require.NoError(r, err)
+	receiverBalanceBefore := result.Value
+	revertBalanceBefore, err := r.SOLZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
 
 	// withdraw
-	tx := r.WithdrawSOLZRC20(receiverRestricted, withdrawAmount, approvedAmount)
+	tx := r.WithdrawSOLZRC20(
+		receiverRestricted,
+		withdrawAmount,
+		approvedAmount,
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
+	)
 
-	// wait for the cctx to be mined
+	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-	// the cctx should be cancelled with zero value
-	r.VerifySolanaWithdrawalAmountFromCCTX(cctx, 0)
+	// the outbound should be cancelled with zero value
+	// note: the first outbound param is the cancel transaction
+	r.SolanaVerifyWithdrawalAmount(cctx.OutboundParams[0].Hash, 0)
+
+	// receiver balance should not change
+	result, err = r.SolanaClient.GetBalance(r.Ctx, receiverRestricted, rpc.CommitmentFinalized)
+	require.NoError(r, err)
+	receiverBalanceAfter := result.Value
+	require.EqualValues(r, receiverBalanceBefore, receiverBalanceAfter)
+
+	// revert address should receive the amount
+	revertBalanceAfter, err := r.SOLZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, withdrawAmount), revertBalanceAfter)
 }

--- a/e2e/e2etests/test_solana_withdraw_revert_executable_receiver.go
+++ b/e2e/e2etests/test_solana_withdraw_revert_executable_receiver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
@@ -36,7 +37,12 @@ func TestSolanaWithdrawRevertExecutableReceiver(r *runner.E2ERunner, args []stri
 	)
 
 	// withdraw using example connected program as receiver
-	tx := r.WithdrawSOLZRC20(runner.ConnectedProgramID, withdrawAmount, approvedAmount)
+	tx := r.WithdrawSOLZRC20(
+		runner.ConnectedProgramID,
+		withdrawAmount,
+		approvedAmount,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+	)
 
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)

--- a/e2e/e2etests/test_sui_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_sui_withdraw_restricted_address.go
@@ -4,27 +4,25 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
 
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
-	"github.com/zeta-chain/node/testutil/sample"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 // TestSuiWithdrawRestrictedAddress tests that a withdrawal to a restricted address reverts to a revert address
 // the test also add a case to check withdrawal to Sui invalid address immediately fail, we don't add a dedicated test as this is a small logic
 func TestSuiWithdrawRestrictedAddress(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
-	amount := utils.ParseBigInt(r, args[0])
-
-	// Restricted address
+	require.Len(r, args, 3)
 
 	// ARRANGE
-	// Given receiver, revert address
-	receiver := sample.RestrictedSuiAddressTest
-	revertAddress := sample.EthAddress()
+	// Given amount, receiver, revert address
+	receiver := args[0]
+	amount := utils.ParseBigInt(r, args[1])
+	revertAddress := ethcommon.HexToAddress(args[2])
 
 	// balances before
 	receiverBalanceBefore := r.SuiGetSUIBalance(receiver)

--- a/e2e/runner/solana.go
+++ b/e2e/runner/solana.go
@@ -577,6 +577,7 @@ func (r *E2ERunner) WithdrawSOLZRC20(
 	to solana.PublicKey,
 	amount *big.Int,
 	approveAmount *big.Int,
+	revertOptions gatewayzevm.RevertOptions,
 ) *ethtypes.Transaction {
 	// approve
 	tx, err := r.SOLZRC20.Approve(r.ZEVMAuth, r.GatewayZEVMAddr, approveAmount)
@@ -590,7 +591,7 @@ func (r *E2ERunner) WithdrawSOLZRC20(
 		[]byte(to.String()),
 		amount,
 		r.SOLZRC20Addr,
-		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		revertOptions,
 	)
 	require.NoError(r, err)
 	r.Logger.EVMTransaction(*tx, "withdraw")

--- a/e2e/runner/verify.go
+++ b/e2e/runner/verify.go
@@ -7,17 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	solanacontracts "github.com/zeta-chain/node/pkg/contracts/solana"
-	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
-// VerifyTransferAmountFromCCTX verifies the transfer amount from the CCTX on EVM
-func (r *E2ERunner) VerifyTransferAmountFromCCTX(cctx *crosschaintypes.CrossChainTx, amount int64) {
-	r.Logger.Info("outTx hash %s", cctx.GetCurrentOutboundParam().Hash)
-
-	receipt, err := r.EVMClient.TransactionReceipt(
-		r.Ctx,
-		ethcommon.HexToHash(cctx.GetCurrentOutboundParam().Hash),
-	)
+// EVMVerifyOutboundTransferAmount verifies the transfer amount on EVM chain for given outbound hash
+func (r *E2ERunner) EVMVerifyOutboundTransferAmount(outboundHash string, amount int64) {
+	receipt, err := r.EVMClient.TransactionReceipt(r.Ctx, ethcommon.HexToHash(outboundHash))
 	require.NoError(r, err)
 
 	r.Logger.Info("Receipt txhash %s status %d", receipt.TxHash, receipt.Status)
@@ -32,13 +26,10 @@ func (r *E2ERunner) VerifyTransferAmountFromCCTX(cctx *crosschaintypes.CrossChai
 	}
 }
 
-// VerifySolanaWithdrawalAmountFromCCTX verifies the withdrawn amount on Solana for given CCTX
-func (r *E2ERunner) VerifySolanaWithdrawalAmountFromCCTX(cctx *crosschaintypes.CrossChainTx, amount uint64) {
-	txHash := cctx.GetCurrentOutboundParam().Hash
-	r.Logger.Info("outbound hash %s", txHash)
-
+// SolanaVerifyWithdrawalAmount verifies the withdrawn amount on Solana for given outbound hash
+func (r *E2ERunner) SolanaVerifyWithdrawalAmount(outboundHash string, amount uint64) {
 	// convert txHash to signature
-	sig, err := solana.SignatureFromBase58(txHash)
+	sig, err := solana.SignatureFromBase58(outboundHash)
 	require.NoError(r, err)
 
 	// query transaction by signature

--- a/testutil/sample/zetaclient.go
+++ b/testutil/sample/zetaclient.go
@@ -12,6 +12,7 @@ const (
 	RestrictedBtcAddressTest = "bcrt1qzp4gt6fc7zkds09kfzaf9ln9c5rvrzxmy6qmpp"
 	RestrictedSolAddressTest = "9fA4vYZfCa9k9UHjnvYCk4YoipsooapGciKMgaTBw9UH"
 	RestrictedSuiAddressTest = "0x14454c46e2ac4603adaa15df30e5dbf7662c3177db4b83c326bed5663d25d1bd"
+	RevertAddressZEVM        = "0x4c40813A6a726FE9353a4A691ecFe2D8641914F7"
 )
 
 // InboundEvent returns a sample InboundEvent.

--- a/zetaclient/chains/base/signer.go
+++ b/zetaclient/chains/base/signer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
+	"github.com/zeta-chain/node/zetaclient/compliance"
 	"github.com/zeta-chain/node/zetaclient/logs"
 )
 
@@ -152,6 +153,29 @@ func (s *Signer) IsOutboundActive(outboundID string) bool {
 
 	_, found := s.activeOutbounds[outboundID]
 	return found
+}
+
+// PassesCompliance checks if the cctx passes the compliance check and prints compliance log.
+func (s *Signer) PassesCompliance(cctx *types.CrossChainTx) bool {
+	restricted := compliance.IsCCTXRestricted(cctx)
+	if !restricted {
+		return true
+	}
+
+	params := cctx.GetCurrentOutboundParam()
+
+	compliance.PrintComplianceLog(
+		s.Logger().Std,
+		s.Logger().Compliance,
+		true,
+		s.Chain().ChainId,
+		cctx.Index,
+		cctx.InboundParams.Sender,
+		params.Receiver,
+		params.CoinType.String(),
+	)
+
+	return false
 }
 
 // OutboundID returns the outbound ID.

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/pkg/constant"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
@@ -146,8 +145,6 @@ func (ob *Observer) VoteOutboundIfConfirmed(ctx context.Context, cctx *crosschai
 		}
 	}
 
-	// It's safe to use cctx's amount to post confirmation because it has already been verified in checkTxInclusion().
-	amountInSat := params.Amount.BigInt()
 	// #nosec G115 always in range
 	if res.Confirmations < int64(ob.ChainParams().OutboundConfirmationSafe()) {
 		ob.logger.Outbound.Debug().
@@ -168,9 +165,18 @@ func (ob *Observer) VoteOutboundIfConfirmed(ctx context.Context, cctx *crosschai
 		)
 	}
 
-	ob.Logger().
-		Outbound.Debug().
-		Msgf("Bitcoin outbound confirmed: txid %s, amount %s\n", res.TxID, amountInSat.String())
+	var (
+		// It's safe to use cctx's amount to post confirmation because it has already been verified in checkTxInclusion().
+		receiveValue  = math.NewUintFromBigInt(params.Amount.BigInt())
+		receiveStatus = chains.ReceiveStatus_success
+		cointype      = cctx.InboundParams.CoinType
+	)
+
+	// cancelled transaction means the outbound is failed
+	// set status to failed to revert the CCTX in zetacore
+	if compliance.IsCCTXRestricted(cctx) {
+		receiveStatus = chains.ReceiveStatus_failed
+	}
 
 	signer := ob.ZetacoreClient().GetKeys().GetOperatorAddress()
 
@@ -178,20 +184,17 @@ func (ob *Observer) VoteOutboundIfConfirmed(ctx context.Context, cctx *crosschai
 		signer.String(),
 		cctx.Index,
 		res.TxID,
-
 		// #nosec G115 always positive
 		uint64(blockHeight),
-
 		// not used with Bitcoin
 		outboundGasUsed,
 		math.NewInt(outboundGasPrice),
 		outboundGasLimit,
-
-		math.NewUintFromBigInt(amountInSat),
-		chains.ReceiveStatus_success,
+		receiveValue,
+		receiveStatus,
 		ob.Chain().ChainId,
 		nonce,
-		coin.CoinType_Gas,
+		cointype,
 		crosschaintypes.ConfirmationMode_SAFE,
 	)
 

--- a/zetaclient/chains/bitcoin/signer/outbound_data.go
+++ b/zetaclient/chains/bitcoin/signer/outbound_data.go
@@ -13,7 +13,6 @@ import (
 	"github.com/zeta-chain/node/pkg/constant"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 )
 
 // OutboundData is a data structure containing necessary data to construct a BTC outbound transaction
@@ -55,7 +54,8 @@ func NewOutboundData(
 	cctx *types.CrossChainTx,
 	height uint64,
 	minRelayFee float64,
-	logger, loggerCompliance zerolog.Logger,
+	restrictedCCTX bool,
+	logger zerolog.Logger,
 ) (*OutboundData, error) {
 	if cctx == nil {
 		return nil, errors.New("cctx is nil")
@@ -116,13 +116,6 @@ func NewOutboundData(
 	// the float64 'amount' is used later to select UTXOs, precision does not matter
 	amount := float64(params.Amount.Uint64()) / 1e8
 	amountSats := params.Amount.BigInt().Int64()
-
-	// compliance check
-	restrictedCCTX := compliance.IsCCTXRestricted(cctx)
-	if restrictedCCTX {
-		compliance.PrintComplianceLog(logger, loggerCompliance,
-			true, params.ReceiverChainId, cctx.Index, cctx.InboundParams.Sender, params.Receiver, "BTC")
-	}
 
 	// check dust amount
 	dustAmount := amountSats < constant.BTCWithdrawalDustAmount

--- a/zetaclient/chains/bitcoin/signer/outbound_data_test.go
+++ b/zetaclient/chains/bitcoin/signer/outbound_data_test.go
@@ -28,13 +28,14 @@ func Test_NewOutboundData(t *testing.T) {
 
 	// test cases
 	tests := []struct {
-		name         string
-		cctx         *crosschaintypes.CrossChainTx
-		cctxModifier func(cctx *crosschaintypes.CrossChainTx)
-		height       uint64
-		minRelayFee  float64
-		expected     *OutboundData
-		errMsg       string
+		name           string
+		cctx           *crosschaintypes.CrossChainTx
+		cctxModifier   func(cctx *crosschaintypes.CrossChainTx)
+		height         uint64
+		minRelayFee    float64
+		restrictedCCTX bool
+		expected       *OutboundData
+		errMsg         string
 	}{
 		{
 			name: "create new outbound data successfully, no fee bump",
@@ -182,8 +183,9 @@ func Test_NewOutboundData(t *testing.T) {
 				cctx.GetCurrentOutboundParam().GasPrice = "8"                // 8 sats/vByte
 				cctx.GetCurrentOutboundParam().TssNonce = 1
 			},
-			height:      101,
-			minRelayFee: 0.00001, // 1000 sat/KB
+			height:         101,
+			minRelayFee:    0.00001, // 1000 sat/KB
+			restrictedCCTX: true,
 			expected: &OutboundData{
 				to:          receiver,
 				amount:      0, // should cancel the tx
@@ -228,7 +230,7 @@ func Test_NewOutboundData(t *testing.T) {
 				tt.cctxModifier(tt.cctx)
 			}
 
-			outboundData, err := NewOutboundData(tt.cctx, tt.height, tt.minRelayFee, log.Logger, log.Logger)
+			outboundData, err := NewOutboundData(tt.cctx, tt.height, tt.minRelayFee, tt.restrictedCCTX, log.Logger)
 			if tt.errMsg != "" {
 				require.Nil(t, outboundData)
 				require.ErrorContains(t, err, tt.errMsg)

--- a/zetaclient/chains/bitcoin/signer/sign_rbf_test.go
+++ b/zetaclient/chains/bitcoin/signer/sign_rbf_test.go
@@ -237,7 +237,7 @@ func mkTxData(t *testing.T, minRelayFee float64, latestFeeRate string) OutboundD
 	cctx.GetCurrentOutboundParam().ReceiverChainId = chains.BitcoinMainnet.ChainId
 	cctx.GetCurrentOutboundParam().Amount = sdkmath.NewUint(1e7) // 0.1 BTC
 
-	txData, err := NewOutboundData(cctx, 1, minRelayFee, zerolog.Nop(), zerolog.Nop())
+	txData, err := NewOutboundData(cctx, 1, minRelayFee, false, zerolog.Nop())
 	require.NoError(t, err)
 	return *txData
 }

--- a/zetaclient/chains/bitcoin/signer/sign_test.go
+++ b/zetaclient/chains/bitcoin/signer/sign_test.go
@@ -46,7 +46,7 @@ func Test_SignWithdrawTx(t *testing.T) {
 	// helper function to create tx data
 	mkTxData := func(height uint64, minRelayFee float64) OutboundData {
 		cctx := mkCCTX(t)
-		txData, err := NewOutboundData(cctx, height, minRelayFee, zerolog.Nop(), zerolog.Nop())
+		txData, err := NewOutboundData(cctx, height, minRelayFee, false, zerolog.Nop())
 		require.NoError(t, err)
 		return *txData
 	}

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -126,8 +126,11 @@ func (signer *Signer) TryProcessOutbound(
 		return
 	}
 
+	// compliance check
+	restrictedCCTX := !signer.PassesCompliance(cctx)
+
 	// setup outbound data
-	txData, err := NewOutboundData(cctx, height, minRelayFee, logger, signer.Logger().Compliance)
+	txData, err := NewOutboundData(cctx, height, minRelayFee, restrictedCCTX, logger)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to setup Bitcoin outbound data")
 		return

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -182,18 +182,18 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	}
 
 	// define a few common variables
-	var receiveValue *big.Int
-	var receiveStatus chains.ReceiveStatus
-	cointype := cctx.InboundParams.CoinType
+	var (
+		receiveValue  *big.Int
+		receiveStatus chains.ReceiveStatus
+		cointype      = cctx.InboundParams.CoinType
+	)
 
-	// compliance check, special handling the cancelled cctx
+	// cancelled transaction means the outbound is failed
+	// - set amount to CCTX's amount to bypass amount check in zetacore
+	// - set status to failed to revert the CCTX in zetacore
 	if compliance.IsCCTXRestricted(cctx) {
-		// use cctx's amount to bypass the amount check in zetacore
 		receiveValue = cctx.GetCurrentOutboundParam().Amount.BigInt()
-		receiveStatus := chains.ReceiveStatus_failed
-		if receipt.Status == ethtypes.ReceiptStatusSuccessful {
-			receiveStatus = chains.ReceiveStatus_success
-		}
+		receiveStatus = chains.ReceiveStatus_failed
 		ob.postVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
 		return false, nil
 	}

--- a/zetaclient/chains/evm/signer/signer.go
+++ b/zetaclient/chains/evm/signer/signer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/evm/client"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/logs"
 	"github.com/zeta-chain/node/zetaclient/zetacore"
@@ -341,19 +340,8 @@ func (signer *Signer) SignOutboundFromCCTX(
 	zetacoreClient interfaces.ZetacoreClient,
 	toChain zctx.Chain,
 ) (*ethtypes.Transaction, error) {
-	if compliance.IsCCTXRestricted(cctx) {
+	if !signer.PassesCompliance(cctx) {
 		// restricted cctx
-		compliance.PrintComplianceLog(
-			logger,
-			signer.Logger().Compliance,
-			true,
-			signer.Chain().ChainId,
-			cctx.Index,
-			cctx.InboundParams.Sender,
-			outboundData.to.Hex(),
-			cctx.GetCurrentOutboundParam().CoinType.String(),
-		)
-
 		return signer.SignCancel(ctx, outboundData)
 	} else if cctx.InboundParams.CoinType == coin.CoinType_Cmd {
 		// admin command

--- a/zetaclient/chains/solana/observer/outbound.go
+++ b/zetaclient/chains/solana/observer/outbound.go
@@ -140,10 +140,12 @@ func (ob *Observer) VoteOutboundIfConfirmed(ctx context.Context, cctx *crosschai
 		outboundStatus = chains.ReceiveStatus_failed
 	}
 
-	// compliance check, special handling the cancelled cctx
+	// cancelled transaction means the outbound is failed
+	// - set amount to CCTX's amount to bypass amount check in zetacore
+	// - set status to failed to revert the CCTX in zetacore
 	if compliance.IsCCTXRestricted(cctx) {
-		// use cctx's amount to bypass the amount check in zetacore
 		outboundAmount = cctx.GetCurrentOutboundParam().Amount.BigInt()
+		outboundStatus = chains.ReceiveStatus_failed
 	}
 
 	// post vote to zetacore

--- a/zetaclient/chains/solana/signer/execute.go
+++ b/zetaclient/chains/solana/signer/execute.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	contracts "github.com/zeta-chain/node/pkg/contracts/solana"
 	"github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 )
 
 // prepareExecuteTx prepares execute outbound
@@ -20,23 +19,10 @@ func (signer *Signer) prepareExecuteTx(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
 	height uint64,
+	cancelTx bool,
 	logger zerolog.Logger,
 ) (outboundGetter, error) {
 	params := cctx.GetCurrentOutboundParam()
-	// compliance check
-	cancelTx := compliance.IsCCTXRestricted(cctx)
-	if cancelTx {
-		compliance.PrintComplianceLog(
-			logger,
-			signer.Logger().Compliance,
-			true,
-			signer.Chain().ChainId,
-			cctx.Index,
-			cctx.InboundParams.Sender,
-			params.Receiver,
-			"SOL",
-		)
-	}
 
 	// create msg execute
 	msg, msgIn, err := signer.createMsgExecute(cctx, cancelTx)

--- a/zetaclient/chains/solana/signer/execute_spl.go
+++ b/zetaclient/chains/solana/signer/execute_spl.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	contracts "github.com/zeta-chain/node/pkg/contracts/solana"
 	"github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 )
 
 // prepareExecuteSPLTx prepares execute spl outbound
@@ -20,23 +19,10 @@ func (signer *Signer) prepareExecuteSPLTx(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
 	height uint64,
+	cancelTx bool,
 	logger zerolog.Logger,
 ) (outboundGetter, error) {
 	params := cctx.GetCurrentOutboundParam()
-	// compliance check
-	cancelTx := compliance.IsCCTXRestricted(cctx)
-	if cancelTx {
-		compliance.PrintComplianceLog(
-			logger,
-			signer.Logger().Compliance,
-			true,
-			signer.Chain().ChainId,
-			cctx.Index,
-			cctx.InboundParams.Sender,
-			params.Receiver,
-			"SPL",
-		)
-	}
 
 	// create msg execute spl
 	msg, msgIn, err := signer.createMsgExecuteSPL(ctx, cctx, cancelTx)

--- a/zetaclient/chains/solana/signer/withdraw.go
+++ b/zetaclient/chains/solana/signer/withdraw.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	contracts "github.com/zeta-chain/node/pkg/contracts/solana"
 	"github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 )
 
 // prepareWithdrawTx prepares withdraw outbound
@@ -20,23 +19,10 @@ func (signer *Signer) prepareWithdrawTx(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
 	height uint64,
+	cancelTx bool,
 	logger zerolog.Logger,
 ) (outboundGetter, error) {
 	params := cctx.GetCurrentOutboundParam()
-	// compliance check
-	cancelTx := compliance.IsCCTXRestricted(cctx)
-	if cancelTx {
-		compliance.PrintComplianceLog(
-			logger,
-			signer.Logger().Compliance,
-			true,
-			signer.Chain().ChainId,
-			cctx.Index,
-			cctx.InboundParams.Sender,
-			params.Receiver,
-			"SOL",
-		)
-	}
 
 	// create msg withdraw
 	msg, msgIn, err := signer.createMsgWithdraw(params, cancelTx)

--- a/zetaclient/chains/solana/signer/withdraw_spl.go
+++ b/zetaclient/chains/solana/signer/withdraw_spl.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	contracts "github.com/zeta-chain/node/pkg/contracts/solana"
 	"github.com/zeta-chain/node/x/crosschain/types"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 )
 
 // prepareWithdrawSPLTx prepares withdraw spl outbound
@@ -20,23 +19,10 @@ func (signer *Signer) prepareWithdrawSPLTx(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
 	height uint64,
+	cancelTx bool,
 	logger zerolog.Logger,
 ) (outboundGetter, error) {
 	params := cctx.GetCurrentOutboundParam()
-	// compliance check
-	cancelTx := compliance.IsCCTXRestricted(cctx)
-	if cancelTx {
-		compliance.PrintComplianceLog(
-			logger,
-			signer.Logger().Compliance,
-			true,
-			signer.Chain().ChainId,
-			cctx.Index,
-			cctx.InboundParams.Sender,
-			params.Receiver,
-			"SPL",
-		)
-	}
 
 	// create msg withdraw spl
 	msg, msgIn, err := signer.createMsgWithdrawSPL(

--- a/zetaclient/chains/sui/signer/signer.go
+++ b/zetaclient/chains/sui/signer/signer.go
@@ -14,7 +14,6 @@ import (
 	cctypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
-	"github.com/zeta-chain/node/zetaclient/compliance"
 	"github.com/zeta-chain/node/zetaclient/logs"
 )
 
@@ -109,7 +108,7 @@ func (s *Signer) ProcessCCTX(ctx context.Context, cctx *cctypes.CrossChainTx, ze
 	var txDigest string
 
 	// broadcast tx according to compliance check result
-	if s.passesCompliance(cctx) {
+	if s.PassesCompliance(cctx) {
 		txDigest, err = s.broadcastWithdrawalWithFallback(ctx, withdrawTxBuilder, cancelTxBuilder)
 	} else {
 		txDigest, err = s.broadcastCancelTx(ctx, cancelTxBuilder)
@@ -200,28 +199,6 @@ func (s *Signer) SignTxWithCancel(
 	}
 
 	return sig, sigCancel, nil
-}
-
-func (s *Signer) passesCompliance(cctx *cctypes.CrossChainTx) bool {
-	restricted := compliance.IsCCTXRestricted(cctx)
-	if !restricted {
-		return true
-	}
-
-	params := cctx.GetCurrentOutboundParam()
-
-	compliance.PrintComplianceLog(
-		s.Logger().Std,
-		s.Logger().Compliance,
-		true,
-		s.Chain().ChainId,
-		cctx.Index,
-		cctx.InboundParams.Sender,
-		params.Receiver,
-		params.CoinType.String(),
-	)
-
-	return false
 }
 
 // wrapDigest wraps the digest with sha256.


### PR DESCRIPTION
# Description

The `EVM, Bitcoin, and Solana` zetaclients will vote with `ReceiveStatus_success` for restricted (censored) outbounds. This results in the user losing funds as they will not get the funds refunded on ZetaChain due to the revert process not being triggered in this case.

The `SUI` zetaclient behaves differently and will vote with `ReceiveStatus_failed`, thus refunding the funds on ZetaChain. This is a better way to deal with restricted CCTX in ZetaChain.

This PR unifies the behavior across `EVM, Bitcoin, Solana and SUI` chains by reverting restricted CCTXs.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
