### PR TITLE
test: remove unused skip-dependency-verification flag in sui package upgrad…

### DIFF
--- a/e2e/runner/sui_gateway_upgrade.go
+++ b/e2e/runner/sui_gateway_upgrade.go
@@ -52,7 +52,6 @@ func (r *E2ERunner) suiUpgradeGatewayPackage() (packageID string, err error) {
 		"client",
 		"upgrade",
 		"--json", // output in JSON format for easier parsing
-		"--skip-dependency-verification",
 		"--upgrade-capability",
 		r.SuiGatewayUpgradeCap,
 	}...)


### PR DESCRIPTION

It is good to keep `--skip-dependency-verification` in the Sui gateway upgrade test CLI command, as it checks the compatibility of dependencies.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
