### PR TITLE
fix: sui stability pool

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v33.0.0
+
+## Fixes
+
+* [4016—](https://github.com/zeta-chain/node/pull/4016) - fixes minting of extra tokens to the SUI stability pool
+
 ## v32.0.0
 
 ### Chores

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ## Fixes
 
-* [4016—](https://github.com/zeta-chain/node/pull/4016) - fixes minting of extra tokens to the SUI stability pool
+* [4016—](https://github.com/zeta-chain/node/pull/4016) - adds a migration script to burn all SUI Gas tokens minted to the gas stability pool and disables further minting.
 
 ## v32.0.0
 

--- a/x/fungible/keeper/migrator.go
+++ b/x/fungible/keeper/migrator.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	v4 "github.com/zeta-chain/node/x/fungible/migrations/v4"
 
 	v3 "github.com/zeta-chain/node/x/fungible/migrations/v3"
 )
@@ -21,4 +22,9 @@ func NewMigrator(keeper Keeper) Migrator {
 // Migrate2to3 migrates the store from consensus version 2 to 3
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 	return v3.MigrateStore(ctx, m.fungibleKeeper)
+}
+
+// Migrate3to4 migrates the store from consensus version 3 to 4
+func (m Migrator) Migrate3to4(ctx sdk.Context) error {
+	return v4.MigrateStore(ctx, &m.fungibleKeeper)
 }

--- a/x/fungible/keeper/migrator.go
+++ b/x/fungible/keeper/migrator.go
@@ -2,9 +2,9 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	v4 "github.com/zeta-chain/node/x/fungible/migrations/v4"
 
 	v3 "github.com/zeta-chain/node/x/fungible/migrations/v3"
+	v4 "github.com/zeta-chain/node/x/fungible/migrations/v4"
 )
 
 // Migrator is a struct for handling in-place store migrations.

--- a/x/fungible/migrations/v4/migrate.go
+++ b/x/fungible/migrations/v4/migrate.go
@@ -1,0 +1,66 @@
+package v4
+
+import (
+	"fmt"
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethermint "github.com/zeta-chain/ethermint/types"
+	"github.com/zeta-chain/node/pkg/chains"
+
+	"github.com/zeta-chain/node/x/fungible/types"
+)
+
+type fungibleKeeper interface {
+	GetAllForeignCoins(ctx sdk.Context) (list []types.ForeignCoins)
+	QuerySystemContractGasCoinZRC20(ctx sdk.Context, chainid *big.Int) (ethcommon.Address, error)
+	ZRC20BalanceOf(ctx sdk.Context, zrc20Address, owner ethcommon.Address) (*big.Int, error)
+	CallZRC20Burn(ctx sdk.Context, sender ethcommon.Address, zrc20address ethcommon.Address, amount *big.Int, noEthereumTxEvent bool) error
+}
+
+// MigrateStore migrates the x/fungible module state from the consensus version 2 to 3
+// It updates all existing address in ForeignCoin to use checksum format if the address is EVM type
+func MigrateStore(ctx sdk.Context, fungibleKeeper fungibleKeeper) error {
+	chainID, err := ethermint.ParseChainID(ctx.ChainID())
+	if err != nil {
+		// Its fine to return nil here and not try to execute the migration at all if the parsing fails
+		ctx.Logger().Error("failed to parse chain ID", "chain_id", ctx.ChainID(), "error", err)
+		return nil
+	}
+	chain, err := getSuiChain(chainID.Int64())
+	if err != nil {
+		ctx.Logger().Error("failed to get Sui chain", "chain_id", chainID.Int64(), "error", err)
+		return nil
+	}
+	suiGasZRC20, err := fungibleKeeper.QuerySystemContractGasCoinZRC20(ctx, big.NewInt(chain.ChainId))
+	if err != nil {
+		return err
+	}
+	stabilityPoolAddress := types.GasStabilityPoolAddressEVM()
+
+	suiBalance, err := fungibleKeeper.ZRC20BalanceOf(ctx, suiGasZRC20, stabilityPoolAddress)
+	if err != nil {
+		return err
+	}
+
+	err = fungibleKeeper.CallZRC20Burn(ctx, stabilityPoolAddress, suiGasZRC20, suiBalance, true)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getSuiChain(chainID int64) (chains.Chain, error) {
+	switch chainID {
+	case chains.ZetaChainMainnet.ChainId:
+		return chains.SuiMainnet, nil
+	case chains.ZetaChainTestnet.ChainId:
+		return chains.SuiTestnet, nil
+	case chains.ZetaChainPrivnet.ChainId:
+		return chains.SuiLocalnet, nil
+	default:
+		return chains.Chain{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+
+}

--- a/x/fungible/migrations/v4/migrate.go
+++ b/x/fungible/migrations/v4/migrate.go
@@ -6,9 +6,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 	ethermint "github.com/zeta-chain/ethermint/types"
-	"github.com/zeta-chain/node/pkg/chains"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/x/fungible/types"
 )
 
@@ -16,32 +17,38 @@ type fungibleKeeper interface {
 	GetAllForeignCoins(ctx sdk.Context) (list []types.ForeignCoins)
 	QuerySystemContractGasCoinZRC20(ctx sdk.Context, chainid *big.Int) (ethcommon.Address, error)
 	ZRC20BalanceOf(ctx sdk.Context, zrc20Address, owner ethcommon.Address) (*big.Int, error)
-	CallZRC20Burn(ctx sdk.Context, sender ethcommon.Address, zrc20address ethcommon.Address, amount *big.Int, noEthereumTxEvent bool) error
+	CallZRC20Burn(
+		ctx sdk.Context,
+		sender ethcommon.Address,
+		zrc20address ethcommon.Address,
+		amount *big.Int,
+		noEthereumTxEvent bool,
+	) error
 }
 
-// MigrateStore migrates the x/fungible module state from the consensus version 2 to 3
-// It updates all existing address in ForeignCoin to use checksum format if the address is EVM type
+// MigrateStore migrates the store from consensus version 3 to 4.
+// It burns the SUI gas ZRC20 from the stability pool address.
 func MigrateStore(ctx sdk.Context, fungibleKeeper fungibleKeeper) error {
 	chainID, err := ethermint.ParseChainID(ctx.ChainID())
 	if err != nil {
-		// Its fine to return nil here and not try to execute the migration at all if the parsing fails
+		// It's fine to return nil here and not try to execute the migration at all if the parsing fails
 		ctx.Logger().Error("failed to parse chain ID", "chain_id", ctx.ChainID(), "error", err)
 		return nil
 	}
-	chain, err := getSuiChain(chainID.Int64())
+	chain, err := GetSuiChain(chainID.Int64())
 	if err != nil {
 		ctx.Logger().Error("failed to get Sui chain", "chain_id", chainID.Int64(), "error", err)
 		return nil
 	}
 	suiGasZRC20, err := fungibleKeeper.QuerySystemContractGasCoinZRC20(ctx, big.NewInt(chain.ChainId))
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to query SUI gas coin ZRC20 for chain ID %d", chain.ChainId)
 	}
 	stabilityPoolAddress := types.GasStabilityPoolAddressEVM()
 
 	suiBalance, err := fungibleKeeper.ZRC20BalanceOf(ctx, suiGasZRC20, stabilityPoolAddress)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to get SUI balance for stability pool %s", stabilityPoolAddress)
 	}
 
 	err = fungibleKeeper.CallZRC20Burn(ctx, stabilityPoolAddress, suiGasZRC20, suiBalance, true)
@@ -51,7 +58,7 @@ func MigrateStore(ctx sdk.Context, fungibleKeeper fungibleKeeper) error {
 	return nil
 }
 
-func getSuiChain(chainID int64) (chains.Chain, error) {
+func GetSuiChain(chainID int64) (chains.Chain, error) {
 	switch chainID {
 	case chains.ZetaChainMainnet.ChainId:
 		return chains.SuiMainnet, nil
@@ -62,5 +69,4 @@ func getSuiChain(chainID int64) (chains.Chain, error) {
 	default:
 		return chains.Chain{}, fmt.Errorf("unsupported chain ID: %d", chainID)
 	}
-
 }

--- a/x/fungible/migrations/v4/migrate_test.go
+++ b/x/fungible/migrations/v4/migrate_test.go
@@ -1,0 +1,116 @@
+package v4_test
+
+import (
+	"math/big"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/ptr"
+	keepertest "github.com/zeta-chain/node/testutil/keeper"
+	fungiblekeeper "github.com/zeta-chain/node/x/fungible/keeper"
+	v4 "github.com/zeta-chain/node/x/fungible/migrations/v4"
+	"github.com/zeta-chain/node/x/fungible/types"
+)
+
+func TestMigrateStore(t *testing.T) {
+	t.Run("successful migration burns SUI balance from stability pool", func(t *testing.T) {
+		// ARRANGE
+		k, ctx, _, _ := keepertest.FungibleKeeper(t)
+		_ = k.GetAuthKeeper().GetModuleAccount(ctx, types.ModuleName)
+		ctx = ctx.WithChainID("zetachain_7000-1")
+		chainID := chains.SuiMainnet.ChainId
+		deploySystemContracts(t, ctx, k)
+		_ = setupGasCoin(t, ctx, k, chainID, "SUI", "SUI")
+		ethGasZRC20 := setupGasCoin(t, ctx, k, chains.Ethereum.ChainId, "ETH", "ETH")
+		k.EnsureGasStabilityPoolAccountCreated(ctx)
+
+		suiGasZRC20, err := k.QuerySystemContractGasCoinZRC20(ctx, big.NewInt(chainID))
+		require.NoError(t, err)
+		stabilityPoolAddress := types.GasStabilityPoolAddressEVM()
+		suiBalance := big.NewInt(1000000)
+
+		_, err = k.DepositZRC20(ctx, suiGasZRC20, stabilityPoolAddress, suiBalance)
+		require.NoError(t, err)
+		_, err = k.DepositZRC20(ctx, ethGasZRC20, stabilityPoolAddress, suiBalance)
+		require.NoError(t, err)
+		fetchedBalance, err := k.ZRC20BalanceOf(ctx, suiGasZRC20, stabilityPoolAddress)
+		require.NoError(t, err)
+		require.Equal(t, suiBalance, fetchedBalance)
+
+		// ACT
+		err = v4.MigrateStore(ctx, k)
+
+		// ASSERT
+		require.NoError(t, err)
+		fetchedBalance, err = k.ZRC20BalanceOf(ctx, suiGasZRC20, stabilityPoolAddress)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), fetchedBalance.Int64(), "SUI balance should be zero after migration")
+
+		fetchedBalance, err = k.ZRC20BalanceOf(ctx, ethGasZRC20, stabilityPoolAddress)
+		require.NoError(t, err)
+		require.Equal(t, int64(1000000), fetchedBalance.Int64(), "Eth balance should remain after migration")
+	})
+}
+
+// deploySystemContracts deploys the system contracts and returns their addresses.
+func deploySystemContracts(
+	t *testing.T,
+	ctx sdk.Context,
+	k *fungiblekeeper.Keeper,
+) (wzeta, uniswapV2Factory, uniswapV2Router, connector, systemContract common.Address) {
+	var err error
+
+	wzeta, err = k.DeployWZETA(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, wzeta)
+
+	uniswapV2Factory, err = k.DeployUniswapV2Factory(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, uniswapV2Factory)
+
+	uniswapV2Router, err = k.DeployUniswapV2Router02(ctx, uniswapV2Factory, wzeta)
+	require.NoError(t, err)
+	require.NotEmpty(t, uniswapV2Router)
+
+	connector, err = k.DeployConnectorZEVM(ctx, wzeta)
+	require.NoError(t, err)
+	require.NotEmpty(t, connector)
+
+	systemContract, err = k.DeploySystemContract(ctx, wzeta, uniswapV2Factory, uniswapV2Router)
+	require.NoError(t, err)
+	require.NotEmpty(t, systemContract)
+
+	return
+}
+
+func setupGasCoin(
+	t *testing.T,
+	ctx sdk.Context,
+	k *fungiblekeeper.Keeper,
+	chainID int64,
+	assetName string,
+	symbol string,
+) (zrc20 common.Address) {
+	addr, err := k.SetupChainGasCoinAndPool(
+		ctx,
+		chainID,
+		assetName,
+		symbol,
+		8,
+		nil,
+		ptr.Ptr(sdkmath.NewUint(1000)),
+	)
+	require.NoError(t, err)
+
+	// increase the default liquidity cap
+	foreignCoin, found := k.GetForeignCoins(ctx, addr.Hex())
+	require.True(t, found)
+	foreignCoin.LiquidityCap = sdkmath.NewUint(1e18).MulUint64(1e12)
+	k.SetForeignCoins(ctx, foreignCoin)
+
+	return addr
+}

--- a/x/fungible/module.go
+++ b/x/fungible/module.go
@@ -21,7 +21,7 @@ import (
 	"github.com/zeta-chain/node/x/fungible/types"
 )
 
-const consensusVersion = 3
+const consensusVersion = 4
 
 var (
 	_ module.AppModule      = AppModule{}
@@ -131,6 +131,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 	m := keeper.NewMigrator(am.keeper)
 	if err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2to3); err != nil {
+		panic(err)
+	}
+	if err := cfg.RegisterMigration(types.ModuleName, 3, m.Migrate3to4); err != nil {
 		panic(err)
 	}
 }

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -420,7 +420,7 @@ func TestObserver(t *testing.T) {
 		assert.Equal(t, uint64(200), vote.ValueReceived.Uint64())
 
 		// gas
-		assert.Equal(t, uint64(maxGasLimit), vote.ObservedOutboundEffectiveGasLimit)
+		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundEffectiveGasLimit)
 		assert.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
 		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
 	})
@@ -499,7 +499,7 @@ func TestObserver(t *testing.T) {
 		assert.Equal(t, uint64(200), vote.ValueReceived.Uint64())
 
 		// gas
-		assert.Equal(t, uint64(maxGasLimit), vote.ObservedOutboundEffectiveGasLimit)
+		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundEffectiveGasLimit)
 		assert.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
 		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
 	})

--- a/zetaclient/chains/sui/observer/outbound.go
+++ b/zetaclient/chains/sui/observer/outbound.go
@@ -19,7 +19,6 @@ import (
 
 // 50 SUI
 // https://docs.sui.io/concepts/tokenomics/gas-in-sui#gas-budgets
-const maxGasLimit = 50_000_000_000
 
 // OutboundCreated checks if the outbound tx exists in the memory
 // and has valid nonce & signature
@@ -134,6 +133,9 @@ func (ob *Observer) VoteOutbound(ctx context.Context, cctx *cctypes.CrossChainTx
 		return errors.Wrap(err, "unable to parse gas used")
 	}
 
+	// TODO : Update the effective gas limit and gas used.
+	// Setting the effective gas limit to the gas used disables the gas stability pool funding
+	// https://github.com/zeta-chain/node/issues/4015
 	// Create message
 	msg := cctypes.NewMsgVoteOutbound(
 		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
@@ -142,7 +144,7 @@ func (ob *Observer) VoteOutbound(ctx context.Context, cctx *cctypes.CrossChainTx
 		checkpoint,
 		outboundGasUsed,
 		outboundGasPrice,
-		maxGasLimit,
+		outboundGasUsed,
 		amount,
 		status,
 		chainID,


### PR DESCRIPTION
# Description

- Adds a new migration script to burn all the zrc20 tokens minted to the Stabilty Pool.
- Updates the `ObservedOutboundEffectiveGasLimit` to the same number as `ObservedOutboundGasUsed` . Although the numbers are not accurate this disables any funcding to the stabilty pool. We can also consider adding logic to zetacore directly to ignore sui chain when funding the stabilty pool , but doing it this way has the most minimal changes . It also provides us to enable stabilty pool for sui through a zetaclient only fix . 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
