### PR TITLE
test: fix flaky depositAndCall test that failed on sender assertion

### DIFF
--- a/e2e/e2etests/test_bitcoin_deposit_call.go
+++ b/e2e/e2etests/test_bitcoin_deposit_call.go
@@ -28,7 +28,8 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	// create a random payload exactly fit max OP_RETURN data size 80 bytes (20 receiver + 60 payload)
 	size := txscript.MaxDataCarrierSize - ethcommon.AddressLength
 	payload := randomPayloadWithSize(r, size)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(amountSats))
+	sender := r.GetBtcAddress().EncodeAddress()
+	r.AssertTestDAppZEVMCalled(false, payload, []byte(sender), big.NewInt(amountSats))
 
 	// ACT
 	// Send BTC to TSS address with a dummy memo
@@ -52,5 +53,5 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.BTCZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(receivedAmount))
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(sender), big.NewInt(receivedAmount))
 }

--- a/e2e/e2etests/test_bitcoin_std_deposit_and_call.go
+++ b/e2e/e2etests/test_bitcoin_std_deposit_and_call.go
@@ -27,7 +27,8 @@ func TestBitcoinStdMemoDepositAndCall(r *runner.E2ERunner, args []string) {
 	// create a random payload exactly fit max OP_RETURN data size 80 bytes
 	// memo size: 4b header + 20b receiver + 1b length + 55b payload == 80 bytes
 	payload := randomPayloadWithSize(r, 55)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(amountSats))
+	sender := r.GetBtcAddress().EncodeAddress()
+	r.AssertTestDAppZEVMCalled(false, payload, []byte(sender), big.NewInt(amountSats))
 
 	// wrap the payload in a standard memo
 	memo := &memo.InboundMemo{
@@ -62,5 +63,5 @@ func TestBitcoinStdMemoDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.BTCZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(receivedAmount))
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(sender), big.NewInt(receivedAmount))
 }

--- a/e2e/e2etests/test_bitcoin_std_memo_inscribed_deposit_and_call.go
+++ b/e2e/e2etests/test_bitcoin_std_memo_inscribed_deposit_and_call.go
@@ -67,5 +67,5 @@ func TestBitcoinStdMemoInscribedDepositAndCall(r *runner.E2ERunner, args []strin
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.BTCZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(receivedAmount))
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(senderAddress), big.NewInt(receivedAmount))
 }

--- a/e2e/e2etests/test_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call.go
@@ -20,8 +20,9 @@ func TestERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	oldBalance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -44,5 +45,5 @@ func TestERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ERC20ZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
@@ -42,5 +42,5 @@ func TestERC20DepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
-	r.AssertTestDAppZEVMCalled(true, messageIndex, amount)
+	r.AssertTestDAppZEVMCalled(true, messageIndex, r.EVMAddress().Bytes(), amount)
 }

--- a/e2e/e2etests/test_erc20_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_call_revert_with_call.go
@@ -19,7 +19,7 @@ func TestERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 
 	payload := randomPayload(r)
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, nil, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -42,7 +42,7 @@ func TestERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 	r.Logger.CCTX(*cctx, "withdraw")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_eth_deposit_and_call.go
@@ -18,8 +18,9 @@ func TestETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseBigInt(r, args[0])
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	oldBalance, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -42,5 +43,5 @@ func TestETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ETHZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_eth_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_eth_deposit_and_call_no_message.go
@@ -33,5 +33,5 @@ func TestETHDepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
-	r.AssertTestDAppZEVMCalled(true, messageIndex, amount)
+	r.AssertTestDAppZEVMCalled(true, messageIndex, r.EVMAddress().Bytes(), amount)
 }

--- a/e2e/e2etests/test_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_revert_with_call.go
@@ -19,7 +19,7 @@ func TestETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 
 	payload := randomPayload(r)
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, nil, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -41,7 +41,7 @@ func TestETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_evm_to_zevm_call.go
@@ -15,8 +15,9 @@ func TestEVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(false, payload, sender, big.NewInt(0))
 
 	// perform the withdraw
 	tx := r.EVMToZEMVCall(
@@ -31,5 +32,5 @@ func TestEVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, sender, big.NewInt(0))
 }

--- a/e2e/e2etests/test_solana_deposit_call.go
+++ b/e2e/e2etests/test_solana_deposit_call.go
@@ -18,8 +18,9 @@ func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 
 	// Given payload and ZEVM contract address
 	payload := randomPayload(r)
+	sender := []byte(r.GetSolanaPrivKey().PublicKey().String())
 	contractAddr := r.TestDAppV2ZEVMAddr
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	// ACT
 	// execute the deposit transaction
@@ -33,5 +34,5 @@ func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_solana_to_zevm_call.go
+++ b/e2e/e2etests/test_solana_to_zevm_call.go
@@ -18,7 +18,8 @@ func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	// Given payload and ZEVM contract address
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, nil)
+	sender := []byte(r.GetSolanaPrivKey().PublicKey().String())
+	r.AssertTestDAppZEVMCalled(false, payload, sender, nil)
 
 	// ACT
 	// execute call transaction
@@ -32,5 +33,5 @@ func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, sender, big.NewInt(0))
 }

--- a/e2e/e2etests/test_solana_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_solana_withdraw_and_call_revert_with_call.go
@@ -88,7 +88,7 @@ func TestSolanaWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 	require.NoError(r, err)
 	r.Logger.Info("runner balance of SOL after withdraw: %d", balanceAfter)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_spl_deposit_and_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call.go
@@ -36,7 +36,8 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	// Given payload and ZEVM contract address
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	sender := []byte(r.GetSolanaPrivKey().PublicKey().String())
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	// get zrc20 balance for recipient
 	zrc20BalanceBefore, err := r.SPLZRC20.BalanceOf(&bind.CallOpts{}, contractAddr)
@@ -55,7 +56,7 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_sui_token_deposit_and_call.go
+++ b/e2e/e2etests/test_sui_token_deposit_and_call.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/contracts/sui"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
@@ -20,6 +21,12 @@ func TestSuiTokenDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 
 	payload := randomPayload(r)
+
+	// given sender
+	signer, err := r.Account.SuiSigner()
+	require.NoError(r, err)
+	sender, err := sui.EncodeAddress(signer.Address())
+	require.NoError(r, err)
 
 	// make the deposit transaction
 	resp := r.SuiFungibleTokenDepositAndCall(r.TestDAppV2ZEVMAddr, math.NewUintFromBigInt(amount), []byte(payload))
@@ -38,5 +45,5 @@ func TestSuiTokenDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.SuiTokenZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_sui_token_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_sui_token_withdraw_and_call_revert_with_call.go
@@ -67,7 +67,7 @@ func TestSuiTokenWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []strin
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_sui_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_sui_withdraw_and_call_revert_with_call.go
@@ -86,7 +86,7 @@ func TestSuiWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.GreaterOrEqual(r, tssBalanceAfter, tssBalanceBefore)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_sui_withdraw_revert_with_call.go
+++ b/e2e/e2etests/test_sui_withdraw_revert_with_call.go
@@ -84,7 +84,7 @@ func TestSuiWithdrawRevertWithCall(r *runner.E2ERunner, args []string) {
 	require.Less(r, tssBalanceAfter, tssBalanceBefore)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_ton_call.go
+++ b/e2e/e2etests/test_ton_call.go
@@ -18,14 +18,15 @@ func TestTONToZEVMCall(r *runner.E2ERunner, args []string) {
 	// Given a gateway
 	gw := toncontracts.NewGateway(r.TONGateway)
 
-	// Given a sender
-	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
+	// Given a senderWallet
+	_, senderWallet, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
+	sender := []byte(senderWallet.GetAddress().String())
 
 	// Given payload and a ZEVM contract
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(false, payload, sender, big.NewInt(0))
 
 	// Given an approx `call` fee
 	callFee, err := gw.GetTxFee(ctx, r.Clients.TON, toncontracts.OpCall)
@@ -33,12 +34,12 @@ func TestTONToZEVMCall(r *runner.E2ERunner, args []string) {
 
 	// ACT
 	// Perform TON tx
-	cctx, err := r.TONCall(gw, sender, callFee, contractAddr, []byte(payload))
+	cctx, err := r.TONCall(gw, senderWallet, callFee, contractAddr, []byte(payload))
 
 	// ASSERT
 	require.NoError(r, err)
 	r.Logger.CCTX(*cctx, "ton_call")
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, sender, big.NewInt(0))
 }

--- a/e2e/e2etests/test_ton_deposit_and_call.go
+++ b/e2e/e2etests/test_ton_deposit_and_call.go
@@ -25,17 +25,18 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	depositFee, err := gw.GetTxFee(ctx, r.Clients.TON, toncontracts.OpDepositAndCall)
 	require.NoError(r, err)
 
-	// Given a sender
-	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
+	// Given a senderWallet
+	_, senderWallet, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
+	sender := []byte(senderWallet.GetAddress().String())
 
 	// Given payload and a ZEVM contract
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(false, payload, sender, big.NewInt(0))
 
 	// ACT
-	_, err = r.TONDepositAndCall(gw, sender, amount, contractAddr, []byte(payload))
+	_, err = r.TONDepositAndCall(gw, senderWallet, amount, contractAddr, []byte(payload))
 
 	// ASSERT
 	require.NoError(r, err)
@@ -47,5 +48,5 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.TONZRC20, contractAddr, big.NewInt(0), change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, expectedDeposit.BigInt())
+	r.AssertTestDAppZEVMCalled(true, payload, sender, expectedDeposit.BigInt())
 }

--- a/e2e/e2etests/test_zeta_deposit_and_call.go
+++ b/e2e/e2etests/test_zeta_deposit_and_call.go
@@ -19,9 +19,10 @@ func TestZetaDepositAndCall(r *runner.E2ERunner, args []string) {
 	r.ApproveZetaOnEVM(r.GatewayEVMAddr)
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 	receiverAddress := r.TestDAppV2ZEVMAddr
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	oldBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, receiverAddress, nil)
 	require.NoError(r, err)
@@ -40,7 +41,7 @@ func TestZetaDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 
 	// check the balance was updated
 	newBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, receiverAddress, nil)

--- a/e2e/e2etests/test_zeta_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_zeta_deposit_and_call_no_message.go
@@ -39,7 +39,7 @@ func TestZetaDepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
-	r.AssertTestDAppZEVMCalled(true, messageIndex, amount)
+	r.AssertTestDAppZEVMCalled(true, messageIndex, r.EVMAddress().Bytes(), amount)
 
 	// check the balance was updated
 	newBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, receiverAddress, nil)

--- a/e2e/e2etests/test_zeta_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_zeta_withdraw_and_call_revert_with_call.go
@@ -21,7 +21,7 @@ func TestZetaWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	evmChainID, err := r.EVMClient.ChainID(r.Ctx)
 	require.NoError(r, err)
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, nil, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -44,7 +44,7 @@ func TestZetaWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -39,7 +39,7 @@ func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "call")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(


### PR DESCRIPTION
# Description

It fixes nightly CI failure like this [test_sui_deposit_and_call ❌](https://github.com/zeta-chain/e2e/actions/runs/17495501705/job/49695216204)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
