### PR TITLE
feat: support hostname in addition to public IP for zetaclient to connect to zetacore

### DIFF
--- a/cmd/zetaclientd-supervisor/lib.go
+++ b/cmd/zetaclientd-supervisor/lib.go
@@ -53,13 +53,13 @@ type zetaclientdSupervisor struct {
 }
 
 func newZetaclientdSupervisor(
-	zetaCoreURL string,
+	zetacoreGRPCURL string,
 	logger zerolog.Logger,
 	enableAutoDownload bool,
 ) (*zetaclientdSupervisor, error) {
 	logger = logger.With().Str("module", "zetaclientdSupervisor").Logger()
 	conn, err := grpc.Dial(
-		fmt.Sprintf("%s:9090", zetaCoreURL),
+		zetacoreGRPCURL,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/cmd/zetaclientd-supervisor/main.go
+++ b/cmd/zetaclientd-supervisor/main.go
@@ -48,8 +48,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	clientCfg := cfg.GetZetacoreClientConfig()
 	_, enableAutoDownload := os.LookupEnv("ZETACLIENTD_SUPERVISOR_ENABLE_AUTO_DOWNLOAD")
-	supervisor, err := newZetaclientdSupervisor(cfg.ZetaCoreURL, logger, enableAutoDownload)
+	supervisor, err := newZetaclientdSupervisor(clientCfg.GRPCURL, logger, enableAutoDownload)
 	if err != nil {
 		logger.Error().Err(err).Msg("unable to get supervisor")
 		os.Exit(1)

--- a/cmd/zetaclientd/initconfig.go
+++ b/cmd/zetaclientd/initconfig.go
@@ -18,7 +18,9 @@ type initializeConfigOptions struct {
 	logSampler         bool
 	preParamsPath      string
 	chainID            string
-	zetacoreURL        string
+	zetacoreIP         string
+	zetacoreGRPCURL    string
+	zetacoreWSSURL     string
 	authzGranter       string
 	authzHotkey        string
 	level              int8
@@ -50,7 +52,9 @@ func setupInitializeConfigOptions() {
 	f.StringVar(&cfg.publicIP, "public-ip", "", "public ip address")
 	f.StringVar(&cfg.preParamsPath, "pre-params", "~/preParams.json", "pre-params file path")
 	f.StringVar(&cfg.chainID, "chain-id", "athens_7001-1", "chain id")
-	f.StringVar(&cfg.zetacoreURL, "zetacore-url", "127.0.0.1", "zetacore node URL")
+	f.StringVar(&cfg.zetacoreIP, "zetacore-ip", "", "zetacore node IP address, leave it empty to use gRPC and WSS URLs")
+	f.StringVar(&cfg.zetacoreGRPCURL, "zetacore-grpc-url", "", "zetacore node gRPC URL")
+	f.StringVar(&cfg.zetacoreWSSURL, "zetacore-wss-url", "", "zetacore node websocket URL")
 	f.StringVar(&cfg.authzGranter, "operator", "", "granter for the authorization , this should be operator address")
 	f.StringVar(&cfg.authzHotkey, "hotkey", "hotkey", usageHotKey)
 	f.Int8Var(&cfg.level, "log-level", int8(zerolog.InfoLevel), usageLogLevel)
@@ -84,7 +88,9 @@ func InitializeConfig(_ *cobra.Command, _ []string) error {
 	configData.PublicIP = opts.publicIP
 	configData.PreParamsPath = opts.preParamsPath
 	configData.ChainID = opts.chainID
-	configData.ZetaCoreURL = opts.zetacoreURL
+	configData.ZetacoreIP = opts.zetacoreIP
+	configData.ZetacoreURLGRPC = opts.zetacoreGRPCURL
+	configData.ZetacoreURLWSS = opts.zetacoreWSSURL
 	configData.AuthzHotkey = opts.authzHotkey
 	configData.AuthzGranter = opts.authzGranter
 	configData.LogLevel = opts.level

--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -87,7 +87,7 @@ func Start(_ *cobra.Command, _ []string) error {
 		return errors.Wrap(err, "unable to update app context")
 	}
 
-	log.Debug().Msgf("Config is updated from zetacore\n %s", cfg.StringMasked())
+	log.Info().Msgf("Config is updated from zetacore\n %s", cfg.StringMasked())
 
 	granteePubKeyBech32, err := resolveObserverPubKeyBech32(cfg, passes.hotkey)
 	if err != nil {

--- a/contrib/localnet/scripts/start-zetaclientd.sh
+++ b/contrib/localnet/scripts/start-zetaclientd.sh
@@ -14,6 +14,22 @@ set_sepolia_endpoint() {
   jq '.EVMChainConfigs."11155111".Endpoint = "http://eth2:8545"' /root/.zetacored/config/zetaclient_config.json > tmp.json && mv tmp.json /root/.zetacored/config/zetaclient_config.json
 }
 
+# calculate zetacore IP address based on zetaclient number
+calculate_zetacore_ip() {
+  local num="$1"
+  local base_ip="172.20.0.11"  # zetacore0 IP address
+  
+  if [[ $num =~ ^[0-9]+$ ]]; then
+    # extract the last octet and add the number
+    local base_octet
+    base_octet=$(echo $base_ip | cut -d. -f4)
+    local target_octet=$((base_octet + num))
+    echo "172.20.0.$target_octet"
+  else
+    echo "zetacore$num" # fallback for non-numeric pattern
+  fi
+}
+
 # import a relayer private key (e.g. Solana relayer key)
 import_relayer_key() {
   local num="$1"
@@ -54,7 +70,6 @@ if [ "$HOTKEY_BACKEND" == "file" ]; then
 fi
 
 num=$(echo $HOSTNAME | tr -dc '0-9')
-node="zetacore$num"
 
 while [ ! -f $HOME/.zetacored/os.json ]; do
     echo "Waiting for zetacore to exchange os.json file..."
@@ -80,7 +95,7 @@ echo "Start zetaclientd"
 
 # skip initialization if the config file already exists (zetaclientd init has already been run)
 if [[ $HOSTNAME == "zetaclient0" && ! -f ~/.zetacored/config/zetaclient_config.json ]] then
-    zetaclientd init --zetacore-url zetacore0 --chain-id athens_101-1 \
+    zetaclientd init --zetacore-ip "$(calculate_zetacore_ip "0")" --chain-id athens_101-1 \
         --operator "$operatorAddress" --log-format=text --public-ip "$MYIP" \
         --keyring-backend "$BACKEND" --pre-params "$PREPARAMS_PATH"
 
@@ -102,9 +117,9 @@ if [[ $HOSTNAME != "zetaclient0" && ! -f ~/.zetacored/config/zetaclient_config.j
       node="zetacore-new-validator"
   else
       num=$(echo $HOSTNAME | tr -dc '0-9')
-      node="zetacore$num"
+      node=$(calculate_zetacore_ip "$num")
   fi
-  zetaclientd init --zetacore-url "$node" --chain-id athens_101-1 --operator "$operatorAddress" --log-format=text --public-ip "$MYIP" --log-level 1 --keyring-backend "$BACKEND" --pre-params "$PREPARAMS_PATH"
+  zetaclientd init --zetacore-ip "$node" --chain-id athens_101-1 --operator "$operatorAddress" --log-format=text --public-ip "$MYIP" --log-level 1 --keyring-backend "$BACKEND" --pre-params "$PREPARAMS_PATH"
 
   # import relayer private key for zetaclient{$num}
   import_relayer_key "${num}"

--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -1,11 +1,16 @@
 package config
 
 import (
+	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/showa-93/go-mask"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // KeyringBackend is the type of keyring backend to use for the hotkey
@@ -27,13 +32,25 @@ const (
 	DefaultRelayerKeyPath = "~/.zetacored/" + DefaultRelayerDir
 )
 
-// ClientConfiguration is a subset of zetaclient config that is used by zetacore client
-type ClientConfiguration struct {
-	ChainHost       string `json:"chain_host"        mapstructure:"chain_host"`
-	ChainRPC        string `json:"chain_rpc"         mapstructure:"chain_rpc"`
-	ChainHomeFolder string `json:"chain_home_folder" mapstructure:"chain_home_folder"`
-	SignerName      string `json:"signer_name"       mapstructure:"signer_name"`
-	SignerPasswd    string `json:"signer_passwd"`
+var (
+	// insecureGRPC is a grpc.DialOption that uses insecure transport credentials
+	// this is used when establishing gRPC connection to zetacore node via IP address
+	insecureGRPC = grpc.WithTransportCredentials(insecure.NewCredentials())
+
+	// credsTLSGRPC is a grpc.DialOption that uses TLS transport credentials
+	// this is used when establishing gRPC connection to zetacore node via hostname
+	credsTLSGRPC = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
+	}))
+)
+
+// ZetacoreClientConfig is a subset of zetaclient config that is used by zetacore client
+type ZetacoreClientConfig struct {
+	GRPCURL     string          `json:"grpc_url"`
+	WSRemote    string          `json:"ws_remote"`
+	SignerName  string          `json:"signer_name"`
+	GRPCDialOpt grpc.DialOption `json:"grpc_dial_opt"`
 }
 
 // EVMConfig is the config for EVM chain
@@ -77,15 +94,18 @@ type ComplianceConfig struct {
 // TODO: use snake case for json fields
 // https://github.com/zeta-chain/node/issues/1020
 type Config struct {
-	Peer                    string         `json:"Peer"`
-	PublicIP                string         `json:"PublicIP"`
-	LogFormat               string         `json:"LogFormat"`
-	LogLevel                int8           `json:"LogLevel"`
-	LogSampler              bool           `json:"LogSampler"`
-	PreParamsPath           string         `json:"PreParamsPath"`
-	ZetaCoreHome            string         `json:"ZetaCoreHome"`
-	ChainID                 string         `json:"ChainID"`
-	ZetaCoreURL             string         `json:"ZetaCoreURL"`
+	Peer          string `json:"Peer"`
+	PublicIP      string `json:"PublicIP"`
+	LogFormat     string `json:"LogFormat"`
+	LogLevel      int8   `json:"LogLevel"`
+	LogSampler    bool   `json:"LogSampler"`
+	PreParamsPath string `json:"PreParamsPath"`
+	ZetaCoreHome  string `json:"ZetaCoreHome"`
+	ChainID       string `json:"ChainID"`
+	// The old name tag 'ZetaCoreURL' is still used for backward compatibility
+	ZetacoreIP              string         `json:"ZetaCoreURL"`
+	ZetacoreURLGRPC         string         `json:"ZetaCoreURLGRPC"`
+	ZetacoreURLWSS          string         `json:"ZetaCoreURLWSS"`
 	AuthzGranter            string         `json:"AuthzGranter"`
 	AuthzHotkey             string         `json:"AuthzHotkey"`
 	P2PDiagnostic           bool           `json:"P2PDiagnostic"`
@@ -108,6 +128,87 @@ type Config struct {
 	ComplianceConfig ComplianceConfig `json:"ComplianceConfig"`
 
 	mu *sync.RWMutex
+}
+
+// GetZetacoreClientConfig returns the zetacore client config
+func (c Config) GetZetacoreClientConfig() ZetacoreClientConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var (
+		gRPCURL    string
+		wsRemote   string
+		dialOption grpc.DialOption
+	)
+
+	// zetaclient accepts both zetacore node IP address and hostnames.
+	// To be compatible with IP address users, try IP address if set, otherwise use hostnames.
+	// Note: leave the IP address field empty to use hostnames.
+	if c.ZetacoreIP != "" {
+		gRPCURL = cosmosGRPCFromIP(c.ZetacoreIP)
+		wsRemote = cosmosWSSRemoteFromIP(c.ZetacoreIP)
+		dialOption = insecureGRPC
+	} else {
+		gRPCURL = cosmosGRPCFromHost(c.ZetacoreURLGRPC)
+		wsRemote = cosmosWSSRemoteFromHost(c.ZetacoreURLWSS)
+		dialOption = credsTLSGRPC
+	}
+
+	return ZetacoreClientConfig{
+		GRPCURL:     gRPCURL,
+		WSRemote:    wsRemote,
+		SignerName:  c.AuthzHotkey,
+		GRPCDialOpt: dialOption,
+	}
+}
+
+// cosmosGRPCFromIP returns the gRPC URL for the given IP address
+func cosmosGRPCFromIP(ipAddress string) string {
+	return fmt.Sprintf("%s:9090", ipAddress)
+}
+
+// cosmosWSSRemoteFromIP returns the websocket remote URI for the given IP address
+func cosmosWSSRemoteFromIP(ipAddress string) string {
+	remote := cometBFTRPC(ipAddress)
+
+	// given an IP address, both remote URI formats will work:
+	// 1. http://zetacore_ip_address:26657
+	// 2. tcp://zetacore_ip_address:26657
+	// append http:// prefix if not present
+	if !strings.HasPrefix(remote, "http://") &&
+		!strings.HasPrefix(remote, "tcp://") {
+		remote = fmt.Sprintf("http://%s", remote)
+	}
+
+	return remote
+}
+
+// cometBFTRPC returns the CometBFT RPC endpoint for the given IP address
+func cometBFTRPC(ipAddress string) string {
+	return fmt.Sprintf("%s:26657", ipAddress)
+}
+
+// cosmosGRPCFromHost returns the gRPC URL for the given host
+// Note: there is no assumption on node provider's gRPC URL format.
+// The given host is expected to be a valid gRPC URL.
+func cosmosGRPCFromHost(host string) string {
+	return host
+}
+
+// cosmosWSSRemoteFromHost returns the websocket remote URI for the given host.
+func cosmosWSSRemoteFromHost(host string) string {
+	// A typical WSS URLs may look like below, and we need to convert them to the remote URI.
+	// wss://rpc.provider.com/zetachain/websocket
+	// wss://zetachain-mainnet.provider.com/websocket
+
+	// remove "wss://" prefix and replace with "https://"
+	remote := "https://" + strings.TrimPrefix(host, "wss://")
+
+	// remove "/websocket" endpoint suffix if present
+	// the suffix will be passed to http.New() as a separate argument
+	remote = strings.TrimSuffix(remote, "/websocket")
+
+	return remote
 }
 
 // GetEVMConfig returns the EVM config for the given chain ID

--- a/zetaclient/zetacore/client.go
+++ b/zetaclient/zetacore/client.go
@@ -14,8 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	etherminttypes "github.com/zeta-chain/ethermint/types"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/zeta-chain/node/app"
 	"github.com/zeta-chain/node/pkg/authz"
@@ -35,7 +33,7 @@ type Client struct {
 	zetacorerpc.Clients
 
 	logger zerolog.Logger
-	config config.ClientConfiguration
+	config config.ZetacoreClientConfig
 
 	cosmosClientContext cosmosclient.Context
 	cometBFTClient      cometbftrpc.Client
@@ -54,8 +52,6 @@ type Client struct {
 
 	mu sync.RWMutex
 }
-
-var unsecureGRPC = grpc.WithTransportCredentials(insecure.NewCredentials())
 
 type constructOpts struct {
 	customCometBFT bool
@@ -86,13 +82,16 @@ func WithCustomAccountRetriever(ac cosmosclient.AccountRetriever) Opt {
 // NewClient create a new instance of Client
 func NewClient(
 	keys keyinterfaces.ObserverKeys,
-	chainIP string,
-	signerName string,
-	chainID string,
+	cfg config.Config,
 	logger zerolog.Logger,
 	opts ...Opt,
 ) (*Client, error) {
-	var constructOptions constructOpts
+	var (
+		chainID          = cfg.ChainID
+		zetacoreCfg      = cfg.GetZetacoreClientConfig()
+		constructOptions constructOpts
+	)
+
 	for _, opt := range opts {
 		opt(&constructOptions)
 	}
@@ -102,18 +101,7 @@ func NewClient(
 		return nil, errors.Wrapf(err, "invalid chain id %q", chainID)
 	}
 
-	log := logger.With().Str(logs.FieldModule, "zetacoreClient").Logger()
-
-	cfg := config.ClientConfiguration{
-		ChainHost:    cosmosREST(chainIP),
-		SignerName:   signerName,
-		SignerPasswd: "password",
-		ChainRPC:     cometBFTRPC(chainIP),
-	}
-
-	encodingCfg := app.MakeEncodingConfig()
-
-	zetacoreClients, err := zetacorerpc.NewGRPCClients(cosmosGRPC(chainIP), unsecureGRPC)
+	zetacoreClients, err := zetacorerpc.NewGRPCClients(zetacoreCfg.GRPCURL, zetacoreCfg.GRPCDialOpt)
 	if err != nil {
 		return nil, errors.Wrap(err, "grpc dial fail")
 	}
@@ -125,27 +113,19 @@ func NewClient(
 		seqMap[keyType] = 0
 	}
 
-	cosmosContext, err := buildCosmosClientContext(chainID, keys, cfg, encodingCfg, constructOptions)
+	encodingCfg := app.MakeEncodingConfig()
+	cosmosContext, err := buildCosmosClientContext(chainID, keys, zetacoreCfg, encodingCfg, constructOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to build cosmos client context")
 	}
 
-	cometBFTClient := constructOptions.cometBFTClient
-
 	// create a cometbft client if one was not provided in the constructOptions
+	cometBFTClient := constructOptions.cometBFTClient
 	if !constructOptions.customCometBFT {
-		base := "http://" + cometBFTRPC(chainIP)
-		client, err := cometbfthttp.New(base, "/websocket")
+		client, err := createCometBFTClient(zetacoreCfg.WSRemote, true)
 		if err != nil {
-			return nil, errors.Wrapf(err, "new cometbft client (%s)", base)
+			return nil, errors.Wrap(err, "unable to create cometbft client")
 		}
-
-		// start websockets
-		err = client.WSEvents.Start()
-		if err != nil {
-			return nil, errors.Wrap(err, "cometbft start")
-		}
-
 		cometBFTClient = client
 	}
 
@@ -165,8 +145,8 @@ func NewClient(
 
 	return &Client{
 		Clients: zetacoreClients,
-		logger:  log,
-		config:  cfg,
+		logger:  logger.With().Str(logs.FieldModule, "zetacoreClient").Logger(),
+		config:  zetacoreCfg,
 
 		cosmosClientContext: cosmosContext,
 		cometBFTClient:      cometBFTClient,
@@ -181,11 +161,29 @@ func NewClient(
 	}, nil
 }
 
+// createCometBFTClient creates a cometbft client and optionally starts websocket
+func createCometBFTClient(remote string, startWS bool) (cometbftrpc.Client, error) {
+	client, err := cometbfthttp.New(remote, "/websocket")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create cometbft client from remote %s", remote)
+	}
+
+	// start websocket if needed
+	if startWS {
+		err = client.WSEvents.Start()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to start cometbft websocket")
+		}
+	}
+
+	return client, nil
+}
+
 // buildCosmosClientContext constructs a valid context with all relevant values set
 func buildCosmosClientContext(
 	chainID string,
 	keys keyinterfaces.ObserverKeys,
-	config config.ClientConfiguration,
+	config config.ZetacoreClientConfig,
 	encodingConfig etherminttypes.EncodingConfig,
 	opts constructOpts,
 ) (cosmosclient.Context, error) {
@@ -199,9 +197,9 @@ func buildCosmosClientContext(
 	}
 
 	var (
-		input   = strings.NewReader("")
-		client  cosmosclient.CometRPC
-		nodeURI string
+		input  = strings.NewReader("")
+		client cosmosclient.CometRPC
+		remote = config.WSRemote
 	)
 
 	// if password is needed, set it as input
@@ -214,18 +212,10 @@ func buildCosmosClientContext(
 	// (google "golang nil interface comparison")
 	client = opts.cometBFTClient
 	if !opts.customCometBFT {
-		remote := config.ChainRPC
-		if !strings.HasPrefix(config.ChainHost, "http") {
-			remote = fmt.Sprintf("tcp://%s", remote)
-		}
-
-		wsClient, err := cometbfthttp.New(remote, "/websocket")
+		client, err = createCometBFTClient(remote, false)
 		if err != nil {
-			return cosmosclient.Context{}, err
+			return cosmosclient.Context{}, errors.Wrap(err, "failed to create cometbft client")
 		}
-
-		client = wsClient
-		nodeURI = remote
 	}
 
 	var accountRetriever cosmosclient.AccountRetriever
@@ -237,12 +227,11 @@ func buildCosmosClientContext(
 
 	return cosmosclient.Context{
 		Client:        client,
-		NodeURI:       nodeURI,
+		NodeURI:       remote,
 		FromAddress:   addr,
 		ChainID:       chainID,
 		Keyring:       keys.GetKeybase(),
 		BroadcastMode: "sync",
-		HomeDir:       config.ChainHomeFolder,
 		FromName:      config.SignerName,
 
 		AccountRetriever: accountRetriever,
@@ -286,16 +275,4 @@ func (c *Client) GetAccountNumberAndSequenceNumber(_ authz.KeyType) (uint64, uin
 		return 0, 0, err
 	}
 	return c.cosmosClientContext.AccountRetriever.GetAccountNumberSequence(c.cosmosClientContext, address)
-}
-
-func cosmosREST(host string) string {
-	return fmt.Sprintf("%s:1317", host)
-}
-
-func cosmosGRPC(host string) string {
-	return fmt.Sprintf("%s:9090", host)
-}
-
-func cometBFTRPC(host string) string {
-	return fmt.Sprintf("%s:26657", host)
 }

--- a/zetaclient/zetacore/client_start.go
+++ b/zetaclient/zetacore/client_start.go
@@ -26,10 +26,6 @@ func NewFromConfig(
 	hotkeyPassword string,
 	logger zerolog.Logger,
 ) (*Client, error) {
-	hotKey := cfg.AuthzHotkey
-
-	chainIP := cfg.ZetaCoreURL
-
 	kb, _, err := keys.GetKeyringKeybase(*cfg, hotkeyPassword)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get keyring base")
@@ -53,7 +49,7 @@ func NewFromConfig(
 	authz.SetupAuthZSignerList(k.GetOperatorAddress().String(), signerAddress)
 
 	// Create client
-	client, err := NewClient(k, chainIP, hotKey, cfg.ChainID, logger)
+	client, err := NewClient(k, *cfg, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create the client")
 	}


### PR DESCRIPTION
# Description

This PR will allow `zetaclientd` to connect to zetacore via hostnames:

- example gRPC hostname: `zetachain.lavenderfive.com:443`
- example websocket hostname: `wss://rpc.lavenderfive.com:443/zetachain/websocket`

Closes: https://github.com/zeta-chain/node/issues/1038

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
