### PR TITLE
fix(rpc): vulnerability in Incorrect TxHash assignment

### DIFF
--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -70,7 +70,7 @@ func EthHeaderFromTendermint(
 	miner sdk.AccAddress,
 ) *ethtypes.Header {
 	txHash := ethtypes.EmptyRootHash
-	if len(header.DataHash) == 0 {
+	if len(header.DataHash) != 0 {
 		txHash = common.BytesToHash(header.DataHash)
 	}
 


### PR DESCRIPTION


# Description
The EthHeaderFromTendermint function, located in the [rpc/types/utils.go](https://dashboard.hackenproof.com/redirect?url=https://github.com/zeta-chain/node/blob/develop/rpc/types/utils.go%23L73) file, converts a Tendermint header into an Ethereum header.

The function initializes txHash with ethtypes.EmptyRootHash and overwrites it only when the block contains no transaction data. As a result, blocks with transactions retain the empty root value, while empty blocks receive a non-empty hash derived from header.DataHash. This causes Ethereum headers to have an incorrect TxHash field for non-empty blocks, which can disrupt the header Merkle-proof validation process.

The issue fixed in the cosmos evm the same changes 

Reference: https://github.com/cosmos/evm/commit/a26cc829acc28d9bdb096231163db27cfa206345


# How Has This Been Tested?

N/A

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the handling of empty data hashes to ensure transaction hashes are only set when data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->