### PR TITLE
test: allow custom gasLimit in ERC20 withdrawAndCall E2E test

### DIFF
--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -489,6 +489,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw ERC20 from ZEVM and authenticated call a contract",
 		[]runner.ArgDefinition{
 			{Description: "amount", DefaultValue: "1000"},
+			{Description: "gas limit for withdraw and call", DefaultValue: "250000"},
 		},
 		TestERC20WithdrawAndCall,
 	),
@@ -497,6 +498,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw ERC20 from ZEVM and authenticated call a contract with no message",
 		[]runner.ArgDefinition{
 			{Description: "amount", DefaultValue: "1000"},
+			{Description: "gas limit for withdraw and call", DefaultValue: "250000"},
 		},
 		TestERC20WithdrawAndCallNoMessage,
 	),
@@ -521,6 +523,7 @@ var AllE2ETests = []runner.E2ETest{
 		"withdraw ERC20 from ZEVM, revert, then abort with onAbort",
 		[]runner.ArgDefinition{
 			{Description: "amount", DefaultValue: "1000"},
+			{Description: "gas limit for withdraw and call", DefaultValue: "250000"},
 		},
 		TestERC20WithdrawRevertAndAbort,
 		runner.WithMinimumVersion("v29.0.0"),

--- a/e2e/e2etests/test_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_call.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000
@@ -22,6 +22,7 @@ func TestERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
 	}()
 
 	amount := utils.ParseBigInt(r, args[0])
+	gasLimit := utils.ParseBigInt(r, args[1])
 
 	payload := randomPayload(r)
 
@@ -36,6 +37,7 @@ func TestERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
 		amount,
 		[]byte(payload),
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_erc20_withdraw_and_call_no_message.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_call_no_message.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestERC20WithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000
@@ -22,6 +22,7 @@ func TestERC20WithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	}()
 
 	amount := utils.ParseBigInt(r, args[0])
+	gasLimit := utils.ParseBigInt(r, args[1])
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -32,6 +33,7 @@ func TestERC20WithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
 		amount,
 		[]byte{},
 		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_erc20_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_erc20_withdraw_revert_and_abort.go
@@ -15,9 +15,10 @@ import (
 )
 
 func TestERC20WithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	amount := utils.ParseBigInt(r, args[0])
+	gasLimit := utils.ParseBigInt(r, args[1])
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -38,6 +39,7 @@ func TestERC20WithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 			OnRevertGasLimit: big.NewInt(200000),
 			AbortAddress:     testAbortAddr,
 		},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/runner/zevm.go
+++ b/e2e/runner/zevm.go
@@ -23,7 +23,7 @@ import (
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
 
-var gasLimit = big.NewInt(250000)
+var defaultGasLimit = big.NewInt(250000)
 
 // ApproveETHZRC20 approves ETH ZRC20 on EVM to a specific address
 func (r *E2ERunner) ApproveETHZRC20(allowed ethcommon.Address) {
@@ -114,7 +114,7 @@ func (r *E2ERunner) ETHWithdrawAndArbitraryCall(
 		amount,
 		r.ETHZRC20Addr,
 		payload,
-		gatewayzevm.CallOptions{GasLimit: gasLimit, IsArbitraryCall: true},
+		gatewayzevm.CallOptions{GasLimit: defaultGasLimit, IsArbitraryCall: true},
 		revertOptions,
 	)
 	require.NoError(r, err)
@@ -164,7 +164,7 @@ func (r *E2ERunner) ETHWithdrawAndCallThroughContract(
 		payload,
 		gatewayzevmcaller.CallOptions{
 			IsArbitraryCall: false,
-			GasLimit:        gasLimit,
+			GasLimit:        defaultGasLimit,
 		},
 		revertOptions,
 	)
@@ -212,7 +212,7 @@ func (r *E2ERunner) ERC20WithdrawAndArbitraryCall(
 		amount,
 		r.ERC20ZRC20Addr,
 		payload,
-		gatewayzevm.CallOptions{GasLimit: gasLimit, IsArbitraryCall: true},
+		gatewayzevm.CallOptions{GasLimit: defaultGasLimit, IsArbitraryCall: true},
 		revertOptions,
 	)
 	require.NoError(r, err)
@@ -226,6 +226,7 @@ func (r *E2ERunner) ERC20WithdrawAndCall(
 	amount *big.Int,
 	payload []byte,
 	revertOptions gatewayzevm.RevertOptions,
+	gasLimit *big.Int,
 ) *ethtypes.Transaction {
 	// this function take more gas than default 500k
 	// so we need to increase the gas limit
@@ -260,7 +261,7 @@ func (r *E2ERunner) ZEVMToEMVArbitraryCall(
 		receiver.Bytes(),
 		r.ETHZRC20Addr,
 		payload,
-		gatewayzevm.CallOptions{GasLimit: gasLimit, IsArbitraryCall: true},
+		gatewayzevm.CallOptions{GasLimit: defaultGasLimit, IsArbitraryCall: true},
 		revertOptions,
 	)
 	require.NoError(r, err)
@@ -280,7 +281,7 @@ func (r *E2ERunner) ZEVMToEMVCall(
 		r.ETHZRC20Addr,
 		payload,
 		gatewayzevm.CallOptions{
-			GasLimit:        gasLimit,
+			GasLimit:        defaultGasLimit,
 			IsArbitraryCall: false,
 		},
 		revertOptions,
@@ -303,7 +304,7 @@ func (r *E2ERunner) ZEVMToEMVCallThroughContract(
 		r.ETHZRC20Addr,
 		payload,
 		gatewayzevmcaller.CallOptions{
-			GasLimit:        gasLimit,
+			GasLimit:        defaultGasLimit,
 			IsArbitraryCall: false,
 		},
 		revertOptions,


### PR DESCRIPTION
# Description

The `eth_withdraw_and_call` takes two arguments `amount` and `gasLimit`. Similarly, use same arguments for the `erc20_withdraw_and_call` E2E test so that they can be adjusted in the CI nightly tests.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
