### PR TITLE
fix(backport/v30): add support for non-base64 formatted payload in Sui DepositAndCall event parsing 

### DIFF
--- a/pkg/contracts/sui/gateway.go
+++ b/pkg/contracts/sui/gateway.go
@@ -349,13 +349,16 @@ func convertPayload(data []any) ([]byte, error) {
 		}
 	}
 
-	// Sui encode bytes in base64
-	decodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
+	// Try decoding the payload from base64
+	// If the payload is not base64 encoded, directly return the payload bytes as is
+	// Currently the localnet Sui RPC will return bytes in Base64 for the payload data while live network return the actual bytes of the payload directly
+	// TODO: fix this discrepancy
+	// https://github.com/zeta-chain/node/issues/3919
+	base64DecodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode payload from base64")
+		return payload, nil
 	}
-
-	return decodedPayload, nil
+	return base64DecodedPayload, nil
 }
 
 func parsePair(pair string) (string, string, error) {

--- a/pkg/contracts/sui/gateway.go
+++ b/pkg/contracts/sui/gateway.go
@@ -355,10 +355,10 @@ func convertPayload(data []any) ([]byte, error) {
 	// TODO: fix this discrepancy
 	// https://github.com/zeta-chain/node/issues/3919
 	base64DecodedPayload, err := base64.StdEncoding.DecodeString(string(payload))
-	if err != nil {
-		return payload, nil
+	if err == nil {
+		return base64DecodedPayload, nil
 	}
-	return base64DecodedPayload, nil
+	return payload, nil
 }
 
 func parsePair(pair string) (string, string, error) {


### PR DESCRIPTION
# Description

Backport for https://github.com/zeta-chain/node/pull/3915 to v30
