### PR TITLE
test(e2e): change gas params in localnet to match better live network

### DIFF
--- a/contrib/localnet/scripts/start-zetacored.sh
+++ b/contrib/localnet/scripts/start-zetacored.sh
@@ -252,7 +252,9 @@ then
     .app_state.emissions.params.ballot_maturity_blocks = "30" |
     .app_state.staking.params.unbonding_time = "10s" |
     .app_state.feemarket.params.min_gas_price = "10000000000.0000" |
-    .consensus.params.block.max_gas = "500000000"
+    .app_state.feemarket.params.base_fee_change_denominator = "300" |
+    .app_state.feemarket.params.elasticity_multiplier = "4" |
+    .consensus.params.block.max_gas = "30000000"
   ' "$HOME/.zetacored/config/genesis.json" > "$HOME/.zetacored/config/tmp_genesis.json" \
     && mv "$HOME/.zetacored/config/tmp_genesis.json" "$HOME/.zetacored/config/genesis.json"
 

--- a/e2e/txserver/zeta_tx_server.go
+++ b/e2e/txserver/zeta_tx_server.go
@@ -278,12 +278,11 @@ func (zts *ZetaTxServer) BroadcastTx(account string, msgs ...sdktypes.Msg) (*sdk
 			return nil, retry.Retry(err)
 		}
 
-		// increase gas and fees if multiple messages are provided
-		txBuilder.SetGasLimit(zts.txFactory.Gas() * uint64(len(msgs)))
-		txBuilder.SetFeeAmount(zts.txFactory.Fees().MulInt(sdkmath.NewInt(int64(len(msgs)))))
+		txBuilder.SetGasLimit(zts.txFactory.Gas())
+		txBuilder.SetFeeAmount(zts.txFactory.Fees())
 
 		// Sign tx
-		err = tx.Sign(context.TODO(), zts.txFactory, account, txBuilder, true)
+		err = tx.Sign(zts.ctx, zts.txFactory, account, txBuilder, true)
 		if err != nil {
 			return nil, retry.Retry(err)
 		}


### PR DESCRIPTION
# Description

Minor preliminary task for https://github.com/zeta-chain/node/issues/4246 

Ensure that we have params for gas similar to live network, (kept 30M block limit to stress the gas price more)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust localnet feemarket and block gas limits; simplify tx gas/fee calculation and use server context for signing.
> 
> - **Localnet/Genesis (`contrib/localnet/scripts/start-zetacored.sh`)**:
>   - Set `feemarket` params: `base_fee_change_denominator = "300"`, `elasticity_multiplier = "4"`.
>   - Update consensus block gas limit: `consensus.params.block.max_gas = "30000000"`.
> - **E2E Tx Server (`e2e/txserver/zeta_tx_server.go`)**:
>   - Stop scaling `gas` and `fees` by number of messages; use factory defaults per tx.
>   - Use `zts.ctx` instead of `context.TODO()` when signing transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65a744a6e02ee023427ab54b19862fd099d2669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced additional fee market parameters in genesis to improve base fee adjustment and elasticity behavior.

- Bug Fixes
  - Transactions no longer scale gas and fees with the number of messages; base gas/fees are applied consistently, preventing overpayment.

- Refactor
  - Aligned transaction signing to use the server context for improved consistency.

- Chores
  - Updated genesis configuration to reduce the default max gas, leading to smaller blocks and more predictable resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->