### PR TITLE
fix: post zero priority fee to avoid gas price bump failure in zetacore

### DIFF
--- a/zetaclient/chains/evm/observer/observer_gas.go
+++ b/zetaclient/chains/evm/observer/observer_gas.go
@@ -15,11 +15,17 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 		return errors.Wrap(err, "unable to suggest gas price")
 	}
 
+	// The zetaclients now only build legacy tx rather than EIP-1559 tx.
+	// Hardcode priority fee to zero to avoid gas price bump failure in the zetacore:
+	// https://github.com/zeta-chain/node/blob/release%2Fv30/x/crosschain/keeper/abci.go#L182
+	// https://github.com/zeta-chain/node/issues/3221
+	priorityFee := big.NewInt(0)
+
 	// PRIORITY FEE (EIP-1559)
-	priorityFee, err := ob.determinePriorityFee(ctx)
-	if err != nil {
-		return errors.Wrap(err, "unable to determine priority fee")
-	}
+	// priorityFee, err := ob.determinePriorityFee(ctx)
+	// if err != nil {
+	// 	return errors.Wrap(err, "unable to determine priority fee")
+	// }
 
 	blockNum, err := ob.evmClient.BlockNumber(ctx)
 	if err != nil {
@@ -37,9 +43,9 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 	return nil
 }
 
-// determinePriorityFee determines the chain priority fee.
+// DeterminePriorityFee determines the chain priority fee.
 // Returns zero for non EIP-1559 (London fork) chains.
-func (ob *Observer) determinePriorityFee(ctx context.Context) (*big.Int, error) {
+func (ob *Observer) DeterminePriorityFee(ctx context.Context) (*big.Int, error) {
 	supported, err := ob.supportsPriorityFee(ctx)
 	switch {
 	case err != nil:

--- a/zetaclient/chains/evm/observer/observer_gas.go
+++ b/zetaclient/chains/evm/observer/observer_gas.go
@@ -19,7 +19,7 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 	// Hardcode priority fee to zero to avoid gas price bump failure in the zetacore:
 	// https://github.com/zeta-chain/node/blob/release%2Fv30/x/crosschain/keeper/abci.go#L182
 	// https://github.com/zeta-chain/node/issues/3221
-	priorityFee := big.NewInt(0)
+	priorityFee := uint64(0)
 
 	// PRIORITY FEE (EIP-1559)
 	// priorityFee, err := ob.determinePriorityFee(ctx)
@@ -34,7 +34,7 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 
 	_, err = ob.
 		ZetacoreClient().
-		PostVoteGasPrice(ctx, ob.Chain(), gasPrice.Uint64(), priorityFee.Uint64(), blockNum)
+		PostVoteGasPrice(ctx, ob.Chain(), gasPrice.Uint64(), priorityFee, blockNum)
 
 	if err != nil {
 		return errors.Wrap(err, "unable to post vote for gas price")

--- a/zetaclient/chains/evm/observer/observer_gas_test.go
+++ b/zetaclient/chains/evm/observer/observer_gas_test.go
@@ -24,11 +24,11 @@ func TestPostGasPrice(t *testing.T) {
 		observer := newTestSuite(t)
 
 		// Given empty baseFee from RPC
-		observer.evmMock.On("HeaderByNumber", anything, anything).Return(&ethtypes.Header{BaseFee: nil}, nil)
+		observer.evmMock.On("HeaderByNumber", anything, anything).Maybe().Return(&ethtypes.Header{BaseFee: nil}, nil)
 
 		// Given gasPrice and priorityFee from RPC
-		observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
-		observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(0), nil)
+		observer.evmMock.On("SuggestGasPrice", anything).Maybe().Return(big.NewInt(3*gwei), nil)
+		observer.evmMock.On("SuggestGasTipCap", anything).Maybe().Return(big.NewInt(0), nil)
 
 		// Given mock collector for zetacore call
 		// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
@@ -54,40 +54,41 @@ func TestPostGasPrice(t *testing.T) {
 		assert.Equal(t, uint64(0), priorityFee)
 	})
 
-	t.Run("Post EIP-1559 supports priorityFee", func(t *testing.T) {
-		// ARRANGE
-		// Given an observer
-		observer := newTestSuite(t)
+	// TODO: https://github.com/zeta-chain/node/issues/3221
+	// t.Run("Post EIP-1559 supports priorityFee", func(t *testing.T) {
+	// 	// ARRANGE
+	// 	// Given an observer
+	// 	observer := newTestSuite(t)
 
-		// Given 1 gwei baseFee from RPC
-		observer.evmMock.On("HeaderByNumber", anything, anything).
-			Return(&ethtypes.Header{BaseFee: big.NewInt(gwei)}, nil)
+	// 	// Given 1 gwei baseFee from RPC
+	// 	observer.evmMock.On("HeaderByNumber", anything, anything).Maybe().
+	// 		Return(&ethtypes.Header{BaseFee: big.NewInt(gwei)}, nil)
 
-		// Given gasPrice and priorityFee from RPC
-		observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
-		observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(2*gwei), nil)
+	// 	// Given gasPrice and priorityFee from RPC
+	// 	observer.evmMock.On("SuggestGasPrice", anything).Maybe().Return(big.NewInt(3*gwei), nil)
+	// 	observer.evmMock.On("SuggestGasTipCap", anything).Maybe().Return(big.NewInt(2*gwei), nil)
 
-		// Given mock collector for zetacore call
-		// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
-		var gasPrice, priorityFee uint64
-		collector := func(args mock.Arguments) {
-			gasPrice = args.Get(2).(uint64)
-			priorityFee = args.Get(3).(uint64)
-		}
+	// 	// Given mock collector for zetacore call
+	// 	// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
+	// 	var gasPrice, priorityFee uint64
+	// 	collector := func(args mock.Arguments) {
+	// 		gasPrice = args.Get(2).(uint64)
+	// 		priorityFee = args.Get(3).(uint64)
+	// 	}
 
-		observer.zetacore.
-			On("PostVoteGasPrice", anything, anything, anything, anything, anything).
-			Run(collector).
-			Return("0xABC123...", nil)
+	// 	observer.zetacore.
+	// 		On("PostVoteGasPrice", anything, anything, anything, anything, anything).
+	// 		Run(collector).
+	// 		Return("0xABC123...", nil)
 
-		// ACT
-		err := observer.PostGasPrice(ctx)
+	// 	// ACT
+	// 	err := observer.PostGasPrice(ctx)
 
-		// ASSERT
-		assert.NoError(t, err)
+	// 	// ASSERT
+	// 	assert.NoError(t, err)
 
-		// Check that gas price is posted with proper gasPrice and priorityFee
-		assert.Equal(t, uint64(3*gwei), gasPrice)
-		assert.Equal(t, uint64(2*gwei), priorityFee)
-	})
+	// 	// Check that gas price is posted with proper gasPrice and priorityFee
+	// 	assert.Equal(t, uint64(3*gwei), gasPrice)
+	// 	assert.Equal(t, uint64(2*gwei), priorityFee)
+	// })
 }


### PR DESCRIPTION
# Description

The Base mainnet CCTX outbound keeps failing. Most likely the gas price in the [CCTX](https://zetachain.blockpi.network/lcd/v1/public/zeta-chain/crosschain/gasPrice/8453) is too low. The outbound tx is dropped by the endpoint right after broadcasting.

We rely on the gas stability pool to increase CCTX's gas price but the gas bumping logic fails due to below error. The fix is to post `zero` priority fee to avoid this failure and allow gas stability pool to kick in.

![image](https://github.com/user-attachments/assets/30cdee9b-879b-4afa-a00b-f4a720ce46f6)


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
