### PR TITLE
fix: revert support setting default config.toml values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@
 * [3864](https://github.com/zeta-chain/node/pull/3864) - add compliance checks for TON inbounds
 * [3881](https://github.com/zeta-chain/node/pull/3881) - add zetatool cmd to analyze size of application.db
 * [3906](https://github.com/zeta-chain/node/pull/3906) - revert restricted cctx for EVM, bitcoin and solana chains
-* [3882](https://github.com/zeta-chain/node/pull/3882) - support setting default config.toml values
+
 
 ### Refactor
 

--- a/cmd/zetacored/root.go
+++ b/cmd/zetacored/root.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"slices"
-	"time"
 
 	"cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
@@ -34,7 +32,6 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	ethermintclient "github.com/zeta-chain/ethermint/client"
 	"github.com/zeta-chain/ethermint/crypto/hd"
 	evmenc "github.com/zeta-chain/ethermint/encoding"
@@ -48,8 +45,6 @@ import (
 )
 
 const EnvPrefix = "zetacore"
-
-const DefaultTimeoutCommit = 5 * time.Second
 
 // NewRootCmd creates a new root command for wasmd. It is called once in the
 // main function.
@@ -123,6 +118,9 @@ func NewRootCmd() (*cobra.Command, types.EncodingConfig) {
 	}
 
 	initRootCmd(rootCmd, encodingConfig)
+	rootCmd.AddCommand(
+		confixcmd.ConfigCommand(),
+	)
 
 	// need to create this app instance to get autocliopts
 	tempApp := app.New(
@@ -205,6 +203,9 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig types.EncodingConfig) {
 		addModuleInitFlags,
 	)
 
+	// the ethermintserver one supercedes the sdk one
+	//server.AddCommands(rootCmd, app.DefaultNodeHome, ac.newApp, ac.createSimappAndExport, addModuleInitFlags)
+
 	// add keybase, auxiliary RPC, query, and tx child commands
 	rootCmd.AddCommand(
 		server.StatusCommand(),
@@ -214,99 +215,14 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig types.EncodingConfig) {
 		ethermintclient.KeyCommands(app.DefaultNodeHome),
 	)
 
-	rootCmd.AddCommand(
-		confixcmd.ConfigCommand(),
-	)
-
-	// override config.toml default values, can be skipped with a flag (eg: in localnet, e2e tests etc.)
-	for i, cmd := range rootCmd.Commands() {
-		if cmd.Name() == "start" {
-			startRunE := cmd.RunE
-
-			cmd.RunE = func(cmd *cobra.Command, args []string) error {
-				serverCtx := server.GetServerContextFromCmd(cmd)
-				skipConfigDefaults := serverCtx.Viper.GetBool(FlagSkipConfigOverride)
-
-				if !skipConfigDefaults {
-					if err := overrideConfigFile(serverCtx); err != nil {
-						return fmt.Errorf("failed to override config file: %w", err)
-					}
-				}
-
-				return startRunE(cmd, args)
-			}
-
-			rootCmd.Commands()[i] = cmd
-			break
-		}
-	}
-
 	// replace the default hd-path for the key add command with Ethereum HD Path
 	if err := SetEthereumHDPath(rootCmd); err != nil {
 		fmt.Printf("warning: unable to set default HD path: %v\n", err)
 	}
 }
 
-// overrideConfigFile handles the configuration of config.toml file,
-// it either creates a new config with optimized defaults or updates an existing one.
-func overrideConfigFile(serverCtx *server.Context) error {
-	rootDir := serverCtx.Viper.GetString(tmcli.HomeFlag)
-	configDir := filepath.Join(rootDir, "config")
-	configPath := filepath.Join(configDir, "config.toml")
-
-	// check if config file exists
-	_, err := os.Stat(configPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to check config file %s: %w", configPath, err)
-		}
-		// config doesn't exist - will be created with defaults by server.InterceptConfigsPreRunHandler
-		return nil
-	}
-
-	fileInfo, err := os.Stat(configPath)
-	if err != nil {
-		return fmt.Errorf("failed to check config file permissions: %w", err)
-	}
-
-	// if config.toml is not writable skip next steps
-	if fileInfo.Mode()&os.FileMode(0200) == 0 {
-		fmt.Println("warning: config.toml is not writable")
-		return nil
-	}
-
-	// config exists - read and update it
-	viperConfig := viper.New()
-	viperConfig.SetConfigType("toml")
-	viperConfig.SetConfigName("config")
-	viperConfig.AddConfigPath(configDir)
-
-	if err := viperConfig.ReadInConfig(); err != nil {
-		return fmt.Errorf("failed to read config file %s: %w", configPath, err)
-	}
-
-	// update consensus timeout
-	serverCtx.Config.Consensus.TimeoutCommit = DefaultTimeoutCommit
-
-	// writeConfigFile panics on error, so we need to recover
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				fmt.Printf("warning: failed to write config file: %v\n", r)
-			}
-		}()
-		tmcfg.WriteConfigFile(configPath, serverCtx.Config)
-	}()
-	return nil
-}
-
-// FlagSkipConfigOverride defines a flag to skip automatic config.toml override.
-// This should be used for localnet, e2e tests etc.
-const FlagSkipConfigOverride = "skip-config-override"
-
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
-	startCmd.Flags().Bool(FlagSkipConfigOverride, false, "Skip automatic config.toml override")
 }
 
 func queryCommand() *cobra.Command {

--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -349,15 +349,4 @@ fi
 # mark init completed so we skip it if container is restarted
 touch ~/.zetacored/init_complete
 
-# check if --skip-config-override flag exists and set it if it does
-# TODO remove after v31 upgrade
-SKIP_CONFIG_FLAG=""
-if zetacored start --help 2>&1 | grep -q "skip-config-override"; then
-  SKIP_CONFIG_FLAG="--skip-config-override"
-else
-  # make it read-only if skip-config-override flag doesn't exist to prevent override
-  # used for upgrade test with old binary, also temporarily until v31
-  chmod 444 /root/.zetacored/config/config.toml
-fi
-
-cosmovisor run start --pruning=nothing --minimum-gas-prices=0.0001azeta --json-rpc.api eth,txpool,personal,net,debug,web3,miner --api.enable --home /root/.zetacored $SKIP_CONFIG_FLAG
+cosmovisor run start --pruning=nothing --minimum-gas-prices=0.0001azeta --json-rpc.api eth,txpool,personal,net,debug,web3,miner --api.enable --home /root/.zetacored

--- a/docs/cli/zetacored/cli.md
+++ b/docs/cli/zetacored/cli.md
@@ -9179,7 +9179,6 @@ zetacored start [flags]
       --rpc.laddr string                                RPC listen address. Port required 
       --rpc.pprof_laddr string                          pprof listen address (https://golang.org/pkg/net/http/pprof)
       --rpc.unsafe                                      enabled unsafe rpc methods
-      --skip-config-override                            Skip automatic config.toml override
       --state-sync.snapshot-interval uint               State sync snapshot interval
       --state-sync.snapshot-keep-recent uint32          State sync snapshot to keep (default 2)
       --tls.certificate-path string                     the cert.pem file path for the server TLS configuration


### PR DESCRIPTION
This reverts commit b427bf356e1128d3be6260b68570b6768ff19e9f.

# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the automatic override of the config.toml file when starting the node, simplifying node startup behavior.
- **Documentation**
  - Updated CLI documentation to remove references to the now-obsolete --skip-config-override flag.
- **Chores**
  - Cleaned up scripts and documentation to reflect the removal of the config override logic and related flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->