### PR TITLE
fix: add support for non-base64 formatted payload in Sui DepositAndCall event parsing

### DIFF
--- a/e2e/e2etests/test_sui_deposit_and_call.go
+++ b/e2e/e2etests/test_sui_deposit_and_call.go
@@ -8,7 +8,6 @@ import (
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/coin"
-	"github.com/zeta-chain/node/pkg/contracts/sui"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
@@ -17,13 +16,19 @@ func TestSuiDepositAndCall(r *runner.E2ERunner, args []string) {
 
 	amount := utils.ParseBigInt(r, args[0])
 
+	// test payload with abi format
+	abiPayload := make([]byte, 96)
+	abiPayload[31] = 32 // set index 31 to 32
+	abiPayload[63] = 5  // set index 63 to 5
+	copy(abiPayload[64:], "hello")
+
 	oldBalance, err := r.SUIZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
 
-	payload := randomPayload(r)
+	//payload := randomPayload(r)
 
 	// make the deposit transaction
-	resp := r.SuiDepositAndCallSUI(r.TestDAppV2ZEVMAddr, math.NewUintFromBigInt(amount), []byte(payload))
+	resp := r.SuiDepositAndCallSUI(r.TestDAppV2ZEVMAddr, math.NewUintFromBigInt(amount), abiPayload)
 
 	r.Logger.Info("Sui deposit and call tx: %s", resp.Digest)
 
@@ -40,16 +45,16 @@ func TestSuiDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.EqualValues(r, oldBalance.Add(oldBalance, amount).Uint64(), newBalance.Uint64())
 
 	// check sender passed in the call
-	signer, err := r.Account.SuiSigner()
-	require.NoError(r, err)
+	//signer, err := r.Account.SuiSigner()
+	//require.NoError(r, err)
 
-	sender, err := sui.EncodeAddress(signer.Address())
-	require.NoError(r, err)
+	//sender, err := sui.EncodeAddress(signer.Address())
+	//require.NoError(r, err)
 
-	actualSender, err := r.TestDAppV2ZEVM.GetSenderWithMessage(&bind.CallOpts{}, payload)
-	require.NoError(r, err)
-	require.EqualValues(r, sender, actualSender)
-
-	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	//actualSender, err := r.TestDAppV2ZEVM.GetSenderWithMessage(&bind.CallOpts{}, payload)
+	//require.NoError(r, err)
+	//require.EqualValues(r, sender, actualSender)
+	//
+	//// check the payload was received on the contract
+	//r.AssertTestDAppZEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_sui_deposit_and_call.go
+++ b/e2e/e2etests/test_sui_deposit_and_call.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/contracts/sui"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
@@ -16,19 +17,13 @@ func TestSuiDepositAndCall(r *runner.E2ERunner, args []string) {
 
 	amount := utils.ParseBigInt(r, args[0])
 
-	// test payload with abi format
-	abiPayload := make([]byte, 96)
-	abiPayload[31] = 32 // set index 31 to 32
-	abiPayload[63] = 5  // set index 63 to 5
-	copy(abiPayload[64:], "hello")
-
 	oldBalance, err := r.SUIZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
 
-	//payload := randomPayload(r)
+	payload := randomPayload(r)
 
 	// make the deposit transaction
-	resp := r.SuiDepositAndCallSUI(r.TestDAppV2ZEVMAddr, math.NewUintFromBigInt(amount), abiPayload)
+	resp := r.SuiDepositAndCallSUI(r.TestDAppV2ZEVMAddr, math.NewUintFromBigInt(amount), []byte(payload))
 
 	r.Logger.Info("Sui deposit and call tx: %s", resp.Digest)
 
@@ -45,16 +40,16 @@ func TestSuiDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.EqualValues(r, oldBalance.Add(oldBalance, amount).Uint64(), newBalance.Uint64())
 
 	// check sender passed in the call
-	//signer, err := r.Account.SuiSigner()
-	//require.NoError(r, err)
+	signer, err := r.Account.SuiSigner()
+	require.NoError(r, err)
 
-	//sender, err := sui.EncodeAddress(signer.Address())
-	//require.NoError(r, err)
+	sender, err := sui.EncodeAddress(signer.Address())
+	require.NoError(r, err)
 
-	//actualSender, err := r.TestDAppV2ZEVM.GetSenderWithMessage(&bind.CallOpts{}, payload)
-	//require.NoError(r, err)
-	//require.EqualValues(r, sender, actualSender)
-	//
-	//// check the payload was received on the contract
-	//r.AssertTestDAppZEVMCalled(true, payload, amount)
+	actualSender, err := r.TestDAppV2ZEVM.GetSenderWithMessage(&bind.CallOpts{}, payload)
+	require.NoError(r, err)
+	require.EqualValues(r, sender, actualSender)
+
+	// check the payload was received on the contract
+	r.AssertTestDAppZEVMCalled(true, payload, amount)
 }

--- a/pkg/contracts/sui/gateway.go
+++ b/pkg/contracts/sui/gateway.go
@@ -379,10 +379,8 @@ func convertPayload(data []any) ([]byte, error) {
 	// TODO: fix this discrepancy
 	// https://github.com/zeta-chain/node/issues/3919
 	base64DecodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
-	if err == nil { 
-	   return base64DecodedPayload, nil
-	}
-		return payload, nil
+	if err == nil {
+		return base64DecodedPayload, nil
 	}
 	return payload, nil
 }

--- a/pkg/contracts/sui/gateway.go
+++ b/pkg/contracts/sui/gateway.go
@@ -379,7 +379,9 @@ func convertPayload(data []any) ([]byte, error) {
 	// TODO: fix this discrepancy
 	// https://github.com/zeta-chain/node/issues/3919
 	base64DecodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
-	if err != nil {
+	if err == nil { 
+	   return base64DecodedPayload, nil
+	}
 		return payload, nil
 	}
 	return base64DecodedPayload, nil

--- a/pkg/contracts/sui/gateway.go
+++ b/pkg/contracts/sui/gateway.go
@@ -384,7 +384,7 @@ func convertPayload(data []any) ([]byte, error) {
 	}
 		return payload, nil
 	}
-	return base64DecodedPayload, nil
+	return payload, nil
 }
 
 func parsePair(pair string) (string, string, error) {

--- a/pkg/contracts/sui/gateway.go
+++ b/pkg/contracts/sui/gateway.go
@@ -373,13 +373,16 @@ func convertPayload(data []any) ([]byte, error) {
 		}
 	}
 
-	// Sui encode bytes in base64
-	decodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
+	// Try decoding the payload from base64
+	// If the payload is not base64 encoded, directly return the payload bytes as is
+	// Currently the localnet Sui RPC will return bytes in Base64 for the payload data while live network return the actual bytes of the payload directly
+	// TODO: fix this discrepancy
+	// https://github.com/zeta-chain/node/issues/3919
+	base64DecodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode payload from base64")
+		return payload, nil
 	}
-
-	return decodedPayload, nil
+	return base64DecodedPayload, nil
 }
 
 func parsePair(pair string) (string, string, error) {

--- a/zetaclient/chains/sui/client/client_live_test.go
+++ b/zetaclient/chains/sui/client/client_live_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"github.com/zeta-chain/node/zetaclient/common"
 	"strconv"
 	"testing"
 	"time"
@@ -18,10 +19,10 @@ const (
 )
 
 func TestClientLive(t *testing.T) {
-	//if !common.LiveTestEnabled() {
-	//	t.Skip("skipping live test")
-	//	return
-	//}
+	if !common.LiveTestEnabled() {
+		t.Skip("skipping live test")
+		return
+	}
 
 	t.Run("HealthCheck", func(t *testing.T) {
 		// ARRANGE


### PR DESCRIPTION
Some context: [Inconsistent payload format when querying depositAndCall event in Sui node](https://github.com/zeta-chain/node/issues/3919)

The depositAndCall parsing will not work on testnet if the node doesn't return an error with base64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of payload data from different Sui RPC environments, ensuring compatibility with both base64-encoded and raw byte formats.

- **Tests**
	- Enhanced test coverage to validate correct parsing of both base64-encoded and raw byte payloads.
	- Added a new live test to verify successful transaction parsing on the Sui testnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->