### PR TITLE
fix: nil reference in trace block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -90,7 +90,6 @@ import (
 	"github.com/cosmos/evm/x/vm"
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-
 	// needed to trigger native tracers registration
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 	"github.com/gorilla/mux"

--- a/app/app.go
+++ b/app/app.go
@@ -90,7 +90,7 @@ import (
 	"github.com/cosmos/evm/x/vm"
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
+	_ "github.com/ethereum/go-ethereum/eth/tracers/native" // register native tracers
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"

--- a/app/app.go
+++ b/app/app.go
@@ -90,7 +90,6 @@ import (
 	"github.com/cosmos/evm/x/vm"
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-	// needed to trigger native tracers registration
 	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"

--- a/app/app.go
+++ b/app/app.go
@@ -90,6 +90,9 @@ import (
 	"github.com/cosmos/evm/x/vm"
 	evmkeeper "github.com/cosmos/evm/x/vm/keeper"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	// needed to trigger native tracers registration
+	_ "github.com/ethereum/go-ethereum/eth/tracers/native"
 	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"


### PR DESCRIPTION
# Description

fixes error

```
"rpc error: code = Internal desc = runtime error: invalid memory address or nil pointer dereference"
```

issue is that native tracers are registered in `init` function in go-ethereum native tracers package, so package should be imported somewhere to force registration

this makes callTracer working, for some reason i can't import js tracers, but for now this should be good enough

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
