### PR TITLE
feat(backport/v36): observe inbound from previous gateway package after upgrade

### DIFF
--- a/cmd/zetae2e/local/performance.go
+++ b/cmd/zetae2e/local/performance.go
@@ -358,7 +358,7 @@ func suiWithdrawPerformanceRoutine(
 		r.RequestSuiFromFaucet(conf.RPCs.SuiFaucet, suiSigner.Address())
 
 		// deposit initial SUI tokens to ZEVM, 100 SUI in MIST
-		resp := r.SuiDepositSUI(r.EVMAddress(), math.NewUint(100*sui.MistPerSUI))
+		resp := r.SuiDepositSUI(r.SuiGateway.PackageID(), r.EVMAddress(), math.NewUint(100*sui.MistPerSUI))
 
 		// wait for the cctx to be mined
 		cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)

--- a/e2e/e2etests/test_bitcoin_withdraw_rbf.go
+++ b/e2e/e2etests/test_bitcoin_withdraw_rbf.go
@@ -34,7 +34,9 @@ func TestBitcoinWithdrawRBF(r *runner.E2ERunner, args []string) {
 	// initiate a withdraw CCTX, and wait for CCTX creation
 	tx := r.WithdrawBTC(to, amount, gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)}, true)
 	utils.WaitForZetaBlocks(r.Ctx, r, r.ZEVMClient, 1, 20*time.Second)
-	cctx := utils.GetCCTXByInboundHash(r.Ctx, r.CctxClient, tx.Hash().Hex())
+	cctxs := utils.GetCCTXByInboundHash(r.Ctx, r.CctxClient, tx.Hash().Hex())
+	require.Len(r, cctxs, 1)
+	cctx := &cctxs[0]
 
 	// wait for the 1st outbound tracker hash to come in
 	nonce := cctx.GetCurrentOutboundParam().TssNonce

--- a/e2e/e2etests/test_stress_sui_deposit.go
+++ b/e2e/e2etests/test_stress_sui_deposit.go
@@ -26,7 +26,7 @@ func TestStressSuiDeposit(r *runner.E2ERunner, args []string) {
 	for i := range numDeposits {
 		// each goroutine captures its own copy of i
 		i := i
-		resp := r.SuiDepositSUI(r.EVMAddress(), math.NewUintFromBigInt(amount))
+		resp := r.SuiDepositSUI(r.SuiGateway.PackageID(), r.EVMAddress(), math.NewUintFromBigInt(amount))
 
 		r.Logger.Print("index %d: started with tx hash: %s", i, resp.Digest)
 

--- a/e2e/e2etests/test_sui_deposit.go
+++ b/e2e/e2etests/test_sui_deposit.go
@@ -20,7 +20,7 @@ func TestSuiDeposit(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 
 	// make the deposit transaction
-	resp := r.SuiDepositSUI(r.EVMAddress(), math.NewUintFromBigInt(amount))
+	resp := r.SuiDepositSUI(r.SuiGateway.PackageID(), r.EVMAddress(), math.NewUintFromBigInt(amount))
 
 	r.Logger.Info("Sui deposit tx: %s", resp.Digest)
 

--- a/e2e/e2etests/test_sui_deposit_restricted_address.go
+++ b/e2e/e2etests/test_sui_deposit_restricted_address.go
@@ -26,7 +26,7 @@ func TestSuiDepositRestrictedAddress(r *runner.E2ERunner, args []string) {
 
 	// ACT
 	// perform the deposit
-	resp := r.SuiDepositSUI(receiver, math.NewUintFromBigInt(amount))
+	resp := r.SuiDepositSUI(r.SuiGateway.PackageID(), receiver, math.NewUintFromBigInt(amount))
 	r.Logger.Info("Sui restricted deposit tx: %s", resp.Digest)
 
 	// wait enough time

--- a/e2e/e2etests/test_sui_token_deposit.go
+++ b/e2e/e2etests/test_sui_token_deposit.go
@@ -20,7 +20,7 @@ func TestSuiTokenDeposit(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 
 	// make the deposit transaction
-	resp := r.SuiDepositFungibleToken(r.EVMAddress(), math.NewUintFromBigInt(amount))
+	resp := r.SuiDepositFungibleToken(r.SuiGateway.PackageID(), r.EVMAddress(), math.NewUintFromBigInt(amount))
 
 	r.Logger.Info("Sui deposit tx: %s", resp.Digest)
 

--- a/e2e/runner/accounting.go
+++ b/e2e/runner/accounting.go
@@ -38,7 +38,7 @@ type Response struct {
 }
 
 func (r *E2ERunner) VerifyAccounting(testLegacy bool) {
-	r.Logger.Print("Verifying accounting")
+	r.Logger.Print("🏃 Verifying accounting")
 	r.checkETHTSSBalance()
 	r.checkERC20TSSBalance()
 	r.checkZETATSSBalance(testLegacy)

--- a/e2e/runner/setup_sui.go
+++ b/e2e/runner/setup_sui.go
@@ -518,3 +518,23 @@ func (r *E2ERunner) suiTransferObjectToTSS(signer *zetasui.SignerSecp256k1, obje
 
 	r.suiExecuteTx(signer, tx)
 }
+
+// suiGetOwnedObjectID gets the first owned object ID by owner address and struct type
+func (r *E2ERunner) suiGetOwnedObjectID(ownerAddress, structType string) (string, bool) {
+	res, err := r.Clients.Sui.SuiXGetOwnedObjects(r.Ctx, models.SuiXGetOwnedObjectsRequest{
+		Address: ownerAddress,
+		Query: models.SuiObjectResponseQuery{
+			Filter: map[string]any{
+				"StructType": structType,
+			},
+		},
+		Limit: 1,
+	})
+	require.NoError(r, err)
+
+	if len(res.Data) == 0 {
+		return "", false
+	}
+
+	return res.Data[0].Data.ObjectId, true
+}

--- a/e2e/runner/setup_sui.go
+++ b/e2e/runner/setup_sui.go
@@ -111,7 +111,7 @@ func (r *E2ERunner) SetupSui(faucetURL string) {
 	//r.suiTransferObjectToTSS(deployerSigner, messageContextID)
 
 	// set the chain params
-	err = r.setSuiChainParams()
+	err = r.setSuiChainParams(true)
 	require.NoError(r, err)
 }
 
@@ -447,7 +447,7 @@ func (r *E2ERunner) whitelistSuiFakeUSDC(signer *zetasui.SignerSecp256k1, fakeUS
 }
 
 // set the chain params for Sui
-func (r *E2ERunner) setSuiChainParams() error {
+func (r *E2ERunner) setSuiChainParams(resetNonces bool) error {
 	if r.ZetaTxServer == nil {
 		return errors.New("ZetaTxServer is not initialized")
 	}
@@ -470,7 +470,7 @@ func (r *E2ERunner) setSuiChainParams() error {
 		BallotThreshold:             observertypes.DefaultBallotThreshold,
 		MinObserverDelegation:       observertypes.DefaultMinObserverDelegation,
 		IsSupported:                 true,
-		GatewayAddress:              fmt.Sprintf("%s,%s", r.SuiGateway.PackageID(), r.SuiGateway.ObjectID()),
+		GatewayAddress:              r.SuiGateway.ToPairID(),
 		ConfirmationParams: &observertypes.ConfirmationParams{
 			SafeInboundCount:  1,
 			SafeOutboundCount: 1,
@@ -483,18 +483,19 @@ func (r *E2ERunner) setSuiChainParams() error {
 		return errors.Wrap(err, "unable to broadcast solana chain params tx")
 	}
 
-	resetMsg := observertypes.NewMsgResetChainNonces(creator, chainID, 0, 0)
-	if _, err := r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, resetMsg); err != nil {
-		return errors.Wrap(err, "unable to broadcast solana chain nonce reset tx")
+	if resetNonces {
+		resetMsg := observertypes.NewMsgResetChainNonces(creator, chainID, 0, 0)
+		if _, err := r.ZetaTxServer.BroadcastTx(utils.OperationalPolicyName, resetMsg); err != nil {
+			return errors.Wrap(err, "unable to broadcast sui chain nonce reset tx")
+		}
 	}
 
 	query := &observertypes.QueryGetChainParamsForChainRequest{ChainId: chainID}
 
 	const duration = 2 * time.Second
 
-	for i := 0; i < 10; i++ {
-		_, err := r.ObserverClient.GetChainParamsForChain(r.Ctx, query)
-		if err == nil {
+	for range 10 {
+		if _, err := r.ObserverClient.GetChainParamsForChain(r.Ctx, query); err == nil {
 			r.Logger.Print("⚙️ Sui chain params are set")
 			return nil
 		}

--- a/e2e/runner/sui.go
+++ b/e2e/runner/sui.go
@@ -111,6 +111,7 @@ func (r *E2ERunner) SuiWithdrawAndCall(
 
 // SuiDepositSUI calls Deposit on Sui
 func (r *E2ERunner) SuiDepositSUI(
+	packageID string,
 	receiver ethcommon.Address,
 	amount math.Uint,
 ) models.SuiTransactionBlockResponse {
@@ -121,7 +122,7 @@ func (r *E2ERunner) SuiDepositSUI(
 	coinObjectID := r.suiSplitSUI(signer, amount)
 
 	// create the tx
-	return r.suiExecuteDeposit(signer, string(sui.SUI), coinObjectID, receiver)
+	return r.suiExecuteDeposit(signer, packageID, string(sui.SUI), coinObjectID, receiver)
 }
 
 // SuiDepositAndCallSUI calls DepositAndCall on Sui
@@ -142,6 +143,7 @@ func (r *E2ERunner) SuiDepositAndCallSUI(
 
 // SuiDepositFungibleToken calls Deposit with fungible token on Sui
 func (r *E2ERunner) SuiDepositFungibleToken(
+	packageID string,
 	receiver ethcommon.Address,
 	amount math.Uint,
 ) models.SuiTransactionBlockResponse {
@@ -152,7 +154,7 @@ func (r *E2ERunner) SuiDepositFungibleToken(
 	coinObjectID := r.suiSplitUSDC(signer, amount)
 
 	// create the tx
-	return r.suiExecuteDeposit(signer, "0x"+r.SuiTokenCoinType, coinObjectID, receiver)
+	return r.suiExecuteDeposit(signer, packageID, "0x"+r.SuiTokenCoinType, coinObjectID, receiver)
 }
 
 // SuiFungibleTokenDepositAndCall calls DepositAndCall with fungible token on Sui
@@ -329,6 +331,7 @@ func (r *E2ERunner) SuiMonitorCCTXByInboundHash(inboundHash string, index int) (
 // suiExecuteDeposit executes a deposit on the SUI contract
 func (r *E2ERunner) suiExecuteDeposit(
 	signer *sui.SignerSecp256k1,
+	packageID string,
 	coinType string,
 	coinObjectID string,
 	receiver ethcommon.Address,
@@ -336,7 +339,7 @@ func (r *E2ERunner) suiExecuteDeposit(
 	// create the tx
 	tx, err := r.Clients.Sui.MoveCall(r.Ctx, models.MoveCallRequest{
 		Signer:          signer.Address(),
-		PackageObjectId: r.SuiGateway.PackageID(),
+		PackageObjectId: packageID,
 		Module:          "gateway",
 		Function:        "deposit",
 		TypeArguments:   []any{coinType},

--- a/e2e/runner/sui_gateway_upgrade.go
+++ b/e2e/runner/sui_gateway_upgrade.go
@@ -3,17 +3,21 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/block-vision/sui-go-sdk/models"
-	"github.com/pkg/errors"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/contracts/sui"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
 // SuiVerifyGatewayPackageUpgrade upgrades the Sui gateway package and verifies the upgrade
@@ -25,13 +29,12 @@ func (r *E2ERunner) SuiVerifyGatewayPackageUpgrade() {
 	require.NoError(r, err)
 
 	// upgrade the Sui gateway package
-	newGatewayPackageID, err := r.suiUpgradeGatewayPackage()
-	require.NoError(r, err)
+	r.suiUpgradeGatewayPackage()
 
-	r.Logger.Print("⚙️ Sui gateway package upgrade completed")
+	r.Logger.Print("⚙️ Sui gateway upgrade completed: %s", r.SuiGateway.PackageID())
 
 	// call the new method 'upgraded' in the new gateway package
-	r.moveCallUpgraded(r.Ctx, newGatewayPackageID)
+	r.moveCallUpgraded(r.Ctx, r.SuiGateway.PackageID())
 
 	// retrieve new gateway object data
 	gatewayDataAfter, err := r.suiGetObjectData(r.Ctx, r.SuiGateway.ObjectID())
@@ -39,10 +42,22 @@ func (r *E2ERunner) SuiVerifyGatewayPackageUpgrade() {
 
 	// gateway data should remain unchanged
 	require.Equal(r, gatewayDataBefore, gatewayDataAfter)
+
+	// it takes 1 Zeta block time for zetaclient to pick up the new chain params
+	// wait for 2 blocks to ensure the new gateway package ID is effective
+	utils.WaitForZetaBlocks(r.Ctx, r, r.ZEVMClient, 2, 10*time.Second)
+
+	// deposit from new gateway package should be observed
+	r.Logger.Print("🏃 Verifying Sui deposit from new package")
+	r.suiVerifyDepositFromPackage(r.SuiGateway.PackageID(), big.NewInt(10000000000))
+
+	// deposit from previous gateway package should be observed
+	r.Logger.Print("🏃 Verifying Sui deposit from previous package")
+	r.suiVerifyDepositFromPackage(r.SuiGateway.Previous().PackageID(), big.NewInt(2000000))
 }
 
 // suiUpgradeGatewayPackage upgrades the Sui gateway package by deploying new compiled gateway package
-func (r *E2ERunner) suiUpgradeGatewayPackage() (packageID string, err error) {
+func (r *E2ERunner) suiUpgradeGatewayPackage() {
 	// build the upgraded gateway package
 	r.suiBuildGatewayUpgraded()
 
@@ -71,13 +86,29 @@ func (r *E2ERunner) suiUpgradeGatewayPackage() (packageID string, err error) {
 	require.NoError(r, err)
 
 	// find packageID
+	packageID := ""
 	for _, change := range response.ObjectChanges {
 		if change.Type == "published" {
-			return change.PackageId, nil
+			packageID = change.PackageId
 		}
 	}
+	require.NotEmpty(r, packageID, "new gateway package ID not found")
 
-	return "", errors.New("new gateway package ID not found")
+	// find withdraw cap ID
+	withdrawCapID, found := r.suiGetOwnedObjectID(r.SuiTSSAddress, r.SuiGateway.WithdrawCapType())
+	require.True(r, found, "withdraw cap object not found")
+
+	// update runner gateway package ID
+	previousPackageID := r.SuiGateway.PackageID()
+	originalPackageID := previousPackageID
+	r.SuiGateway, err = sui.NewGatewayFromPairID(
+		sui.MakePairID(packageID, r.SuiGateway.ObjectID(), withdrawCapID, previousPackageID, originalPackageID),
+	)
+	require.NoError(r, err)
+
+	// update the chain params so zetaclient can pick it up
+	err = r.setSuiChainParams(false)
+	require.NoError(r, err)
 }
 
 // moveCallUpgraded performs a move call to 'upgraded' method on the new Sui gateway package
@@ -128,4 +159,27 @@ func (r *E2ERunner) suiGetObjectData(ctx context.Context, objectID string) (mode
 	require.NotNil(r, object.Data.Content)
 
 	return *object.Data.Content, nil
+}
+
+// suiVerifyDepositFromPackage verifies the deposit from given Sui gateway packageID and amount
+func (r *E2ERunner) suiVerifyDepositFromPackage(packageID string, amount *big.Int) {
+	oldBalance, err := r.SUIZRC20.BalanceOf(&bind.CallOpts{}, r.EVMAddress())
+	require.NoError(r, err)
+
+	// make a deposit from gateway package
+	resp := r.SuiDepositSUI(packageID, r.EVMAddress(), math.NewUintFromBigInt(amount))
+	r.Logger.Info("Sui deposit tx: %s from package: %s", resp.Digest, packageID)
+
+	// wait for the CCTX to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, resp.Digest, r.CctxClient, r.Logger, r.CctxTimeout)
+	require.EqualValues(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
+
+	// wait for the SUI ZRC20 balance to be updated
+	change := utils.NewExactChange(amount)
+	utils.WaitAndVerifyZRC20BalanceChange(r, r.SUIZRC20, r.EVMAddress(), oldBalance, change, r.Logger)
+	require.Equal(r, amount.Uint64(), cctx.InboundParams.Amount.Uint64())
+
+	// only one single CCTX should be created
+	cctxs := utils.GetCCTXByInboundHash(r.Ctx, r.CctxClient, resp.Digest)
+	require.Len(r, cctxs, 1)
 }

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -69,7 +69,7 @@ func GetCCTXByInboundHash(
 	ctx context.Context,
 	client crosschaintypes.QueryClient,
 	inboundHash string,
-) *crosschaintypes.CrossChainTx {
+) []crosschaintypes.CrossChainTx {
 	t := TestingFromContext(ctx)
 
 	// query cctx by inbound hash
@@ -77,9 +77,8 @@ func GetCCTXByInboundHash(
 	res, err := client.InTxHashToCctxData(ctx, in)
 
 	require.NoError(t, err)
-	require.Len(t, res.CrossChainTxs, 1)
 
-	return &res.CrossChainTxs[0]
+	return res.CrossChainTxs
 }
 
 // WaitCctxMinedByInboundHash waits until cctx is mined; returns the cctxIndex (the last one)

--- a/pkg/contracts/sui/gateway_test.go
+++ b/pkg/contracts/sui/gateway_test.go
@@ -2,47 +2,80 @@ package sui
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"cosmossdk.io/math"
 	"github.com/block-vision/sui-go-sdk/models"
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_ActiveMessageContextDynamicFieldName(t *testing.T) {
+	got, err := ActiveMessageContextDynamicFieldName()
+	require.NoError(t, err)
+
+	expectedJSON := json.RawMessage(`[97,99,116,105,118,101,95,109,101,115,115,97,103,101,95,99,111,110,116,101,120,116]`)
+	require.Equal(t, expectedJSON, got)
+}
 
 func TestNewGatewayFromPairID(t *testing.T) {
 	// stubs
 	const (
-		packageID = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
-		gatewayID = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		packageID         = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID         = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
 	)
 
 	tests := []struct {
-		name    string
-		triplet string
-		wantErr string
+		name         string
+		pair         string
+		wantErr      string
+		wantOriginal bool
 	}{
 		{
-			name:    "valid pair",
-			triplet: fmt.Sprintf("%s,%s", packageID, gatewayID),
+			name: "valid pair",
+			pair: MakePairID(packageID, gatewayID, "", "", ""),
 		},
 		{
-			name:    "invalid pair, missing gateway object id",
-			triplet: "0x123",
+			name:         "valid pair id with 5 parts",
+			pair:         MakePairID(packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID),
+			wantOriginal: true,
+		},
+		{
+			name:    "invalid pair, empty string",
+			pair:    "",
+			wantErr: "invalid pair",
+		},
+		{
+			name:    "invalid pair, contains 1 part",
+			pair:    "0x123",
+			wantErr: "invalid pair",
+		},
+		{
+			name:    "invalid pair, contains 3 parts",
+			pair:    fmt.Sprintf("%s,%s,%s", packageID, gatewayID, originalPackageID),
+			wantErr: "invalid pair",
+		},
+		{
+			name:    "invalid pair, contains 4 parts",
+			pair:    fmt.Sprintf("%s,%s,%s,%s", packageID, gatewayID, previousPackageID, originalPackageID),
 			wantErr: "invalid pair",
 		},
 		{
 			name:    "invalid Sui address",
-			triplet: fmt.Sprintf("%s,0xabc", packageID),
+			pair:    fmt.Sprintf("%s,0xabc", packageID),
 			wantErr: "invalid Sui address",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gw, err := NewGatewayFromPairID(tt.triplet)
+			gw, err := NewGatewayFromPairID(tt.pair)
 			if tt.wantErr != "" {
 				require.Nil(t, gw)
 				require.ErrorContains(t, err, tt.wantErr)
@@ -50,25 +83,172 @@ func TestNewGatewayFromPairID(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, packageID, gw.PackageID())
-			assert.Equal(t, gatewayID, gw.ObjectID())
+			require.Equal(t, packageID, gw.PackageID())
+			require.Equal(t, gatewayID, gw.ObjectID())
+
+			if !tt.wantOriginal {
+				require.Equal(t, []string{packageID}, gw.PackageIDs())
+				return
+			}
+
+			require.Equal(t, withdrawCapID, gw.WithdrawCapID())
+			require.Equal(t, previousPackageID, gw.Previous().PackageID())
+			require.Equal(t, originalPackageID, gw.Original().PackageID())
+			require.True(t, slices.Equal([]string{packageID, previousPackageID, originalPackageID}, gw.PackageIDs()))
 		})
 	}
+}
+
+func Test_MakePairID(t *testing.T) {
+	const (
+		packageID         = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID         = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+	)
+
+	t.Run("original package id is empty", func(t *testing.T) {
+		gatewayAddress := MakePairID(packageID, gatewayID, "", "", "")
+		require.Equal(t, fmt.Sprintf("%s,%s", packageID, gatewayID), gatewayAddress)
+	})
+
+	t.Run("original package id is not empty", func(t *testing.T) {
+		gatewayAddress := MakePairID(packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID)
+		require.Equal(t, fmt.Sprintf("%s,%s,%s,%s,%s", packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID), gatewayAddress)
+	})
+}
+
+func Test_ToPairID(t *testing.T) {
+	const (
+		packageID         = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID         = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+	)
+
+	t.Run("original package id is empty", func(t *testing.T) {
+		gw := NewGateway(packageID, gatewayID)
+		require.Equal(t, MakePairID(packageID, gatewayID, withdrawCapID, "", ""), gw.ToPairID())
+	})
+
+	t.Run("original package id is not empty", func(t *testing.T) {
+		gatewayAddress := MakePairID(packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID)
+		gw, err := NewGatewayFromPairID(gatewayAddress)
+		require.NoError(t, err)
+		require.Equal(t, gatewayAddress, gw.ToPairID())
+	})
+}
+
+func Test_Previous(t *testing.T) {
+	const (
+		packageID         = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID         = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+	)
+
+	t.Run("previous package id is not empty", func(t *testing.T) {
+		gw, err := NewGatewayFromPairID(MakePairID(packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID))
+		require.NoError(t, err)
+
+		gwPrevious := gw.Previous()
+		require.Equal(t, previousPackageID, gwPrevious.PackageID())
+		require.Equal(t, gatewayID, gwPrevious.ObjectID())
+		require.Equal(t, withdrawCapID, gwPrevious.WithdrawCapID())
+		require.Empty(t, gwPrevious.previousPackageID)
+		require.Empty(t, gwPrevious.originalPackageID)
+	})
+
+	t.Run("previous package id is empty", func(t *testing.T) {
+		gw, err := NewGatewayFromPairID(MakePairID(packageID, gatewayID, withdrawCapID, "", ""))
+		require.NoError(t, err)
+		require.Nil(t, gw.Previous())
+	})
+}
+
+func Test_Original(t *testing.T) {
+	const (
+		packageID         = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID         = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+	)
+
+	t.Run("original package id is not empty", func(t *testing.T) {
+		gw, err := NewGatewayFromPairID(MakePairID(packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID))
+		require.NoError(t, err)
+
+		gwOriginal := gw.Original()
+		require.Equal(t, originalPackageID, gwOriginal.PackageID())
+		require.Equal(t, gatewayID, gwOriginal.ObjectID())
+		require.Equal(t, withdrawCapID, gwOriginal.WithdrawCapID())
+		require.Empty(t, gwOriginal.previousPackageID)
+		require.Empty(t, gwOriginal.originalPackageID)
+	})
+
+	t.Run("original package id is empty", func(t *testing.T) {
+		gw, err := NewGatewayFromPairID(MakePairID(packageID, gatewayID, withdrawCapID, "", ""))
+		require.NoError(t, err)
+
+		gwOriginal := gw.Original()
+		require.Equal(t, packageID, gwOriginal.PackageID())
+		require.Equal(t, gatewayID, gwOriginal.ObjectID())
+		require.Empty(t, gwOriginal.WithdrawCapID())
+		require.Empty(t, gwOriginal.previousPackageID)
+		require.Empty(t, gwOriginal.originalPackageID)
+	})
+}
+
+func Test_UpdateIDs(t *testing.T) {
+	const (
+		packageID = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+
+		packageID2        = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+		gatewayID2        = "0xaf52affd195806d9aa9d967462cbda411bfed9a6efc4a032bf8e34a391469878"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+	)
+
+	// before update
+	gw := NewGateway(packageID, gatewayID)
+	require.Equal(t, packageID, gw.PackageID())
+	require.Equal(t, gatewayID, gw.ObjectID())
+	require.Empty(t, gw.WithdrawCapID())
+	require.Empty(t, gw.previousPackageID)
+	require.Empty(t, gw.originalPackageID)
+
+	// after update
+	require.NoError(t, gw.UpdateIDs(MakePairID(packageID2, gatewayID2, withdrawCapID, previousPackageID, originalPackageID)))
+	require.Equal(t, packageID2, gw.PackageID())
+	require.Equal(t, gatewayID2, gw.ObjectID())
+	require.Equal(t, withdrawCapID, gw.WithdrawCapID())
+	require.Equal(t, previousPackageID, gw.Previous().PackageID())
+	require.Equal(t, originalPackageID, gw.Original().PackageID())
 }
 
 func TestParseEvent(t *testing.T) {
 	// stubs
 	const (
-		packageID = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
-		gatewayID = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
-		sender    = "0x70386a9a912d9f7a603263abfbd8faae861df0ee5f8e2dbdf731fbd159f10e52"
-		txHash    = "HjxLMxMXNz8YfUc2qT4e4CrogKvGeHRbDW7Arr6ntzqq"
+		packageID         = "0x3e9fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443cf"
+		gatewayID         = "0x444fb7c01ef0d97911ccfec79306d9de2d58daa996bd3469da0f6d640cc443aa"
+		withdrawCapID     = "0x84d96419097f3cd66c7dd732cd28c8df58c1183768ae617c0705a6261a60a870"
+		previousPackageID = "0x903b713792ee26d4f57e31a7bed113563f3c427506579e9f38bff5adf5524dfd"
+		originalPackageID = "0x9a6e7366064fb27ac1daeca6f7d4c13af2f86d26433b5e70bea9b6214e6253e4"
+		sender            = "0x70386a9a912d9f7a603263abfbd8faae861df0ee5f8e2dbdf731fbd159f10e52"
+		txHash            = "HjxLMxMXNz8YfUc2qT4e4CrogKvGeHRbDW7Arr6ntzqq"
 	)
 
-	gw := NewGateway(packageID, gatewayID)
+	gw, err := NewGatewayFromPairID(MakePairID(packageID, gatewayID, withdrawCapID, previousPackageID, originalPackageID))
+	require.NoError(t, err)
 
 	eventType := func(t string) string {
-		return fmt.Sprintf("%s::%s::%s", packageID, GatewayModule, t)
+		return fmt.Sprintf("%s::%s::%s", originalPackageID, GatewayModule, t)
 	}
 
 	receiverAlice := ethcommon.HexToAddress("0xa64AeD687591CfCAB52F2C1DF79a2424BbC5fEA1")
@@ -89,7 +269,7 @@ func TestParseEvent(t *testing.T) {
 		assert      func(t *testing.T, raw models.SuiEventResponse, out Event)
 	}{
 		{
-			name: "deposit",
+			name: "deposit from current gateway",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
 				PackageId: packageID,
@@ -103,26 +283,26 @@ func TestParseEvent(t *testing.T) {
 				},
 			},
 			assert: func(t *testing.T, raw models.SuiEventResponse, out Event) {
-				assert.Equal(t, txHash, out.TxHash)
-				assert.Equal(t, DepositEvent, out.EventType)
-				assert.Equal(t, uint64(0), out.EventIndex)
+				require.Equal(t, txHash, out.TxHash)
+				require.Equal(t, DepositEvent, out.EventType)
+				require.Equal(t, uint64(0), out.EventIndex)
 
 				deposit, err := out.Deposit()
 				require.NoError(t, err)
 
-				assert.Equal(t, SUI, deposit.CoinType)
-				assert.True(t, math.NewUint(100).Equal(deposit.Amount))
-				assert.Equal(t, sender, deposit.Sender)
-				assert.Equal(t, receiverAlice, deposit.Receiver)
-				assert.False(t, deposit.IsCrossChainCall)
-				assert.True(t, deposit.IsGas())
+				require.Equal(t, SUI, deposit.CoinType)
+				require.True(t, math.NewUint(100).Equal(deposit.Amount))
+				require.Equal(t, sender, deposit.Sender)
+				require.Equal(t, receiverAlice, deposit.Receiver)
+				require.False(t, deposit.IsCrossChainCall)
+				require.True(t, deposit.IsGas())
 			},
 		},
 		{
 			name: "depositAndCall with bytes payload",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "1"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositAndCallEvent"),
 				ParsedJson: map[string]any{
@@ -134,26 +314,26 @@ func TestParseEvent(t *testing.T) {
 				},
 			},
 			assert: func(t *testing.T, raw models.SuiEventResponse, out Event) {
-				assert.Equal(t, txHash, out.TxHash)
-				assert.Equal(t, DepositAndCallEvent, out.EventType)
-				assert.Equal(t, uint64(1), out.EventIndex)
+				require.Equal(t, txHash, out.TxHash)
+				require.Equal(t, DepositAndCallEvent, out.EventType)
+				require.Equal(t, uint64(1), out.EventIndex)
 
 				deposit, err := out.Deposit()
 				require.NoError(t, err)
 
-				assert.Equal(t, SUI, deposit.CoinType)
-				assert.True(t, math.NewUint(200).Equal(deposit.Amount))
-				assert.Equal(t, sender, deposit.Sender)
-				assert.Equal(t, receiverBob, deposit.Receiver)
-				assert.True(t, deposit.IsCrossChainCall)
-				assert.Equal(t, []byte{0, 1, 2}, deposit.Payload)
+				require.Equal(t, SUI, deposit.CoinType)
+				require.True(t, math.NewUint(200).Equal(deposit.Amount))
+				require.Equal(t, sender, deposit.Sender)
+				require.Equal(t, receiverBob, deposit.Receiver)
+				require.True(t, deposit.IsCrossChainCall)
+				require.Equal(t, []byte{0, 1, 2}, deposit.Payload)
 			},
 		},
 		{
 			name: "depositAndCall with Base64 formatted payload",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "1"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositAndCallEvent"),
 				ParsedJson: map[string]any{
@@ -165,26 +345,26 @@ func TestParseEvent(t *testing.T) {
 				},
 			},
 			assert: func(t *testing.T, raw models.SuiEventResponse, out Event) {
-				assert.Equal(t, txHash, out.TxHash)
-				assert.Equal(t, DepositAndCallEvent, out.EventType)
-				assert.Equal(t, uint64(1), out.EventIndex)
+				require.Equal(t, txHash, out.TxHash)
+				require.Equal(t, DepositAndCallEvent, out.EventType)
+				require.Equal(t, uint64(1), out.EventIndex)
 
 				deposit, err := out.Deposit()
 				require.NoError(t, err)
 
-				assert.Equal(t, SUI, deposit.CoinType)
-				assert.True(t, math.NewUint(200).Equal(deposit.Amount))
-				assert.Equal(t, sender, deposit.Sender)
-				assert.Equal(t, receiverBob, deposit.Receiver)
-				assert.True(t, deposit.IsCrossChainCall)
-				assert.Equal(t, []byte{3, 4, 5}, deposit.Payload)
+				require.Equal(t, SUI, deposit.CoinType)
+				require.True(t, math.NewUint(200).Equal(deposit.Amount))
+				require.Equal(t, sender, deposit.Sender)
+				require.Equal(t, receiverBob, deposit.Receiver)
+				require.True(t, deposit.IsCrossChainCall)
+				require.Equal(t, []byte{3, 4, 5}, deposit.Payload)
 			},
 		},
 		{
 			name: "depositAndCall_empty_payload",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "1"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositAndCallEvent"),
 				ParsedJson: map[string]any{
@@ -196,26 +376,26 @@ func TestParseEvent(t *testing.T) {
 				},
 			},
 			assert: func(t *testing.T, raw models.SuiEventResponse, out Event) {
-				assert.Equal(t, txHash, out.TxHash)
-				assert.Equal(t, DepositAndCallEvent, out.EventType)
-				assert.Equal(t, uint64(1), out.EventIndex)
+				require.Equal(t, txHash, out.TxHash)
+				require.Equal(t, DepositAndCallEvent, out.EventType)
+				require.Equal(t, uint64(1), out.EventIndex)
 
 				deposit, err := out.Deposit()
 				require.NoError(t, err)
 
-				assert.Equal(t, SUI, deposit.CoinType)
-				assert.True(t, math.NewUint(200).Equal(deposit.Amount))
-				assert.Equal(t, sender, deposit.Sender)
-				assert.Equal(t, receiverBob, deposit.Receiver)
-				assert.True(t, deposit.IsCrossChainCall)
-				assert.Equal(t, []byte{}, deposit.Payload)
+				require.Equal(t, SUI, deposit.CoinType)
+				require.True(t, math.NewUint(200).Equal(deposit.Amount))
+				require.Equal(t, sender, deposit.Sender)
+				require.Equal(t, receiverBob, deposit.Receiver)
+				require.True(t, deposit.IsCrossChainCall)
+				require.Equal(t, []byte{}, deposit.Payload)
 			},
 		},
 		{
 			name: "withdraw",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "1"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("WithdrawEvent"),
 				ParsedJson: map[string]any{
@@ -227,17 +407,17 @@ func TestParseEvent(t *testing.T) {
 				},
 			},
 			assert: func(t *testing.T, raw models.SuiEventResponse, out Event) {
-				assert.Equal(t, txHash, out.TxHash)
-				assert.Equal(t, WithdrawEvent, out.EventType)
+				require.Equal(t, txHash, out.TxHash)
+				require.Equal(t, WithdrawEvent, out.EventType)
 
 				wd, err := out.Withdrawal()
 				require.NoError(t, err)
 
-				assert.Equal(t, SUI, wd.CoinType)
-				assert.True(t, math.NewUint(200).Equal(wd.Amount))
-				assert.Equal(t, sender, wd.Sender)
-				assert.Equal(t, receiverBob.String(), wd.Receiver)
-				assert.True(t, wd.IsGas())
+				require.Equal(t, SUI, wd.CoinType)
+				require.True(t, math.NewUint(200).Equal(wd.Amount))
+				require.Equal(t, sender, wd.Sender)
+				require.Equal(t, receiverBob.String(), wd.Receiver)
+				require.True(t, wd.IsGas())
 			},
 		},
 		// ERRORS
@@ -261,7 +441,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid event id",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "hey"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 			},
 			errContains: `failed to parse event id "hey"`,
 		},
@@ -277,8 +457,8 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid module",
 			event: models.SuiEventResponse{
 				Id:                models.EventId{TxDigest: txHash, EventSeq: "0"},
-				PackageId:         packageID,
-				Type:              fmt.Sprintf("%s::%s::%s", packageID, "not_a_gateway", DepositEvent),
+				PackageId:         originalPackageID,
+				Type:              fmt.Sprintf("%s::%s::%s", originalPackageID, "not_a_gateway", DepositEvent),
 				TransactionModule: "foo",
 			},
 			errContains: "module mismatch",
@@ -287,7 +467,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid event type",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Type:      eventType("bar"),
 			},
 			errContains: `unknown event "bar"`,
@@ -296,7 +476,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid coin type",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositEvent"),
 				ParsedJson: map[string]any{
@@ -309,7 +489,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid amount",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositEvent"),
 				ParsedJson: map[string]any{
@@ -323,7 +503,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid sender",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositEvent"),
 				ParsedJson: map[string]any{
@@ -338,7 +518,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid receiver",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "0"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositEvent"),
 				ParsedJson: map[string]any{
@@ -354,7 +534,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid payload",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "1"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositAndCallEvent"),
 				ParsedJson: map[string]any{
@@ -371,7 +551,7 @@ func TestParseEvent(t *testing.T) {
 			name: "invalid payload float64",
 			event: models.SuiEventResponse{
 				Id:        models.EventId{TxDigest: txHash, EventSeq: "1"},
-				PackageId: packageID,
+				PackageId: originalPackageID,
 				Sender:    sender,
 				Type:      eventType("DepositAndCallEvent"),
 				ParsedJson: map[string]any{

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -58,6 +58,10 @@ type Observer struct {
 	// lastTxScanned is the last transaction hash scanned by the observer
 	lastTxScanned string
 
+	// auxStringMap is a key-value map to store any auxiliary string values used by the observer
+	// it is now only used by Sui observer to store old/new Sui gateway inbound cursors
+	auxStringMap map[string]string
+
 	blockCache *lru.Cache
 
 	// db is the database to persist data
@@ -102,6 +106,7 @@ func NewObserver(
 		lastBlock:        0,
 		lastBlockScanned: 0,
 		lastTxScanned:    "",
+		auxStringMap:     make(map[string]string),
 		ts:               ts,
 		db:               database,
 		blockCache:       blockCache,
@@ -228,6 +233,8 @@ func (ob *Observer) WithLastBlockScanned(blockNumber uint64) *Observer {
 
 // LastTxScanned get last transaction scanned.
 func (ob *Observer) LastTxScanned() string {
+	ob.mu.Lock()
+	defer ob.mu.Unlock()
 	return ob.lastTxScanned
 }
 
@@ -236,7 +243,11 @@ func (ob *Observer) WithLastTxScanned(txHash string) *Observer {
 	ob.mu.Lock()
 	defer ob.mu.Unlock()
 
+	if ob.lastTxScanned == "" {
+		ob.logger.Chain.Info().Str("tx", txHash).Msg("initializing last tx scanned")
+	}
 	ob.lastTxScanned = txHash
+
 	return ob
 }
 
@@ -381,6 +392,71 @@ func (ob *Observer) ReadLastTxScannedFromDB() (string, error) {
 	return lastTx.Hash, nil
 }
 
+// GetAuxString get any auxiliary string data by key
+func (ob *Observer) GetAuxString(key string) string {
+	ob.mu.Lock()
+	defer ob.mu.Unlock()
+	return ob.auxStringMap[key]
+}
+
+// WithAuxString set any auxiliary string data by key
+func (ob *Observer) WithAuxString(key, value string) *Observer {
+	ob.mu.Lock()
+	defer ob.mu.Unlock()
+
+	if ob.auxStringMap[key] == "" {
+		ob.logger.Chain.Info().Str("key", key).Str("value", value).Msg("initializing auxiliary string value")
+	}
+	ob.auxStringMap[key] = value
+
+	return ob
+}
+
+// WriteAuxStringToDB writes the auxiliary string data to the database.
+func (ob *Observer) WriteAuxStringToDB(key, value string) error {
+	// create new record if not found
+	var existingRecord clienttypes.AuxStringSQLType
+	if err := ob.db.Client().Where("key_name = ?", key).First(&existingRecord).Error; err != nil {
+		return ob.db.Client().Create(clienttypes.ToAuxStringSQLType(key, value)).Error
+	}
+
+	// record exists, update it
+	return ob.db.Client().Model(&existingRecord).Update("value", value).Error
+}
+
+// LoadAuxString loads auxiliary string data from environment variable or from database.
+func (ob *Observer) LoadAuxString(key string) {
+	// get environment variable
+	envvar := EnvVarLatestAuxStringByChain(ob.chain, key)
+	value := os.Getenv(envvar)
+
+	// load from environment variable if set
+	if value != "" {
+		ob.logger.Chain.Info().Str("envvar", envvar).Str("value", value).Msg("environment variable is set")
+		ob.WithAuxString(key, value)
+		return
+	}
+
+	// load from DB otherwise
+	value, err := ob.ReadAuxStringFromDB(key)
+	if err != nil {
+		// if not found, let the concrete chain observer decide where to start
+		chainID := ob.chain.ChainId
+		ob.logger.Chain.Info().Int64(logs.FieldChain, chainID).Str("key", key).Msg("string value not found in db")
+		return
+	}
+	ob.WithAuxString(key, value)
+}
+
+// ReadAuxStringFromDB reads the auxiliary string data from the database.
+func (ob *Observer) ReadAuxStringFromDB(key string) (string, error) {
+	var record clienttypes.AuxStringSQLType
+	if err := ob.db.Client().Where("key_name = ?", key).First(&record).Error; err != nil {
+		return "", err
+	}
+	return record.Value, nil
+}
+
 // PostVoteInbound posts a vote for the given vote message and returns the ballot.
 func (ob *Observer) PostVoteInbound(
 	ctx context.Context,
@@ -452,6 +528,11 @@ func EnvVarLatestBlockByChain(chain chains.Chain) string {
 // EnvVarLatestTxByChain returns the environment variable for the last tx by chain.
 func EnvVarLatestTxByChain(chain chains.Chain) string {
 	return fmt.Sprintf("CHAIN_%d_SCAN_FROM_TX", chain.ChainId)
+}
+
+// EnvVarLatestAuxStringByChain returns the environment variable for auxiliary string data by chain for the given key.
+func EnvVarLatestAuxStringByChain(chain chains.Chain, key string) string {
+	return fmt.Sprintf("CHAIN_%d_AUX_STRING_%s", chain.ChainId, key)
 }
 
 func newObserverLogger(chain chains.Chain, logger Logger) ObserverLogger {

--- a/zetaclient/chains/base/observer_test.go
+++ b/zetaclient/chains/base/observer_test.go
@@ -516,6 +516,75 @@ func TestReadWriteDBLastTxScanned(t *testing.T) {
 	})
 }
 
+func Test_GetSetAuxString(t *testing.T) {
+	chain := chains.SuiMainnet
+
+	t.Run("should be able to update auxiliary string value", func(t *testing.T) {
+		ob := newTestSuite(t, chain)
+
+		// should return empty value if not set
+		key := "test key"
+		require.Empty(t, ob.GetAuxString(key))
+
+		// update auxiliary string value
+
+		value := "test value"
+		ob.Observer.WithAuxString(key, value)
+		require.Equal(t, value, ob.GetAuxString(key))
+	})
+}
+
+func Test_LoadAuxString(t *testing.T) {
+	chain := chains.SuiMainnet
+	key := "test key"
+	envvar := base.EnvVarLatestAuxStringByChain(chain, key)
+
+	t.Run("should be able to load/update auxiliary string value", func(t *testing.T) {
+		// create observer and open db
+		ob := newTestSuite(t, chain)
+
+		// create db and write auxiliary string value
+		err := ob.WriteAuxStringToDB(key, "test value")
+		require.NoError(t, err)
+
+		// read auxiliary string value
+		ob.LoadAuxString(key)
+		require.EqualValues(t, "test value", ob.GetAuxString(key))
+
+		// update auxiliary string value
+		err = ob.WriteAuxStringToDB(key, "test value 2")
+		require.NoError(t, err)
+
+		// read again
+		ob.LoadAuxString(key)
+		require.EqualValues(t, "test value 2", ob.GetAuxString(key))
+	})
+
+	t.Run("should return empty value if not found in db", func(t *testing.T) {
+		// create observer and open db
+		ob := newTestSuite(t, chain)
+
+		// read auxiliary string value
+		ob.LoadAuxString(key)
+		require.Empty(t, ob.GetAuxString(key))
+	})
+
+	t.Run("should overwrite string value if env var is set", func(t *testing.T) {
+		// create observer and open db
+		ob := newTestSuite(t, chain)
+
+		// create db and write auxiliary string value
+		ob.WriteAuxStringToDB(key, "test value 1")
+
+		// set env var
+		os.Setenv(envvar, "test value 2")
+
+		// read auxiliary string value
+		ob.LoadAuxString(key)
+		require.EqualValues(t, "test value 2", ob.GetAuxString(key))
+	})
+}
+
 func TestPostVoteInbound(t *testing.T) {
 	t.Run("should be able to post vote inbound", func(t *testing.T) {
 		// create observer

--- a/zetaclient/chains/solana/observer/inbound.go
+++ b/zetaclient/chains/solana/observer/inbound.go
@@ -61,8 +61,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		ob.Logger().Inbound.Info().
 			Str(logs.FieldMethod, "ObserveInbound").
 			Int("signatures", len(signatures)).
-			Int64(logs.FieldChain, chainID).
-			Msg("got wrong amount of signatures")
+			Msg("got inbound signatures")
 	}
 
 	// loop signature from oldest to latest to filter inbound events

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -9,7 +9,6 @@ import (
 	"cosmossdk.io/math"
 	"github.com/block-vision/sui-go-sdk/models"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/node/pkg/chains"
@@ -61,7 +60,13 @@ func TestObserver(t *testing.T) {
 
 	t.Run("ObserveInbound", func(t *testing.T) {
 		// ARRANGE
-		ts := newTestSuite(t)
+		previousPackageID := sample.SuiAddress(t)
+		originalPackageID := sample.SuiAddress(t)
+		ts := newTestSuite(t, func(cfg *testSuiteConfig) {
+			cfg.withdrawCapID = sample.SuiAddress(t)
+			cfg.previousPackageID = previousPackageID
+			cfg.originalPackageID = originalPackageID
+		})
 
 		evmBob := sample.EthAddress()
 		evmAlice := sample.EthAddress()
@@ -70,7 +75,7 @@ func TestObserver(t *testing.T) {
 
 		// Given list of gateway events...
 		expectedQuery := client.EventQuery{
-			PackageID: ts.gateway.PackageID(),
+			PackageID: originalPackageID,
 			Module:    sui.GatewayModule,
 			Cursor:    "",
 			Limit:     client.DefaultEventsLimit,
@@ -78,19 +83,19 @@ func TestObserver(t *testing.T) {
 
 		// ...two of which are valid (1 & 3)
 		events := []models.SuiEventResponse{
-			ts.SampleEvent("TX_1_ok", string(sui.DepositEvent), map[string]any{
+			ts.SampleEvent(originalPackageID, "TX_1_ok", string(sui.DepositEvent), map[string]any{
 				"coin_type": string(sui.SUI),
 				"amount":    "200",
 				"sender":    "SUI_BOB",
 				"receiver":  evmBob.String(),
 			}),
-			ts.SampleEvent("TX_2_unrelated_event", "something", map[string]any{
+			ts.SampleEvent(originalPackageID, "TX_2_unrelated_event", "something", map[string]any{
 				"coin_type": string(sui.SUI),
 				"amount":    "200",
 				"sender":    "SUI_BOB",
 				"receiver":  evmBob.String(),
 			}),
-			ts.SampleEvent("TX_3_ok", string(sui.DepositAndCallEvent), map[string]any{
+			ts.SampleEvent(originalPackageID, "TX_3_ok", string(sui.DepositAndCallEvent), map[string]any{
 				// USDC
 				"coin_type": usdc,
 				"amount":    "300",
@@ -98,7 +103,7 @@ func TestObserver(t *testing.T) {
 				"receiver":  evmAlice.String(),
 				"payload":   preparePayload([]byte{1, 2, 3}),
 			}),
-			ts.SampleEvent("TX_4_invalid_data", string(sui.DepositEvent), map[string]any{
+			ts.SampleEvent(originalPackageID, "TX_4_invalid_data", string(sui.DepositEvent), map[string]any{
 				"coin_type": string(sui.SUI),
 				"amount":    "hello",
 				"sender":    "SUI_BOB",
@@ -109,8 +114,8 @@ func TestObserver(t *testing.T) {
 		ts.suiMock.On("QueryModuleEvents", mock.Anything, expectedQuery).Return(events, "", nil)
 
 		// Given 2 transaction blocks
-		ts.OnGetTx("TX_1_ok", "10000", false, nil)
-		ts.OnGetTx("TX_3_ok", "20000", false, nil)
+		ts.OnGetTx("TX_1_ok", "10000", true, false, nil)
+		ts.OnGetTx("TX_3_ok", "20000", true, false, nil)
 
 		// Given inbound votes catches so we can assert them later
 		ts.CatchInboundVotes()
@@ -123,37 +128,37 @@ func TestObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check that final cursor is on INVALID event, that's expected
-		assert.Equal(t, "TX_4_invalid_data,0", ts.LastTxScanned())
+		require.Equal(t, "TX_4_invalid_data,0", ts.GetAuxString(originalPackageID))
 
 		// Check for transactions
 		require.Equal(t, 2, len(ts.inboundVotesBag))
 
 		vote1 := ts.inboundVotesBag[0]
-		assert.Equal(t, "TX_1_ok", vote1.InboundHash)
-		assert.Equal(t, uint64(10_000), vote1.InboundBlockHeight)
-		assert.Equal(t, coin.CoinType_Gas, vote1.CoinType)
-		assert.Equal(t, false, vote1.IsCrossChainCall)
-		assert.Equal(t, math.NewUint(200), vote1.Amount)
-		assert.Equal(t, "", vote1.Asset)
-		assert.Equal(t, evmBob.String(), vote1.Receiver)
+		require.Equal(t, "TX_1_ok", vote1.InboundHash)
+		require.Equal(t, uint64(10_000), vote1.InboundBlockHeight)
+		require.Equal(t, coin.CoinType_Gas, vote1.CoinType)
+		require.Equal(t, false, vote1.IsCrossChainCall)
+		require.Equal(t, math.NewUint(200), vote1.Amount)
+		require.Equal(t, "", vote1.Asset)
+		require.Equal(t, evmBob.String(), vote1.Receiver)
 
 		vote3 := ts.inboundVotesBag[1]
-		assert.Equal(t, "TX_3_ok", vote3.InboundHash)
-		assert.Equal(t, uint64(20_000), vote3.InboundBlockHeight)
-		assert.Equal(t, coin.CoinType_ERC20, vote3.CoinType)
-		assert.Equal(t, true, vote3.IsCrossChainCall)
-		assert.Equal(t, usdc, vote3.Asset)
-		assert.Equal(t, math.NewUint(300), vote3.Amount)
-		assert.Equal(t, evmAlice.String(), vote3.Receiver)
-		assert.Equal(t, "010203", vote3.Message)
+		require.Equal(t, "TX_3_ok", vote3.InboundHash)
+		require.Equal(t, uint64(20_000), vote3.InboundBlockHeight)
+		require.Equal(t, coin.CoinType_ERC20, vote3.CoinType)
+		require.Equal(t, true, vote3.IsCrossChainCall)
+		require.Equal(t, usdc, vote3.Asset)
+		require.Equal(t, math.NewUint(300), vote3.Amount)
+		require.Equal(t, evmAlice.String(), vote3.Receiver)
+		require.Equal(t, "010203", vote3.Message)
 
 		// Check that other 2 txs are skipped
-		assert.Contains(
+		require.Contains(
 			t,
 			ts.log.String(),
 			`unable to parse amount: cannot convert \"hello\" to big.Int: event parse error","message":"Unable to parse event. Skipping"`,
 		)
-		assert.Contains(
+		require.Contains(
 			t,
 			ts.log.String(),
 			`cannot convert \"hello\" to big.Int: event parse error","message":"Unable to parse event. Skipping"`,
@@ -175,15 +180,16 @@ func TestObserver(t *testing.T) {
 		config.SetRestrictedAddressesFromConfig(cfg)
 
 		// Given a deposit containing restricted address
+		packageID := ts.gateway.PackageID()
 		expectedQuery := client.EventQuery{
-			PackageID: ts.gateway.PackageID(),
+			PackageID: packageID,
 			Module:    sui.GatewayModule,
 			Cursor:    "",
 			Limit:     client.DefaultEventsLimit,
 		}
 
 		events := []models.SuiEventResponse{
-			ts.SampleEvent("TX_restricted", string(sui.DepositEvent), map[string]any{
+			ts.SampleEvent(packageID, "TX_restricted", string(sui.DepositEvent), map[string]any{
 				"coin_type": string(sui.SUI),
 				"amount":    "200",
 				"sender":    "SUI_BOB",
@@ -194,7 +200,7 @@ func TestObserver(t *testing.T) {
 		ts.suiMock.On("QueryModuleEvents", mock.Anything, expectedQuery).Return(events, "", nil)
 
 		// Given transaction block
-		ts.OnGetTx("TX_restricted", "10000", false, nil)
+		ts.OnGetTx("TX_restricted", "10000", true, false, nil)
 
 		// Given inbound votes catches so we can assert them later
 		ts.CatchInboundVotes()
@@ -206,7 +212,7 @@ func TestObserver(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check that final cursor is expected on restricted tx
-		assert.Equal(t, "TX_restricted,0", ts.LastTxScanned())
+		require.Equal(t, "TX_restricted,0", ts.GetAuxString(packageID))
 
 		// No inbound votes should be created
 		require.Empty(t, ts.inboundVotesBag)
@@ -214,25 +220,32 @@ func TestObserver(t *testing.T) {
 
 	t.Run("ProcessInboundTrackers", func(t *testing.T) {
 		// ARRANGE
-		ts := newTestSuite(t)
+		previousPackageID := sample.SuiAddress(t)
+		originalPackageID := sample.SuiAddress(t)
+		ts := newTestSuite(t, func(cfg *testSuiteConfig) {
+			cfg.withdrawCapID = sample.SuiAddress(t)
+			cfg.previousPackageID = previousPackageID
+			cfg.originalPackageID = originalPackageID
+		})
 
 		// Given inbound tracker
 		chainID := ts.Chain().ChainId
-		ts.zetaMock.
-			On("GetInboundTrackersForChain", mock.Anything, chainID).
-			Return([]cctypes.InboundTracker{
-				{
-					ChainId:  chainID,
-					TxHash:   "TX_TRACKER_1",
-					CoinType: coin.CoinType_Gas,
-				},
-			}, nil)
+		txHash := "TX_TRACKER_1"
+		trackers := []cctypes.InboundTracker{
+			{
+				ChainId:  chainID,
+				TxHash:   txHash,
+				CoinType: coin.CoinType_Gas,
+			},
+		}
+
+		ts.zetaMock.On("GetInboundTrackersForChain", mock.Anything, chainID).Return(trackers, nil)
 
 		// Given underlying tx with event
 		evmAlice := sample.EthAddress()
 
-		ts.OnGetTx("TX_TRACKER_1", "15000", true, []models.SuiEventResponse{
-			ts.SampleEvent("TX_TRACKER_1", string(sui.DepositEvent), map[string]any{
+		ts.OnGetTx(txHash, "15000", true, true, []models.SuiEventResponse{
+			ts.SampleEvent(originalPackageID, txHash, string(sui.DepositEvent), map[string]any{
 				"coin_type": string(sui.SUI),
 				"amount":    "1000",
 				"sender":    "SUI_ALICE",
@@ -250,17 +263,16 @@ func TestObserver(t *testing.T) {
 
 		// ASSERT
 		require.NoError(t, err)
-
 		require.Equal(t, 1, len(ts.inboundVotesBag))
 
 		vote := ts.inboundVotesBag[0]
 
-		assert.Equal(t, "TX_TRACKER_1", vote.InboundHash)
-		assert.Equal(t, uint64(15_000), vote.InboundBlockHeight)
-		assert.Equal(t, coin.CoinType_Gas, vote.CoinType)
-		assert.Equal(t, false, vote.IsCrossChainCall)
-		assert.Equal(t, math.NewUint(1000), vote.Amount)
-		assert.Equal(t, evmAlice.String(), vote.Receiver)
+		require.Equal(t, txHash, vote.InboundHash)
+		require.Equal(t, uint64(15_000), vote.InboundBlockHeight)
+		require.Equal(t, coin.CoinType_Gas, vote.CoinType)
+		require.Equal(t, false, vote.IsCrossChainCall)
+		require.Equal(t, math.NewUint(1000), vote.Amount)
+		require.Equal(t, evmAlice.String(), vote.Receiver)
 	})
 
 	t.Run("ProcessOutboundTrackers", func(t *testing.T) {
@@ -340,8 +352,8 @@ func TestObserver(t *testing.T) {
 
 		// ASSERT
 		require.NoError(t, err)
-		assert.True(t, ts.OutboundCreated(nonce))
-		assert.False(t, ts.OutboundCreated(nonce+1))
+		require.True(t, ts.OutboundCreated(nonce))
+		require.False(t, ts.OutboundCreated(nonce+1))
 	})
 
 	t.Run("VoteOutbound successful withdrawal", func(t *testing.T) {
@@ -406,23 +418,23 @@ func TestObserver(t *testing.T) {
 		vote := ts.outboundVotesBag[0]
 
 		// common
-		assert.Equal(t, chains.ReceiveStatus_success, vote.Status) // success
-		assert.Equal(t, cctx.Index, vote.CctxHash)
-		assert.Equal(t, uint64(nonce), vote.OutboundTssNonce)
-		assert.Equal(t, ts.Chain().ChainId, vote.OutboundChain)
+		require.Equal(t, chains.ReceiveStatus_success, vote.Status) // success
+		require.Equal(t, cctx.Index, vote.CctxHash)
+		require.Equal(t, uint64(nonce), vote.OutboundTssNonce)
+		require.Equal(t, ts.Chain().ChainId, vote.OutboundChain)
 
 		// digest + checkpoint
-		assert.Equal(t, digest, vote.ObservedOutboundHash)
-		assert.Equal(t, uint64(999), vote.ObservedOutboundBlockHeight)
+		require.Equal(t, digest, vote.ObservedOutboundHash)
+		require.Equal(t, uint64(999), vote.ObservedOutboundBlockHeight)
 
 		// amount
-		assert.Equal(t, coin.CoinType_Gas, vote.CoinType)
-		assert.Equal(t, uint64(200), vote.ValueReceived.Uint64())
+		require.Equal(t, coin.CoinType_Gas, vote.CoinType)
+		require.Equal(t, uint64(200), vote.ValueReceived.Uint64())
 
 		// gas
-		assert.Equal(t, uint64(0), vote.ObservedOutboundEffectiveGasLimit)
-		assert.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
-		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
+		require.Equal(t, uint64(0), vote.ObservedOutboundEffectiveGasLimit)
+		require.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
+		require.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
 	})
 
 	t.Run("VoteOutbound failed withdrawal", func(t *testing.T) {
@@ -485,24 +497,110 @@ func TestObserver(t *testing.T) {
 		vote := ts.outboundVotesBag[0]
 
 		// common
-		assert.Equal(t, chains.ReceiveStatus_failed, vote.Status) // failure
-		assert.Equal(t, cctx.Index, vote.CctxHash)
-		assert.Equal(t, uint64(nonce), vote.OutboundTssNonce)
-		assert.Equal(t, ts.Chain().ChainId, vote.OutboundChain)
+		require.Equal(t, chains.ReceiveStatus_failed, vote.Status) // failure
+		require.Equal(t, cctx.Index, vote.CctxHash)
+		require.Equal(t, uint64(nonce), vote.OutboundTssNonce)
+		require.Equal(t, ts.Chain().ChainId, vote.OutboundChain)
 
 		// digest + checkpoint
-		assert.Equal(t, digest, vote.ObservedOutboundHash)
-		assert.Equal(t, uint64(999), vote.ObservedOutboundBlockHeight)
+		require.Equal(t, digest, vote.ObservedOutboundHash)
+		require.Equal(t, uint64(999), vote.ObservedOutboundBlockHeight)
 
 		// amount
-		assert.Equal(t, coin.CoinType_Gas, vote.CoinType)
-		assert.Equal(t, uint64(200), vote.ValueReceived.Uint64())
+		require.Equal(t, coin.CoinType_Gas, vote.CoinType)
+		require.Equal(t, uint64(200), vote.ValueReceived.Uint64())
 
 		// gas
-		assert.Equal(t, uint64(0), vote.ObservedOutboundEffectiveGasLimit)
-		assert.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
-		assert.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
+		require.Equal(t, uint64(0), vote.ObservedOutboundEffectiveGasLimit)
+		require.Equal(t, uint64(1000), vote.ObservedOutboundEffectiveGasPrice.Uint64())
+		require.Equal(t, uint64(200+300-50), vote.ObservedOutboundGasUsed)
 	})
+}
+
+func Test_MigrateCursorForAuthenticatedCallUpgrade(t *testing.T) {
+	withdrawCapID := sample.SuiAddress(t)
+	previousPackageID := sample.SuiAddress(t)
+	originalPackageID := previousPackageID
+
+	tests := []struct {
+		name              string
+		cursor            string
+		originalPackageID string
+		wantKey           string
+	}{
+		{
+			name:              "migration with empty original package ID",
+			cursor:            "HBgprKGko6Kk1q7cjZpg1KHVUqFXE7PFhT2M9DaPAezi,0",
+			originalPackageID: "",
+		},
+		{
+			name:              "migration with non-empty original package ID",
+			cursor:            "DVmb9QoJKRvSZfw6SkL8Zp1vRESxS7RuHy6XEYGT7WWn,0",
+			originalPackageID: originalPackageID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			ts := newTestSuite(t, func(cfg *testSuiteConfig) {
+				cfg.withdrawCapID = withdrawCapID
+				cfg.previousPackageID = previousPackageID
+				cfg.originalPackageID = tt.originalPackageID
+			})
+			packageID := ts.Gateway().PackageID()
+			originalPackageID := ts.Gateway().Original().PackageID()
+
+			// write a pre-v35 old cursor to the DB
+			err := ts.WriteLastTxScannedToDB(tt.cursor)
+			require.NoError(t, err)
+			ts.WithLastTxScanned(tt.cursor)
+
+			// ensure the old cursor is set
+			oldCursor, err := ts.ReadLastTxScannedFromDB()
+			require.NoError(t, err)
+			require.Equal(t, tt.cursor, oldCursor)
+			require.Equal(t, tt.cursor, ts.LastTxScanned())
+
+			// ACT-1
+			err = ts.MigrateCursorForAuthenticatedCallUpgrade()
+
+			// ASSERT
+			require.NoError(t, err)
+
+			// ensure the new cursor is stored under original package ID
+			newCursor, err := ts.ReadAuxStringFromDB(originalPackageID)
+			require.NoError(t, err)
+			require.Equal(t, tt.cursor, newCursor)
+			require.Equal(t, tt.cursor, ts.GetAuxString(originalPackageID))
+
+			// ensure nothing is stored under new package ID
+			if packageID != originalPackageID {
+				cursor, err := ts.ReadAuxStringFromDB(packageID)
+				require.ErrorContains(t, err, "record not found")
+				require.Empty(t, cursor)
+				require.Empty(t, ts.GetAuxString(packageID))
+			}
+
+			// ensure the old cursor is set to empty
+			oldCursor, err = ts.ReadLastTxScannedFromDB()
+			require.NoError(t, err)
+			require.Empty(t, oldCursor)
+			require.Empty(t, ts.LastTxScanned())
+
+			// ACT-2, migrate again
+			err = ts.MigrateCursorForAuthenticatedCallUpgrade()
+
+			// ASSERT
+			require.NoError(t, err)
+
+			// ensure the new cursor stay untouched
+			cursor, err := ts.ReadAuxStringFromDB(originalPackageID)
+			require.NoError(t, err)
+			require.Equal(t, tt.cursor, cursor)
+			require.Equal(t, tt.cursor, ts.GetAuxString(originalPackageID))
+		})
+	}
 }
 
 type testSuite struct {
@@ -520,12 +618,28 @@ type testSuite struct {
 	*Observer
 }
 
-func newTestSuite(t *testing.T) *testSuite {
+type testSuiteConfig struct {
+	withdrawCapID     string
+	previousPackageID string
+	originalPackageID string
+}
+
+func newTestSuite(t *testing.T, opts ...func(*testSuiteConfig)) *testSuite {
 	ctx := context.Background()
+
+	var cfg testSuiteConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	chain := chains.SuiMainnet
 	chainParams := mocks.MockChainParams(chain.ChainId, 10)
 	require.NotEmpty(t, chainParams.GatewayAddress)
+
+	// append withdraw cap ID, previous package ID and original package ID if provided
+	if cfg.withdrawCapID != "" && cfg.previousPackageID != "" && cfg.originalPackageID != "" {
+		chainParams.GatewayAddress = fmt.Sprintf("%s,%s,%s,%s", chainParams.GatewayAddress, cfg.withdrawCapID, cfg.previousPackageID, cfg.originalPackageID)
+	}
 
 	zetacore := mocks.NewZetacoreClient(t).
 		WithZetaChain().
@@ -566,15 +680,15 @@ func newTestSuite(t *testing.T) *testSuite {
 	}
 }
 
-func (ts *testSuite) SampleEvent(txHash, event string, kv map[string]any) models.SuiEventResponse {
-	eventType := fmt.Sprintf("%s::%s::%s", ts.gateway.PackageID(), sui.GatewayModule, event)
+func (ts *testSuite) SampleEvent(packageID, txHash, event string, kv map[string]any) models.SuiEventResponse {
+	eventType := fmt.Sprintf("%s::%s::%s", packageID, sui.GatewayModule, event)
 
 	return models.SuiEventResponse{
 		Id: models.EventId{
 			TxDigest: txHash,
 			EventSeq: "0",
 		},
-		PackageId:         ts.gateway.PackageID(),
+		PackageId:         packageID,
 		TransactionModule: "gateway",
 		Sender:            "SENDER_ABC",
 		Type:              eventType,
@@ -582,14 +696,20 @@ func (ts *testSuite) SampleEvent(txHash, event string, kv map[string]any) models
 	}
 }
 
-func (ts *testSuite) OnGetTx(digest, checkpoint string, showEvents bool, events []models.SuiEventResponse) {
+func (ts *testSuite) OnGetTx(digest, checkpoint string, showEffects, showEvents bool, events []models.SuiEventResponse) {
 	req := models.SuiGetTransactionBlockRequest{
-		Digest:  digest,
-		Options: models.SuiTransactionBlockOptions{ShowEvents: showEvents},
+		Digest: digest,
+		Options: models.SuiTransactionBlockOptions{
+			ShowEffects: showEffects,
+			ShowEvents:  showEvents,
+		},
 	}
 
 	res := models.SuiTransactionBlockResponse{
-		Digest:     digest,
+		Digest: digest,
+		Effects: models.SuiEffects{
+			Status: models.ExecutionStatus{Status: client.TxStatusSuccess},
+		},
 		Events:     events,
 		Checkpoint: checkpoint,
 	}

--- a/zetaclient/chains/sui/observer/outbound.go
+++ b/zetaclient/chains/sui/observer/outbound.go
@@ -94,7 +94,10 @@ func (ob *Observer) VoteOutbound(ctx context.Context, cctx *cctypes.CrossChainTx
 	// used checkpoint instead of block height
 	checkpoint, err := strconv.ParseUint(tx.Checkpoint, 10, 64)
 	if err != nil {
-		return errors.Wrap(err, "unable to parse checkpoint")
+		return errors.Wrapf(err, "invalid checkpoint: %s", tx.Checkpoint)
+	}
+	if checkpoint == 0 {
+		return errors.New("checkpoint is zero")
 	}
 
 	// parse outbound event
@@ -235,6 +238,7 @@ func (ob *Observer) postVoteOutbound(ctx context.Context, msg *cctypes.MsgVoteOu
 	case zetaTxHash != "":
 		ob.Logger().Outbound.Info().
 			Str(logs.FieldTx, msg.ObservedOutboundHash).
+			Uint64(logs.FieldNonce, msg.OutboundTssNonce).
 			Str(logs.FieldZetaTx, zetaTxHash).
 			Str(logs.FieldBallot, ballot).
 			Msg("Outbound vote posted")

--- a/zetaclient/chains/sui/signer/signer_test.go
+++ b/zetaclient/chains/sui/signer/signer_test.go
@@ -322,7 +322,18 @@ type testSuite struct {
 	TrackerBag []testTracker
 }
 
-func newTestSuite(t *testing.T) *testSuite {
+type testSuiteConfig struct {
+	withdrawCapID     string
+	previousPackageID string
+	originalPackageID string
+}
+
+func newTestSuite(t *testing.T, opts ...func(*testSuiteConfig)) *testSuite {
+	var cfg testSuiteConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	var (
 		ctx = context.Background()
 
@@ -335,6 +346,11 @@ func newTestSuite(t *testing.T) *testSuite {
 		testLogger = testlog.New(t)
 		logger     = base.Logger{Std: testLogger.Logger, Compliance: testLogger.Logger}
 	)
+
+	// append withdraw cap ID, previous package ID and original package ID if provided
+	if cfg.withdrawCapID != "" && cfg.previousPackageID != "" && cfg.originalPackageID != "" {
+		chainParams.GatewayAddress = fmt.Sprintf("%s,%s,%s,%s", chainParams.GatewayAddress, cfg.withdrawCapID, cfg.previousPackageID, cfg.originalPackageID)
+	}
 
 	suiMock := mocks.NewSuiClient(t)
 

--- a/zetaclient/chains/sui/signer/signer_tx.go
+++ b/zetaclient/chains/sui/signer/signer_tx.go
@@ -89,7 +89,7 @@ func (s *Signer) buildWithdrawal(ctx context.Context, cctx *cctypes.CrossChainTx
 	gasBudget := gasPrice * params.CallOptions.GasLimit
 
 	// Retrieve withdraw cap ID
-	withdrawCapID, err := s.getWithdrawCapIDCached(ctx)
+	withdrawCapID, err := s.withdrawCapID(ctx)
 	if err != nil {
 		return tx, errors.Wrap(err, "unable to get withdraw cap ID")
 	}

--- a/zetaclient/chains/sui/signer/tss_owned_object.go
+++ b/zetaclient/chains/sui/signer/tss_owned_object.go
@@ -37,6 +37,17 @@ func (wc *tssOwnedObject) set(objectID string) {
 	wc.fetchedAt = time.Now()
 }
 
+// withdrawCapID returns the objectID of the WithdrawCap.
+func (s *Signer) withdrawCapID(ctx context.Context) (string, error) {
+	// withdraw cap ID in the chain params is preferred
+	if withdrawCapID := s.gateway.WithdrawCapID(); withdrawCapID != "" {
+		return withdrawCapID, nil
+	}
+
+	// query from Sui network for backward compatibility
+	return s.getWithdrawCapIDCached(ctx)
+}
+
 // getWithdrawCapIDCached getWithdrawCapID with tssOwnedObjectTTL cache.
 func (s *Signer) getWithdrawCapIDCached(ctx context.Context) (string, error) {
 	if s.withdrawCap.valid() {

--- a/zetaclient/chains/sui/signer/tss_owned_object_test.go
+++ b/zetaclient/chains/sui/signer/tss_owned_object_test.go
@@ -1,0 +1,113 @@
+package signer
+
+import (
+	"testing"
+
+	"github.com/block-vision/sui-go-sdk/models"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/node/testutil/sample"
+)
+
+func Test_withdrawCapID(t *testing.T) {
+	// ARRANGE
+	withdrawCapID := sample.SuiAddress(t)
+	previousPackageID := sample.SuiAddress(t)
+	originalPackageID := sample.SuiAddress(t)
+
+	// create test suite and specify withdraw cap ID
+	ts := newTestSuite(t, func(cfg *testSuiteConfig) {
+		cfg.withdrawCapID = withdrawCapID
+		cfg.previousPackageID = previousPackageID
+		cfg.originalPackageID = originalPackageID
+	})
+
+	// ACT
+	got, err := ts.withdrawCapID(ts.Ctx)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Equal(t, withdrawCapID, got)
+}
+
+func Test_getMessageContextID(t *testing.T) {
+	tests := []struct {
+		name       string
+		mockObject *models.SuiObjectData
+		rpcError   bool
+		want       string
+		errMsg     string
+	}{
+		{
+			name: "success",
+			mockObject: &models.SuiObjectData{
+				Content: &models.SuiParsedData{
+					SuiMoveObject: models.SuiMoveObject{
+						Fields: map[string]any{"value": "0x123"},
+					},
+				},
+			},
+			want: "0x123",
+		},
+		{
+			name:     "rpc error",
+			rpcError: true,
+			errMsg:   "unable to get message context dynamic field object",
+		},
+		{
+			name:       "Sui object data is nil",
+			mockObject: nil,
+			errMsg:     "dynamic field object data is nil",
+		},
+		{
+			name: "Sui object data content is nil",
+			mockObject: &models.SuiObjectData{
+				Content: nil,
+			},
+			errMsg: "dynamic field object data is nil",
+		},
+		{
+			name: "unable to parse message context ID",
+			mockObject: &models.SuiObjectData{
+				Content: &models.SuiParsedData{
+					SuiMoveObject: models.SuiMoveObject{
+						Fields: map[string]any{"value": 123},
+					},
+				},
+			},
+			errMsg: "unable to parse message context ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// ARRANGE
+			ts := newTestSuite(t)
+
+			// setup RPC mock
+			if tt.rpcError {
+				ts.SuiMock.On("SuiXGetDynamicFieldObject", ts.Ctx, mock.Anything).Return(models.SuiObjectResponse{
+					Data: nil,
+				}, errors.New("rpc error"))
+			} else {
+				ts.SuiMock.On("SuiXGetDynamicFieldObject", ts.Ctx, mock.Anything).Return(models.SuiObjectResponse{
+					Data: tt.mockObject,
+				}, nil)
+			}
+
+			// ACT
+			got, err := ts.getMessageContextID(ts.Ctx)
+
+			// ASSERT
+			if tt.errMsg != "" {
+				require.Empty(t, got)
+				require.ErrorContains(t, err, tt.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/zetaclient/chains/sui/sui.go
+++ b/zetaclient/chains/sui/sui.go
@@ -212,7 +212,7 @@ func (s *Sui) updateChainParams(ctx context.Context) error {
 
 	s.observer.SetChainParams(*params)
 
-	// note that address should be in format of `$packageID,$gatewayObjectID`
+	// note that address should be in format of `$packageID,$gatewayObjectID[,withdrawCapID,previousPackageID,originalPackageID]`
 	if err := s.observer.Gateway().UpdateIDs(params.GatewayAddress); err != nil {
 		return errors.Wrap(err, "unable to update gateway ids")
 	}

--- a/zetaclient/db/db.go
+++ b/zetaclient/db/db.go
@@ -33,6 +33,7 @@ var (
 		&types.TransactionResultSQLType{},
 		&types.OutboundHashSQLType{},
 		&types.LastTransactionSQLType{},
+		&types.AuxStringSQLType{},
 	}
 )
 

--- a/zetaclient/types/sql.go
+++ b/zetaclient/types/sql.go
@@ -24,6 +24,13 @@ type LastTransactionSQLType struct {
 	Hash string
 }
 
+// AuxStringSQLType is a model for storing auxiliary string data
+type AuxStringSQLType struct {
+	gorm.Model
+	Key   string `gorm:"column:key_name;uniqueIndex;not null"`
+	Value string
+}
+
 // ToLastBlockSQLType converts a last block number to a LastBlockSQLType
 func ToLastBlockSQLType(lastBlock uint64) *LastBlockSQLType {
 	return &LastBlockSQLType{
@@ -37,5 +44,13 @@ func ToLastTxHashSQLType(lastTx string) *LastTransactionSQLType {
 	return &LastTransactionSQLType{
 		Model: gorm.Model{ID: LastTxHashID},
 		Hash:  lastTx,
+	}
+}
+
+// ToAuxStringSQLType converts given key and value to a AuxStringSQLType
+func ToAuxStringSQLType(key, value string) *AuxStringSQLType {
+	return &AuxStringSQLType{
+		Key:   key,
+		Value: value,
 	}
 }


### PR DESCRIPTION
# Description

This PR backport [4138](https://github.com/zeta-chain/node/pull/4138) and depends on [4127](https://github.com/zeta-chain/node/pull/4127)

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
