### PR TITLE
test(`e2e`): improve logs for CCTX status assertion

### DIFF
--- a/e2e/e2etests/test_bitcoin_deposit_and_withdraw_with_dust.go
+++ b/e2e/e2etests/test_bitcoin_deposit_and_withdraw_with_dust.go
@@ -43,7 +43,7 @@ func TestBitcoinDepositAndWithdrawWithDust(r *runner.E2ERunner, args []string) {
 	// Now we want to make sure the cctx is reverted with expected error message
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 	require.Contains(r, cctx.CctxStatus.ErrorMessage, crosschaintypes.ErrCannotProcessWithdrawal.Error())
 
 	// check the contract has no BTC balance, this would mean the contract call state transition is not reverted

--- a/e2e/e2etests/test_bitcoin_deposit_fast_confirmation.go
+++ b/e2e/e2etests/test_bitcoin_deposit_fast_confirmation.go
@@ -68,7 +68,7 @@ func TestBitcoinDepositFastConfirmation(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be FAST confirmed
 	timeStart := time.Now()
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, crosschaintypes.ConfirmationMode_FAST, cctx.InboundParams.ConfirmationMode)
 	fastConfirmTime := time.Since(timeStart)
 
@@ -89,7 +89,7 @@ func TestBitcoinDepositFastConfirmation(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be SAFE confirmed
 	timeStart = time.Now()
 	cctx = utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, crosschaintypes.ConfirmationMode_SAFE, cctx.InboundParams.ConfirmationMode)
 	safeConfirmTime := time.Since(timeStart)
 

--- a/e2e/e2etests/test_deposit_and_call_out_of_gas.go
+++ b/e2e/e2etests/test_deposit_and_call_out_of_gas.go
@@ -33,5 +33,6 @@ func TestDepositAndCallOutOfGas(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
 }

--- a/e2e/e2etests/test_deposit_and_call_out_of_gas.go
+++ b/e2e/e2etests/test_deposit_and_call_out_of_gas.go
@@ -34,5 +34,4 @@ func TestDepositAndCallOutOfGas(r *runner.E2ERunner, args []string) {
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
-
 }

--- a/e2e/e2etests/test_deposit_and_call_swap.go
+++ b/e2e/e2etests/test_deposit_and_call_swap.go
@@ -87,5 +87,5 @@ func TestDepositAndCallSwap(r *runner.E2ERunner, _ []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 }

--- a/e2e/e2etests/test_erc20_deposit.go
+++ b/e2e/e2etests/test_erc20_deposit.go
@@ -28,7 +28,7 @@ func TestERC20Deposit(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call.go
@@ -37,7 +37,7 @@ func TestERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
@@ -33,7 +33,7 @@ func TestERC20DepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_erc20_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call_revert.go
@@ -35,7 +35,7 @@ func TestERC20DepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the balance is more than 0
 	balance, err = r.ERC20.BalanceOf(&bind.CallOpts{}, revertAddress)

--- a/e2e/e2etests/test_erc20_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call_revert_with_call.go
@@ -34,7 +34,7 @@ func TestERC20DepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the payload was received on the contract
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))

--- a/e2e/e2etests/test_erc20_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_erc20_deposit_revert_and_abort.go
@@ -42,7 +42,7 @@ func TestERC20DepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go
@@ -34,7 +34,7 @@ func TestERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	r.AssertTestDAppEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_erc20_withdraw_and_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_call.go
@@ -43,7 +43,7 @@ func TestERC20WithdrawAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_erc20_withdraw_and_call_revert.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_call_revert.go
@@ -41,7 +41,7 @@ func TestERC20WithdrawAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the balance is more than 0
 	balance, err = r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)

--- a/e2e/e2etests/test_erc20_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_erc20_withdraw_revert_and_abort.go
@@ -45,7 +45,7 @@ func TestERC20WithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_eth_deposit.go
+++ b/e2e/e2etests/test_eth_deposit.go
@@ -28,7 +28,7 @@ func TestETHDeposit(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_eth_deposit_and_call.go
@@ -35,7 +35,7 @@ func TestETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_eth_deposit_and_call_big_payload.go
+++ b/e2e/e2etests/test_eth_deposit_and_call_big_payload.go
@@ -37,5 +37,5 @@ func TestETHDepositAndCallBigPayload(r *runner.E2ERunner, _ []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 }

--- a/e2e/e2etests/test_eth_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_eth_deposit_and_call_no_message.go
@@ -28,7 +28,7 @@ func TestETHDepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())

--- a/e2e/e2etests/test_eth_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_eth_deposit_and_call_revert.go
@@ -34,7 +34,7 @@ func TestETHDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the balance is more than 0
 	balance, err = r.EVMClient.BalanceAt(r.Ctx, revertAddress, nil)

--- a/e2e/e2etests/test_eth_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_eth_deposit_and_call_revert_with_call.go
@@ -36,7 +36,7 @@ func TestETHDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the payload was received on the contract
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))

--- a/e2e/e2etests/test_eth_deposit_fast_confirmation.go
+++ b/e2e/e2etests/test_eth_deposit_fast_confirmation.go
@@ -77,7 +77,7 @@ func TestETHDepositFastConfirmation(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be FAST confirmed
 	timeStart := time.Now()
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, crosschaintypes.ConfirmationMode_FAST, cctx.InboundParams.ConfirmationMode)
 	fastConfirmTime := time.Since(timeStart)
 
@@ -104,7 +104,7 @@ func TestETHDepositFastConfirmation(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be SAFE confirmed
 	timeStart = time.Now()
 	cctx = utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, crosschaintypes.ConfirmationMode_SAFE, cctx.InboundParams.ConfirmationMode)
 	safeConfirmTime := time.Since(timeStart)
 

--- a/e2e/e2etests/test_eth_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_eth_deposit_revert_and_abort.go
@@ -42,7 +42,7 @@ func TestETHDepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})
@@ -79,7 +79,7 @@ func TestETHDepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx = utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// wait for the eoa to receive tokens
 	change = utils.NewBalanceChange(true)

--- a/e2e/e2etests/test_eth_withdraw.go
+++ b/e2e/e2etests/test_eth_withdraw.go
@@ -27,7 +27,7 @@ func TestETHWithdraw(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the balance was updated, we just check newBalance is greater than oldBalance because of the gas fee
 	newBalance, err := r.EVMClient.BalanceAt(r.Ctx, r.EVMAddress(), nil)

--- a/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
@@ -33,7 +33,7 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	r.AssertTestDAppEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_eth_withdraw_and_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call.go
@@ -42,7 +42,7 @@ func TestETHWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	r.AssertTestDAppEVMCalled(true, payload, amount)
 

--- a/e2e/e2etests/test_eth_withdraw_and_call_big_payload.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_big_payload.go
@@ -42,5 +42,5 @@ func TestETHWithdrawAndCallBigPayload(r *runner.E2ERunner, _ []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 }

--- a/e2e/e2etests/test_eth_withdraw_and_call_no_message.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_no_message.go
@@ -38,7 +38,7 @@ func TestETHWithdrawAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check called
 	messageIndex, err := r.TestDAppV2EVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())

--- a/e2e/e2etests/test_eth_withdraw_and_call_revert.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_revert.go
@@ -40,7 +40,7 @@ func TestETHWithdrawAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the balance is more than 0
 	balance, err = r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)

--- a/e2e/e2etests/test_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_revert_with_call.go
@@ -39,7 +39,7 @@ func TestETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_eth_withdraw_and_call_revert_with_withdraw.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_revert_with_withdraw.go
@@ -35,6 +35,7 @@ func TestETHWithdrawAndCallRevertWithWithdraw(r *runner.E2ERunner, args []string
 	cctxRevert := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctxRevert, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctxRevert.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctxRevert, crosschaintypes.CctxStatus_Reverted)
 
 	cctxWithdrawFromRevert := utils.WaitCctxMinedByInboundHash(
 		r.Ctx,

--- a/e2e/e2etests/test_eth_withdraw_and_call_revert_with_withdraw.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_revert_with_withdraw.go
@@ -34,7 +34,6 @@ func TestETHWithdrawAndCallRevertWithWithdraw(r *runner.E2ERunner, args []string
 	// wait for the cctx to be mined
 	cctxRevert := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctxRevert, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctxRevert.CctxStatus.Status)
 	utils.RequireCCTXStatus(r, cctxRevert, crosschaintypes.CctxStatus_Reverted)
 
 	cctxWithdrawFromRevert := utils.WaitCctxMinedByInboundHash(

--- a/e2e/e2etests/test_eth_withdraw_and_call_through_contract.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_through_contract.go
@@ -48,7 +48,7 @@ func TestETHWithdrawAndCallThroughContract(r *runner.E2ERunner, args []string) {
 	utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	r.AssertTestDAppEVMCalled(true, payload, amount)
 

--- a/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
+++ b/e2e/e2etests/test_eth_withdraw_custom_gas_limit.go
@@ -36,7 +36,7 @@ func TestETHWithdrawCustomGasLimit(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check gas limit used
 	require.EqualValues(r, customGasLimit.Uint64(), cctx.OutboundParams[0].CallOptions.GasLimit)

--- a/e2e/e2etests/test_eth_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_eth_withdraw_revert_and_abort.go
@@ -46,7 +46,7 @@ func TestETHWithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_evm_to_zevm_call.go
@@ -28,7 +28,7 @@ func TestEVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the payload was received on the contract
 	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))

--- a/e2e/e2etests/test_evm_to_zevm_call_abort.go
+++ b/e2e/e2etests/test_evm_to_zevm_call_abort.go
@@ -34,7 +34,7 @@ func TestEVMToZEVMCallAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_inbound_trackers.go
+++ b/e2e/e2etests/test_inbound_trackers.go
@@ -24,7 +24,7 @@ func TestInboundTrackers(r *runner.E2ERunner, args []string) {
 	addTrackerAndWaitForCCTX := func(coinType coin.CoinType, txHash string) {
 		r.AddInboundTracker(coinType, txHash)
 		cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash, r.CctxClient, r.Logger, r.CctxTimeout)
-		require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+		utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 		r.Logger.CCTX(*cctx, "cctx")
 	}
 

--- a/e2e/e2etests/test_migrate_tss.go
+++ b/e2e/e2etests/test_migrate_tss.go
@@ -98,10 +98,10 @@ func TestMigrateTSS(r *runner.E2ERunner, _ []string) {
 	cctxETHMigration := migrator.TssFundsMigrator.MigrationCctxIndex
 
 	cctxBTC := utils.WaitCCTXMinedByIndex(r.Ctx, cctxBTCMigration, r.CctxClient, r.Logger, r.CctxTimeout)
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctxBTC.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctxBTC, crosschaintypes.CctxStatus_OutboundMined)
 
 	cctxETH := utils.WaitCCTXMinedByIndex(r.Ctx, cctxETHMigration, r.CctxClient, r.Logger, r.CctxTimeout)
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctxETH.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctxETH, crosschaintypes.CctxStatus_OutboundMined)
 
 	// Check if new TSS is added to list
 	allTss, err := r.ObserverClient.TssHistory(r.Ctx, &observertypes.QueryTssHistoryRequest{})

--- a/e2e/e2etests/test_solana_to_zevm_call_abort.go
+++ b/e2e/e2etests/test_solana_to_zevm_call_abort.go
@@ -29,7 +29,7 @@ func TestSolanaToZEVMCallAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, sig.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "solana_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_sui_deposit.go
+++ b/e2e/e2etests/test_sui_deposit.go
@@ -27,7 +27,7 @@ func TestSuiDeposit(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.EqualValues(r, coin.CoinType_Gas, cctx.InboundParams.CoinType)
 	require.EqualValues(r, amount.Uint64(), cctx.InboundParams.Amount.Uint64())
 

--- a/e2e/e2etests/test_sui_deposit_and_call.go
+++ b/e2e/e2etests/test_sui_deposit_and_call.go
@@ -30,7 +30,7 @@ func TestSuiDepositAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.EqualValues(r, coin.CoinType_Gas, cctx.InboundParams.CoinType)
 	require.EqualValues(r, amount.Uint64(), cctx.InboundParams.Amount.Uint64())
 	require.True(r, cctx.InboundParams.IsCrossChainCall)

--- a/e2e/e2etests/test_sui_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_sui_deposit_and_call_revert.go
@@ -28,7 +28,7 @@ func TestSuiDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.EqualValues(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 	require.EqualValues(r, coin.CoinType_Gas, cctx.InboundParams.CoinType)
 	require.True(r, cctx.InboundParams.IsCrossChainCall)
 

--- a/e2e/e2etests/test_sui_token_deposit.go
+++ b/e2e/e2etests/test_sui_token_deposit.go
@@ -27,7 +27,7 @@ func TestSuiTokenDeposit(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.EqualValues(r, coin.CoinType_ERC20, cctx.InboundParams.CoinType)
 	require.EqualValues(r, amount.Uint64(), cctx.InboundParams.Amount.Uint64())
 

--- a/e2e/e2etests/test_sui_token_deposit_and_call.go
+++ b/e2e/e2etests/test_sui_token_deposit_and_call.go
@@ -29,7 +29,7 @@ func TestSuiTokenDepositAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.EqualValues(r, coin.CoinType_ERC20, cctx.InboundParams.CoinType)
 	require.EqualValues(r, amount.Uint64(), cctx.InboundParams.Amount.Uint64())
 

--- a/e2e/e2etests/test_sui_token_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_sui_token_deposit_and_call_revert.go
@@ -36,7 +36,7 @@ func TestSuiTokenDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "deposit")
-	require.EqualValues(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 	require.EqualValues(r, coin.CoinType_ERC20, cctx.InboundParams.CoinType)
 	require.EqualValues(r, amount.Uint64(), cctx.InboundParams.Amount.Uint64())
 

--- a/e2e/e2etests/test_sui_token_withdraw.go
+++ b/e2e/e2etests/test_sui_token_withdraw.go
@@ -36,7 +36,7 @@ func TestSuiTokenWithdraw(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the balance after the withdraw
 	balanceAfter := r.SuiGetFungibleTokenBalance(signer.Address())

--- a/e2e/e2etests/test_sui_token_withdraw_and_call.go
+++ b/e2e/e2etests/test_sui_token_withdraw_and_call.go
@@ -55,7 +55,7 @@ func TestSuiTokenWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw_and_call")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the balance after the withdraw
 	balanceAfter := r.SuiGetFungibleTokenBalance(signer.Address())

--- a/e2e/e2etests/test_sui_withdraw.go
+++ b/e2e/e2etests/test_sui_withdraw.go
@@ -36,7 +36,7 @@ func TestSuiWithdraw(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the balance after the withdraw
 	balanceAfter := r.SuiGetSUIBalance(signer.Address())

--- a/e2e/e2etests/test_sui_withdraw_and_call.go
+++ b/e2e/e2etests/test_sui_withdraw_and_call.go
@@ -54,7 +54,7 @@ func TestSuiWithdrawAndCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw_and_call")
-	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// balance after
 	balanceAfter := r.SuiGetSUIBalance(suiAddress)

--- a/e2e/e2etests/test_zeta_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_zeta_deposit_and_call_revert.go
@@ -35,7 +35,7 @@ func TestZetaDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "zeta_deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the balance is more than 0
 	balance, err = r.ZetaEth.BalanceOf(&bind.CallOpts{}, revertAddress)

--- a/e2e/e2etests/test_zeta_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_zeta_deposit_and_call_revert_with_call.go
@@ -35,7 +35,7 @@ func TestZetaDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "zeta_deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// check the payload was received on the contract
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))

--- a/e2e/e2etests/test_zeta_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_zeta_deposit_revert_and_abort.go
@@ -46,7 +46,7 @@ func TestZetaDepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "zeta_deposit_and_call")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_zeta_withdraw_and_call_revert.go
+++ b/e2e/e2etests/test_zeta_withdraw_and_call_revert.go
@@ -44,7 +44,7 @@ func TestZetaWithdrawAndCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be reverted
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	newBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, revertAddress, nil)
 	require.NoError(r, err)

--- a/e2e/e2etests/test_zeta_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_zeta_withdraw_revert_and_abort.go
@@ -49,7 +49,7 @@ func TestZetaWithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_zevm_to_evm_arbitrary_call.go
+++ b/e2e/e2etests/test_zevm_to_evm_arbitrary_call.go
@@ -33,7 +33,7 @@ func TestZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the payload was received on the contract
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))

--- a/e2e/e2etests/test_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_zevm_to_evm_call.go
@@ -34,7 +34,7 @@ func TestZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the payload was received on the contract
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -35,7 +35,7 @@ func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 

--- a/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
@@ -39,7 +39,7 @@ func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_Aborted, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Aborted)
 
 	// check onAbort was called
 	aborted, err := testAbort.IsAborted(&bind.CallOpts{})

--- a/e2e/e2etests/test_zevm_to_evm_call_through_contract.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_through_contract.go
@@ -45,7 +45,7 @@ func TestZEVMToEVMCallThroughContract(r *runner.E2ERunner, args []string) {
 	utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
 

--- a/e2e/utils/require.go
+++ b/e2e/utils/require.go
@@ -17,9 +17,10 @@ func RequireCCTXStatus(
 	msgAndArgs ...any,
 ) {
 	msg := fmt.Sprintf(
-		"cctx status is not %q cctx index %s, status: %s, error: %s",
+		"cctx status is not %q cctx index %s, status: %s, status message %s, error: %s",
 		expected.String(),
 		cctx.Index,
+		cctx.CctxStatus.Status.String(),
 		cctx.CctxStatus.StatusMessage,
 		cctx.CctxStatus.ErrorMessage,
 	)


### PR DESCRIPTION
# Description

Use `RequireCCTXStatus` throughout all E2E tests to have more compelling log when one of the CCTX fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Standardized CCTX status assertions across end-to-end scenarios (deposits, withdrawals, calls, reverts, aborts) for BTC, ETH, ERC20, Sui, Solana, and ZEVM/EVM flows.
  - Improved failure messages for CCTX validations by including explicit status messages, aiding faster diagnostics.
- Refactor
  - Centralized status checking logic in tests to reduce duplication and enhance consistency across suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->