### PR TITLE
fix: just in case we need to delay gas price vote

### DIFF
--- a/zetaclient/chains/bitcoin/observer/gas_price.go
+++ b/zetaclient/chains/bitcoin/observer/gas_price.go
@@ -3,6 +3,7 @@ package observer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -13,6 +14,11 @@ import (
 
 // PostGasPrice posts gas price to zetacore
 func (ob *Observer) PostGasPrice(ctx context.Context) error {
+	// add 1 min delay to not immediately post gas price
+	if ob.Chain().NetworkType != chains.NetworkType_privnet {
+		time.Sleep(1 * time.Minute)
+	}
+
 	var (
 		err              error
 		feeRateEstimated uint64

--- a/zetaclient/chains/evm/observer/observer_gas.go
+++ b/zetaclient/chains/evm/observer/observer_gas.go
@@ -3,12 +3,20 @@ package observer
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/zeta-chain/node/pkg/chains"
 )
 
 // PostGasPrice posts gas price to zetacore.
 func (ob *Observer) PostGasPrice(ctx context.Context) error {
+	// add 1 min delay to not immediately post gas price
+	if ob.Chain().NetworkType != chains.NetworkType_privnet {
+		time.Sleep(1 * time.Minute)
+	}
+
 	// GAS PRICE
 	gasPrice, err := ob.evmClient.SuggestGasPrice(ctx)
 	if err != nil {

--- a/zetaclient/chains/solana/observer/observer_gas.go
+++ b/zetaclient/chains/solana/observer/observer_gas.go
@@ -2,10 +2,12 @@ package observer
 
 import (
 	"context"
+	"time"
 
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/pkg/errors"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	zetamath "github.com/zeta-chain/node/pkg/math"
 )
 
@@ -31,6 +33,11 @@ const (
 
 // PostGasPrice posts gas price to zetacore
 func (ob *Observer) PostGasPrice(ctx context.Context) error {
+	// add 1 min delay to not immediately post gas price
+	if ob.Chain().NetworkType != chains.NetworkType_privnet {
+		time.Sleep(1 * time.Minute)
+	}
+
 	// get current slot
 	slot, err := ob.solClient.GetSlot(ctx, rpc.CommitmentConfirmed)
 	if err != nil {

--- a/zetaclient/chains/sui/observer/observer.go
+++ b/zetaclient/chains/sui/observer/observer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/block-vision/sui-go-sdk/models"
 	"github.com/pkg/errors"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/contracts/sui"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/sui/client"
@@ -85,6 +86,11 @@ func (ob *Observer) CheckRPCStatus(ctx context.Context) error {
 // - "Validators update the ReferencePrice every epoch (~24h)"
 // - "Storage price is updated infrequently through gov proposals"
 func (ob *Observer) PostGasPrice(ctx context.Context) error {
+	// add 1 min delay to not immediately post gas price
+	if ob.Chain().NetworkType != chains.NetworkType_privnet {
+		time.Sleep(1 * time.Minute)
+	}
+
 	checkpoint, err := ob.client.GetLatestCheckpoint(ctx)
 	if err != nil {
 		return errors.Wrap(err, "unable to get latest checkpoint")

--- a/zetaclient/chains/ton/observer/observer.go
+++ b/zetaclient/chains/ton/observer/observer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tonkeeper/tongo/boc"
 	"github.com/tonkeeper/tongo/ton"
 
+	"github.com/zeta-chain/node/pkg/chains"
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/ton/rpc"
@@ -74,6 +75,11 @@ func New(bo *base.Observer, rpc RPC, gateway *toncontracts.Gateway) (*Observer, 
 
 // PostGasPrice fetches on-chain gas config and reports it to Zetacore.
 func (ob *Observer) PostGasPrice(ctx context.Context) error {
+	// add 1 min delay to not immediately post gas price
+	if ob.Chain().NetworkType != chains.NetworkType_privnet {
+		time.Sleep(1 * time.Minute)
+	}
+
 	cfg, err := rpc.FetchGasConfigRPC(ctx, ob.rpc)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch gas config")


### PR DESCRIPTION
# Description

In case we want to avoid too many gas price vote due to repeated `zetaclient` restart.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
