### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/testutil/sample/observer.go
+++ b/testutil/sample/observer.go
@@ -282,7 +282,7 @@ func BallotList(n int, observerSet []string) []types.Ballot {
 	ballotList := make([]types.Ballot, n)
 
 	for i := 0; i < n; i++ {
-		identifier := crypto.Keccak256Hash([]byte(fmt.Sprintf("%d-%d-%d", r.Int63(), r.Int63(), r.Int63())))
+		identifier := crypto.Keccak256Hash(fmt.Appendf(nil, "%d-%d-%d", r.Int63(), r.Int63(), r.Int63()))
 		ballotList[i] = types.Ballot{
 			Index:                identifier.Hex(),
 			BallotIdentifier:     identifier.Hex(),

--- a/x/crosschain/keeper/inbound_tracker.go
+++ b/x/crosschain/keeper/inbound_tracker.go
@@ -79,7 +79,7 @@ func (k Keeper) GetAllInboundTracker(ctx sdk.Context) (inTxTrackers []types.Inbo
 
 func (k Keeper) GetAllInboundTrackerForChain(ctx sdk.Context, chainID int64) (list []types.InboundTracker) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.InboundTrackerKeyPrefix))
-	iterator := storetypes.KVStorePrefixIterator(store, []byte(fmt.Sprintf("%d-", chainID)))
+	iterator := storetypes.KVStorePrefixIterator(store, fmt.Appendf(nil, "%d-", chainID))
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		var val types.InboundTracker

--- a/x/crosschain/simulation/operation_vote_outbound.go
+++ b/x/crosschain/simulation/operation_vote_outbound.go
@@ -85,7 +85,7 @@ func SimulateVoteOutbound(k keeper.Keeper) simtypes.Operation {
 		if err != nil {
 			return simtypes.OperationMsg{}, nil, nil
 		}
-		index := ethcrypto.Keccak256Hash([]byte(fmt.Sprintf("%d", r.Int63()))).Hex()
+		index := ethcrypto.Keccak256Hash(fmt.Appendf(nil, "%d", r.Int63())).Hex()
 
 		tss, found := k.GetObserverKeeper().GetTSS(ctx)
 		if !found {

--- a/x/observer/keeper/tss_funds_migrator.go
+++ b/x/observer/keeper/tss_funds_migrator.go
@@ -13,12 +13,12 @@ import (
 func (k Keeper) SetFundMigrator(ctx sdk.Context, fm types.TssFundMigratorInfo) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.TssFundMigratorKey))
 	b := k.cdc.MustMarshal(&fm)
-	store.Set([]byte(fmt.Sprintf("%d", fm.ChainId)), b)
+	store.Set(fmt.Appendf(nil, "%d", fm.ChainId), b)
 }
 
 func (k Keeper) GetFundMigrator(ctx sdk.Context, chainID int64) (val types.TssFundMigratorInfo, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.TssFundMigratorKey))
-	b := store.Get([]byte(fmt.Sprintf("%d", chainID)))
+	b := store.Get(fmt.Appendf(nil, "%d", chainID))
 	if b == nil {
 		return val, false
 	}

--- a/x/observer/keeper/tss_funds_migrator_test.go
+++ b/x/observer/keeper/tss_funds_migrator_test.go
@@ -1,13 +1,48 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	keepertest "github.com/zeta-chain/node/testutil/keeper"
 	"github.com/zeta-chain/node/testutil/sample"
 )
+
+func TestAppendFVsSprintf(t *testing.T) {
+	// Test cases for tss_funds_migrator.go
+	testCases := []struct {
+		name   string
+		values []interface{}
+		format string
+	}{
+		{
+			name:   "chain id format",
+			values: []interface{}{int64(123)},
+			format: "%d",
+		},
+		{
+			name:   "large chain id",
+			values: []interface{}{int64(9223372036854775807)}, // Max int64
+			format: "%d",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Generate string using fmt.Sprintf
+			sprintfResult := []byte(fmt.Sprintf(tc.format, tc.values...))
+			
+			// Generate string using fmt.Appendf
+			appendResult := fmt.Appendf(nil, tc.format, tc.values...)
+			
+			// Assert that both methods produce the same byte slice
+			assert.Equal(t, sprintfResult, appendResult, "[]byte(fmt.Sprintf) and fmt.Appendf should produce identical byte slices")
+		})
+	}
+}
 
 func TestKeeper_GetTssFundMigrator(t *testing.T) {
 	t.Run("Successfully set funds migrator for chain", func(t *testing.T) {

--- a/x/observer/types/keys.go
+++ b/x/observer/types/keys.go
@@ -41,7 +41,7 @@ func KeyPrefix(p string) []byte {
 }
 
 func BallotListKeyPrefix(p int64) []byte {
-	return []byte(fmt.Sprintf("%d", p))
+	return fmt.Appendf(nil, "%d", p)
 }
 
 func ChainNoncesKeyPrefix(chainID int64) []byte {


### PR DESCRIPTION
# Description

Optimize code using a more modern writing style. Official support from Go, for more details visit https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.


The new pr for https://github.com/zeta-chain/node/pull/4105  and add `TestAppendFVsSprintf` unit test.

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized byte formatting for hashing and key generation to reduce allocations without changing behavior. Updates affect ballot lists, cross-chain inbound tracking, outbound vote index generation, and TSS funds migrator keys.
- Tests
  - Added tests confirming equivalence between alternative formatting methods for key construction, ensuring no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->