### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/x/crosschain/keeper/inbound_tracker.go
+++ b/x/crosschain/keeper/inbound_tracker.go
@@ -79,7 +79,7 @@ func (k Keeper) GetAllInboundTracker(ctx sdk.Context) (inTxTrackers []types.Inbo
 
 func (k Keeper) GetAllInboundTrackerForChain(ctx sdk.Context, chainID int64) (list []types.InboundTracker) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.InboundTrackerKeyPrefix))
-	iterator := storetypes.KVStorePrefixIterator(store, []byte(fmt.Sprintf("%d-", chainID)))
+	iterator := storetypes.KVStorePrefixIterator(store, fmt.Appendf(nil, "%d-", chainID))
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		var val types.InboundTracker

--- a/x/crosschain/simulation/operation_vote_outbound.go
+++ b/x/crosschain/simulation/operation_vote_outbound.go
@@ -85,7 +85,7 @@ func SimulateVoteOutbound(k keeper.Keeper) simtypes.Operation {
 		if err != nil {
 			return simtypes.OperationMsg{}, nil, nil
 		}
-		index := ethcrypto.Keccak256Hash([]byte(fmt.Sprintf("%d", r.Int63()))).Hex()
+		index := ethcrypto.Keccak256Hash(fmt.Appendf(nil, "%d", r.Int63())).Hex()
 
 		tss, found := k.GetObserverKeeper().GetTSS(ctx)
 		if !found {

--- a/x/observer/keeper/tss_funds_migrator.go
+++ b/x/observer/keeper/tss_funds_migrator.go
@@ -13,12 +13,12 @@ import (
 func (k Keeper) SetFundMigrator(ctx sdk.Context, fm types.TssFundMigratorInfo) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.TssFundMigratorKey))
 	b := k.cdc.MustMarshal(&fm)
-	store.Set([]byte(fmt.Sprintf("%d", fm.ChainId)), b)
+	store.Set(fmt.Appendf(nil, "%d", fm.ChainId), b)
 }
 
 func (k Keeper) GetFundMigrator(ctx sdk.Context, chainID int64) (val types.TssFundMigratorInfo, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.TssFundMigratorKey))
-	b := store.Get([]byte(fmt.Sprintf("%d", chainID)))
+	b := store.Get(fmt.Appendf(nil, "%d", chainID))
 	if b == nil {
 		return val, false
 	}

--- a/x/observer/types/keys.go
+++ b/x/observer/types/keys.go
@@ -41,7 +41,7 @@ func KeyPrefix(p string) []byte {
 }
 
 func BallotListKeyPrefix(p int64) []byte {
-	return []byte(fmt.Sprintf("%d", p))
+	return fmt.Appendf(nil, "%d", p)
 }
 
 func ChainNoncesKeyPrefix(chainID int64) []byte {


### PR DESCRIPTION
# Description

Optimize code using a more modern writing style. Official support from Go, for more details visit https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized construction of byte prefixes/keys and hash inputs to avoid intermediate allocations across cross-chain tracking, outbound vote simulation, and observer components.
  * Streamlined internal key generation for improved efficiency without altering logic or APIs.

* **Performance**
  * Minor memory and throughput improvements in key lookups and hashing paths.
  * No changes to behavior, data, or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->