### PR TITLE
test: fix eth deposit test to check balance after deposit

### DIFF
--- a/e2e/e2etests/test_erc20_deposit.go
+++ b/e2e/e2etests/test_erc20_deposit.go
@@ -30,7 +30,7 @@ func TestERC20Deposit(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "deposit")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	// wait for the arc20 balance to be updated
+	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ERC20ZRC20, r.EVMAddress(), oldBalance, change, r.Logger)
 }

--- a/e2e/e2etests/test_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call.go
@@ -39,7 +39,7 @@ func TestERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "deposit_and_call")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	// wait for the arc20 balance to be updated
+	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ERC20ZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 

--- a/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
@@ -35,7 +35,7 @@ func TestERC20DepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "deposit_and_call")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	// wait for the arc20 balance to be updated
+	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ERC20ZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 

--- a/e2e/e2etests/test_erc20_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_erc20_deposit_revert_and_abort.go
@@ -54,7 +54,7 @@ func TestERC20DepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 	require.EqualValues(r, r.ERC20ZRC20Addr.Hex(), abortContext.Asset.Hex())
 
-	// wait for the arc20 balance to be updated
+	// wait for the zrc20 balance to be updated
 	change := utils.NewBalanceChange(true)
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ERC20ZRC20, testAbortAddr, big.NewInt(0), change, r.Logger)
 }

--- a/e2e/e2etests/test_eth_deposit.go
+++ b/e2e/e2etests/test_eth_deposit.go
@@ -29,7 +29,7 @@ func TestETHDeposit(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "deposit")
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	// check the balance after the deposit
+	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ETHZRC20, r.EVMAddress(), oldBalance, change, r.Logger)
 }

--- a/e2e/e2etests/test_eth_deposit.go
+++ b/e2e/e2etests/test_eth_deposit.go
@@ -3,6 +3,7 @@ package e2etests
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts/pkg/gatewayevm.sol"
 


### PR DESCRIPTION
# Description

- This PR is to fix our eth deposit tests to check the zrc20 balance after a deposit is made.
- Fix small typo in comments

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened ETH deposit end-to-end test by verifying the user’s ZRC20 balance increases exactly by the deposited amount after the transaction is mined, including pre/post balance checks and balance update verification.
  * Corrected comments in ERC20 deposit, deposit-and-call, no-message, and revert/abort tests to reference ZRC20 balances; no functional behavior changes in these tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->