### PR TITLE
fix: dbg trace block by number gas limit legacy

### DIFF
--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -323,10 +323,14 @@ func (b *Backend) parseSyntethicTxFromAdditionalFields(
 	additional *rpctypes.TxResultAdditionalFields,
 ) *evmtypes.MsgEthereumTx {
 	recipient := additional.Recipient
+	gas := additional.GasUsed
+	if additional.GasLimit != nil {
+		gas = *additional.GasLimit
+	}
 	t := ethtypes.NewTx(&ethtypes.LegacyTx{
 		Nonce:    additional.Nonce,
 		Data:     additional.Data,
-		Gas:      additional.GasLimit,
+		Gas:      gas,
 		To:       &recipient,
 		GasPrice: nil,
 		Value:    additional.Value,

--- a/rpc/types/events.go
+++ b/rpc/types/events.go
@@ -71,7 +71,7 @@ type ParsedTx struct {
 	// -1 means uninitialized
 	EthTxIndex int32
 	GasUsed    uint64
-	GasLimit   uint64
+	GasLimit   *uint64
 	Failed     bool
 	// Additional cosmos EVM tx fields
 	TxHash    string
@@ -395,7 +395,7 @@ func fillTxAttribute(tx *ParsedTx, key string, value string) error {
 		if err != nil {
 			return err
 		}
-		tx.GasLimit = gasLimit
+		tx.GasLimit = &gasLimit
 	case evmtypes.AttributeKeyEthereumTxFailed:
 		tx.Failed = len(value) > 0
 	case SenderType:

--- a/rpc/types/types.go
+++ b/rpc/types/types.go
@@ -39,7 +39,7 @@ type TxResultAdditionalFields struct {
 	Recipient common.Address `json:"recipient"`
 	Sender    common.Address `json:"sender"`
 	GasUsed   uint64         `json:"gasUsed"`
-	GasLimit  uint64         `json:"gasLimit"`
+	GasLimit  *uint64        `json:"gasLimit"`
 	Nonce     uint64         `json:"nonce"`
 	Data      []byte         `json:"data"`
 }

--- a/rpc/types/utils.go
+++ b/rpc/types/utils.go
@@ -243,10 +243,14 @@ func NewRPCTransactionFromIncompleteMsg(
 ) (*RPCTransaction, error) {
 	to := &common.Address{}
 	*to = txAdditional.Recipient
+	gas := txAdditional.GasUsed
+	if txAdditional.GasLimit != nil {
+		gas = *txAdditional.GasLimit
+	}
 	result := &RPCTransaction{
 		Type:     hexutil.Uint64(txAdditional.Type),
 		From:     common.BytesToAddress(msg.From),
-		Gas:      hexutil.Uint64(txAdditional.GasLimit),
+		Gas:      hexutil.Uint64(gas),
 		GasPrice: (*hexutil.Big)(baseFee),
 		Hash:     common.HexToHash(msg.Hash),
 		Input:    txAdditional.Data,


### PR DESCRIPTION
# Description

Started noticing issues with v34, but checking blocks on testnet, it was failing for pre-v31 blocks, and worked after v31. 
With tracer specified in request error was:
```
"rpc error: code = Internal desc = runtime error: index out of range [0] with length 0"
```

Without tracer specified:
```
"error": "rpc error: code = Internal desc = apply message: intrinsic gas too low"
```

 Only change in v31 changelog that could impact this is indexing gas limit for synthetic txs and using correct gas limit: https://github.com/zeta-chain/node/pull/3920/files. However, for pre-v31 txs `GasUsed` field was user instead, so tracing those blocks was using wrong value (0 since it cant be read from cosmos events), leading to issues when applying msgs in trace block.
 
 This PR falls back to previously used value in case gas limit is not present in cosmos events for synthetic txs.

# How Has This Been Tested?

Tested locally by reverting this fix on branch branched out from v32, and running upgrade tests v32 -> v34, error was there for blocks before upgrade, and gone after fixing this in v34 code.

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
