### PR TITLE
fix(backport): update evm version for missing tx types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -415,7 +415,7 @@ replace (
 	// which is a fork of https://github.com/threshold-network/tss-lib
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 
-	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20250917182935-3e0537bd8a01
+	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
 )

--- a/go.sum
+++ b/go.sum
@@ -1959,8 +1959,8 @@ github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-github.com/zeta-chain/evm v0.0.0-20250917182935-3e0537bd8a01 h1:comNWsnOiQXngn/5DqB1PrzRzlqHMEJ65IpgaGYOBQM=
-github.com/zeta-chain/evm v0.0.0-20250917182935-3e0537bd8a01/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
+github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348 h1:Ta+tRdJ608We92ybjAUrOZ8SwnMP7YJM3v4K7HqT/co=
+github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
 github.com/zeta-chain/go-tss v0.6.3 h1:c/zSEvI0h7MJ+xxu42M58uBdEWrlzfD3NI1kP/FlWBE=


### PR DESCRIPTION
# Description

Update version to use types registered in https://github.com/zeta-chain/evm/pull/10

[DO NOT MERGE] - we should create a release/v37 branch, this is for test purpose