### PR TITLE
refactor: enable Bitcoin inscription parsing on mainnet

### DIFF
--- a/zetaclient/chains/bitcoin/observer/event.go
+++ b/zetaclient/chains/bitcoin/observer/event.go
@@ -97,13 +97,10 @@ func (event *BTCInboundEvent) DecodeMemoBytes(chainID int64) error {
 	}
 
 	// try to decode the standard memo as the preferred format
-	// the standard memo is NOT enabled for Bitcoin mainnet
-
-	if chainID != chains.BitcoinMainnet.ChainId {
-		memoStd, isStandardMemo, err = memo.DecodeFromBytes(event.MemoBytes)
-	}
-
-	// process standard memo or fallback to legacy memo
+	// then process standard memo or fallback to legacy memo
+	// TODO: improve this logic, err should be handled if isStandardMemo is false
+	// https://github.com/zeta-chain/node/issues/4024
+	memoStd, isStandardMemo, err = memo.DecodeFromBytes(event.MemoBytes)
 	if isStandardMemo {
 		// skip standard memo that carries improper data
 		if err != nil {

--- a/zetaclient/chains/bitcoin/observer/event_test.go
+++ b/zetaclient/chains/bitcoin/observer/event_test.go
@@ -156,7 +156,7 @@ func Test_DecodeEventMemoBytes(t *testing.T) {
 			expectedReceiver: common.HexToAddress("0x2D07A9CBd57DCca3E2cF966C88Bc874445b6E3B6"),
 		},
 		{
-			name:    "should disable standard memo for Bitcoin mainnet",
+			name:    "should decode standard memo bytes successfully for Bitcoin Mainnet",
 			chainID: chains.BitcoinMainnet.ChainId,
 			event: &BTCInboundEvent{
 				// a deposit and call
@@ -165,7 +165,18 @@ func Test_DecodeEventMemoBytes(t *testing.T) {
 					"5a0110032d07a9cbd57dcca3e2cf966c88bc874445b6e3b60d68656c6c6f207361746f736869",
 				),
 			},
-			expectedReceiver: common.HexToAddress("0x5A0110032d07A9cbd57dcCa3e2Cf966c88bC8744"),
+			expectedMemoStd: &memo.InboundMemo{
+				Header: memo.Header{
+					Version:     0,
+					EncodingFmt: memo.EncodingFmtCompactShort,
+					OpCode:      memo.OpCodeDepositAndCall,
+					DataFlags:   3, // reciever + payload
+				},
+				FieldsV0: memo.FieldsV0{
+					Receiver: common.HexToAddress("0x2D07A9CBd57DCca3E2cF966C88Bc874445b6E3B6"),
+					Payload:  []byte("hello satoshi"),
+				},
+			},
 		},
 		{
 			name:    "should return error if no memo is found",


### PR DESCRIPTION
# Description

Enable Bitcoin inscription support.

There are some issues in the error handling already existing, opened an issue for this one [Fix error handling logic when decoding Bitcoin inscription memo standard](https://github.com/zeta-chain/node/issues/4024)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standard memo decoding is now consistently attempted for Bitcoin mainnet, improving compatibility with standard memo formats.

* **Tests**
  * Updated tests to verify successful decoding of standard memos on Bitcoin mainnet, ensuring correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->