### PR TITLE
feat(release): publish zetae2e

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -90,7 +90,7 @@ jobs:
             sleep 5
             echo "Re-Create Tag."
             git tag ${GITHUB_TAG_VERSION}
-            git push --tags      
+            git push --tags
           fi
 
       - name: Create GitHub Release
@@ -117,6 +117,7 @@ jobs:
           subject-path: |
             dist/zetacored_**/*
             dist/zetaclientd_**/*
+            dist/zetae2e_**/*
             dist/checksums.txt
 
       - name: Upload Attestation Bundle

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,23 @@ builds:
     flags: *default_flags
     ldflags: *default_ldflags
 
+  - id: "zetae2e"
+    main: ./cmd/zetae2e
+    binary: "zetae2e-{{ .Os }}-{{ .Arch }}"
+    env:
+      - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
+      - 'CXX={{ index .Env (print "CXX_" .Os "_" .Arch) }}'
+    goos:
+      - linux
+    goarch:
+      - arm64
+      - amd64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags: *default_flags
+    ldflags: *default_ldflags
+
 archives:
   - format: binary
     name_template: "{{ .Binary }}"


### PR DESCRIPTION
This PR adds `zetae2e` binary to the release section

Related: https://github.com/zeta-chain/node/pull/3991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new release build for the "zetae2e" tool, supporting Linux on amd64 and arm64 architectures.

* **Chores**
  * Expanded the set of files included in artifact attestation during release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->