### PR TITLE
fix: use 0 for effective gas limit for Sui and TON

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,18 @@
 # CHANGELOG
 
+## v32.0.3
+
+### Fixes
+
+* [4019](https://github.com/zeta-chain/node/pull/4019) - use 0 for effective gas limit for Sui and TON
+
 ## v32.0.0
 
 ### Chores
 
 * [4003](https://github.com/zeta-chain/node/pull/4003) - upgrade Cosmos SDK to v0.50.14
 
-## v31.1
+## v31.0.1
 
 ### Features
 

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -420,7 +420,7 @@ func TestObserver(t *testing.T) {
 		assert.Equal(t, uint64(200), vote.ValueReceived.Uint64())
 
 		// gas
-		assert.Equal(t, uint64(maxGasLimit), vote.ObservedOutboundEffectiveGasLimit)
+		assert.Equal(t, uint64(0), vote.ObservedOutboundEffectiveGasLimit)
 		assert.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
 		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
 	})
@@ -499,7 +499,7 @@ func TestObserver(t *testing.T) {
 		assert.Equal(t, uint64(200), vote.ValueReceived.Uint64())
 
 		// gas
-		assert.Equal(t, uint64(maxGasLimit), vote.ObservedOutboundEffectiveGasLimit)
+		assert.Equal(t, uint64(0), vote.ObservedOutboundEffectiveGasLimit)
 		assert.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
 		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
 	})

--- a/zetaclient/chains/sui/observer/outbound.go
+++ b/zetaclient/chains/sui/observer/outbound.go
@@ -17,10 +17,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
 
-// 50 SUI
-// https://docs.sui.io/concepts/tokenomics/gas-in-sui#gas-budgets
-const maxGasLimit = 50_000_000_000
-
 // OutboundCreated checks if the outbound tx exists in the memory
 // and has valid nonce & signature
 func (ob *Observer) OutboundCreated(nonce uint64) bool {
@@ -142,7 +138,7 @@ func (ob *Observer) VoteOutbound(ctx context.Context, cctx *cctypes.CrossChainTx
 		checkpoint,
 		outboundGasUsed,
 		outboundGasPrice,
-		maxGasLimit,
+		0, // We don't specify an effective gas limit for Sui outbound, this value is used for the gas stability pool funding, which is not used for Sui
 		amount,
 		status,
 		chainID,

--- a/zetaclient/chains/ton/observer/inbound.go
+++ b/zetaclient/chains/ton/observer/inbound.go
@@ -20,6 +20,10 @@ import (
 )
 
 const (
+	// https://tonscan.com/config-parameters (N21: "Computation costs")
+	// This might changes in the future by TON's gov proposal (very unlikely though)
+	maxGasLimit = 1_000_000
+
 	// maximum number of transactions to process on a ticker
 	// TODO: move to config
 	// https://github.com/zeta-chain/node/issues/3086

--- a/zetaclient/chains/ton/observer/outbound.go
+++ b/zetaclient/chains/ton/observer/outbound.go
@@ -17,10 +17,6 @@ import (
 	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
 
-// https://tonscan.com/config-parameters (N21: "Computation costs")
-// This might changes in the future by TON's gov proposal (very unlikely though)
-const maxGasLimit = 1_000_000
-
 type outbound struct {
 	tx            *toncontracts.Transaction
 	receiveStatus chains.ReceiveStatus
@@ -241,7 +237,7 @@ func (ob *Observer) postVoteOutbound(
 		tonBlockHeight,
 		outboundRes.tx.GasUsed().Uint64(),
 		gasPriceInt,
-		maxGasLimit,
+		0, // We don't specify an effective gas limit for TON outbound, this value is used for the gas stability pool funding, which is not used for TON
 		w.Amount,
 		outboundRes.receiveStatus,
 		chainID,


### PR DESCRIPTION
# Description

Fix the invalid Sui minting for the gas stability pool when doing Sui outbounds

Effective gas limit to fund gas stability pool which is not used for Sui and TON