### PR TITLE
fix(backport):  force rescan if inbound vote monitoring fails using a context that can timeout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,9 +8,6 @@
 
 * [4153](https://github.com/zeta-chain/node/pull/4153) - make the gas limit used for gateway calls a configurable parameter
 
-## Fixes
-* [4183](https://github.com/zeta-chain/node/pull/4183) - force rescan if inbound vote monitoring fails
-
 ## v33.0.0
 
 ### Features

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@
 
 * [4153](https://github.com/zeta-chain/node/pull/4153) - make the gas limit used for gateway calls a configurable parameter
 
+## Fixes
+* [4183](https://github.com/zeta-chain/node/pull/4183) - force rescan if inbound vote monitoring fails
+
 ## v33.0.0
 
 ### Features

--- a/pkg/errors/monitor_error.go
+++ b/pkg/errors/monitor_error.go
@@ -1,0 +1,19 @@
+package errors
+
+import "fmt"
+
+// ErrTxMonitor represents an error from the monitoring goroutine.
+type ErrTxMonitor struct {
+	Err                error
+	InboundBlockHeight uint64
+	ZetaTxHash         string
+	BallotIndex        string
+}
+
+func (m ErrTxMonitor) Error() string {
+	if m.Err == nil {
+		return "monitoring completed without error"
+	}
+	return fmt.Sprintf("monitoring error: %v, inbound block height: %d, zeta tx hash: %s, ballot index: %s",
+		m.Err, m.InboundBlockHeight, m.ZetaTxHash, m.BallotIndex)
+}

--- a/zetaclient/chains/base/confirmation.go
+++ b/zetaclient/chains/base/confirmation.go
@@ -95,6 +95,7 @@ func (ob *Observer) IsInboundEligibleForFastConfirmation(
 //
 // example 1: given lastBlock =  99, lastScanned = 90, confirmation = 10, then no unscanned block
 // example 2: given lastBlock = 100, lastScanned = 90, confirmation = 10, then 1 unscanned block (block 91)
+// example 3: given lastBlock = 100, lastScanned = 50, confirmation = 10, then 41 unscanned blocks[51 - 91] (last scanned is reset by monitoring thread)
 func calcUnscannedBlockRange(lastBlock, lastScanned, confirmation, blockLimit uint64) (from uint64, end uint64) {
 	// got unscanned blocks or not?
 	// returning same values to indicate no unscanned block

--- a/zetaclient/chains/base/confirmation_test.go
+++ b/zetaclient/chains/base/confirmation_test.go
@@ -67,13 +67,23 @@ func Test_GetScanRangeInboundSafe(t *testing.T) {
 			},
 			expectedBlockRange: [2]uint64{91, 101}, // [91, 101), 11 unscanned blocks, but capped to 10
 		},
+		{
+			name:        "last scanned reset by monitering thread (Low last scanned compared to last block)",
+			lastBlock:   100,
+			lastScanned: 50,
+			blockLimit:  10,
+			confParams: observertypes.ConfirmationParams{
+				SafeInboundCount: 10,
+			},
+			expectedBlockRange: [2]uint64{51, 61},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ob := newTestSuite(t, chain, withConfirmationParams(tt.confParams))
 			ob.Observer.WithLastBlock(tt.lastBlock)
-			ob.Observer.WithLastBlockScanned(tt.lastScanned)
+			ob.Observer.WithLastBlockScanned(tt.lastScanned, false)
 
 			start, end := ob.GetScanRangeInboundSafe(tt.blockLimit)
 			require.Equal(t, tt.expectedBlockRange, [2]uint64{start, end})
@@ -131,7 +141,7 @@ func Test_GetScanRangeInboundFast(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ob := newTestSuite(t, chain, withConfirmationParams(tt.confParams))
 			ob.Observer.WithLastBlock(tt.lastBlock)
-			ob.Observer.WithLastBlockScanned(tt.lastScanned)
+			ob.Observer.WithLastBlockScanned(tt.lastScanned, false)
 
 			start, end := ob.GetScanRangeInboundFast(tt.blockLimit)
 			require.Equal(t, tt.expectedBlockRange, [2]uint64{start, end})

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -526,9 +526,9 @@ func (ob *Observer) handleMonitoringError(
 			}
 		}
 	case <-ctx.Done():
-		logger.Error().
+		logger.Debug().
 			Str(logs.FieldZetaTx, zetaHash).
-			Msg("unable to monitor vote transaction: timeout")
+			Msg("tx succeeded no err from monitor channel before timeout")
 	}
 }
 

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
@@ -34,6 +35,9 @@ const (
 	// DefaultBlockCacheSize is the default number of blocks that the observer will keep in cache for performance (without RPC calls)
 	// Cached blocks can be used to get block information and verify transactions
 	DefaultBlockCacheSize = 1000
+
+	// MonitoringErrHandlerRoutineTimeout is the timeout for the handleMonitoring routine that waits for an error from the monitorVote channel
+	MonitoringErrHandlerRoutineTimeout = 5 * time.Minute
 )
 
 // Observer is the base structure for chain observers, grouping the common logic for each chain observer client.
@@ -462,8 +466,14 @@ func (ob *Observer) PostVoteInbound(
 	}
 
 	monitorErrCh := make(chan zetaerrors.ErrTxMonitor, 1)
+
+	// Create a timeout context for the entire monitoring process
+	// This ensures both the monitoring goroutine and error handler respect the same timeout
+	ctxWithTimeout, cancel := zctx.CopyWithTimeout(ctx, context.Background(), MonitoringErrHandlerRoutineTimeout)
+	defer cancel()
+
 	// post vote to zetacore
-	zetaHash, ballot, err := ob.ZetacoreClient().PostVoteInbound(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
+	zetaHash, ballot, err := ob.ZetacoreClient().PostVoteInbound(ctxWithTimeout, gasLimit, retryGasLimit, msg, monitorErrCh)
 	lf[logs.FieldZetaTx] = zetaHash
 	lf[logs.FieldBallot] = ballot
 
@@ -478,8 +488,7 @@ func (ob *Observer) PostVoteInbound(
 	}
 
 	go func() {
-		ctxForHandler := zctx.Copy(ctx, context.Background())
-		ob.handleMonitoringError(ctxForHandler, monitorErrCh)
+		ob.handleMonitoringError(ctxWithTimeout, monitorErrCh, zetaHash)
 	}()
 
 	return ballot, nil
@@ -488,6 +497,7 @@ func (ob *Observer) PostVoteInbound(
 func (ob *Observer) handleMonitoringError(
 	ctx context.Context,
 	monitorErrCh <-chan zetaerrors.ErrTxMonitor,
+	zetaHash string,
 ) {
 	logger := ob.logger.Inbound
 	defer func() {
@@ -501,7 +511,6 @@ func (ob *Observer) handleMonitoringError(
 		if monitorErr.Err != nil {
 			logger.Error().
 				Err(monitorErr).
-				Str(logs.FieldMethod, "handleMonitoringError").
 				Str(logs.FieldZetaTx, monitorErr.ZetaTxHash).
 				Str(logs.FieldBallot, monitorErr.BallotIndex).
 				Uint64(logs.FieldBlock, monitorErr.InboundBlockHeight).
@@ -517,7 +526,9 @@ func (ob *Observer) handleMonitoringError(
 			}
 		}
 	case <-ctx.Done():
-		logger.Debug().Msg("context cancelled while waiting for monitoring result")
+		logger.Error().
+			Str(logs.FieldZetaTx, zetaHash).
+			Msg("unable to monitor vote transaction: timeout")
 	}
 }
 

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -15,9 +15,11 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/zeta-chain/node/pkg/chains"
+	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
+	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/logs"
 	"github.com/zeta-chain/node/zetaclient/metrics"
@@ -76,6 +78,8 @@ type Observer struct {
 
 	// stop is the channel to signal the observer to stop
 	stop chan struct{}
+
+	forceResetLastScanned bool
 }
 
 // NewObserver creates a new base observer.
@@ -95,19 +99,20 @@ func NewObserver(
 	}
 
 	return &Observer{
-		chain:            chain,
-		chainParams:      chainParams,
-		zetacoreClient:   zetacoreClient,
-		tss:              tss,
-		lastBlock:        0,
-		lastBlockScanned: 0,
-		lastTxScanned:    "",
-		ts:               ts,
-		db:               database,
-		blockCache:       blockCache,
-		mu:               &sync.Mutex{},
-		logger:           newObserverLogger(chain, logger),
-		stop:             make(chan struct{}),
+		chain:                 chain,
+		chainParams:           chainParams,
+		zetacoreClient:        zetacoreClient,
+		tss:                   tss,
+		lastBlock:             0,
+		lastBlockScanned:      0,
+		lastTxScanned:         "",
+		ts:                    ts,
+		db:                    database,
+		blockCache:            blockCache,
+		mu:                    &sync.Mutex{},
+		logger:                newObserverLogger(chain, logger),
+		stop:                  make(chan struct{}),
+		forceResetLastScanned: false,
 	}, nil
 }
 
@@ -215,15 +220,31 @@ func (ob *Observer) WithLastBlock(lastBlock uint64) *Observer {
 
 // LastBlockScanned get last block scanned (not necessarily caught up with the chain; could be slow/paused).
 func (ob *Observer) LastBlockScanned() uint64 {
+	ob.mu.Lock()
+	defer ob.mu.Unlock()
 	height := atomic.LoadUint64(&ob.lastBlockScanned)
 	return height
 }
 
 // WithLastBlockScanned set last block scanned (not necessarily caught up with the chain; could be slow/paused).
-func (ob *Observer) WithLastBlockScanned(blockNumber uint64) *Observer {
+// it also set the value of forceResetLastScanned and returns the previous value.
+// If forceResetLastScanned was true before, it means the monitoring thread would have updated it and so it skips updating the last scanned block.
+func (ob *Observer) WithLastBlockScanned(blockNumber uint64, forceResetLastScanned bool) (*Observer, bool) {
+	ob.mu.Lock()
+	defer ob.mu.Unlock()
+
+	wasForceReset := ob.forceResetLastScanned
+	ob.forceResetLastScanned = forceResetLastScanned
+
+	// forceResetLastScanned was set to true before; it means the monitoring thread would have updated it
+	// In this case we should not update the last scanned block and just return
+	if wasForceReset && !forceResetLastScanned {
+		return ob, wasForceReset
+	}
+
 	atomic.StoreUint64(&ob.lastBlockScanned, blockNumber)
 	metrics.LastScannedBlockNumber.WithLabelValues(ob.chain.Name).Set(float64(blockNumber))
-	return ob
+	return ob, wasForceReset
 }
 
 // LastTxScanned get last transaction scanned.
@@ -295,7 +316,7 @@ func (ob *Observer) LoadLastBlockScanned(logger zerolog.Logger) error {
 		if err != nil {
 			return errors.Wrapf(err, "unable to parse block number from ENV %s=%s", envvar, scanFromBlock)
 		}
-		ob.WithLastBlockScanned(blockNumber)
+		ob.WithLastBlockScanned(blockNumber, false)
 		return nil
 	}
 
@@ -305,14 +326,28 @@ func (ob *Observer) LoadLastBlockScanned(logger zerolog.Logger) error {
 		logger.Info().Msgf("LoadLastBlockScanned: last scanned block not found in db for chain %d", ob.chain.ChainId)
 		return nil
 	}
-	ob.WithLastBlockScanned(blockNumber)
+	ob.WithLastBlockScanned(blockNumber, false)
 
 	return nil
 }
 
 // SaveLastBlockScanned saves the last scanned block to memory and database.
 func (ob *Observer) SaveLastBlockScanned(blockNumber uint64) error {
-	ob.WithLastBlockScanned(blockNumber)
+	_, forceResetLastScannedBeforeUpdate := ob.WithLastBlockScanned(blockNumber, false)
+	if forceResetLastScannedBeforeUpdate {
+		return nil
+	}
+	return ob.WriteLastBlockScannedToDB(blockNumber)
+}
+
+// ForceSaveLastBlockScanned saves the last scanned block to memory if the new blocknumber is less than the current last scanned block.
+// It also forces the update of the last scanned block in the database, to makes sure any other the block gets rescanned.
+func (ob *Observer) ForceSaveLastBlockScanned(blockNumber uint64) error {
+	currentLastScanned := ob.LastBlockScanned()
+	if blockNumber > currentLastScanned {
+		return nil
+	}
+	ob.WithLastBlockScanned(blockNumber, true)
 	return ob.WriteLastBlockScannedToDB(blockNumber)
 }
 
@@ -361,7 +396,7 @@ func (ob *Observer) SaveLastTxScanned(txHash string, slot uint64) error {
 	ob.WithLastTxScanned(txHash)
 
 	// update last_scanned_block_number metrics
-	ob.WithLastBlockScanned(slot)
+	ob.WithLastBlockScanned(slot, false)
 
 	return ob.WriteLastTxScannedToDB(txHash)
 }
@@ -426,8 +461,9 @@ func (ob *Observer) PostVoteInbound(
 		return "", nil
 	}
 
+	monitorErrCh := make(chan zetaerrors.ErrTxMonitor, 1)
 	// post vote to zetacore
-	zetaHash, ballot, err := ob.ZetacoreClient().PostVoteInbound(ctx, gasLimit, retryGasLimit, msg)
+	zetaHash, ballot, err := ob.ZetacoreClient().PostVoteInbound(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
 	lf[logs.FieldZetaTx] = zetaHash
 	lf[logs.FieldBallot] = ballot
 
@@ -441,7 +477,48 @@ func (ob *Observer) PostVoteInbound(
 		ob.logger.Inbound.Info().Fields(lf).Msgf("inbound detected: vote posted")
 	}
 
+	go func() {
+		ctxForHandler := zctx.Copy(ctx, context.Background())
+		ob.handleMonitoringError(ctxForHandler, monitorErrCh)
+	}()
+
 	return ballot, nil
+}
+
+func (ob *Observer) handleMonitoringError(
+	ctx context.Context,
+	monitorErrCh <-chan zetaerrors.ErrTxMonitor,
+) {
+	logger := ob.logger.Inbound
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error().Any("panic", r).Msg("recovered from panic in monitoring error handler")
+		}
+	}()
+
+	select {
+	case monitorErr := <-monitorErrCh:
+		if monitorErr.Err != nil {
+			logger.Error().
+				Err(monitorErr).
+				Str(logs.FieldMethod, "handleMonitoringError").
+				Str(logs.FieldZetaTx, monitorErr.ZetaTxHash).
+				Str(logs.FieldBallot, monitorErr.BallotIndex).
+				Uint64(logs.FieldBlock, monitorErr.InboundBlockHeight).
+				Msg("error monitoring vote transaction")
+
+			if monitorErr.InboundBlockHeight > 0 {
+				err := ob.ForceSaveLastBlockScanned(monitorErr.InboundBlockHeight - 1)
+				if err != nil {
+					logger.Error().Err(err).
+						Str(logs.FieldZetaTx, monitorErr.ZetaTxHash).
+						Msg("unable to save last scanned block after monitoring error")
+				}
+			}
+		}
+	case <-ctx.Done():
+		logger.Debug().Msg("context cancelled while waiting for monitoring result")
+	}
 }
 
 // EnvVarLatestBlockByChain returns the environment variable for the last block by chain.

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -467,10 +467,8 @@ func (ob *Observer) PostVoteInbound(
 
 	monitorErrCh := make(chan zetaerrors.ErrTxMonitor, 1)
 
-	// Create a timeout context for the entire monitoring process
-	// This ensures both the monitoring goroutine and error handler respect the same timeout
-	ctxWithTimeout, cancel := zctx.CopyWithTimeout(ctx, context.Background(), MonitoringErrHandlerRoutineTimeout)
-	defer cancel()
+	// ctxWithTimeout is a context with timeout used for monitoring the vote transaction
+	ctxWithTimeout, _ := zctx.CopyWithTimeout(ctx, context.Background(), MonitoringErrHandlerRoutineTimeout)
 
 	// post vote to zetacore
 	zetaHash, ballot, err := ob.ZetacoreClient().PostVoteInbound(ctxWithTimeout, gasLimit, retryGasLimit, msg, monitorErrCh)
@@ -528,7 +526,7 @@ func (ob *Observer) handleMonitoringError(
 	case <-ctx.Done():
 		logger.Debug().
 			Str(logs.FieldZetaTx, zetaHash).
-			Msg("tx succeeded no err from monitor channel before timeout")
+			Msg("no error received for the monitoring, the transaction likely succeeded")
 	}
 }
 

--- a/zetaclient/chains/base/observer.go
+++ b/zetaclient/chains/base/observer.go
@@ -471,7 +471,8 @@ func (ob *Observer) PostVoteInbound(
 	ctxWithTimeout, _ := zctx.CopyWithTimeout(ctx, context.Background(), MonitoringErrHandlerRoutineTimeout)
 
 	// post vote to zetacore
-	zetaHash, ballot, err := ob.ZetacoreClient().PostVoteInbound(ctxWithTimeout, gasLimit, retryGasLimit, msg, monitorErrCh)
+	zetaHash, ballot, err := ob.ZetacoreClient().
+		PostVoteInbound(ctxWithTimeout, gasLimit, retryGasLimit, msg, monitorErrCh)
 	lf[logs.FieldZetaTx] = zetaHash
 	lf[logs.FieldBallot] = ballot
 

--- a/zetaclient/chains/base/observer_test.go
+++ b/zetaclient/chains/base/observer_test.go
@@ -194,7 +194,7 @@ func TestObserverGetterAndSetter(t *testing.T) {
 
 		// update last block scanned
 		newLastBlockScanned := uint64(100)
-		ob.Observer.WithLastBlockScanned(newLastBlockScanned)
+		ob.Observer.WithLastBlockScanned(newLastBlockScanned, false)
 		require.Equal(t, newLastBlockScanned, ob.LastBlockScanned())
 	})
 

--- a/zetaclient/chains/bitcoin/observer/db.go
+++ b/zetaclient/chains/bitcoin/observer/db.go
@@ -46,12 +46,12 @@ func (ob *Observer) LoadLastBlockScanned(ctx context.Context) error {
 			return errors.Wrap(err, "unable to get block count")
 		}
 		// #nosec G115 always positive
-		ob.WithLastBlockScanned(uint64(blockNumber))
+		ob.WithLastBlockScanned(uint64(blockNumber), false)
 	}
 
 	// bitcoin regtest starts from hardcoded block 100
 	if chains.IsBitcoinRegnet(ob.Chain().ChainId) {
-		ob.WithLastBlockScanned(RegnetStartBlock)
+		ob.WithLastBlockScanned(RegnetStartBlock, false)
 	}
 	ob.Logger().Chain.Info().Uint64("last_block_scanned", ob.LastBlockScanned()).Msg("LoadLastBlockScanned succeed")
 

--- a/zetaclient/chains/bitcoin/observer/db_test.go
+++ b/zetaclient/chains/bitcoin/observer/db_test.go
@@ -96,7 +96,7 @@ func Test_LoadLastBlockScanned(t *testing.T) {
 		obOther := newTestSuite(t, chain)
 
 		// reset last block scanned to 0 so that it will be loaded from RPC
-		obOther.WithLastBlockScanned(0)
+		obOther.WithLastBlockScanned(0, false)
 
 		// attach a mock btc client that returns rpc error
 		obOther.client.ExpectedCalls = nil

--- a/zetaclient/chains/evm/observer/observer.go
+++ b/zetaclient/chains/evm/observer/observer.go
@@ -229,7 +229,7 @@ func (ob *Observer) loadLastBlockScanned(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "error BlockNumber for chain %d", ob.Chain().ChainId)
 		}
-		ob.WithLastBlockScanned(blockNumber)
+		ob.WithLastBlockScanned(blockNumber, false)
 	}
 	ob.Logger().Chain.Info().Uint64("last_block_scanned", ob.LastBlockScanned()).Msg("LoadLastBlockScanned succeed")
 

--- a/zetaclient/chains/evm/observer/observer_test.go
+++ b/zetaclient/chains/evm/observer/observer_test.go
@@ -238,7 +238,7 @@ func Test_LoadLastBlockScanned(t *testing.T) {
 		obOther := newTestSuite(t)
 
 		// reset last block scanned to 0 so that it will be loaded from RPC
-		obOther.WithLastBlockScanned(0)
+		obOther.WithLastBlockScanned(0, false)
 
 		// attach mock evm client to observer
 		obOther.evmMock.On("BlockNumber", mock.Anything).Unset()

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/zeta-chain/go-tss/blame"
+	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 
 	"github.com/zeta-chain/node/pkg/chains"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
@@ -43,6 +44,7 @@ type ZetacoreVoter interface {
 		ctx context.Context,
 		gasLimit, retryGasLimit uint64,
 		msg *crosschaintypes.MsgVoteInbound,
+		monitorErrCh chan<- zetaerrors.ErrTxMonitor,
 	) (string, string, error)
 	PostVoteOutbound(
 		ctx context.Context,

--- a/zetaclient/chains/interfaces/interfaces.go
+++ b/zetaclient/chains/interfaces/interfaces.go
@@ -15,9 +15,9 @@ import (
 	"github.com/gagliardetto/solana-go"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 	"github.com/zeta-chain/go-tss/blame"
-	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 
 	"github.com/zeta-chain/node/pkg/chains"
+	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"

--- a/zetaclient/chains/solana/observer/inbound.go
+++ b/zetaclient/chains/solana/observer/inbound.go
@@ -55,7 +55,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// update metrics if no new signatures found
 	if len(signatures) == 0 {
 		if errSlot == nil {
-			ob.WithLastBlockScanned(lastSlot)
+			ob.WithLastBlockScanned(lastSlot, false)
 		}
 	} else {
 		ob.Logger().Inbound.Info().

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/pkg/contracts/sui"
+	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 	"github.com/zeta-chain/node/testutil/sample"
 	cctypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
@@ -602,13 +603,13 @@ func (ts *testSuite) MockGetTxOnce(tx models.SuiTransactionBlockResponse) {
 }
 
 func (ts *testSuite) CatchInboundVotes() {
-	callback := func(_ context.Context, _, _ uint64, msg *cctypes.MsgVoteInbound) (string, string, error) {
+	callback := func(_ context.Context, _, _ uint64, msg *cctypes.MsgVoteInbound, _ chan<- zetaerrors.ErrTxMonitor) (string, string, error) {
 		ts.inboundVotesBag = append(ts.inboundVotesBag, msg)
 		return "", "", nil
 	}
 
 	ts.zetaMock.
-		On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(callback).
 		Maybe()
 }

--- a/zetaclient/chains/ton/observer/observer_test.go
+++ b/zetaclient/chains/ton/observer/observer_test.go
@@ -244,7 +244,7 @@ func setupVotesBag(ts *testSuite) {
 		ts.votesBag = append(ts.votesBag, cctx)
 	}
 	ts.zetacore.
-		On("PostVoteInbound", ts.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Run(catcher).
 		Return("", "", nil) // zeta hash, ballot index, error

--- a/zetaclient/chains/ton/observer/observer_test.go
+++ b/zetaclient/chains/ton/observer/observer_test.go
@@ -244,7 +244,7 @@ func setupVotesBag(ts *testSuite) {
 		ts.votesBag = append(ts.votesBag, cctx)
 	}
 	ts.zetacore.
-		On("PostVoteInbound", ts.ctx, mock.Anything, mock.Anything, mock.Anything).
+		On("PostVoteInbound", ts.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Run(catcher).
 		Return("", "", nil) // zeta hash, ballot index, error

--- a/zetaclient/context/context.go
+++ b/zetaclient/context/context.go
@@ -2,8 +2,10 @@ package context
 
 import (
 	goctx "context"
+	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 type appContextKey struct{}
@@ -35,4 +37,18 @@ func Copy(from, to goctx.Context) goctx.Context {
 	}
 
 	return WithAppContext(to, app)
+}
+
+// CopyWithTimeout copies AppContext from one context to another (if present)
+// and adds a timeout to the new context.
+// It returns the new context and a cancel function to cancel the timeout.
+func CopyWithTimeout(from, to goctx.Context, timeout time.Duration) (goctx.Context, context.CancelFunc) {
+	app, err := FromContext(from)
+	if err != nil {
+		return context.WithTimeout(to, timeout)
+	}
+
+	ctxWithTimeout, cancel := context.WithTimeout(to, timeout)
+
+	return WithAppContext(ctxWithTimeout, app), cancel
 }

--- a/zetaclient/context/context.go
+++ b/zetaclient/context/context.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type appContextKey struct{}
@@ -39,16 +38,13 @@ func Copy(from, to goctx.Context) goctx.Context {
 	return WithAppContext(to, app)
 }
 
-// CopyWithTimeout copies AppContext from one context to another (if present)
-// and adds a timeout to the new context.
-// It returns the new context and a cancel function to cancel the timeout.
-func CopyWithTimeout(from, to goctx.Context, timeout time.Duration) (goctx.Context, context.CancelFunc) {
+// CopyWithTimeout copies AppContext from one context to another and adds a timeout.
+// This is useful when you want to run something in another goroutine with a timeout.
+func CopyWithTimeout(from, to goctx.Context, timeout time.Duration) (goctx.Context, goctx.CancelFunc) {
 	app, err := FromContext(from)
 	if err != nil {
-		return context.WithTimeout(to, timeout)
+		return goctx.WithTimeout(to, timeout)
 	}
-
-	ctxWithTimeout, cancel := context.WithTimeout(to, timeout)
-
+	ctxWithTimeout, cancel := goctx.WithTimeout(to, timeout)
 	return WithAppContext(ctxWithTimeout, app), cancel
 }

--- a/zetaclient/testutils/mocks/zetacore_client.go
+++ b/zetaclient/testutils/mocks/zetacore_client.go
@@ -12,6 +12,8 @@ import (
 
 	context "context"
 
+	errors "github.com/zeta-chain/node/pkg/errors"
+
 	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
 
 	interfaces "github.com/zeta-chain/node/zetaclient/chains/interfaces"
@@ -923,9 +925,9 @@ func (_m *ZetacoreClient) PostVoteGasPrice(ctx context.Context, chain chains.Cha
 	return r0, r1
 }
 
-// PostVoteInbound provides a mock function with given fields: ctx, gasLimit, retryGasLimit, msg
-func (_m *ZetacoreClient) PostVoteInbound(ctx context.Context, gasLimit uint64, retryGasLimit uint64, msg *types.MsgVoteInbound) (string, string, error) {
-	ret := _m.Called(ctx, gasLimit, retryGasLimit, msg)
+// PostVoteInbound provides a mock function with given fields: ctx, gasLimit, retryGasLimit, msg, monitorErrCh
+func (_m *ZetacoreClient) PostVoteInbound(ctx context.Context, gasLimit uint64, retryGasLimit uint64, msg *types.MsgVoteInbound, monitorErrCh chan<- errors.ErrTxMonitor) (string, string, error) {
+	ret := _m.Called(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PostVoteInbound")
@@ -934,23 +936,23 @@ func (_m *ZetacoreClient) PostVoteInbound(ctx context.Context, gasLimit uint64, 
 	var r0 string
 	var r1 string
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, *types.MsgVoteInbound) (string, string, error)); ok {
-		return rf(ctx, gasLimit, retryGasLimit, msg)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, *types.MsgVoteInbound, chan<- errors.ErrTxMonitor) (string, string, error)); ok {
+		return rf(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, *types.MsgVoteInbound) string); ok {
-		r0 = rf(ctx, gasLimit, retryGasLimit, msg)
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, *types.MsgVoteInbound, chan<- errors.ErrTxMonitor) string); ok {
+		r0 = rf(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64, *types.MsgVoteInbound) string); ok {
-		r1 = rf(ctx, gasLimit, retryGasLimit, msg)
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64, *types.MsgVoteInbound, chan<- errors.ErrTxMonitor) string); ok {
+		r1 = rf(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
 	} else {
 		r1 = ret.Get(1).(string)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, uint64, uint64, *types.MsgVoteInbound) error); ok {
-		r2 = rf(ctx, gasLimit, retryGasLimit, msg)
+	if rf, ok := ret.Get(2).(func(context.Context, uint64, uint64, *types.MsgVoteInbound, chan<- errors.ErrTxMonitor) error); ok {
+		r2 = rf(ctx, gasLimit, retryGasLimit, msg, monitorErrCh)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/zetaclient/testutils/mocks/zetacore_client_opts.go
+++ b/zetaclient/testutils/mocks/zetacore_client_opts.go
@@ -47,7 +47,7 @@ func (_m *ZetacoreClient) WithPostOutboundTracker(zetaTxHash string) *ZetacoreCl
 }
 
 func (_m *ZetacoreClient) WithPostVoteInbound(zetaTxHash string, ballotIndex string) *ZetacoreClient {
-	_m.On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	_m.On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Return(zetaTxHash, ballotIndex, nil)
 

--- a/zetaclient/zetacore/client_monitor.go
+++ b/zetaclient/zetacore/client_monitor.go
@@ -128,6 +128,9 @@ func (c *Client) MonitorVoteInboundResult(
 		return retry.Retry(err)
 	}
 
+	//                               10 attempts,    2 seconds,     4 seconds max
+	// This will retry for a maximum of ~40 seconds with exponential backoff,
+	// However, this call is recursive for up to 1 layer and so the maxim time this can take is ~80 seconds
 	err := retryWithBackoff(call, monitorRetryCount, monitorInterval, monitorInterval*2)
 	if err != nil {
 		// All errors are forced to be retryable, we only return an error if the tx result cannot be queri

--- a/zetaclient/zetacore/client_monitor.go
+++ b/zetaclient/zetacore/client_monitor.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
-	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 
 	"github.com/zeta-chain/node/pkg/constant"
+	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 	"github.com/zeta-chain/node/pkg/retry"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/logs"

--- a/zetaclient/zetacore/client_vote.go
+++ b/zetaclient/zetacore/client_vote.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/zeta-chain/go-tss/blame"
-	zetaerrors "github.com/zeta-chain/node/pkg/errors"
-	"github.com/zeta-chain/node/zetaclient/logs"
 
 	"github.com/zeta-chain/node/pkg/chains"
+	zetaerrors "github.com/zeta-chain/node/pkg/errors"
 	"github.com/zeta-chain/node/pkg/retry"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	observerclient "github.com/zeta-chain/node/x/observer/client/cli"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
+	"github.com/zeta-chain/node/zetaclient/logs"
 )
 
 // PostVoteGasPrice posts a gas price vote. Returns txHash and error.

--- a/zetaclient/zetacore/tx_test.go
+++ b/zetaclient/zetacore/tx_test.go
@@ -239,7 +239,7 @@ func TestZetacore_PostVoteInbound(t *testing.T) {
 	t.Run("post inbound vote already voted", func(t *testing.T) {
 		hash, _, err := client.PostVoteInbound(ctx, 100, 200, &crosschaintypes.MsgVoteInbound{
 			Creator: address.String(),
-		})
+		}, nil)
 		require.NoError(t, err)
 		require.Equal(t, sampleHash, hash)
 	})
@@ -281,7 +281,7 @@ func TestZetacore_MonitorVoteInboundResult(t *testing.T) {
 	t.Run("monitor inbound vote", func(t *testing.T) {
 		err := client.MonitorVoteInboundResult(ctx, sampleHash, 1000, &crosschaintypes.MsgVoteInbound{
 			Creator: address.String(),
-		})
+		}, nil)
 
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
