### PR TITLE
fix(`crosschain`): remove confirmation mode from outbound and inbound digest

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 ### Fixes
 
 * [4090](https://github.com/zeta-chain/node/pull/4090) - print error message in detail if unable to decode Bitcoin memo
+* [4116](https://github.com/zeta-chain/node/pull/4116) - remove confirmation mode from outbound and inbound digest
 
 ### Tests
 

--- a/x/crosschain/types/message_vote_inbound.go
+++ b/x/crosschain/types/message_vote_inbound.go
@@ -162,6 +162,7 @@ func (msg *MsgVoteInbound) Digest() string {
 	m := *msg
 	m.Creator = ""
 	m.InboundBlockHeight = 0
+	m.ConfirmationMode = ConfirmationMode_SAFE
 	hash := crypto.Keccak256Hash([]byte(m.String()))
 	return hash.Hex()
 }

--- a/x/crosschain/types/message_vote_inbound_test.go
+++ b/x/crosschain/types/message_vote_inbound_test.go
@@ -615,11 +615,11 @@ func TestMsgVoteInbound_Digest(t *testing.T) {
 	hash2 = msg.Digest()
 	require.NotEqual(t, hash, hash2, "inbound status should change hash")
 
-	// confirmation mode used
+	// confirmation mode not used
 	msg = getMsg()
 	msg.ConfirmationMode = types.ConfirmationMode_FAST
 	hash2 = msg.Digest()
-	require.NotEqual(t, hash, hash2, "confirmation mode should change hash")
+	require.Equal(t, hash, hash2, "confirmation mode should not change hash")
 }
 
 func TestMsgVoteInbound_EligibleForFastConfirmation(t *testing.T) {

--- a/x/crosschain/types/message_vote_outbound.go
+++ b/x/crosschain/types/message_vote_outbound.go
@@ -82,6 +82,7 @@ func (msg *MsgVoteOutbound) ValidateBasic() error {
 func (msg *MsgVoteOutbound) Digest() string {
 	m := *msg
 	m.Creator = ""
+	m.ConfirmationMode = ConfirmationMode_SAFE
 
 	// Set status to ReceiveStatus_created to make sure both successful and failed votes are added to the same ballot
 	m.Status = chains.ReceiveStatus_created

--- a/x/crosschain/types/message_vote_outbound_test.go
+++ b/x/crosschain/types/message_vote_outbound_test.go
@@ -184,11 +184,11 @@ func TestMsgVoteOutbound_Digest(t *testing.T) {
 	hash2 = msgNew.Digest()
 	require.NotEqual(t, hash, hash2, "coin type should change hash")
 
-	// confirmation mode used
+	// confirmation mode not used
 	msgNew = msg
 	msgNew.ConfirmationMode = types.ConfirmationMode_FAST
 	hash2 = msgNew.Digest()
-	require.NotEqual(t, hash, hash2, "confirmation mode should change hash")
+	require.Equal(t, hash, hash2, "confirmation mode should not change hash")
 }
 
 func TestMsgVoteOutbound_GetSigners(t *testing.T) {


### PR DESCRIPTION
# Description

Closes https://github.com/zeta-chain/node/issues/4106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized digest computation for inbound and outbound vote messages to be independent of confirmation mode, ensuring consistent hashes and improving reliability of cross-chain message verification.

- Tests
  - Updated test cases to confirm that changing the confirmation mode does not affect digest results.

- Documentation
  - Added changelog entry under Unreleased > Fixes noting the removal of confirmation mode influence from digest calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->