### PR TITLE
test(`e2e`): add e2e test to check withdraw with custom gas limit

### DIFF
--- a/cmd/zetae2e/local/evm.go
+++ b/cmd/zetae2e/local/evm.go
@@ -21,6 +21,7 @@ func startEVMTests(eg *errgroup.Group, conf config.Config, deployerRunner *runne
 		e2etests.TestETHDepositAndCallBigPayloadName,
 		e2etests.TestETHDepositFastConfirmationName,
 		e2etests.TestETHWithdrawName,
+		e2etests.TestETHWithdrawCustomGasLimitName,
 		e2etests.TestETHWithdrawAndArbitraryCallName,
 		e2etests.TestETHWithdrawAndCallName,
 		e2etests.TestETHWithdrawAndCallBigPayloadName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -21,6 +21,7 @@ const (
 	TestETHDepositRevertAndAbortName        = "eth_deposit_revert_and_abort"
 
 	TestETHWithdrawName                          = "eth_withdraw"
+	TestETHWithdrawCustomGasLimitName            = "eth_withdraw_custom_gas_limit"
 	TestETHWithdrawAndArbitraryCallName          = "eth_withdraw_and_arbitrary_call"
 	TestETHWithdrawAndCallName                   = "eth_withdraw_and_call"
 	TestETHWithdrawAndCallBigPayloadName         = "eth_withdraw_and_call_big_payload"
@@ -416,6 +417,15 @@ var AllE2ETests = []runner.E2ETest{
 			{Description: "amount in wei", DefaultValue: "100000"},
 		},
 		TestETHWithdraw,
+	),
+	runner.NewE2ETest(
+		TestETHWithdrawCustomGasLimitName,
+		"withdraw Ether from ZEVM using a custom gas limit",
+		[]runner.ArgDefinition{
+			{Description: "amount in wei", DefaultValue: "100000"},
+			{Description: "gas limit for withdraw", DefaultValue: "200000"},
+		},
+		TestETHWithdrawCustomGasLimit,
 	),
 	runner.NewE2ETest(
 		TestETHWithdrawAndArbitraryCallName,

--- a/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
+++ b/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
@@ -1,0 +1,48 @@
+package e2etests
+
+import (
+	"math/big"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts/pkg/gatewayzevm.sol"
+
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+func TestETHWithdrawCustomGasLimit(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 1)
+
+	amount := utils.ParseBigInt(r, args[0])
+	customGasLimit := utils.ParseBigInt(r, args[1])
+
+	oldBalance, err := r.EVMClient.BalanceAt(r.Ctx, r.EVMAddress(), nil)
+	require.NoError(r, err)
+
+	r.ApproveETHZRC20(r.GatewayZEVMAddr)
+
+	// perform the withdraw with the custom gas limit option
+	tx, err := r.GatewayZEVM.Withdraw1(
+		r.ZEVMAuth,
+		r.EVMAddress().Bytes(),
+		amount,
+		r.ETHZRC20Addr,
+		customGasLimit,
+		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+	)
+	require.NoError(r, err)
+
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "withdraw")
+	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+
+	// check gas limit used
+	require.EqualValues(r, customGasLimit.Uint64(), cctx.OutboundParams[0].GasLimit)
+
+	// check the balance was updated, we just check newBalance is greater than oldBalance because of the gas fee
+	newBalance, err := r.EVMClient.BalanceAt(r.Ctx, r.EVMAddress(), nil)
+	require.NoError(r, err)
+	require.Greater(r, newBalance.Uint64(), oldBalance.Uint64())
+}

--- a/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
+++ b/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestETHWithdrawCustomGasLimit(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 1)
+	require.Len(r, args, 2)
 
 	amount := utils.ParseBigInt(r, args[0])
 	customGasLimit := utils.ParseBigInt(r, args[1])

--- a/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
+++ b/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
@@ -39,7 +39,7 @@ func TestETHWithdrawCustomGasLimit(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check gas limit used
-	require.EqualValues(r, customGasLimit.Uint64(), cctx.OutboundParams[0].GasLimit)
+	require.EqualValues(r, customGasLimit.Uint64(), cctx.OutboundParams[0].CallOptions.GasLimit)
 
 	// check the balance was updated, we just check newBalance is greater than oldBalance because of the gas fee
 	newBalance, err := r.EVMClient.BalanceAt(r.Ctx, r.EVMAddress(), nil)

--- a/e2e/e2etests/test_sui_withdraw_restricted_address.go
+++ b/e2e/e2etests/test_sui_withdraw_restricted_address.go
@@ -66,7 +66,7 @@ func TestSuiWithdrawRestrictedAddress(r *runner.E2ERunner, args []string) {
 	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 
 	// Invalid address format
-	tx, err = r.GatewayZEVM.Withdraw(
+	tx, err = r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		[]byte("0x25db16c3ca555f6702c07860503107bb73cce9f6c1d6df00464529db15d5a5abaa"),
 		amount,

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -253,7 +253,7 @@ func (r *E2ERunner) WithdrawBTC(
 	}
 
 	// withdraw 'amount' of BTC through ZEVM gateway
-	tx, err := r.GatewayZEVM.Withdraw(
+	tx, err := r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		[]byte(to.EncodeAddress()),
 		amount,

--- a/e2e/runner/solana.go
+++ b/e2e/runner/solana.go
@@ -586,7 +586,7 @@ func (r *E2ERunner) WithdrawSOLZRC20(
 	utils.RequireTxSuccessful(r, receipt, "approve")
 
 	// withdraw
-	tx, err = r.GatewayZEVM.Withdraw(
+	tx, err = r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		[]byte(to.String()),
 		amount,
@@ -620,7 +620,7 @@ func (r *E2ERunner) WithdrawAndCallSOLZRC20(
 	utils.RequireTxSuccessful(r, receipt, "approve")
 
 	// withdraw
-	tx, err = r.GatewayZEVM.WithdrawAndCall0(
+	tx, err = r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		[]byte(receiver),
 		amount,
@@ -757,7 +757,7 @@ func (r *E2ERunner) WithdrawAndCallSPLZRC20(
 	require.NoError(r, err)
 
 	// withdraw
-	tx, err = r.GatewayZEVM.WithdrawAndCall0(
+	tx, err = r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		[]byte(receiver),
 		amount,

--- a/e2e/runner/sui.go
+++ b/e2e/runner/sui.go
@@ -64,7 +64,7 @@ func (r *E2ERunner) SuiWithdraw(
 	receiverBytes, err := hex.DecodeString(receiver[2:])
 	require.NoError(r, err, "receiver: "+receiver[2:])
 
-	tx, err := r.GatewayZEVM.Withdraw(
+	tx, err := r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		receiverBytes,
 		amount,
@@ -92,7 +92,7 @@ func (r *E2ERunner) SuiWithdrawAndCall(
 	payloadBytes, err := payload.PackABI()
 	require.NoError(r, err)
 
-	tx, err := r.GatewayZEVM.WithdrawAndCall0(
+	tx, err := r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		receiverBytes,
 		amount,

--- a/e2e/runner/ton.go
+++ b/e2e/runner/ton.go
@@ -319,7 +319,7 @@ func (r *E2ERunner) SendWithdrawTONZRC20(
 	r.ApproveTONZRC20(r.GatewayZEVMAddr)
 
 	// Perform the withdrawal
-	tx, err := r.GatewayZEVM.Withdraw(
+	tx, err := r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		[]byte(to.ToRaw()),
 		amount,

--- a/e2e/runner/zevm.go
+++ b/e2e/runner/zevm.go
@@ -89,7 +89,7 @@ func (r *E2ERunner) ETHWithdraw(
 	amount *big.Int,
 	revertOptions gatewayzevm.RevertOptions,
 ) *ethtypes.Transaction {
-	tx, err := r.GatewayZEVM.Withdraw(
+	tx, err := r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		receiver.Bytes(),
 		amount,
@@ -108,7 +108,7 @@ func (r *E2ERunner) ETHWithdrawAndArbitraryCall(
 	payload []byte,
 	revertOptions gatewayzevm.RevertOptions,
 ) *ethtypes.Transaction {
-	tx, err := r.GatewayZEVM.WithdrawAndCall0(
+	tx, err := r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		receiver.Bytes(),
 		amount,
@@ -130,7 +130,7 @@ func (r *E2ERunner) ETHWithdrawAndCall(
 	revertOptions gatewayzevm.RevertOptions,
 	gasLimit *big.Int,
 ) *ethtypes.Transaction {
-	tx, err := r.GatewayZEVM.WithdrawAndCall0(
+	tx, err := r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		receiver.Bytes(),
 		amount,
@@ -179,7 +179,7 @@ func (r *E2ERunner) ERC20Withdraw(
 	amount *big.Int,
 	revertOptions gatewayzevm.RevertOptions,
 ) *ethtypes.Transaction {
-	tx, err := r.GatewayZEVM.Withdraw(
+	tx, err := r.GatewayZEVM.Withdraw0(
 		r.ZEVMAuth,
 		receiver.Bytes(),
 		amount,
@@ -206,7 +206,7 @@ func (r *E2ERunner) ERC20WithdrawAndArbitraryCall(
 		r.ZEVMAuth.GasLimit = previousGasLimit
 	}()
 
-	tx, err := r.GatewayZEVM.WithdrawAndCall0(
+	tx, err := r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		receiver.Bytes(),
 		amount,
@@ -236,7 +236,7 @@ func (r *E2ERunner) ERC20WithdrawAndCall(
 		r.ZEVMAuth.GasLimit = previousGasLimit
 	}()
 
-	tx, err := r.GatewayZEVM.WithdrawAndCall0(
+	tx, err := r.GatewayZEVM.WithdrawAndCall(
 		r.ZEVMAuth,
 		receiver.Bytes(),
 		amount,

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/zeta-chain/ethermint v0.0.0-20250606151045-75716891f3f0
-	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250701190647-e8f7932aa325
+	github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250728071033-90592fb858dd
 	go.nhat.io/grpcmock v0.25.0
 	golang.org/x/crypto v0.38.0
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394

--- a/go.sum
+++ b/go.sum
@@ -1473,6 +1473,8 @@ github.com/zeta-chain/go-tss v0.6.3 h1:c/zSEvI0h7MJ+xxu42M58uBdEWrlzfD3NI1kP/FlW
 github.com/zeta-chain/go-tss v0.6.3/go.mod h1:xLssidNiAP/fcdcw+cUPA2VS7Td2bnPMS/8x0jnde8w=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250701190647-e8f7932aa325 h1:A3AMZ9SEpTZwMrle1ytZcjiVBANb1hGFOF+5Z2/e2Aw=
 github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250701190647-e8f7932aa325/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
+github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250728071033-90592fb858dd h1:Nlu25LE943pGRGDzXSfyYFIB5cSswolHc56my68LQ3E=
+github.com/zeta-chain/protocol-contracts v1.0.2-athens3.0.20250728071033-90592fb858dd/go.mod h1:SjT7QirtJE8stnAe1SlNOanxtfSfijJm3MGJ+Ax7w7w=
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46 h1:xbgrVDXWkZaWhMAuD3Q5A13jmRKYQbjZMPBaCkv3cns=
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46/go.mod h1:DcDY828o773soiU/h0XpC+naxitrIMFVZqEvq/EJxMA=
 github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901 h1:9whtN5fjYHfk4yXIuAsYP2EHxImwDWDVUOnZJ2pfL3w=


### PR DESCRIPTION
# Description

E2E test for https://github.com/zeta-chain/protocol-contracts/pull/548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new end-to-end test for withdrawing Ether from ZEVM using a custom gas limit, allowing verification of custom gas usage during withdrawals.

* **Bug Fixes**
  * Updated internal method calls for withdrawals and withdraw-and-call operations across multiple chains (Ethereum, Bitcoin, Solana, Sui, TON) to ensure consistency and correct contract interactions.

* **Chores**
  * Upgraded the protocol contracts dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->