### PR TITLE
fix: skip writing config file to the filesystem

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -132,7 +132,11 @@ which accepts a path for the resulting pprof file.
 					return err
 				}
 			}
-			skipOverwrite, _ := cmd.Flags().GetBool(FlagSkipConfigOverwrite)
+			// Default value is false we always use default value
+			skipOverwrite := false
+			if val, err := cmd.Flags().GetBool(FlagSkipConfigOverwrite); err == nil {
+				skipOverwrite = val
+			}
 			//zevmChainID, err := genesisChainID(serverCtx.Config.GenesisFile())
 			//if err != nil {
 			//	return errorsmod.Wrapf(err, "failed to get genesis chain ID from genesis file")

--- a/server/start.go
+++ b/server/start.go
@@ -46,7 +46,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/zeta-chain/node/pkg/chains"
 	ethdebug "github.com/zeta-chain/node/rpc/namespaces/ethereum/debug"
 )
 
@@ -134,18 +133,18 @@ which accepts a path for the resulting pprof file.
 				}
 			}
 			skipOverwrite, _ := cmd.Flags().GetBool(FlagSkipConfigOverwrite)
-			zevmChainID, err := genesisChainID(serverCtx.Config.GenesisFile())
-			if err != nil {
-				return errorsmod.Wrapf(err, "failed to get genesis chain ID from genesis file")
-			}
-
-			// Cannot skip over writing the config file for ZetaChain mainnet
-			if zevmChainID == chains.ZetaChainMainnet.ChainId && skipOverwrite {
-				return fmt.Errorf(
-					"config overwrite is required for ZetaChain mainnet , please run the command without the --%s flag",
-					FlagSkipConfigOverwrite,
-				)
-			}
+			//zevmChainID, err := genesisChainID(serverCtx.Config.GenesisFile())
+			//if err != nil {
+			//	return errorsmod.Wrapf(err, "failed to get genesis chain ID from genesis file")
+			//}
+			//
+			//// Cannot skip over writing the config file for ZetaChain mainnet
+			//if zevmChainID == chains.ZetaChainMainnet.ChainId && skipOverwrite {
+			//	return fmt.Errorf(
+			//		"config overwrite is required for ZetaChain mainnet , please run the command without the --%s flag",
+			//		FlagSkipConfigOverwrite,
+			//	)
+			//}
 
 			if !skipOverwrite {
 				err := overWriteConfig(cmd)

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -59,6 +59,7 @@ func overWriteConfig(cmd *cobra.Command) error {
 			return fmt.Errorf("failed to set server context: %w", err)
 		}
 
+		// Skip writing to config file to prevent error for read-only file systems
 		//err = updateConfigFile(cmd, serverCtx.Config)
 		//if err != nil {
 		//	return err

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -59,10 +59,10 @@ func overWriteConfig(cmd *cobra.Command) error {
 			return fmt.Errorf("failed to set server context: %w", err)
 		}
 
-		err = updateConfigFile(cmd, serverCtx.Config)
-		if err != nil {
-			return err
-		}
+		//err = updateConfigFile(cmd, serverCtx.Config)
+		//if err != nil {
+		//	return err
+		//}
 	}
 	return nil
 }

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -2,16 +2,10 @@ package server
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
-	cmtcfg "github.com/cometbft/cometbft/config"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/spf13/cobra"
-
-	"github.com/zeta-chain/node/pkg/chains"
 )
 
 // REF: https://github.com/zeta-chain/node/issues/4032
@@ -66,30 +60,4 @@ func overWriteConfig(cmd *cobra.Command) error {
 		//}
 	}
 	return nil
-}
-
-// updateConfigFile updates the config file with the current server context configuration.
-func updateConfigFile(cmd *cobra.Command, conf *cmtcfg.Config) error {
-	rootDir, err := cmd.Flags().GetString(flags.FlagHome)
-	if err != nil || rootDir == "" {
-		fmt.Println("root directory :", rootDir)
-		return fmt.Errorf("failed to get home directory: %w", err)
-	}
-	configPath := filepath.Join(rootDir, "config")
-	cmtCfgFile := filepath.Join(configPath, "config.toml")
-	cmtcfg.WriteConfigFile(cmtCfgFile, conf)
-	return nil
-}
-
-// genesisChainID reads the genesis file at the given path and returns the corresponding chain ID in int64 format(EVM)
-func genesisChainID(genesisFilePath string) (int64, error) {
-	_, genesis, err := genutiltypes.GenesisStateFromGenFile(genesisFilePath)
-	if err != nil {
-		return -1, fmt.Errorf("failed to get genesis state from genesis file: %w", err)
-	}
-	evmChainID, err := chains.CosmosToEthChainID(genesis.ChainID)
-	if err != nil {
-		return -1, fmt.Errorf("failed to convert cosmos chain ID to ethereum chain ID: %w", err)
-	}
-	return evmChainID, nil
 }

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/stretchr/testify/require"
-	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/testutil/sample"
 )
 
@@ -84,89 +82,90 @@ func Test_OverWriteConfig(t *testing.T) {
 	}
 }
 
-func Test_UpdateConfigFile(t *testing.T) {
-	t.Run("should create config.toml in specified directory", func(t *testing.T) {
-		// Arrange
-		cmd := StartCmd(StartOptions{})
-		serverCtx := server.NewDefaultContext()
-
-		// Create a temporary directory for testing
-		tempDir := t.TempDir()
-		configDir := filepath.Join(tempDir, "config")
-		err := os.MkdirAll(configDir, 0755)
-		require.NoError(t, err)
-		require.NoError(t, cmd.Flags().Set(flags.FlagHome, tempDir))
-
-		// Act
-		err = updateConfigFile(cmd, serverCtx.Config)
-
-		// Assert
-		require.NoError(t, err)
-		configPath := filepath.Join(tempDir, "config", "config.toml")
-		_, err = os.Stat(configPath)
-		require.NoError(t, err, "config.toml file should exist")
-	})
-
-	t.Run("fail if home directory not set", func(t *testing.T) {
-		// Arrange
-		cmd := StartCmd(StartOptions{})
-		serverCtx := server.NewDefaultContext()
-
-		// Act
-		err := updateConfigFile(cmd, serverCtx.Config)
-
-		// Assert
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get home directory")
-	})
-}
-
-func Test_GenesisChainID(t *testing.T) {
-	t.Run("get chainID for ZetaChainPrivnet", func(t *testing.T) {
-		genesis := sample.AppGenesis(t)
-		genesis.ChainID = fmt.Sprintf("test_%d-%d", chains.ZetaChainPrivnet.ChainId, 1)
-		tempDir := t.TempDir()
-		rootConfigDir := filepath.Join(tempDir, "config")
-		require.NoError(t, os.MkdirAll(rootConfigDir, 0755))
-		genesisFile := filepath.Join(rootConfigDir, "genesis.json")
-		err := genesis.SaveAs(genesisFile)
-		require.NoError(t, err)
-
-		id, err := genesisChainID(genesisFile)
-
-		require.NoError(t, err)
-		require.Equal(t, id, chains.ZetaChainPrivnet.ChainId)
-	})
-
-	t.Run("fail to get chainID if genesis file does not exist", func(t *testing.T) {
-		tempDir := t.TempDir()
-		genesisFile := filepath.Join(tempDir, "config", "genesis.json")
-
-		// Act
-		_, err := genesisChainID(genesisFile)
-
-		// Assert
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to get genesis state from genesis file")
-	})
-
-	t.Run("fail to get chain Id if genesis file has invalid chainID", func(t *testing.T) {
-		// Arrange
-		tempDir := t.TempDir()
-		rootConfigDir := filepath.Join(tempDir, "config")
-		require.NoError(t, os.MkdirAll(rootConfigDir, 0755))
-		genesisFile := filepath.Join(rootConfigDir, "genesis.json")
-
-		genesis := sample.AppGenesis(t)
-		genesis.ChainID = "invalid_chain_id"
-		err := genesis.SaveAs(genesisFile)
-		require.NoError(t, err)
-
-		// Act
-		_, err = genesisChainID(genesisFile)
-
-		// Assert
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to convert cosmos chain ID to ethereum chain ID")
-	})
-}
+//
+//func Test_UpdateConfigFile(t *testing.T) {
+//	t.Run("should create config.toml in specified directory", func(t *testing.T) {
+//		// Arrange
+//		cmd := StartCmd(StartOptions{})
+//		serverCtx := server.NewDefaultContext()
+//
+//		// Create a temporary directory for testing
+//		tempDir := t.TempDir()
+//		configDir := filepath.Join(tempDir, "config")
+//		err := os.MkdirAll(configDir, 0755)
+//		require.NoError(t, err)
+//		require.NoError(t, cmd.Flags().Set(flags.FlagHome, tempDir))
+//
+//		// Act
+//		err = updateConfigFile(cmd, serverCtx.Config)
+//
+//		// Assert
+//		require.NoError(t, err)
+//		configPath := filepath.Join(tempDir, "config", "config.toml")
+//		_, err = os.Stat(configPath)
+//		require.NoError(t, err, "config.toml file should exist")
+//	})
+//
+//	t.Run("fail if home directory not set", func(t *testing.T) {
+//		// Arrange
+//		cmd := StartCmd(StartOptions{})
+//		serverCtx := server.NewDefaultContext()
+//
+//		// Act
+//		err := updateConfigFile(cmd, serverCtx.Config)
+//
+//		// Assert
+//		require.Error(t, err)
+//		require.Contains(t, err.Error(), "failed to get home directory")
+//	})
+//}
+//
+//func Test_GenesisChainID(t *testing.T) {
+//	t.Run("get chainID for ZetaChainPrivnet", func(t *testing.T) {
+//		genesis := sample.AppGenesis(t)
+//		genesis.ChainID = fmt.Sprintf("test_%d-%d", chains.ZetaChainPrivnet.ChainId, 1)
+//		tempDir := t.TempDir()
+//		rootConfigDir := filepath.Join(tempDir, "config")
+//		require.NoError(t, os.MkdirAll(rootConfigDir, 0755))
+//		genesisFile := filepath.Join(rootConfigDir, "genesis.json")
+//		err := genesis.SaveAs(genesisFile)
+//		require.NoError(t, err)
+//
+//		id, err := genesisChainID(genesisFile)
+//
+//		require.NoError(t, err)
+//		require.Equal(t, id, chains.ZetaChainPrivnet.ChainId)
+//	})
+//
+//	t.Run("fail to get chainID if genesis file does not exist", func(t *testing.T) {
+//		tempDir := t.TempDir()
+//		genesisFile := filepath.Join(tempDir, "config", "genesis.json")
+//
+//		// Act
+//		_, err := genesisChainID(genesisFile)
+//
+//		// Assert
+//		require.Error(t, err)
+//		require.Contains(t, err.Error(), "failed to get genesis state from genesis file")
+//	})
+//
+//	t.Run("fail to get chain Id if genesis file has invalid chainID", func(t *testing.T) {
+//		// Arrange
+//		tempDir := t.TempDir()
+//		rootConfigDir := filepath.Join(tempDir, "config")
+//		require.NoError(t, os.MkdirAll(rootConfigDir, 0755))
+//		genesisFile := filepath.Join(rootConfigDir, "genesis.json")
+//
+//		genesis := sample.AppGenesis(t)
+//		genesis.ChainID = "invalid_chain_id"
+//		err := genesis.SaveAs(genesisFile)
+//		require.NoError(t, err)
+//
+//		// Act
+//		_, err = genesisChainID(genesisFile)
+//
+//		// Assert
+//		require.Error(t, err)
+//		require.Contains(t, err.Error(), "failed to convert cosmos chain ID to ethereum chain ID")
+//	})
+//}


### PR DESCRIPTION
# Description

- Remove restrictions for mainnet, and instead use the value of ` --skip-config-overwrite` flag directly
- Remove logic to write the config back to the filesystem

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
