### PR TITLE
chore(backport/v36): cherry pick e2e tests changes for live networks

### DIFF
--- a/e2e/e2etests/e2etests.go
+++ b/e2e/e2etests/e2etests.go
@@ -628,20 +628,26 @@ var AllE2ETests = []runner.E2ETest{
 	runner.NewE2ETest(
 		TestZEVMToEVMCallName,
 		"zevm -> evm call",
-		[]runner.ArgDefinition{},
+		[]runner.ArgDefinition{
+			{Description: "gas limit for call", DefaultValue: "250000"},
+		},
 		TestZEVMToEVMCall,
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallRevertName,
 		"zevm -> evm call that reverts and call onRevert",
-		[]runner.ArgDefinition{},
+		[]runner.ArgDefinition{
+			{Description: "gas limit for call", DefaultValue: "250000"},
+		},
 		TestZEVMToEVMCallRevert,
 		runner.WithMinimumVersion("v29.0.0"),
 	),
 	runner.NewE2ETest(
 		TestZEVMToEVMCallRevertAndAbortName,
 		"zevm -> evm call that reverts and abort with onAbort",
-		[]runner.ArgDefinition{},
+		[]runner.ArgDefinition{
+			{Description: "gas limit for call", DefaultValue: "250000"},
+		},
 		TestZEVMToEVMCallRevertAndAbort,
 		runner.WithMinimumVersion("v29.0.0"),
 	),

--- a/e2e/e2etests/helpers.go
+++ b/e2e/e2etests/helpers.go
@@ -50,14 +50,6 @@ func randomPayloadWithSize(r *runner.E2ERunner, size int) string {
 	return hex.EncodeToString(bytes)[:size]
 }
 
-func randomPayloadBytes(r *runner.E2ERunner) []byte {
-	bytes := make([]byte, 50)
-	_, err := rand.Read(bytes)
-	require.NoError(r, err)
-
-	return bytes
-}
-
 func formatDuration(d time.Duration) string {
 	minutes := int(d.Minutes())
 	seconds := d.Seconds() - float64(minutes*60)

--- a/e2e/e2etests/legacy/test_eth_deposit_call.go
+++ b/e2e/e2etests/legacy/test_eth_deposit_call.go
@@ -55,7 +55,7 @@ func TestEtherDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, types.CctxStatus_OutboundMined)
 
 	// Checking example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContract(r, exampleContract, value, r.EVMAddress().Bytes())
+	utils.WaitAndVerifyExampleContractCall(r, exampleContract, value, r.EVMAddress().Bytes())
 	r.Logger.Info("Cross-chain call succeeded")
 
 	r.Logger.Info("Deploying reverter contract")

--- a/e2e/e2etests/test_bitcoin_deposit_call.go
+++ b/e2e/e2etests/test_bitcoin_deposit_call.go
@@ -28,7 +28,8 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	// create a random payload exactly fit max OP_RETURN data size 80 bytes (20 receiver + 60 payload)
 	size := txscript.MaxDataCarrierSize - ethcommon.AddressLength
 	payload := randomPayloadWithSize(r, size)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(amountSats))
+	sender := r.GetBtcAddress().EncodeAddress()
+	r.AssertTestDAppZEVMCalled(false, payload, []byte(sender), big.NewInt(amountSats))
 
 	// ACT
 	// Send BTC to TSS address with a dummy memo
@@ -52,5 +53,5 @@ func TestBitcoinDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.BTCZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(receivedAmount))
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(sender), big.NewInt(receivedAmount))
 }

--- a/e2e/e2etests/test_bitcoin_std_deposit_and_call.go
+++ b/e2e/e2etests/test_bitcoin_std_deposit_and_call.go
@@ -27,7 +27,8 @@ func TestBitcoinStdMemoDepositAndCall(r *runner.E2ERunner, args []string) {
 	// create a random payload exactly fit max OP_RETURN data size 80 bytes
 	// memo size: 4b header + 20b receiver + 1b length + 55b payload == 80 bytes
 	payload := randomPayloadWithSize(r, 55)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(amountSats))
+	sender := r.GetBtcAddress().EncodeAddress()
+	r.AssertTestDAppZEVMCalled(false, payload, []byte(sender), big.NewInt(amountSats))
 
 	// wrap the payload in a standard memo
 	memo := &memo.InboundMemo{
@@ -62,5 +63,5 @@ func TestBitcoinStdMemoDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.BTCZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(receivedAmount))
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(sender), big.NewInt(receivedAmount))
 }

--- a/e2e/e2etests/test_bitcoin_std_memo_inscribed_deposit_and_call.go
+++ b/e2e/e2etests/test_bitcoin_std_memo_inscribed_deposit_and_call.go
@@ -67,5 +67,5 @@ func TestBitcoinStdMemoInscribedDepositAndCall(r *runner.E2ERunner, args []strin
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.BTCZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(receivedAmount))
+	r.AssertTestDAppZEVMCalled(true, payload, []byte(senderAddress), big.NewInt(receivedAmount))
 }

--- a/e2e/e2etests/test_erc20_deposit_and_call.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call.go
@@ -20,8 +20,9 @@ func TestERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	oldBalance, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -44,5 +45,5 @@ func TestERC20DepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ERC20ZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_erc20_deposit_and_call_no_message.go
@@ -42,5 +42,5 @@ func TestERC20DepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
-	r.AssertTestDAppZEVMCalled(true, messageIndex, amount)
+	r.AssertTestDAppZEVMCalled(true, messageIndex, r.EVMAddress().Bytes(), amount)
 }

--- a/e2e/e2etests/test_erc20_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_call_revert_with_call.go
@@ -19,7 +19,7 @@ func TestERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 
 	payload := randomPayload(r)
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, nil, amount)
 
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
@@ -42,7 +42,7 @@ func TestERC20WithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 	r.Logger.CCTX(*cctx, "withdraw")
 	requireCCTXStatus(r, crosschaintypes.CctxStatus_Reverted, cctx)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_eth_deposit_and_call.go
+++ b/e2e/e2etests/test_eth_deposit_and_call.go
@@ -18,8 +18,9 @@ func TestETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseBigInt(r, args[0])
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	oldBalance, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, r.TestDAppV2ZEVMAddr)
 	require.NoError(r, err)
@@ -42,5 +43,5 @@ func TestETHDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.ETHZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_eth_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_eth_deposit_and_call_no_message.go
@@ -33,5 +33,5 @@ func TestETHDepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
-	r.AssertTestDAppZEVMCalled(true, messageIndex, amount)
+	r.AssertTestDAppZEVMCalled(true, messageIndex, r.EVMAddress().Bytes(), amount)
 }

--- a/e2e/e2etests/test_eth_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_revert_with_call.go
@@ -19,7 +19,7 @@ func TestETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 
 	payload := randomPayload(r)
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, nil, amount)
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -41,7 +41,7 @@ func TestETHWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "withdraw")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_evm_to_zevm_call.go
+++ b/e2e/e2etests/test_evm_to_zevm_call.go
@@ -15,8 +15,9 @@ func TestEVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(false, payload, sender, big.NewInt(0))
 
 	// perform the withdraw
 	tx := r.EVMToZEMVCall(
@@ -31,5 +32,5 @@ func TestEVMToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, sender, big.NewInt(0))
 }

--- a/e2e/e2etests/test_solana_deposit_call.go
+++ b/e2e/e2etests/test_solana_deposit_call.go
@@ -32,7 +32,7 @@ func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContractWithMsg(
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		depositAmount,

--- a/e2e/e2etests/test_solana_deposit_call.go
+++ b/e2e/e2etests/test_solana_deposit_call.go
@@ -3,7 +3,6 @@ package e2etests
 import (
 	"github.com/stretchr/testify/require"
 
-	testcontract "github.com/zeta-chain/node/e2e/contracts/example"
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
@@ -13,30 +12,26 @@ import (
 func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 1)
 
+	// ARRANGE
 	// parse deposit amount (in lamports)
-	depositAmount := utils.ParseBigInt(r, args[0])
+	amount := utils.ParseBigInt(r, args[0])
 
-	// deploy an example contract in ZEVM
-	contractAddr, _, contract, err := testcontract.DeployExample(r.ZEVMAuth, r.ZEVMClient)
-	require.NoError(r, err)
-	r.Logger.Info("Example contract deployed at: %s", contractAddr.String())
+	// Given payload and ZEVM contract address
+	payload := randomPayload(r)
+	contractAddr := r.TestDAppV2ZEVMAddr
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
 
+	// ACT
 	// execute the deposit transaction
-	data := []byte("hello lamports")
-	sig := r.SOLDepositAndCall(nil, contractAddr, depositAmount, data, nil)
+	sig := r.SOLDepositAndCall(nil, contractAddr, amount, []byte(payload), nil)
 
+	// ASSERT
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, sig.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "solana_deposit_and_call")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
-	// check if example contract has been called, bar value should be set to amount
-	utils.WaitAndVerifyExampleContractCallWithMsg(
-		r,
-		contract,
-		depositAmount,
-		data,
-		[]byte(r.GetSolanaPrivKey().PublicKey().String()),
-	)
+	// check the payload was received on the contract
+	r.AssertTestDAppZEVMCalled(true, payload, amount)
 }

--- a/e2e/e2etests/test_solana_deposit_call.go
+++ b/e2e/e2etests/test_solana_deposit_call.go
@@ -18,8 +18,9 @@ func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 
 	// Given payload and ZEVM contract address
 	payload := randomPayload(r)
+	sender := []byte(r.GetSolanaPrivKey().PublicKey().String())
 	contractAddr := r.TestDAppV2ZEVMAddr
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	// ACT
 	// execute the deposit transaction
@@ -33,5 +34,5 @@ func TestSolanaDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_solana_to_zevm_call.go
+++ b/e2e/e2etests/test_solana_to_zevm_call.go
@@ -31,7 +31,7 @@ func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContractWithMsg(
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		big.NewInt(0),

--- a/e2e/e2etests/test_solana_to_zevm_call.go
+++ b/e2e/e2etests/test_solana_to_zevm_call.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	testcontract "github.com/zeta-chain/node/e2e/contracts/example"
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
@@ -15,27 +14,23 @@ import (
 func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
-	// deploy an example contract in ZEVM
-	contractAddr, _, contract, err := testcontract.DeployExample(r.ZEVMAuth, r.ZEVMClient)
-	require.NoError(r, err)
-	r.Logger.Info("Example contract deployed at: %s", contractAddr.String())
+	// ARRANGE
+	// Given payload and ZEVM contract address
+	contractAddr := r.TestDAppV2ZEVMAddr
+	payload := randomPayload(r)
+	r.AssertTestDAppZEVMCalled(false, payload, nil)
 
+	// ACT
 	// execute call transaction
-	data := []byte("hello")
-	sig := r.SOLCall(nil, contractAddr, data, nil)
+	sig := r.SOLCall(nil, contractAddr, []byte(payload), nil)
 
+	// ASSERT
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, sig.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "solana_call")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
-	// check if example contract has been called, bar value should be set to amount
-	utils.WaitAndVerifyExampleContractCallWithMsg(
-		r,
-		contract,
-		big.NewInt(0),
-		data,
-		[]byte(r.GetSolanaPrivKey().PublicKey().String()),
-	)
+	// check the payload was received on the contract
+	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
 }

--- a/e2e/e2etests/test_solana_to_zevm_call.go
+++ b/e2e/e2etests/test_solana_to_zevm_call.go
@@ -18,7 +18,8 @@ func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	// Given payload and ZEVM contract address
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, nil)
+	sender := []byte(r.GetSolanaPrivKey().PublicKey().String())
+	r.AssertTestDAppZEVMCalled(false, payload, sender, nil)
 
 	// ACT
 	// execute call transaction
@@ -32,5 +33,5 @@ func TestSolanaToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, sender, big.NewInt(0))
 }

--- a/e2e/e2etests/test_solana_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_solana_withdraw_and_call_revert_with_call.go
@@ -88,7 +88,7 @@ func TestSolanaWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string)
 	require.NoError(r, err)
 	r.Logger.Info("runner balance of SOL after withdraw: %d", balanceAfter)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_spl_deposit_and_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call.go
@@ -54,7 +54,7 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContractWithMsg(
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		amount,

--- a/e2e/e2etests/test_spl_deposit_and_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/stretchr/testify/require"
 
-	testcontract "github.com/zeta-chain/node/e2e/contracts/example"
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
@@ -19,11 +18,7 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseBigInt(r, args[0])
 	require.True(r, amount.IsUint64(), fmt.Sprintf("arg[0] is not a uint64: %s", args[0]))
 
-	// deploy an example contract in ZEVM
-	contractAddr, _, contract, err := testcontract.DeployExample(r.ZEVMAuth, r.ZEVMClient)
-	require.NoError(r, err)
-	r.Logger.Info("Example contract deployed at: %s", contractAddr.String())
-
+	// ARRANGE
 	// load deployer private key
 	privKey := r.GetSolanaPrivKey()
 
@@ -38,29 +33,33 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	senderBalanceBefore, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, senderAta, rpc.CommitmentConfirmed)
 	require.NoError(r, err)
 
+	// Given payload and ZEVM contract address
+	contractAddr := r.TestDAppV2ZEVMAddr
+	payload := randomPayload(r)
+	r.AssertTestDAppZEVMCalled(false, payload, amount)
+
 	// get zrc20 balance for recipient
 	zrc20BalanceBefore, err := r.SPLZRC20.BalanceOf(&bind.CallOpts{}, contractAddr)
 	require.NoError(r, err)
 
+	// ACT
 	// execute the deposit transaction
-	data := []byte("hello spl tokens")
 	// #nosec G115 e2eTest - always in range
-	sig := r.SPLDepositAndCall(&privKey, amount.Uint64(), r.SPLAddr, contractAddr, data, nil)
+	sig := r.SPLDepositAndCall(&privKey, amount.Uint64(), r.SPLAddr, contractAddr, []byte(payload), nil)
 
+	// ASSERT
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, sig.String(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "solana_deposit_spl_and_call")
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
-	// check if example contract has been called, bar value should be set to amount
-	utils.WaitAndVerifyExampleContractCallWithMsg(
-		r,
-		contract,
-		amount,
-		data,
-		[]byte(r.GetSolanaPrivKey().PublicKey().String()),
-	)
+	// check the payload was received on the contract
+	r.AssertTestDAppZEVMCalled(true, payload, amount)
+
+	// wait for the zrc20 balance to be updated
+	change := utils.NewExactChange(amount)
+	utils.WaitAndVerifyZRC20BalanceChange(r, r.SPLZRC20, contractAddr, zrc20BalanceBefore, change, r.Logger)
 
 	// verify balances are updated
 	pdaBalanceAfter, err := r.SolanaClient.GetTokenAccountBalance(r.Ctx, pdaAta, rpc.CommitmentConfirmed)
@@ -82,8 +81,4 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 		new(big.Int).Sub(utils.ParseBigInt(r, senderBalanceBefore.Value.Amount), amount),
 		utils.ParseBigInt(r, senderBalanceAfter.Value.Amount),
 	)
-
-	// wait for the zrc20 balance to be updated
-	change := utils.NewExactChange(amount)
-	utils.WaitAndVerifyZRC20BalanceChange(r, r.SPLZRC20, contractAddr, zrc20BalanceBefore, change, r.Logger)
 }

--- a/e2e/e2etests/test_spl_deposit_and_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call.go
@@ -36,7 +36,8 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	// Given payload and ZEVM contract address
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	sender := []byte(r.GetSolanaPrivKey().PublicKey().String())
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	// get zrc20 balance for recipient
 	zrc20BalanceBefore, err := r.SPLZRC20.BalanceOf(&bind.CallOpts{}, contractAddr)
@@ -55,7 +56,7 @@ func TestSPLDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.Equal(r, cctx.GetCurrentOutboundParam().Receiver, contractAddr.Hex())
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 
 	// wait for the zrc20 balance to be updated
 	change := utils.NewExactChange(amount)

--- a/e2e/e2etests/test_sui_token_deposit_and_call.go
+++ b/e2e/e2etests/test_sui_token_deposit_and_call.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/pkg/contracts/sui"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
 
@@ -20,6 +21,12 @@ func TestSuiTokenDepositAndCall(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 
 	payload := randomPayload(r)
+
+	// given sender
+	signer, err := r.Account.SuiSigner()
+	require.NoError(r, err)
+	sender, err := sui.EncodeAddress(signer.Address())
+	require.NoError(r, err)
 
 	// make the deposit transaction
 	resp := r.SuiFungibleTokenDepositAndCall(r.TestDAppV2ZEVMAddr, math.NewUintFromBigInt(amount), []byte(payload))
@@ -38,5 +45,5 @@ func TestSuiTokenDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.SuiTokenZRC20, r.TestDAppV2ZEVMAddr, oldBalance, change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 }

--- a/e2e/e2etests/test_sui_token_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_sui_token_withdraw_and_call_revert_with_call.go
@@ -65,7 +65,7 @@ func TestSuiTokenWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []strin
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_sui_token_withdraw_and_call_revert_with_call_legacy.go
+++ b/e2e/e2etests/test_sui_token_withdraw_and_call_revert_with_call_legacy.go
@@ -63,7 +63,7 @@ func TestSuiTokenWithdrawAndCallRevertWithCallLegacy(r *runner.E2ERunner, args [
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_sui_withdraw_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_sui_withdraw_and_call_revert_with_call.go
@@ -71,7 +71,7 @@ func TestSuiWithdrawAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_sui_withdraw_and_call_revert_with_call_legacy.go
+++ b/e2e/e2etests/test_sui_withdraw_and_call_revert_with_call_legacy.go
@@ -65,7 +65,7 @@ func TestSuiWithdrawAndCallRevertWithCallLegacy(r *runner.E2ERunner, args []stri
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payloadOnRevert, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_sui_withdraw_revert_with_call.go
+++ b/e2e/e2etests/test_sui_withdraw_revert_with_call.go
@@ -73,7 +73,7 @@ func TestSuiWithdrawRevertWithCall(r *runner.E2ERunner, args []string) {
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
 	// should have called 'onRevert'
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// sender and message should match
 	sender, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_ton_call.go
+++ b/e2e/e2etests/test_ton_call.go
@@ -18,14 +18,15 @@ func TestTONToZEVMCall(r *runner.E2ERunner, args []string) {
 	// Given a gateway
 	gw := toncontracts.NewGateway(r.TONGateway)
 
-	// Given a sender
-	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
+	// Given a senderWallet
+	_, senderWallet, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
+	sender := []byte(senderWallet.GetAddress().String())
 
 	// Given payload and a ZEVM contract
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(false, payload, sender, big.NewInt(0))
 
 	// Given an approx `call` fee
 	callFee, err := gw.GetTxFee(ctx, r.Clients.TON, toncontracts.OpCall)
@@ -33,12 +34,12 @@ func TestTONToZEVMCall(r *runner.E2ERunner, args []string) {
 
 	// ACT
 	// Perform TON tx
-	cctx, err := r.TONCall(gw, sender, callFee, contractAddr, []byte(payload))
+	cctx, err := r.TONCall(gw, senderWallet, callFee, contractAddr, []byte(payload))
 
 	// ASSERT
 	require.NoError(r, err)
 	r.Logger.CCTX(*cctx, "ton_call")
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, sender, big.NewInt(0))
 }

--- a/e2e/e2etests/test_ton_call.go
+++ b/e2e/e2etests/test_ton_call.go
@@ -45,8 +45,8 @@ func TestTONToZEVMCall(r *runner.E2ERunner, args []string) {
 	require.NoError(r, err)
 	r.Logger.CCTX(*cctx, "ton_call")
 
-	// Ensure the dapp is called
-	utils.MustHaveCalledExampleContractWithMsg(
+	// Ensure the example contract has been called, bar value should be set to amount
+	utils.WaitAndVerifyExampleContractCallWithMsg(
 		r,
 		contract,
 		big.NewInt(0),

--- a/e2e/e2etests/test_ton_deposit_and_call.go
+++ b/e2e/e2etests/test_ton_deposit_and_call.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	testcontract "github.com/zeta-chain/node/e2e/contracts/example"
 	"github.com/zeta-chain/node/e2e/runner"
 	"github.com/zeta-chain/node/e2e/utils"
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
@@ -30,16 +29,13 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
 
-	// Given sample zEVM contract deployed by userTON account
-	contractAddr, _, contract, err := testcontract.DeployExample(r.ZEVMAuth, r.ZEVMClient)
-	require.NoError(r, err, "unable to deploy example contract")
-	r.Logger.Info("Example zevm contract deployed at: %s", contractAddr.String())
-
-	// Given call data
-	callData := []byte("hello from TON!")
+	// Given payload and a ZEVM contract
+	contractAddr := r.TestDAppV2ZEVMAddr
+	payload := randomPayload(r)
+	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
 
 	// ACT
-	_, err = r.TONDepositAndCall(gw, sender, amount, contractAddr, callData)
+	_, err = r.TONDepositAndCall(gw, sender, amount, contractAddr, []byte(payload))
 
 	// ASSERT
 	require.NoError(r, err)
@@ -50,6 +46,6 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	change := utils.NewExactChange(expectedDeposit.BigInt())
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.TONZRC20, contractAddr, big.NewInt(0), change, r.Logger)
 
-	// check if example contract has been called, bar value should be set to amount
-	utils.WaitAndVerifyExampleContractCall(r, contract, expectedDeposit.BigInt(), []byte(sender.GetAddress().ToRaw()))
+	// check the payload was received on the contract
+	r.AssertTestDAppZEVMCalled(true, payload, expectedDeposit.BigInt())
 }

--- a/e2e/e2etests/test_ton_deposit_and_call.go
+++ b/e2e/e2etests/test_ton_deposit_and_call.go
@@ -51,5 +51,5 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.TONZRC20, contractAddr, big.NewInt(0), change, r.Logger)
 
 	// check if example contract has been called, bar value should be set to amount
-	utils.MustHaveCalledExampleContract(r, contract, expectedDeposit.BigInt(), []byte(sender.GetAddress().ToRaw()))
+	utils.WaitAndVerifyExampleContractCall(r, contract, expectedDeposit.BigInt(), []byte(sender.GetAddress().ToRaw()))
 }

--- a/e2e/e2etests/test_ton_deposit_and_call.go
+++ b/e2e/e2etests/test_ton_deposit_and_call.go
@@ -25,17 +25,18 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	depositFee, err := gw.GetTxFee(ctx, r.Clients.TON, toncontracts.OpDepositAndCall)
 	require.NoError(r, err)
 
-	// Given a sender
-	_, sender, err := r.Account.AsTONWallet(r.Clients.TON)
+	// Given a senderWallet
+	_, senderWallet, err := r.Account.AsTONWallet(r.Clients.TON)
 	require.NoError(r, err)
+	sender := []byte(senderWallet.GetAddress().String())
 
 	// Given payload and a ZEVM contract
 	contractAddr := r.TestDAppV2ZEVMAddr
 	payload := randomPayload(r)
-	r.AssertTestDAppZEVMCalled(false, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(false, payload, sender, big.NewInt(0))
 
 	// ACT
-	_, err = r.TONDepositAndCall(gw, sender, amount, contractAddr, []byte(payload))
+	_, err = r.TONDepositAndCall(gw, senderWallet, amount, contractAddr, []byte(payload))
 
 	// ASSERT
 	require.NoError(r, err)
@@ -47,5 +48,5 @@ func TestTONDepositAndCall(r *runner.E2ERunner, args []string) {
 	utils.WaitAndVerifyZRC20BalanceChange(r, r.TONZRC20, contractAddr, big.NewInt(0), change, r.Logger)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, expectedDeposit.BigInt())
+	r.AssertTestDAppZEVMCalled(true, payload, sender, expectedDeposit.BigInt())
 }

--- a/e2e/e2etests/test_zeta_deposit_and_call.go
+++ b/e2e/e2etests/test_zeta_deposit_and_call.go
@@ -19,9 +19,10 @@ func TestZetaDepositAndCall(r *runner.E2ERunner, args []string) {
 	r.ApproveZetaOnEVM(r.GatewayEVMAddr)
 
 	payload := randomPayload(r)
+	sender := r.EVMAddress().Bytes()
 	receiverAddress := r.TestDAppV2ZEVMAddr
 
-	r.AssertTestDAppZEVMCalled(false, payload, amount)
+	r.AssertTestDAppZEVMCalled(false, payload, sender, amount)
 
 	oldBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, receiverAddress, nil)
 	require.NoError(r, err)
@@ -40,7 +41,7 @@ func TestZetaDepositAndCall(r *runner.E2ERunner, args []string) {
 	requireCCTXStatus(r, crosschaintypes.CctxStatus_OutboundMined, cctx)
 
 	// check the payload was received on the contract
-	r.AssertTestDAppZEVMCalled(true, payload, amount)
+	r.AssertTestDAppZEVMCalled(true, payload, sender, amount)
 
 	// check the balance was updated
 	newBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, receiverAddress, nil)

--- a/e2e/e2etests/test_zeta_deposit_and_call_no_message.go
+++ b/e2e/e2etests/test_zeta_deposit_and_call_no_message.go
@@ -39,7 +39,7 @@ func TestZetaDepositAndCallNoMessage(r *runner.E2ERunner, args []string) {
 	// check the payload was received on the contract
 	messageIndex, err := r.TestDAppV2ZEVM.GetNoMessageIndex(&bind.CallOpts{}, r.EVMAddress())
 	require.NoError(r, err)
-	r.AssertTestDAppZEVMCalled(true, messageIndex, amount)
+	r.AssertTestDAppZEVMCalled(true, messageIndex, r.EVMAddress().Bytes(), amount)
 
 	// check the balance was updated
 	newBalance, err := r.ZEVMClient.BalanceAt(r.Ctx, receiverAddress, nil)

--- a/e2e/e2etests/test_zevm_to_evm_call.go
+++ b/e2e/e2etests/test_zevm_to_evm_call.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestZEVMToEVMCall(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 0)
+	require.Len(r, args, 1)
+	gasLimit := utils.ParseBigInt(r, args[0])
 
 	payload := randomPayload(r)
 
@@ -29,6 +30,7 @@ func TestZEVMToEVMCall(r *runner.E2ERunner, args []string) {
 		gatewayzevm.RevertOptions{
 			OnRevertGasLimit: big.NewInt(0),
 		},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 0)
+	require.Len(r, args, 1)
+	gasLimit := utils.ParseBigInt(r, args[0])
 
 	payload := randomPayload(r)
 
@@ -30,6 +31,7 @@ func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
 			RevertMessage:    []byte(payload),
 			OnRevertGasLimit: big.NewInt(200000),
 		},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/e2etests/test_zevm_to_evm_call_revert.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert.go
@@ -39,7 +39,7 @@ func TestZEVMToEVMCallRevert(r *runner.E2ERunner, args []string) {
 	r.Logger.CCTX(*cctx, "call")
 	require.Equal(r, crosschaintypes.CctxStatus_Reverted, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppZEVMCalled(true, payload, big.NewInt(0))
+	r.AssertTestDAppZEVMCalled(true, payload, nil, big.NewInt(0))
 
 	// check expected sender was used
 	senderForMsg, err := r.TestDAppV2ZEVM.SenderWithMessage(

--- a/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
-	require.Len(r, args, 0)
+	require.Len(r, args, 1)
+	gasLimit := utils.ParseBigInt(r, args[0])
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
@@ -34,6 +35,7 @@ func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
 			OnRevertGasLimit: big.NewInt(200000),
 			AbortAddress:     testAbortAddr,
 		},
+		gasLimit,
 	)
 
 	// wait for the cctx to be mined

--- a/e2e/runner/testdapp.go
+++ b/e2e/runner/testdapp.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"math/big"
 	"time"
 
@@ -21,28 +22,29 @@ const (
 // AssertTestDAppZEVMCalled is a function that asserts the values of the test dapp on the ZEVM
 // this function uses TestDAppV2 for the assertions, in the future we should only use this contracts for all tests
 // https://github.com/zeta-chain/node/issues/2655
-func (r *E2ERunner) AssertTestDAppZEVMCalled(expectedCalled bool, message string, amount *big.Int) {
-	r.waitAndVerifyTestDAppCall(r.TestDAppV2ZEVM, message, expectedCalled, amount)
+func (r *E2ERunner) AssertTestDAppZEVMCalled(expectedCalled bool, message string, sender []byte, amount *big.Int) {
+	r.waitAndVerifyTestDAppCall(r.TestDAppV2ZEVM, expectedCalled, message, sender, amount)
 }
 
 // AssertTestDAppEVMCalled is a function that asserts the values of the test dapp on the external EVM
 func (r *E2ERunner) AssertTestDAppEVMCalled(expectedCalled bool, message string, amount *big.Int) {
-	r.waitAndVerifyTestDAppCall(r.TestDAppV2EVM, message, expectedCalled, amount)
+	r.waitAndVerifyTestDAppCall(r.TestDAppV2EVM, expectedCalled, message, nil, amount)
 }
 
-// waitAndVerifyTestDAppCall waits for the test dapp to be called with the expected message and amount
+// waitAndVerifyTestDAppCall waits for the test dapp to be called with the expected message, sender and amount
 // This function is to tolerate the fact that the dApp state may not be synced across all nodes behind a RPC.
 func (r *E2ERunner) waitAndVerifyTestDAppCall(
 	testDApp *testdappv2.TestDAppV2,
-	message string,
 	expectedCalled bool,
+	message string,
+	expectedSender []byte,
 	expectedAmount *big.Int,
 ) {
 	// do simply assert if the dApp is NOT expected to be called, no need to wait
 	if !expectedCalled {
 		called, err := testDApp.GetCalledWithMessage(&bind.CallOpts{}, message)
 		require.NoError(r, err)
-		require.EqualValues(r, expectedCalled, called)
+		require.EqualValues(r, false, called)
 		return
 	}
 
@@ -57,11 +59,17 @@ func (r *E2ERunner) waitAndVerifyTestDAppCall(
 		called, err := testDApp.GetCalledWithMessage(&bind.CallOpts{}, message)
 		require.NoError(r, err)
 
+		sender, err := testDApp.GetSenderWithMessage(&bind.CallOpts{}, message)
+		require.NoError(r, err)
+
 		amount, err := testDApp.GetAmountWithMessage(&bind.CallOpts{}, message)
 		require.NoError(r, err)
 
-		// stop only if both message and amount are matching the expected values
-		if called == expectedCalled && amount.Cmp(expectedAmount) == 0 {
+		// if sender is provided, check if it matches the actual sender, otherwise skip the check
+		senderMatched := len(expectedSender) == 0 || bytes.Equal(sender, expectedSender)
+
+		// stop only if sender, message and amount are matching the expected values
+		if called == expectedCalled && amount.Cmp(expectedAmount) == 0 && senderMatched {
 			return
 		}
 	}

--- a/e2e/runner/zevm.go
+++ b/e2e/runner/zevm.go
@@ -274,6 +274,7 @@ func (r *E2ERunner) ZEVMToEMVCall(
 	receiver ethcommon.Address,
 	payload []byte,
 	revertOptions gatewayzevm.RevertOptions,
+	gasLimit *big.Int,
 ) *ethtypes.Transaction {
 	tx, err := r.GatewayZEVM.Call(
 		r.ZEVMAuth,
@@ -281,7 +282,7 @@ func (r *E2ERunner) ZEVMToEMVCall(
 		r.ETHZRC20Addr,
 		payload,
 		gatewayzevm.CallOptions{
-			GasLimit:        defaultGasLimit,
+			GasLimit:        gasLimit,
 			IsArbitraryCall: false,
 		},
 		revertOptions,

--- a/e2e/utils/balance_change.go
+++ b/e2e/utils/balance_change.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"math/big"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BalanceChange contains details about the balance change
+type BalanceChange struct {
+	// If provided, when set to
+	//  - true: the balance change must be positive
+	//  - false: the balance change must be negative
+	positive *bool
+
+	// If provided, it's the exact value of the balance change
+	// delta value can be positive or negative
+	delta *big.Int
+}
+
+// NewBalanceChange returns a new BalanceChange with given positive flag
+func NewBalanceChange(positive bool) BalanceChange {
+	return BalanceChange{
+		positive: &[]bool{positive}[0],
+	}
+}
+
+// NewExactChange returns a new BalanceChange with the Delta field set to the exact value
+func NewExactChange(delta *big.Int) BalanceChange {
+	return BalanceChange{
+		delta: delta,
+	}
+}
+
+// Verify verifies the balance change
+func (c BalanceChange) Verify(t require.TestingT, oldBalance *big.Int, newBalance *big.Int) {
+	// check exact amount change if provided
+	if c.delta != nil {
+		require.Equal(t, new(big.Int).Add(oldBalance, c.delta), newBalance)
+		return
+	}
+
+	// otherwise, check positive/negative only
+	if c.positive != nil {
+		if *c.positive {
+			require.True(t, newBalance.Cmp(oldBalance) > 0, "balance should be increased")
+		} else {
+			require.True(t, newBalance.Cmp(oldBalance) < 0, "balance should be decreased")
+		}
+	}
+}

--- a/e2e/utils/zetacore.go
+++ b/e2e/utils/zetacore.go
@@ -38,32 +38,6 @@ const (
 	nodeSyncTolerance = constant.ZetaBlockTime * 5
 )
 
-// BalanceChange contains details about the balance change
-type BalanceChange struct {
-	// If provided, when set to
-	//  - true: the balance change must be positive
-	//  - false: the balance change must be negative
-	positive *bool
-
-	// If provided, it's the exact value of the balance change
-	// Delta value can be positive or negative
-	delta *big.Int
-}
-
-// NewBalanceChange returns a new BalanceChange with given positive flag
-func NewBalanceChange(positive bool) BalanceChange {
-	return BalanceChange{
-		positive: &[]bool{positive}[0],
-	}
-}
-
-// NewExactChange returns a new BalanceChange with the Delta field set to the exact value
-func NewExactChange(delta *big.Int) BalanceChange {
-	return BalanceChange{
-		delta: delta,
-	}
-}
-
 // GetCCTXByInboundHash gets cctx by inbound hash
 func GetCCTXByInboundHash(
 	ctx context.Context,
@@ -517,19 +491,7 @@ func WaitAndVerifyZRC20BalanceChange(
 		}
 		logger.Info("%s balance changed from %d to %d on address %s", symbol, oldBalance, newBalance, address.Hex())
 
-		// balance should increase or decrease?
-		if change.positive != nil {
-			if *change.positive {
-				require.True(t, newBalance.Cmp(oldBalance) > 0, "balance should be increased")
-			} else {
-				require.True(t, newBalance.Cmp(oldBalance) < 0, "balance should be decreased")
-			}
-		}
-
-		// check exact amount change if provided
-		if change.delta != nil {
-			require.Equal(t, new(big.Int).Add(oldBalance, change.delta), newBalance)
-		}
+		change.Verify(t, oldBalance, newBalance)
 
 		return
 	}


### PR DESCRIPTION
# Description

cherry picking e2e tests changes specific for live networks, so we can use release branches to run e2e tests on testnet/mainnet

details: https://github.com/zeta-chain/e2e/issues/116

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
