### PR TITLE
test: use grpc to query zeta supply in accounting check

### DIFF
--- a/e2e/runner/accounting.go
+++ b/e2e/runner/accounting.go
@@ -2,12 +2,13 @@ package runner
 
 import (
 	"fmt"
+	"math/big"
+
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
-	"math/big"
 
 	zetacrypto "github.com/zeta-chain/node/pkg/crypto"
 	observertypes "github.com/zeta-chain/node/x/observer/types"


### PR DESCRIPTION
# Description

Replace HTTP query with GRPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the method for retrieving ZETA token supply, enhancing reliability and efficiency.
  * Cleaned up unused imports and updated internal logic for balance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->