### PR TITLE
feat: enable NoAssetCall from Bitcoin

### DIFF
--- a/cmd/zetae2e/local/bitcoin.go
+++ b/cmd/zetae2e/local/bitcoin.go
@@ -40,6 +40,8 @@ func startBitcoinTests(
 		e2etests.TestBitcoinStdMemoDepositAndCallRevertName,
 		e2etests.TestBitcoinStdMemoDepositAndCallRevertAndAbortName,
 		e2etests.TestBitcoinStdMemoInscribedDepositAndCallName,
+		e2etests.TestBitcoinToZEVMCallName,
+		e2etests.TestBitcoinToZEVMCallAbortName,
 		e2etests.TestBitcoinDepositAndAbortWithLowDepositFeeName,
 		e2etests.TestBitcoinDepositInvalidMemoRevertName,
 		e2etests.TestCrosschainSwapName,

--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -143,6 +143,8 @@ const (
 	TestBitcoinStdMemoDepositAndCallRevertOtherAddressName = "bitcoin_std_memo_deposit_and_call_revert_other_address"
 	TestBitcoinStdMemoDepositAndCallRevertAndAbortName     = "bitcoin_std_memo_deposit_and_call_revert_and_abort"
 	TestBitcoinStdMemoInscribedDepositAndCallName          = "bitcoin_std_memo_inscribed_deposit_and_call"
+	TestBitcoinToZEVMCallName                              = "bitcoin_to_zevm_call"
+	TestBitcoinToZEVMCallAbortName                         = "bitcoin_to_zevm_call_abort"
 	TestBitcoinDepositAndAbortWithLowDepositFeeName        = "bitcoin_deposit_and_abort_with_low_deposit_fee"
 	TestBitcoinWithdrawSegWitName                          = "bitcoin_withdraw_segwit"
 	TestBitcoinWithdrawTaprootName                         = "bitcoin_withdraw_taproot"
@@ -1318,6 +1320,18 @@ var AllE2ETests = []runner.E2ETest{
 		},
 		TestBitcoinStdMemoInscribedDepositAndCall,
 		runner.WithMinimumVersion("v32.0.0"),
+	),
+	runner.NewE2ETest(
+		TestBitcoinToZEVMCallName,
+		"bitcoin -> zevm call",
+		[]runner.ArgDefinition{},
+		TestBitcoinToZEVMCall,
+	),
+	runner.NewE2ETest(
+		TestBitcoinToZEVMCallAbortName,
+		"bitcoin -> zevm call fails and abort with onAbort",
+		[]runner.ArgDefinition{},
+		TestBitcoinToZEVMCallAbort,
 	),
 	runner.NewE2ETest(
 		TestBitcoinDepositAndAbortWithLowDepositFeeName,

--- a/e2e/e2etests/test_bitcoin_to_zevm_call.go
+++ b/e2e/e2etests/test_bitcoin_to_zevm_call.go
@@ -1,0 +1,51 @@
+package e2etests
+
+import (
+	"math/big"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/e2e/runner"
+	"github.com/zeta-chain/node/e2e/utils"
+	"github.com/zeta-chain/node/pkg/memo"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	zetabtc "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+func TestBitcoinToZEVMCall(r *runner.E2ERunner, args []string) {
+	require.Len(r, args, 0)
+
+	// ARRANGE
+	// create a short payload less than max OP_RETURN data size (80 bytes)
+	payload := randomPayloadWithSize(r, 50)
+	sender := r.GetBtcAddress().EncodeAddress()
+	r.AssertTestDAppZEVMCalled(false, payload, []byte(sender), big.NewInt(0))
+
+	// wrap the payload in a standard memo
+	memo := &memo.InboundMemo{
+		Header: memo.Header{
+			Version:     0,
+			EncodingFmt: memo.EncodingFmtCompactShort,
+			OpCode:      memo.OpCodeCall,
+		},
+		FieldsV0: memo.FieldsV0{
+			Receiver: r.TestDAppV2ZEVMAddr,
+			Payload:  []byte(payload),
+		},
+	}
+
+	// ACT
+	// make a NoAssetCall to ZEVM with tiny amount
+	// the amount barely covers the depositor fee, the remaining amount is ignored
+	amount := zetabtc.DefaultDepositorFee + 0.0000001
+	txHash := r.DepositBTCWithAmount(amount, memo)
+
+	// ASSERT
+	// wait for the cctx to be mined
+	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, txHash.String(), r.CctxClient, r.Logger, r.CctxTimeout)
+	r.Logger.CCTX(*cctx, "call")
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
+
+	// check the payload was received on the contract
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(sender), big.NewInt(0))
+}

--- a/e2e/runner/runner.go
+++ b/e2e/runner/runner.go
@@ -474,7 +474,7 @@ func (r *E2ERunner) PrintContractAddresses() {
 	r.Logger.Print("ZetaEth:           	%s", r.ZetaEthAddr.Hex())
 	r.Logger.Print("ConnectorEthLegacy:	%s", r.ConnectorEthAddr.Hex())
 	r.Logger.Print("ConnectorEth:  		%s", r.ConnectorNativeAddr.Hex())
-	r.Logger.Print("ERC20Custody:   	%s", r.ERC20CustodyAddr.Hex())
+	r.Logger.Print("ERC20Custody  		%s", r.ERC20CustodyAddr.Hex())
 	r.Logger.Print("ERC20:            	%s", r.ERC20Addr.Hex())
 	r.Logger.Print("GatewayEVM:       	%s", r.GatewayEVMAddr.Hex())
 	r.Logger.Print("TestDAppV2EVM:     	%s", r.TestDAppV2EVMAddr.Hex())

--- a/zetaclient/chains/bitcoin/observer/event.go
+++ b/zetaclient/chains/bitcoin/observer/event.go
@@ -137,12 +137,6 @@ func (event *BTCInboundEvent) DecodeMemoBytes(chainID int64) error {
 
 // ValidateStandardMemo validates the standard memo in Bitcoin context
 func ValidateStandardMemo(memoStd memo.InboundMemo, chainID int64) error {
-	// NoAssetCall will be disabled for Bitcoin until full V2 support
-	// https://github.com/zeta-chain/node/issues/2711
-	if memoStd.OpCode == memo.OpCodeCall {
-		return errors.New("NoAssetCall is disabled for Bitcoin")
-	}
-
 	// ensure the revert address is a valid and supported BTC address
 	revertAddress := memoStd.RevertOptions.RevertAddress
 	if revertAddress != "" {

--- a/zetaclient/chains/bitcoin/observer/event_test.go
+++ b/zetaclient/chains/bitcoin/observer/event_test.go
@@ -210,10 +210,11 @@ func Test_DecodeEventMemoBytes(t *testing.T) {
 			name:    "should return error if standard memo validation failed",
 			chainID: chains.BitcoinTestnet.ChainId,
 			event: &BTCInboundEvent{
-				// a no asset call opCode passed, not supported at the moment
+				// a no asset call opCode passed with payload and revert address
+				// the revert address passed is an invalid BTC address: "abcd"
 				MemoBytes: testutil.HexToBytes(
 					t,
-					"5a0120032d07a9cbd57dcca3e2cf966c88bc874445b6e3b60d68656c6c6f207361746f736869",
+					"5a0120072d07a9cbd57dcca3e2cf966c88bc874445b6e3b60d68656c6c6f207361746f7368690461626364",
 				),
 			},
 			errMsg: "invalid standard memo for bitcoin",
@@ -269,15 +270,6 @@ func Test_ValidateStandardMemo(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "NoAssetCall is disabled for Bitcoin",
-			memo: memo.InboundMemo{
-				Header: memo.Header{
-					OpCode: memo.OpCodeCall,
-				},
-			},
-			errMsg: "NoAssetCall is disabled for Bitcoin",
 		},
 		{
 			name: "should return error on invalid revert address",

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -265,6 +265,13 @@ func (ob *Observer) NewInboundVoteFromStdMemo(
 	event *BTCInboundEvent,
 	amountSats *big.Int,
 ) *crosschaintypes.MsgVoteInbound {
+	// determine amount and coin type according to operation code
+	coinType := coin.CoinType_Gas
+	if event.MemoStd.OpCode == memo.OpCodeCall {
+		amountSats = big.NewInt(0)
+		coinType = coin.CoinType_NoAssetCall
+	}
+
 	// inject revert options specified by the memo
 	// 'CallOnRevert' and 'RevertGasLimit' are irrelevant to bitcoin inbound
 	revertOptions := crosschaintypes.RevertOptions{
@@ -294,7 +301,7 @@ func (ob *Observer) NewInboundVoteFromStdMemo(
 		event.TxHash,
 		event.BlockNumber,
 		0,
-		coin.CoinType_Gas,
+		coinType,
 		"",
 		0,
 		crosschaintypes.ProtocolContractVersion_V2,


### PR DESCRIPTION
# Description

This PR enables `NoAssetCall` from bitcoin. This is done by enabling the `OpCodeCall` operation code in Bitcoin standard memo.

Closes https://github.com/zeta-chain/node/issues/4214

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
