### PR TITLE
refactor: replace the deprecated function in the ioutil package

### DIFF
--- a/pkg/parsers/observer_info.go
+++ b/pkg/parsers/observer_info.go
@@ -2,7 +2,7 @@ package parsers
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -34,7 +34,7 @@ func ParsefileToObserverDetails(fp string) ([]ObserverInfoReader, error) {
 		return nil, err
 	}
 	file = filepath.Clean(file)
-	input, err := ioutil.ReadFile(file) // #nosec G304
+	input, err := os.ReadFile(file) // #nosec G304
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parsers/observer_info_test.go
+++ b/pkg/parsers/observer_info_test.go
@@ -2,7 +2,6 @@ package parsers
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -55,5 +54,5 @@ func createObserverList(fp string, observerAddress, commonGrantAddress, validato
 	listReader = append(listReader, info)
 
 	file, _ := json.MarshalIndent(listReader, "", " ")
-	_ = ioutil.WriteFile(fp, file, 0600)
+	_ = os.WriteFile(fp, file, 0600)
 }

--- a/scripts/gen-spec.go
+++ b/scripts/gen-spec.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -215,7 +214,7 @@ func readAllFilesFromDocsSpec(docsSpecDir, moduleName string) []FileData {
 		}
 
 		// #nosec G304 -- path is validated to be within moduleDir above
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			fmt.Printf("Error reading file %q: %v\n", path, err)
 			return nil


### PR DESCRIPTION
# Description



Starting from Go 1.16, some functions in the ioutil package have been deprecated. The Go team recommends quickly switching to methods from the os or io packages instead. 

More info can see: https://github.com/golang/go/issues/45557



# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [x] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches file reads from ioutil.ReadFile to os.ReadFile in parser and spec generator.
> 
> - **Refactor**:
>   - Update file reading to `os.ReadFile` (replacing deprecated `ioutil.ReadFile`).
>     - `pkg/parsers/observer_info.go`: read observer JSON with `os.ReadFile`; adjust imports.
>     - `scripts/gen-spec.go`: read docs/spec files with `os.ReadFile`; adjust imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7789ee08c6c3fc2412087cc4cc1ef175a05efc26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal file-reading logic to use modern, supported APIs, maintaining existing behavior and error handling.
* **Chores**
  * General code maintenance to remove deprecated dependencies and align with current platform standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->