### PR TITLE
chore: use fixed version for typescript proto bindings

### DIFF
--- a/proto/buf.ts.yaml
+++ b/proto/buf.ts.yaml
@@ -2,6 +2,6 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - plugin: buf.build/bufbuild/es
+  - plugin: buf.build/bufbuild/es:v2.6.3
     out: ../typescript
     opt: target=ts


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/4080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version in configuration to improve consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->