### PR TITLE
fix: revert sui CCTX that contains invalid receiver address

### DIFF
--- a/cmd/zetae2e/local/local.go
+++ b/cmd/zetae2e/local/local.go
@@ -500,6 +500,7 @@ func localE2ETest(cmd *cobra.Command, _ []string) {
 			e2etests.TestSuiTokenWithdrawAndCallRevertWithCallName,
 			e2etests.TestSuiDepositRestrictedName,
 			e2etests.TestSuiWithdrawRestrictedName,
+			e2etests.TestSuiWithdrawInvalidReceiverName,
 		}
 		eg.Go(suiTestRoutine(conf, deployerRunner, verbose, suiTests...))
 	}

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -115,6 +115,7 @@ const (
 	TestSuiWithdrawAndCallRevertWithCallName      = "sui_withdraw_and_call_revert_with_call" // #nosec G101: Potential hardcoded credentials (gosec), not a credential
 	TestSuiDepositRestrictedName                  = "sui_deposit_restricted"
 	TestSuiWithdrawRestrictedName                 = "sui_withdraw_restricted"
+	TestSuiWithdrawInvalidReceiverName            = "sui_withdraw_invalid_receiver"
 
 	/*
 	 Bitcoin tests
@@ -995,6 +996,15 @@ var AllE2ETests = []runner.E2ETest{
 		},
 		TestSuiWithdrawRestrictedAddress,
 		runner.WithMinimumVersion("v30.0.0"),
+	),
+	runner.NewE2ETest(
+		TestSuiWithdrawInvalidReceiverName,
+		"withdraw SUI from ZEVM to invalid receiver address",
+		[]runner.ArgDefinition{
+			{Description: "receiver", DefaultValue: "0x547a07f0564e0c8d48c4ae53305eabdef87e9610"},
+			{Description: "amount in mist", DefaultValue: "1000000"},
+		},
+		TestSuiWithdrawInvalidReceiver,
 	),
 	/*
 	 Bitcoin tests

--- a/e2e/e2etests/test_sui_withdraw_invalid_receiver.go
+++ b/e2e/e2etests/test_sui_withdraw_invalid_receiver.go
@@ -1,0 +1,58 @@
+package e2etests
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
+
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+// TestSuiWithdrawInvalidReceiver tests that a withdrawal to a invalid receiver address that reverts
+func TestSuiWithdrawInvalidReceiver(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 2)
+
+	// ARRANGE
+	// Given amount, receiver, revert address
+	receiver := args[0]
+	amount := utils.ParseBigInt(r, args[1])
+	revertAddress := r.EVMAddress()
+
+	// approve the ZRC20
+	r.ApproveSUIZRC20(r.GatewayZEVMAddr)
+
+	// ACT
+	// perform the withdraw to invalid receiver
+	tx := r.SuiWithdrawSUI(
+		receiver,
+		amount,
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
+	)
+	r.Logger.EVMTransaction(*tx, "withdraw to invalid sui address")
+
+	// wait for the withdraw tx to be mined
+	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+	utils.RequireTxSuccessful(r, receipt)
+
+	// revert address balance before
+	revertBalanceBefore, err := r.SUIZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+
+	// ASSERT
+	// wait for the cctx to be reverted
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// revert address should receive the amount
+	revertBalanceAfter, err := r.SUIZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
+}

--- a/zetaclient/chains/sui/signer/signer_test.go
+++ b/zetaclient/chains/sui/signer/signer_test.go
@@ -312,7 +312,12 @@ func Test_ValidSuiAddress(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "Valid short address",
+			name:    "Uppercase addresses are explicitly rejected",
+			address: "0X2A4C5A97B561AC5B38EDC4B4E9B2C183C57B56DF5B1EA2F1C6F2E4A44B92D59F",
+			wantErr: true,
+		},
+		{
+			name:    "Short addresses are explicitly rejected",
 			address: "0x1a",
 			wantErr: true,
 		},
@@ -350,12 +355,13 @@ func Test_ValidSuiAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validSuiAddress(tt.address)
+			err := ValidateAddress(tt.address)
 			if tt.wantErr {
-				require.Error(t, err, "expected error for address: %s", tt.address)
-			} else {
-				require.NoError(t, err, "unexpected error for address: %s", tt.address)
+				require.Error(t, err, tt.address)
+				return
 			}
+
+			require.NoError(t, err, tt.address)
 		})
 	}
 }


### PR DESCRIPTION
# Description

This PR is to unblock any future CCTXs that contain invalid Sui receiver addresses.

Here is an example CCTX in the history: https://zetachain-testnet-api.itrocket.net/zeta-chain/crosschain/cctx/103/215

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
