### PR TITLE
test(e2e): increase upgrade tests upgrade height to 240

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ start-upgrade-test: zetanode-upgrade solana
 	@echo "--> Starting upgrade test"
 	export LOCALNET_MODE=upgrade && \
 	export UPGRADE_HEIGHT=225 && \
-	export E2E_ARGS="--test-solana --test-sui" && \
+	export E2E_ARGS="--test-solana --test-sui --verbose" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade --profile solana --profile sui -f docker-compose-upgrade.yml up -d
 
 start-upgrade-test-light: zetanode-upgrade

--- a/Makefile
+++ b/Makefile
@@ -379,8 +379,8 @@ endif
 start-upgrade-test: zetanode-upgrade solana
 	@echo "--> Starting upgrade test"
 	export LOCALNET_MODE=upgrade && \
-	export UPGRADE_HEIGHT=225 && \
-	export E2E_ARGS="--test-solana --test-sui --verbose" && \
+	export UPGRADE_HEIGHT=240 && \
+	export E2E_ARGS="--test-solana --test-sui" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade --profile solana --profile sui -f docker-compose-upgrade.yml up -d
 
 start-upgrade-test-light: zetanode-upgrade


### PR DESCRIPTION
This value mitigate the bug attached, seems we added too many tests over time that don't complete before the upgrade hieght.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the upgrade test environment to trigger at a new block height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->