### PR TITLE
fix(e2e): check test contracts deployment

### DIFF
--- a/e2e/e2etests/legacy/test_erc20_multiple_deposits.go
+++ b/e2e/e2etests/legacy/test_erc20_multiple_deposits.go
@@ -46,8 +46,9 @@ func TestMultipleERC20Deposit(r *runner.E2ERunner, args []string) {
 
 func multipleDeposits(r *runner.E2ERunner, amount, count *big.Int) ethcommon.Hash {
 	// deploy depositor
-	depositorAddr, _, depositor, err := testcontract.DeployDepositor(r.EVMAuth, r.EVMClient, r.ERC20CustodyAddr)
+	depositorAddr, txDeploy, depositor, err := testcontract.DeployDepositor(r.EVMAuth, r.EVMClient, r.ERC20CustodyAddr)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	fullAmount := big.NewInt(0).Mul(amount, count)
 

--- a/e2e/e2etests/legacy/test_erc20_multiple_deposits.go
+++ b/e2e/e2etests/legacy/test_erc20_multiple_deposits.go
@@ -48,7 +48,7 @@ func multipleDeposits(r *runner.E2ERunner, amount, count *big.Int) ethcommon.Has
 	// deploy depositor
 	depositorAddr, txDeploy, depositor, err := testcontract.DeployDepositor(r.EVMAuth, r.EVMClient, r.ERC20CustodyAddr)
 	require.NoError(r, err)
-	r.WaitForTxReceiptOnZEVM(txDeploy)
+	r.WaitForTxReceiptOnEVM(txDeploy)
 
 	fullAmount := big.NewInt(0).Mul(amount, count)
 

--- a/e2e/e2etests/legacy/test_erc20_multiple_withdraws.go
+++ b/e2e/e2etests/legacy/test_erc20_multiple_withdraws.go
@@ -32,8 +32,9 @@ func TestMultipleERC20Withdraws(r *runner.E2ERunner, args []string) {
 	require.Equal(r, -1, totalWithdrawal.Cmp(approvedAmount), "Total withdrawal amount exceeds approved limit.")
 
 	// deploy withdrawer
-	withdrawerAddr, _, withdrawer, err := testcontract.DeployWithdrawer(r.ZEVMAuth, r.ZEVMClient)
+	withdrawerAddr, txDeploy, withdrawer, err := testcontract.DeployWithdrawer(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// approve
 	tx, err := r.ERC20ZRC20.Approve(r.ZEVMAuth, withdrawerAddr, approvedAmount)

--- a/e2e/e2etests/legacy/test_eth_deposit_call.go
+++ b/e2e/e2etests/legacy/test_eth_deposit_call.go
@@ -19,8 +19,9 @@ func TestEtherDepositAndCall(r *runner.E2ERunner, args []string) {
 	value := utils.ParseBigInt(r, args[0])
 
 	r.Logger.Info("Deploying example contract")
-	exampleAddr, _, exampleContract, err := example.DeployExample(r.ZEVMAuth, r.ZEVMClient)
+	exampleAddr, txDeploy, exampleContract, err := example.DeployExample(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	r.Logger.Info("Example contract deployed")
 
@@ -59,8 +60,9 @@ func TestEtherDepositAndCall(r *runner.E2ERunner, args []string) {
 	r.Logger.Info("Cross-chain call succeeded")
 
 	r.Logger.Info("Deploying reverter contract")
-	reverterAddr, _, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
+	reverterAddr, txDeploy, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	r.Logger.Info("Example reverter deployed")
 

--- a/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
+++ b/e2e/e2etests/test_bitcoin_std_deposit_and_call_revert_and_abort.go
@@ -23,8 +23,9 @@ func TestBitcoinStdMemoDepositAndCallRevertAndAbort(r *runner.E2ERunner, args []
 	amount := 0.00000001 // 1 satoshi so revert fails because of insufficient gas
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// Create a memo to call non-existing contract
 	abortMessage := "abort message"

--- a/e2e/e2etests/test_deposit_and_call_out_of_gas.go
+++ b/e2e/e2etests/test_deposit_and_call_out_of_gas.go
@@ -19,8 +19,9 @@ func TestDepositAndCallOutOfGas(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseBigInt(r, args[0])
 
 	// Deploy the GasConsumer contract
-	gasConsumerAddress, _, _, err := testgasconsumer.DeployTestGasConsumer(r.ZEVMAuth, r.ZEVMClient)
+	gasConsumerAddress, txDeploy, _, err := testgasconsumer.DeployTestGasConsumer(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the deposit and call to the GasConsumer contract
 	tx := r.ETHDepositAndCall(

--- a/e2e/e2etests/test_erc20_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_erc20_deposit_revert_and_abort.go
@@ -20,8 +20,9 @@ func TestERC20DepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the deposit
 	tx := r.ERC20DepositAndCall(

--- a/e2e/e2etests/test_erc20_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_erc20_withdraw_revert_and_abort.go
@@ -24,8 +24,9 @@ func TestERC20WithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the withdraw
 	tx := r.ERC20WithdrawAndCall(

--- a/e2e/e2etests/test_eth_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_eth_deposit_revert_and_abort.go
@@ -22,8 +22,9 @@ func TestETHDepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	r.ApproveERC20OnEVM(r.GatewayEVMAddr)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the deposit
 	tx := r.ETHDepositAndCall(

--- a/e2e/e2etests/test_eth_withdraw_and_call_big_payload.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_big_payload.go
@@ -14,8 +14,9 @@ import (
 
 func TestETHWithdrawAndCallBigPayload(r *runner.E2ERunner, _ []string) {
 	// deploy the TestDAppEmpty contract on the EVM chain
-	testDAppAddr, _, _, err := testdappempty.DeployTestDAppEmpty(r.EVMAuth, r.EVMClient)
+	testDAppAddr, txDeploy, _, err := testdappempty.DeployTestDAppEmpty(r.EVMAuth, r.EVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000

--- a/e2e/e2etests/test_eth_withdraw_and_call_big_payload.go
+++ b/e2e/e2etests/test_eth_withdraw_and_call_big_payload.go
@@ -16,7 +16,7 @@ func TestETHWithdrawAndCallBigPayload(r *runner.E2ERunner, _ []string) {
 	// deploy the TestDAppEmpty contract on the EVM chain
 	testDAppAddr, txDeploy, _, err := testdappempty.DeployTestDAppEmpty(r.EVMAuth, r.EVMClient)
 	require.NoError(r, err)
-	r.WaitForTxReceiptOnZEVM(txDeploy)
+	r.WaitForTxReceiptOnEVM(txDeploy)
 
 	previousGasLimit := r.ZEVMAuth.GasLimit
 	r.ZEVMAuth.GasLimit = 10000000

--- a/e2e/e2etests/test_eth_withdraw_revert_and_abort.go
+++ b/e2e/e2etests/test_eth_withdraw_revert_and_abort.go
@@ -23,8 +23,9 @@ func TestETHWithdrawRevertAndAbort(r *runner.E2ERunner, args []string) {
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the withdraw
 	tx := r.ETHWithdrawAndCall(

--- a/e2e/e2etests/test_evm_to_zevm_call_abort.go
+++ b/e2e/e2etests/test_evm_to_zevm_call_abort.go
@@ -18,7 +18,8 @@ func TestEVMToZEVMCallAbort(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 	require.NoError(r, err)
 
 	// perform the withdraw

--- a/e2e/e2etests/test_evm_to_zevm_call_abort.go
+++ b/e2e/e2etests/test_evm_to_zevm_call_abort.go
@@ -19,8 +19,8 @@ func TestEVMToZEVMCallAbort(r *runner.E2ERunner, args []string) {
 
 	// deploy testabort contract
 	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
-	r.WaitForTxReceiptOnZEVM(txDeploy)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the withdraw
 	tx := r.EVMToZEMVCall(

--- a/e2e/e2etests/test_solana_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_solana_deposit_and_call_revert_with_call.go
@@ -22,8 +22,9 @@ func TestSolanaDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) 
 
 	// deploy a reverter contract in ZEVM
 	// TODO: consider removing repeated deployments of reverter contract
-	reverterAddr, _, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
+	reverterAddr, txDeploy, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 	r.Logger.Info("Reverter contract deployed at: %s", reverterAddr.String())
 
 	// execute the deposit transaction

--- a/e2e/e2etests/test_solana_deposit_and_call_revert_with_call_that_reverts.go
+++ b/e2e/e2etests/test_solana_deposit_and_call_revert_with_call_that_reverts.go
@@ -23,8 +23,9 @@ func TestSolanaDepositAndCallRevertWithCallThatReverts(r *runner.E2ERunner, args
 
 	// deploy a reverter contract in ZEVM
 	// TODO: consider removing repeated deployments of reverter contract
-	reverterAddr, _, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
+	reverterAddr, txDeploy, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 	r.Logger.Info("Reverter contract deployed at: %s", reverterAddr.String())
 
 	// execute the deposit transaction

--- a/e2e/e2etests/test_solana_to_zevm_call_abort.go
+++ b/e2e/e2etests/test_solana_to_zevm_call_abort.go
@@ -16,8 +16,9 @@ func TestSolanaToZEVMCallAbort(r *runner.E2ERunner, args []string) {
 	require.Len(r, args, 0)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// execute call transaction, receiver is non existing address
 	data := []byte("hello")

--- a/e2e/e2etests/test_spl_deposit_and_call_revert.go
+++ b/e2e/e2etests/test_spl_deposit_and_call_revert.go
@@ -26,8 +26,9 @@ func TestSPLDepositAndCallRevert(r *runner.E2ERunner, args []string) {
 	r.AddLiquiditySPL(zetaAmount, zrc20Amount)
 
 	// deploy a reverter contract in ZEVM
-	reverterAddr, _, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
+	reverterAddr, txDeploy, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 	r.Logger.Info("Reverter contract deployed at: %s", reverterAddr.String())
 
 	// load deployer private key

--- a/e2e/e2etests/test_spl_deposit_and_call_revert_with_call.go
+++ b/e2e/e2etests/test_spl_deposit_and_call_revert_with_call.go
@@ -20,8 +20,9 @@ func TestSPLDepositAndCallRevertWithCall(r *runner.E2ERunner, args []string) {
 	amount := utils.ParseInt(r, args[0])
 
 	// deploy a reverter contract in ZEVM
-	reverterAddr, _, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
+	reverterAddr, txDeploy, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 	r.Logger.Info("Reverter contract deployed at: %s", reverterAddr.String())
 
 	// load deployer private key

--- a/e2e/e2etests/test_spl_deposit_and_call_revert_with_call_that_reverts.go
+++ b/e2e/e2etests/test_spl_deposit_and_call_revert_with_call_that_reverts.go
@@ -19,8 +19,9 @@ func TestSPLDepositAndCallRevertWithCallThatReverts(r *runner.E2ERunner, args []
 	amount := utils.ParseInt(r, args[0])
 
 	// deploy a reverter contract in ZEVM
-	reverterAddr, _, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
+	reverterAddr, txDeploy, _, err := testcontract.DeployReverter(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 	r.Logger.Info("Reverter contract deployed at: %s", reverterAddr.String())
 
 	// load deployer private key

--- a/e2e/e2etests/test_zeta_deposit_revert_and_abort.go
+++ b/e2e/e2etests/test_zeta_deposit_revert_and_abort.go
@@ -21,8 +21,9 @@ func TestZetaDepositRevertAndAbort(r *runner.E2ERunner, args []string) {
 	r.ApproveZetaOnEVM(r.GatewayEVMAddr)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the deposit
 	// Deposit (Fails as the address is non-existing)

--- a/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
+++ b/e2e/e2etests/test_zevm_to_evm_call_revert_and_abort.go
@@ -21,8 +21,9 @@ func TestZEVMToEVMCallRevertAndAbort(r *runner.E2ERunner, args []string) {
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
 	// deploy testabort contract
-	testAbortAddr, _, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
+	testAbortAddr, txDeploy, testAbort, err := testabort.DeployTestAbort(r.ZEVMAuth, r.ZEVMClient)
 	require.NoError(r, err)
+	r.WaitForTxReceiptOnZEVM(txDeploy)
 
 	// perform the withdraw
 	tx := r.ZEVMToEMVCall(


### PR DESCRIPTION
# Description

Sync https://github.com/zeta-chain/node/pull/4251 on develop since the bug can happen here as well


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added explicit waits for deployment transaction receipts across e2e tests (ERC20, ETH, Bitcoin, Solana, SPL, Zeta, and cross-chain calls) to ensure contracts are fully deployed before interactions.
- Bug Fixes
  - Improved reliability and reduced flakiness of end-to-end test runs by synchronizing on deployment confirmations.
  - Stabilized CI by preventing race conditions during contract deployment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->