### PR TITLE
revert: add timeout to monitoring routine"

### DIFF
--- a/zetaclient/chains/ton/observer/observer_test.go
+++ b/zetaclient/chains/ton/observer/observer_test.go
@@ -244,7 +244,7 @@ func setupVotesBag(ts *testSuite) {
 		ts.votesBag = append(ts.votesBag, cctx)
 	}
 	ts.zetacore.
-		On("PostVoteInbound", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		On("PostVoteInbound", ts.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Run(catcher).
 		Return("", "", nil) // zeta hash, ballot index, error

--- a/zetaclient/context/context.go
+++ b/zetaclient/context/context.go
@@ -2,7 +2,6 @@ package context
 
 import (
 	goctx "context"
-	"time"
 
 	"github.com/pkg/errors"
 )
@@ -36,15 +35,4 @@ func Copy(from, to goctx.Context) goctx.Context {
 	}
 
 	return WithAppContext(to, app)
-}
-
-// CopyWithTimeout copies AppContext from one context to another and adds a timeout.
-// This is useful when you want to run something in another goroutine with a timeout.
-func CopyWithTimeout(from, to goctx.Context, timeout time.Duration) (goctx.Context, goctx.CancelFunc) {
-	app, err := FromContext(from)
-	if err != nil {
-		return goctx.WithTimeout(to, timeout)
-	}
-	ctxWithTimeout, cancel := goctx.WithTimeout(to, timeout)
-	return WithAppContext(ctxWithTimeout, app), cancel
 }


### PR DESCRIPTION
Reverts zeta-chain/node#4196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Eliminates spurious timeout errors during inbound vote monitoring, reducing false failures.
  - More consistent cancellation behavior to prevent misleading log messages.
- Performance/Reliability
  - Streamlined context handling for monitoring to improve stability and reduce unnecessary timeouts.
- Tests
  - Updated mocks to use concrete contexts for more accurate test coverage.
- Chores
  - Removed unused timeout utilities to simplify context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->