### PR TITLE
refactor: improve error handling when decoding Bitcoin inscribed memo standard

### DIFF
--- a/pkg/memo/memo.go
+++ b/pkg/memo/memo.go
@@ -59,7 +59,7 @@ func (m *InboundMemo) EncodeToBytes() ([]byte, error) {
 // Returns:
 //   - [memo, true, nil] if given data is successfully decoded as a memo.
 //   - [nil,  true, err] if given data is successfully decoded as a memo but contains improper field values.
-//   - [nil, false, err] if given data can't be decoded as a memo.
+//   - [nil, false, nil] if given data can't be decoded as a standard memo, leave the error to nil.
 //
 // Note: we won't have to differentiate between the two 'true' cases if legacy memo phase out is completed.
 func DecodeFromBytes(data []byte) (*InboundMemo, bool, error) {
@@ -68,7 +68,7 @@ func DecodeFromBytes(data []byte) (*InboundMemo, bool, error) {
 	// decode header
 	err := memo.Header.DecodeFromBytes(data)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "failed to decode memo header")
+		return nil, false, nil
 	}
 
 	// decode fields based on version
@@ -77,7 +77,7 @@ func DecodeFromBytes(data []byte) (*InboundMemo, bool, error) {
 		// unpack fields
 		err = memo.FieldsV0.Unpack(memo.EncodingFmt, memo.Header.DataFlags, data[HeaderSize:])
 		if err != nil {
-			return nil, false, errors.Wrap(err, "failed to unpack memo FieldsV0")
+			return nil, true, errors.Wrap(err, "failed to unpack memo FieldsV0")
 		}
 
 		// validate fields
@@ -87,7 +87,9 @@ func DecodeFromBytes(data []byte) (*InboundMemo, bool, error) {
 			return nil, true, errors.Wrap(err, "failed to validate memo FieldsV0")
 		}
 	default:
-		return nil, false, fmt.Errorf("invalid memo version: %d", memo.Version)
+		// unreachable code
+		// version is validated when decoding the header
+		return nil, true, fmt.Errorf("invalid memo version: %d", memo.Version)
 	}
 
 	return memo, true, nil

--- a/zetaclient/chains/bitcoin/observer/event.go
+++ b/zetaclient/chains/bitcoin/observer/event.go
@@ -98,8 +98,7 @@ func (event *BTCInboundEvent) DecodeMemoBytes(chainID int64) error {
 
 	// try to decode the standard memo as the preferred format
 	// then process standard memo or fallback to legacy memo
-	// TODO: improve this logic, err should be handled if isStandardMemo is false
-	// https://github.com/zeta-chain/node/issues/4024
+	// note: err is guaranteed to be nil when 'isStandardMemo == false'
 	memoStd, isStandardMemo, err = memo.DecodeFromBytes(event.MemoBytes)
 	if isStandardMemo {
 		// skip standard memo that carries improper data


### PR DESCRIPTION
# Description

Closes: https://github.com/zeta-chain/node/issues/4024

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
