### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
@@ -179,9 +180,7 @@ func (c Config) GetAllEVMConfigs() map[int64]EVMConfig {
 
 	// deep copy evm configs
 	copied := make(map[int64]EVMConfig, len(c.EVMChainConfigs))
-	for chainID, evmConfig := range c.EVMChainConfigs {
-		copied[chainID] = evmConfig
-	}
+	maps.Copy(copied, c.EVMChainConfigs)
 	return copied
 }
 


### PR DESCRIPTION
# Description

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of EVM configuration data using standard utilities to simplify copying logic and improve maintainability.
  * No functional changes: behavior remains equivalent and existing workflows are unaffected.
  * No public API changes: integrations and external usage remain the same.
  * Users do not need to take any action; this is an internal improvement with no visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->