### PR TITLE
fix(zetaclient/sui): set latest gas price after posting

### DIFF
--- a/zetaclient/chains/sui/observer/observer.go
+++ b/zetaclient/chains/sui/observer/observer.go
@@ -105,12 +105,12 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 	// no priority fee for Sui
 	const priorityFee = 0
 
-	ob.setLatestGasPrice(gasPrice)
-
 	_, err = ob.ZetacoreClient().PostVoteGasPrice(ctx, ob.Chain(), gasPrice, priorityFee, epochNum)
 	if err != nil {
 		return errors.Wrap(err, "unable to post vote for gas price")
 	}
+
+	ob.setLatestGasPrice(gasPrice)
 
 	return nil
 }


### PR DESCRIPTION
# Description

Change order for `setLatestGasPrice` and keep consistency with other chain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the timing of gas price updates to occur after successfully posting the gas price vote, ensuring state reflects only completed actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->