### PR TITLE
test: fix flaky Solana depositAndCall tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 ### Tests
 
 * [4071](https://github.com/zeta-chain/node/pull/4071) - use v2 connector contract in admin e2e tests
+* [4113](https://github.com/zeta-chain/node/pull/4113) - fix Solana flaky depositAndCall e2e tests in live networks
 
 ## v33.0.0
 

--- a/e2e/e2etests/legacy/test_eth_deposit_call.go
+++ b/e2e/e2etests/legacy/test_eth_deposit_call.go
@@ -55,7 +55,7 @@ func TestEtherDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, types.CctxStatus_OutboundMined)
 
 	// Checking example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContract(r, exampleContract, value, r.EVMAddress().Bytes())
+	utils.WaitAndVerifyExampleContractCall(r, exampleContract, value, r.EVMAddress().Bytes())
 	r.Logger.Info("Cross-chain call succeeded")
 
 	r.Logger.Info("Deploying reverter contract")

--- a/e2e/e2etests/test_solana_deposit_call.go
+++ b/e2e/e2etests/test_solana_deposit_call.go
@@ -32,7 +32,7 @@ func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContractWithMsg(
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		depositAmount,

--- a/e2e/e2etests/test_solana_to_zevm_call.go
+++ b/e2e/e2etests/test_solana_to_zevm_call.go
@@ -31,7 +31,7 @@ func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContractWithMsg(
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		big.NewInt(0),

--- a/e2e/e2etests/test_spl_deposit_and_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call.go
@@ -54,7 +54,7 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContractWithMsg(
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		amount,

--- a/e2e/e2etests/test_ton_call.go
+++ b/e2e/e2etests/test_ton_call.go
@@ -45,8 +45,8 @@ func TestTONToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 	r.Logger.CCTX(*cctx, "ton_call")
 
-	// Ensure the dapp is called
-	utils.MustHaveCalledExampleContractWithMsg(
+	// Ensure the example contract has been called, bar value should be set to amount
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		big.NewInt(0),

--- a/e2e/e2etests/test_ton_deposit_and_call.go
+++ b/e2e/e2etests/test_ton_deposit_and_call.go
@@ -51,5 +51,5 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.TONZRC20, contractAddr, big.NewInt(0), change, r.Logger)
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContract(r, contract, expectedDeposit.BigInt(), []byte(sender.GetAddress().ToRaw()))
+	utils.WaitAndVerifyExampleContractCall(r, contract, expectedDeposit.BigInt(), []byte(sender.GetAddress().ToRaw()))
 }


### PR DESCRIPTION
# Description
This PR is to mitigate the following flaky E2E tests in live network.

1. The `depositAndCall` E2E tests in live networks when the example contract's state diverges between ZetaChain nodes behind the RPC.
The failure happened to assertions like this: [spl_deposit_and_call ❌](https://github.com/zeta-chain/e2e/actions/runs/17042931360/job/48311107315)

2. The `withdrawAndCall` E2E tests in live networks when external chain dApp's state is not fully in sync behind the RPC.
The failure happened to assertions like this: [test_erc20_withdraw_and_call ❌](https://github.com/zeta-chain/e2e/actions/runs/17072162228/job/48403788787)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Improved reliability of deposit-and-call end-to-end tests across Solana, SPL, Solana→ZEVM, Ethereum, and TON by adopting wait-and-verify polling with timeouts, reducing flakiness on live networks.
- Documentation
  - Updated the Unreleased section of the changelog under Tests to note the fix for flaky Solana deposit-and-call e2e tests on live networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->