### PR TITLE
fix: use loaded addresses to refresh restricted address book

### DIFF
--- a/zetaclient/config/config.go
+++ b/zetaclient/config/config.go
@@ -93,6 +93,18 @@ func SetRestrictedAddressesFromConfig(cfg Config) {
 	restrictedAddressBook = cfg.GetRestrictedAddressBook()
 }
 
+// GetRestrictedAddresses returns a list of restricted addresses
+func GetRestrictedAddresses() []string {
+	restrictedAddressBookLock.RLock()
+	defer restrictedAddressBookLock.RUnlock()
+
+	addresses := []string{}
+	for addr := range restrictedAddressBook {
+		addresses = append(addresses, addr)
+	}
+	return addresses
+}
+
 func getRestrictedAddressAbsPath(basePath string) (string, error) {
 	file := filepath.Join(basePath, folder, restrictedAddressesPath)
 	file, err := filepath.Abs(file)
@@ -119,7 +131,7 @@ func loadRestrictedAddressesConfig(cfg Config, file string) error {
 	// Clear the existing map, load addresses from main config, then load addresses
 	// from dedicated config file
 	SetRestrictedAddressesFromConfig(cfg)
-	for _, addr := range cfg.ComplianceConfig.RestrictedAddresses {
+	for _, addr := range addresses {
 		restrictedAddressBook[strings.ToLower(addr)] = true
 	}
 	return nil

--- a/zetaclient/config/config_test.go
+++ b/zetaclient/config/config_test.go
@@ -1,0 +1,62 @@
+package config_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/testutil/sample"
+	"github.com/zeta-chain/node/zetaclient/config"
+)
+
+func Test_LoadRestrictedAddressesConfig(t *testing.T) {
+	// Create test addresses
+	testAddresses := []string{
+		sample.RestrictedEVMAddressTest,
+		sample.RestrictedBtcAddressTest,
+		sample.RestrictedSolAddressTest,
+		sample.RestrictedSuiAddressTest,
+	}
+
+	t.Run("should load restricted addresses from config file", func(t *testing.T) {
+		// ARRANGE
+		// create temporary directory
+		basePath := sample.CreateTempDir(t)
+		defer os.RemoveAll(basePath) // Clean up after test
+
+		// create restricted addresses config file
+		createRestrictedAddressesConfig(t, basePath, testAddresses)
+
+		// ACT
+		err := config.LoadRestrictedAddressesConfig(config.New(false), basePath)
+		require.NoError(t, err)
+
+		// ASSERT
+		addresses := config.GetRestrictedAddresses()
+		require.Equal(t, len(testAddresses), len(addresses))
+		for _, addr := range testAddresses {
+			require.True(t, slices.Contains(addresses, strings.ToLower(addr)))
+		}
+	})
+}
+
+// createRestrictedAddressesConfig creates a restricted addresses config file
+func createRestrictedAddressesConfig(t *testing.T, basePath string, addresses []string) {
+	// create config directory
+	configDir := filepath.Join(basePath, "config")
+	err := os.MkdirAll(configDir, 0o700)
+	require.NoError(t, err)
+
+	// marshal addresses and write to json file
+	jsonData, err := json.Marshal(addresses)
+	require.NoError(t, err)
+
+	configFile := filepath.Join(configDir, "zetaclient_restricted_addresses.json")
+	err = os.WriteFile(configFile, jsonData, 0600)
+	require.NoError(t, err)
+
+}


### PR DESCRIPTION
# Description

The original code seems to be a typo and it still uses the old compliance config in `zetaclient_config.json` rather than the dedicated `zetaclient_restricted_addresses.json` file.

original code:
```
for _, addr := range cfg.ComplianceConfig.RestrictedAddresses {
	restrictedAddressBook[strings.ToLower(addr)] = true
}
```

modified code:
```
for _, addr := range addresses {
	restrictedAddressBook[strings.ToLower(addr)] = true
}
```


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
