### PR TITLE
fix: post zero priority fee to avoid gas price bump failure in zetacore

### DIFF
--- a/zetaclient/chains/evm/observer/observer.go
+++ b/zetaclient/chains/evm/observer/observer.go
@@ -43,9 +43,11 @@ type Observer struct {
 type priorityFeeConfig struct {
 	// checked indicates whether the observer checked
 	// this EVM chain for EIP-1559 (further checks are cached)
+	// nolint:unused
 	checked bool
 
 	// supported indicates whether this EVM chain supports EIP-1559
+	// nolint:unused
 	supported bool
 }
 

--- a/zetaclient/chains/evm/observer/observer_gas.go
+++ b/zetaclient/chains/evm/observer/observer_gas.go
@@ -45,6 +45,7 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 
 // determinePriorityFee determines the chain priority fee.
 // Returns zero for non EIP-1559 (London fork) chains.
+// nolint:unused
 func (ob *Observer) determinePriorityFee(ctx context.Context) (*big.Int, error) {
 	supported, err := ob.supportsPriorityFee(ctx)
 	switch {
@@ -65,6 +66,7 @@ func (ob *Observer) determinePriorityFee(ctx context.Context) (*big.Int, error) 
 
 // supportsPriorityFee checks if the chain supports EIP-1559 (London fork).
 // uses cache so actual RPC call is made only once.
+// nolint:unused
 func (ob *Observer) supportsPriorityFee(ctx context.Context) (bool, error) {
 	// noop
 	if ob.priorityFeeConfig.checked {
@@ -95,6 +97,7 @@ func (ob *Observer) supportsPriorityFee(ctx context.Context) (bool, error) {
 }
 
 // getChainBaseFee fetches baseFee from latest block's header.
+// nolint:unused
 func (ob *Observer) getChainBaseFee(ctx context.Context) (*big.Int, error) {
 	// get latest block
 	header, err := ob.evmClient.HeaderByNumber(ctx, nil)

--- a/zetaclient/chains/evm/observer/observer_gas.go
+++ b/zetaclient/chains/evm/observer/observer_gas.go
@@ -43,9 +43,9 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 	return nil
 }
 
-// DeterminePriorityFee determines the chain priority fee.
+// determinePriorityFee determines the chain priority fee.
 // Returns zero for non EIP-1559 (London fork) chains.
-func (ob *Observer) DeterminePriorityFee(ctx context.Context) (*big.Int, error) {
+func (ob *Observer) determinePriorityFee(ctx context.Context) (*big.Int, error) {
 	supported, err := ob.supportsPriorityFee(ctx)
 	switch {
 	case err != nil:

--- a/zetaclient/chains/evm/observer/observer_gas_test.go
+++ b/zetaclient/chains/evm/observer/observer_gas_test.go
@@ -24,11 +24,11 @@ func TestPostGasPrice(t *testing.T) {
 		observer := newTestSuite(t)
 
 		// Given empty baseFee from RPC
-		observer.evmMock.On("HeaderByNumber", anything, anything).Return(&ethtypes.Header{BaseFee: nil}, nil)
+		observer.evmMock.On("HeaderByNumber", anything, anything).Maybe().Return(&ethtypes.Header{BaseFee: nil}, nil)
 
 		// Given gasPrice and priorityFee from RPC
-		observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
-		observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(0), nil)
+		observer.evmMock.On("SuggestGasPrice", anything).Maybe().Return(big.NewInt(3*gwei), nil)
+		observer.evmMock.On("SuggestGasTipCap", anything).Maybe().Return(big.NewInt(0), nil)
 
 		// Given mock collector for zetacore call
 		// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
@@ -54,40 +54,41 @@ func TestPostGasPrice(t *testing.T) {
 		assert.Equal(t, uint64(0), priorityFee)
 	})
 
-	t.Run("Post EIP-1559 supports priorityFee", func(t *testing.T) {
-		// ARRANGE
-		// Given an observer
-		observer := newTestSuite(t)
+	// TODO: https://github.com/zeta-chain/node/issues/3221
+	// t.Run("Post EIP-1559 supports priorityFee", func(t *testing.T) {
+	// 	// ARRANGE
+	// 	// Given an observer
+	// 	observer := newTestSuite(t)
 
-		// Given 1 gwei baseFee from RPC
-		observer.evmMock.On("HeaderByNumber", anything, anything).
-			Return(&ethtypes.Header{BaseFee: big.NewInt(gwei)}, nil)
+	// 	// Given 1 gwei baseFee from RPC
+	// 	observer.evmMock.On("HeaderByNumber", anything, anything).Maybe().
+	// 		Return(&ethtypes.Header{BaseFee: big.NewInt(gwei)}, nil)
 
-		// Given gasPrice and priorityFee from RPC
-		observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
-		observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(2*gwei), nil)
+	// 	// Given gasPrice and priorityFee from RPC
+	// 	observer.evmMock.On("SuggestGasPrice", anything).Maybe().Return(big.NewInt(3*gwei), nil)
+	// 	observer.evmMock.On("SuggestGasTipCap", anything).Maybe().Return(big.NewInt(2*gwei), nil)
 
-		// Given mock collector for zetacore call
-		// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
-		var gasPrice, priorityFee uint64
-		collector := func(args mock.Arguments) {
-			gasPrice = args.Get(2).(uint64)
-			priorityFee = args.Get(3).(uint64)
-		}
+	// 	// Given mock collector for zetacore call
+	// 	// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
+	// 	var gasPrice, priorityFee uint64
+	// 	collector := func(args mock.Arguments) {
+	// 		gasPrice = args.Get(2).(uint64)
+	// 		priorityFee = args.Get(3).(uint64)
+	// 	}
 
-		observer.zetacore.
-			On("PostVoteGasPrice", anything, anything, anything, anything, anything).
-			Run(collector).
-			Return("0xABC123...", nil)
+	// 	observer.zetacore.
+	// 		On("PostVoteGasPrice", anything, anything, anything, anything, anything).
+	// 		Run(collector).
+	// 		Return("0xABC123...", nil)
 
-		// ACT
-		err := observer.PostGasPrice(ctx)
+	// 	// ACT
+	// 	err := observer.PostGasPrice(ctx)
 
-		// ASSERT
-		assert.NoError(t, err)
+	// 	// ASSERT
+	// 	assert.NoError(t, err)
 
-		// Check that gas price is posted with proper gasPrice and priorityFee
-		assert.Equal(t, uint64(3*gwei), gasPrice)
-		assert.Equal(t, uint64(2*gwei), priorityFee)
-	})
+	// 	// Check that gas price is posted with proper gasPrice and priorityFee
+	// 	assert.Equal(t, uint64(3*gwei), gasPrice)
+	// 	assert.Equal(t, uint64(2*gwei), priorityFee)
+	// })
 }


### PR DESCRIPTION
https://github.com/zeta-chain/node/pull/3931

Update the change on develop as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- The priority fee is now fixed to zero for all transactions, ensuring compatibility with legacy transaction formats and avoiding issues with EIP-1559 fee logic.
- **Tests**
	- Updated test mocks to allow certain method calls to be optional.
	- Temporarily disabled a test related to EIP-1559 support, with a note for future re-enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->