### PR TITLE
fix: (backport) post zero priority fee to avoid gas price bump failure in zetacore

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -59,6 +59,7 @@
 * [3895](https://github.com/zeta-chain/node/pull/3895) - solana call required accounts number condition
 * [3896](https://github.com/zeta-chain/node/pull/3896) - add sender to solana execute message hash
 * [3920](https://github.com/zeta-chain/node/pull/3920) - show correct gas limit for synthetic txs
+* [3934](https://github.com/zeta-chain/node/pull/3934) - post zero priority fee for EVM chains to avoid gas price pump failure in the zetacore
 
 ### Tests
 

--- a/zetaclient/chains/evm/observer/observer_gas_test.go
+++ b/zetaclient/chains/evm/observer/observer_gas_test.go
@@ -24,11 +24,11 @@ func TestPostGasPrice(t *testing.T) {
 		observer := newTestSuite(t)
 
 		// Given empty baseFee from RPC
-		observer.evmMock.On("HeaderByNumber", anything, anything).Return(&ethtypes.Header{BaseFee: nil}, nil)
+		observer.evmMock.On("HeaderByNumber", anything, anything).Maybe().Return(&ethtypes.Header{BaseFee: nil}, nil)
 
 		// Given gasPrice and priorityFee from RPC
-		observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
-		observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(0), nil)
+		observer.evmMock.On("SuggestGasPrice", anything).Maybe().Return(big.NewInt(3*gwei), nil)
+		observer.evmMock.On("SuggestGasTipCap", anything).Maybe().Return(big.NewInt(0), nil)
 
 		// Given mock collector for zetacore call
 		// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
@@ -54,40 +54,41 @@ func TestPostGasPrice(t *testing.T) {
 		assert.Equal(t, uint64(0), priorityFee)
 	})
 
-	t.Run("Post EIP-1559 supports priorityFee", func(t *testing.T) {
-		// ARRANGE
-		// Given an observer
-		observer := newTestSuite(t)
+	// TODO: https://github.com/zeta-chain/node/issues/3221
+	// t.Run("Post EIP-1559 supports priorityFee", func(t *testing.T) {
+	// 	// ARRANGE
+	// 	// Given an observer
+	// 	observer := newTestSuite(t)
 
-		// Given 1 gwei baseFee from RPC
-		observer.evmMock.On("HeaderByNumber", anything, anything).
-			Return(&ethtypes.Header{BaseFee: big.NewInt(gwei)}, nil)
+	// 	// Given 1 gwei baseFee from RPC
+	// 	observer.evmMock.On("HeaderByNumber", anything, anything).
+	// 		Return(&ethtypes.Header{BaseFee: big.NewInt(gwei)}, nil)
 
-		// Given gasPrice and priorityFee from RPC
-		observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
-		observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(2*gwei), nil)
+	// 	// Given gasPrice and priorityFee from RPC
+	// 	observer.evmMock.On("SuggestGasPrice", anything).Return(big.NewInt(3*gwei), nil)
+	// 	observer.evmMock.On("SuggestGasTipCap", anything).Return(big.NewInt(2*gwei), nil)
 
-		// Given mock collector for zetacore call
-		// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
-		var gasPrice, priorityFee uint64
-		collector := func(args mock.Arguments) {
-			gasPrice = args.Get(2).(uint64)
-			priorityFee = args.Get(3).(uint64)
-		}
+	// 	// Given mock collector for zetacore call
+	// 	// PostVoteGasPrice(ctx, chain, gasPrice, priorityFee, blockNum)
+	// 	var gasPrice, priorityFee uint64
+	// 	collector := func(args mock.Arguments) {
+	// 		gasPrice = args.Get(2).(uint64)
+	// 		priorityFee = args.Get(3).(uint64)
+	// 	}
 
-		observer.zetacore.
-			On("PostVoteGasPrice", anything, anything, anything, anything, anything).
-			Run(collector).
-			Return("0xABC123...", nil)
+	// 	observer.zetacore.
+	// 		On("PostVoteGasPrice", anything, anything, anything, anything, anything).
+	// 		Run(collector).
+	// 		Return("0xABC123...", nil)
 
-		// ACT
-		err := observer.PostGasPrice(ctx)
+	// 	// ACT
+	// 	err := observer.PostGasPrice(ctx)
 
-		// ASSERT
-		assert.NoError(t, err)
+	// 	// ASSERT
+	// 	assert.NoError(t, err)
 
-		// Check that gas price is posted with proper gasPrice and priorityFee
-		assert.Equal(t, uint64(3*gwei), gasPrice)
-		assert.Equal(t, uint64(2*gwei), priorityFee)
-	})
+	// 	// Check that gas price is posted with proper gasPrice and priorityFee
+	// 	assert.Equal(t, uint64(3*gwei), gasPrice)
+	// 	assert.Equal(t, uint64(2*gwei), priorityFee)
+	// })
 }


### PR DESCRIPTION
# Description

Backport the original fix https://github.com/zeta-chain/node/pull/3930

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved gas price bump failures on EVM chains by posting a zero priority fee, ensuring smoother transaction processing.
- **Documentation**
  - Updated changelog with details of the fix for gas price handling on EVM chains.
- **Tests**
  - Adjusted test cases to align with the updated priority fee logic for EVM transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->