### PR TITLE
test: lower Bitcoin E2E deposit tx fee to make nightly test cheaper

### DIFF
--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -35,6 +35,10 @@ import (
 const (
 	// BTCRegnetBlockTime is the block time for the Bitcoin regnet
 	BTCRegnetBlockTime = 6 * time.Second
+
+	// BTCDepositTxFee is the fixed deposit transaction fee (0.00003 BTC) for E2E tests
+	// Given one UTXO input, the deposit transaction fee rate is approximately 10 sat/vB
+	BTCDepositTxFee = 0.00003
 )
 
 // ListUTXOs list the deployer's UTXOs
@@ -290,7 +294,7 @@ func (r *E2ERunner) sendToAddrWithMemo(
 	allUTXOs := r.ListUTXOs()
 
 	// Calculate required amount including fee
-	feeSats := btcutil.Amount(0.0005 * btcutil.SatoshiPerBitcoin)
+	feeSats := btcutil.Amount(BTCDepositTxFee * btcutil.SatoshiPerBitcoin)
 	amountInt, err := zetabtc.GetSatoshis(amount)
 	require.NoError(r, err)
 	amountSats := btcutil.Amount(amountInt)


### PR DESCRIPTION
# Description

The current fee `0.0005 BTC` used in the E2E deposit test is quite generous and should be reduced for nightly CI test. 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Bitcoin deposit transaction fee used in end-to-end tests to a new fixed value, ensuring more accurate fee calculations during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->