### PR TITLE
refactor: add `zrepo` package to zetaclient with dry-mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,10 @@ by calling `updateAdditionalActionFee` admin function.
 * [4274](https://github.com/zeta-chain/node/pull/4274) - multiple evm calls in single tx
 * [4288](https://github.com/zeta-chain/node/pull/4288) - zetaclient config feature flag for multiple evm calls
 
+### Refactor
+
+* [4296](https://github.com/zeta-chain/node/pull/4296) - add zrepo package to zetaclient
+
 ## v36.0.0
 
 ### Features

--- a/e2e/e2etests/test_ton_withdrawal_concurrent.go
+++ b/e2e/e2etests/test_ton_withdrawal_concurrent.go
@@ -27,7 +27,7 @@ func TestTONWithdrawConcurrent(r *runner.E2ERunner, _ []string) {
 
 	// Fire withdrawals. Note that zevm sender is r.ZEVMAuth
 	var wg sync.WaitGroup
-	for i := 0; i < recipientsCount; i++ {
+	for i := range recipientsCount {
 		// ARRANGE
 		// Given multiple recipients WITHOUT deployed wallet-contracts
 		// and withdrawal amounts between 1 and 5 TON

--- a/testutil/sample/crosschain.go
+++ b/testutil/sample/crosschain.go
@@ -265,7 +265,6 @@ func GetCctxIndexFromString(index string) string {
 
 func CrossChainTx(t *testing.T, index string) *types.CrossChainTx {
 	r := newRandFromStringSeed(t, index)
-
 	return &types.CrossChainTx{
 		Creator:                 AccAddress(),
 		Index:                   GetCctxIndexFromString(index),
@@ -371,6 +370,24 @@ func InboundVote(coinType coin.CoinType, from, to int64) types.MsgVoteInbound {
 		TxOrigin:    EthAddress().String(),
 		Asset:       "",
 		EventIndex:  EventIndex(),
+	}
+}
+
+func OutboundVote(t *testing.T) types.MsgVoteOutbound {
+	cctx := CrossChainTx(t, EthAddress().String())
+	return types.MsgVoteOutbound{
+		CctxHash:                          cctx.Index,
+		OutboundTssNonce:                  cctx.GetCurrentOutboundParam().TssNonce,
+		OutboundChain:                     cctx.GetCurrentOutboundParam().ReceiverChainId,
+		Status:                            chains.ReceiveStatus_success,
+		Creator:                           cctx.Creator,
+		ObservedOutboundHash:              common.BytesToHash(EthAddress().Bytes()).String(),
+		ValueReceived:                     cctx.GetCurrentOutboundParam().Amount,
+		ObservedOutboundBlockHeight:       cctx.GetCurrentOutboundParam().ObservedExternalHeight,
+		ObservedOutboundEffectiveGasPrice: cctx.GetCurrentOutboundParam().EffectiveGasPrice,
+		ObservedOutboundGasUsed:           cctx.GetCurrentOutboundParam().GasUsed,
+		CoinType:                          cctx.InboundParams.CoinType,
+		ConfirmationMode:                  cctx.GetCurrentOutboundParam().ConfirmationMode,
 	}
 }
 
@@ -493,27 +510,6 @@ func CCTXfromRand(r *rand.Rand,
 		ProtocolContractVersion: ProtocolVersionFromRand(r),
 	}
 	return cctx
-}
-
-func OutboundVoteSim(r *rand.Rand,
-	cctx types.CrossChainTx,
-) (types.CrossChainTx, types.MsgVoteOutbound) {
-	msg := types.MsgVoteOutbound{
-		CctxHash:                          cctx.Index,
-		OutboundTssNonce:                  cctx.GetCurrentOutboundParam().TssNonce,
-		OutboundChain:                     cctx.GetCurrentOutboundParam().ReceiverChainId,
-		Status:                            chains.ReceiveStatus_success,
-		Creator:                           cctx.Creator,
-		ObservedOutboundHash:              common.BytesToHash(EthAddressFromRand(r).Bytes()).String(),
-		ValueReceived:                     cctx.GetCurrentOutboundParam().Amount,
-		ObservedOutboundBlockHeight:       cctx.GetCurrentOutboundParam().ObservedExternalHeight,
-		ObservedOutboundEffectiveGasPrice: cctx.GetCurrentOutboundParam().EffectiveGasPrice,
-		ObservedOutboundGasUsed:           cctx.GetCurrentOutboundParam().GasUsed,
-		CoinType:                          cctx.InboundParams.CoinType,
-		ConfirmationMode:                  cctx.GetCurrentOutboundParam().ConfirmationMode,
-	}
-
-	return cctx, msg
 }
 
 func ZRC20Withdrawal(to []byte, value *big.Int) *zrc20.ZRC20Withdrawal {

--- a/zetaclient/chains/base/confirmation.go
+++ b/zetaclient/chains/base/confirmation.go
@@ -3,9 +3,6 @@ package base
 import (
 	"context"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
-
 	"github.com/zeta-chain/node/pkg/chains"
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 )
@@ -77,9 +74,9 @@ func (ob *Observer) IsInboundEligibleForFastConfirmation(
 
 	// query liquidity cap for asset
 	chainID := msg.SenderChainId
-	fCoins, err := ob.zetacoreClient.GetForeignCoinsFromAsset(ctx, chainID, ethcommon.HexToAddress(msg.Asset))
+	fCoins, err := ob.ZetaRepo().GetForeignCoinsFromAsset(ctx, msg.Asset)
 	if err != nil {
-		return false, errors.Wrapf(err, "unable to get foreign coins for asset %s on chain %d", msg.Asset, chainID)
+		return false, err
 	}
 
 	// ensure the deposit amount does not exceed amount cap

--- a/zetaclient/chains/base/confirmation_test.go
+++ b/zetaclient/chains/base/confirmation_test.go
@@ -14,6 +14,7 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 )
 
 func Test_GetScanRangeInboundSafe(t *testing.T) {
@@ -367,7 +368,7 @@ func Test_IsInboundEligibleForFastConfirmation(t *testing.T) {
 			},
 			failForeignCoinsRPC: true,
 			eligible:            false,
-			errMsg:              "unable to get foreign coins",
+			errMsg:              zrepo.ErrClientGetForeignCoinsForAsset.Error(),
 		},
 		{
 			name:       "not eligible if amount exceeds fast amount cap",
@@ -391,11 +392,15 @@ func Test_IsInboundEligibleForFastConfirmation(t *testing.T) {
 			// mock up the foreign coins RPC
 			assetAddress := ethcommon.HexToAddress(tt.msg.Asset)
 			if tt.failForeignCoinsRPC {
-				ob.zetacore.On("GetForeignCoinsFromAsset", mock.Anything, chain.ChainId, assetAddress).
+				ob.zetacore.
+					On("GetForeignCoinsFromAsset", mock.Anything, chain.ChainId, assetAddress).
 					Maybe().
 					Return(fungibletypes.ForeignCoins{}, errors.New("rpc failed"))
 			} else {
-				ob.zetacore.On("GetForeignCoinsFromAsset", mock.Anything, chain.ChainId, assetAddress).Maybe().Return(fungibletypes.ForeignCoins{LiquidityCap: liquidityCap}, nil)
+				ob.zetacore.
+					On("GetForeignCoinsFromAsset", mock.Anything, chain.ChainId, assetAddress).
+					Maybe().
+					Return(fungibletypes.ForeignCoins{LiquidityCap: liquidityCap}, nil)
 			}
 
 			// ACT

--- a/zetaclient/chains/bitcoin/bitcoin.go
+++ b/zetaclient/chains/bitcoin/bitcoin.go
@@ -47,9 +47,9 @@ func (b *Bitcoin) Start(ctx context.Context) error {
 		return errors.Wrap(err, "unable to get app from context")
 	}
 
-	newBlockChan, err := b.observer.ZetacoreClient().NewBlockSubscriber(ctx)
+	newBlockChan, err := b.observer.ZetaRepo().WatchNewBlocks(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to create new block subscriber")
+		return err
 	}
 
 	optInboundInterval := scheduler.IntervalUpdater(func() time.Duration {
@@ -141,9 +141,9 @@ func (b *Bitcoin) scheduleCCTX(ctx context.Context) error {
 	// #nosec G115 positive
 	scheduleInterval := uint64(b.observer.ChainParams().OutboundScheduleInterval)
 
-	cctxList, _, err := b.observer.ZetacoreClient().ListPendingCCTX(ctx, chain)
+	cctxList, err := b.observer.ZetaRepo().GetPendingCCTXs(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to list pending cctx")
+		return err
 	}
 
 	// schedule at most one keysign per ticker

--- a/zetaclient/chains/bitcoin/observer/db_test.go
+++ b/zetaclient/chains/bitcoin/observer/db_test.go
@@ -29,7 +29,6 @@ func Test_SaveBroadcastedTx(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// ARRANGE
 			// test data

--- a/zetaclient/chains/bitcoin/observer/gas_price.go
+++ b/zetaclient/chains/bitcoin/observer/gas_price.go
@@ -48,11 +48,8 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 	const priorityFee = 0
 
 	// #nosec G115 always positive
-	_, err = ob.ZetacoreClient().
-		PostVoteGasPrice(ctx, ob.Chain(), feeRateEstimated, priorityFee, uint64(blockNumber))
-	if err != nil {
-		return errors.Wrap(err, "PostVoteGasPrice error")
-	}
-
-	return nil
+	block := uint64(blockNumber)
+	logger := ob.Logger().Chain
+	_, err = ob.ZetaRepo().VoteGasPrice(ctx, logger, feeRateEstimated, priorityFee, block)
+	return err
 }

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -123,10 +123,14 @@ func (ob *Observer) observeInboundInBlockRange(ctx context.Context, startBlock, 
 					}
 				}
 
-				_, err = ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+				_, err = ob.ZetaRepo().VoteInbound(ctx,
+					ob.logger.Inbound,
+					msg,
+					zetacore.PostVoteInboundExecutionGasLimit,
+				)
 				if err != nil {
 					// we have to re-scan this block next time
-					return blockNumber - 1, errors.Wrapf(err, "error posting inbound vote for tx %s", event.TxHash)
+					return blockNumber - 1, errors.Wrapf(err, " (tx %s)", event.TxHash)
 				}
 			}
 		}
@@ -238,12 +242,12 @@ func (ob *Observer) NewInboundVoteFromLegacyMemo(
 	}
 
 	return crosschaintypes.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		event.FromAddress,
 		ob.Chain().ChainId,
 		event.FromAddress,
 		event.ToAddress,
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		cosmosmath.NewUintFromBigInt(amountSats),
 		hex.EncodeToString(event.MemoBytes),
 		event.TxHash,
@@ -283,12 +287,12 @@ func (ob *Observer) NewInboundVoteFromStdMemo(
 	}
 
 	return crosschaintypes.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		event.FromAddress,
 		ob.Chain().ChainId,
 		event.FromAddress,
 		event.MemoStd.Receiver.Hex(),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		cosmosmath.NewUintFromBigInt(amountSats),
 		hex.EncodeToString(event.MemoStd.Payload),
 		event.TxHash,

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -247,7 +247,7 @@ func Test_NewInboundVoteFromLegacyMemo(t *testing.T) {
 			SenderChainId:      chain.ChainId,
 			TxOrigin:           event.FromAddress,
 			Receiver:           event.ToAddress,
-			ReceiverChain:      ob.ZetacoreClient().Chain().ChainId,
+			ReceiverChain:      ob.ZetaRepo().ZetaChain().ChainId,
 			Amount:             cosmosmath.NewUint(amountSats.Uint64()),
 			Message:            hex.EncodeToString(event.MemoBytes),
 			InboundHash:        event.TxHash,
@@ -308,7 +308,7 @@ func Test_NewInboundVoteFromStdMemo(t *testing.T) {
 			SenderChainId:      chain.ChainId,
 			TxOrigin:           event.FromAddress,
 			Receiver:           event.MemoStd.Receiver.Hex(),
-			ReceiverChain:      ob.ZetacoreClient().Chain().ChainId,
+			ReceiverChain:      ob.ZetaRepo().ZetaChain().ChainId,
 			Amount:             cosmosmath.NewUint(amountSats.Uint64()),
 			Message:            hex.EncodeToString(memoBytesExpected), // a simulated legacy memo
 			InboundHash:        event.TxHash,

--- a/zetaclient/chains/bitcoin/observer/inbound_tracker.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_tracker.go
@@ -14,7 +14,7 @@ import (
 
 // ProcessInboundTrackers processes inbound trackers
 func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
-	trackers, err := ob.ZetacoreClient().GetInboundTrackersForChain(ctx, ob.Chain().ChainId)
+	trackers, err := ob.ZetaRepo().GetInboundTrackers(ctx)
 	if err != nil {
 		return err
 	}
@@ -58,9 +58,9 @@ func (ob *Observer) CheckReceiptForBtcTxHash(ctx context.Context, txHash string,
 		return "", fmt.Errorf("block %d has no transactions", blockVb.Height)
 	}
 
-	tss, err := ob.ZetacoreClient().GetBTCTSSAddress(ctx, ob.Chain().ChainId)
+	tss, err := ob.ZetaRepo().GetBTCTSSAddress(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "error getting btc tss address for chain %d", ob.Chain().ChainId)
+		return "", err
 	}
 
 	// check confirmation
@@ -97,5 +97,9 @@ func (ob *Observer) CheckReceiptForBtcTxHash(ctx context.Context, txHash string,
 		return msg.Digest(), nil
 	}
 
-	return ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+	return ob.ZetaRepo().VoteInbound(ctx,
+		ob.logger.Inbound,
+		msg,
+		zetacore.PostVoteInboundExecutionGasLimit,
+	)
 }

--- a/zetaclient/chains/bitcoin/observer/mempool.go
+++ b/zetaclient/chains/bitcoin/observer/mempool.go
@@ -133,9 +133,9 @@ func (ob *Observer) getLastPendingOutbound(ctx context.Context) (tx *btcutil.Tx,
 
 	// source 2:
 	// pick highest nonce tx from broadcasted txs
-	p, err := ob.ZetacoreClient().GetPendingNoncesByChain(ctx, ob.Chain().ChainId)
+	p, err := ob.ZetaRepo().GetPendingNonces(ctx)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "GetPendingNoncesByChain failed")
+		return nil, 0, err
 	}
 
 	// #nosec G115 always in range

--- a/zetaclient/chains/bitcoin/observer/mempool_test.go
+++ b/zetaclient/chains/bitcoin/observer/mempool_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/testutil/sample"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/testutils"
 )
 
@@ -199,7 +200,7 @@ func Test_GetLastPendingOutbound(t *testing.T) {
 			includeTx:     false,
 			expectedTx:    nil,
 			expectedNonce: 0,
-			errMsg:        "GetPendingNoncesByChain failed",
+			errMsg:        zrepo.ErrClientGetPendingNonces.Error(),
 		},
 		{
 			name:         "return error if no last tx found",

--- a/zetaclient/chains/bitcoin/observer/observer_test.go
+++ b/zetaclient/chains/bitcoin/observer/observer_test.go
@@ -44,7 +44,7 @@ func setupDBTxResults(t *testing.T) (*gorm.DB, map[string]btcjson.GetTransaction
 	require.NoError(t, err)
 
 	//Create some Transaction entries in the DB
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		txResult := btcjson.GetTransactionResult{
 			Amount:          float64(i),
 			Fee:             0,
@@ -145,13 +145,12 @@ func Test_NewObserver(t *testing.T) {
 			baseObserver, err := base.NewObserver(
 				tt.chain,
 				tt.chainParams,
-				tt.zetacoreClient,
+				zrepo.New(tt.zetacoreClient, tt.chain, mode.StandardMode),
 				tt.tssSigner,
 				100,
 				tt.ts,
 				database,
 				tt.logger,
-				mode.StandardMode,
 			)
 			require.NoError(t, err)
 
@@ -327,13 +326,12 @@ func newTestSuite(t *testing.T, chain chains.Chain, opts ...opt) *testSuite {
 	baseObserver, err := base.NewObserver(
 		chain,
 		chainParams,
-		zetacore,
+		zrepo.New(zetacore, chain, mode.StandardMode),
 		tssSigner,
 		100,
 		&metrics.TelemetryServer{},
 		database,
 		baseLogger,
-		mode.StandardMode,
 	)
 	require.NoError(t, err)
 

--- a/zetaclient/chains/bitcoin/observer/outbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/outbound_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcjson"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/mode"
 
@@ -38,26 +38,13 @@ func MockBTCObserverMainnet(t *testing.T, tssSigner interfaces.TSSSigner) *Obser
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 	baseLogger := base.Logger{Std: logger, Compliance: logger}
 
-	baseObserver, err := base.NewObserver(chain, params, nil, tssSigner, 100, nil, database,
-		baseLogger, mode.StandardMode)
+	baseObserver, err := base.NewObserver(chain, params, zrepo.New(nil, chain, mode.StandardMode),
+		tssSigner, 100, nil, database, baseLogger)
 	require.NoError(t, err)
 
 	// create Bitcoin observer
 	ob, err := New(baseObserver, btcClient, chain)
 	require.NoError(t, err)
-
-	return ob
-}
-
-// helper function to create a test Bitcoin observer
-func createObserverWithPrivateKey(t *testing.T) *Observer {
-	skHex := "7b8507ba117e069f4a3f456f505276084f8c92aee86ac78ae37b4d1801d35fa8"
-	privateKey, err := crypto.HexToECDSA(skHex)
-	require.NoError(t, err)
-	tss := mocks.NewTSSFromPrivateKey(t, privateKey)
-
-	// create Bitcoin observer with mock tss
-	ob := MockBTCObserverMainnet(t, tss)
 
 	return ob
 }

--- a/zetaclient/chains/bitcoin/observer/utxos_test.go
+++ b/zetaclient/chains/bitcoin/observer/utxos_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"golang.org/x/exp/rand"
 
 	"github.com/zeta-chain/node/pkg/chains"
@@ -45,7 +46,9 @@ func Test_SelectUTXOs(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, selected.UTXOs)
 		require.Zero(t, selected.Value)
-		require.ErrorContains(t, err, "error getting cctx for nonce 0")
+		require.ErrorIs(t, err, zrepo.ErrClient)
+		require.ErrorIs(t, err, zrepo.ErrClientGetCCTX)
+		require.ErrorContains(t, err, "for nonce 0")
 	})
 
 	t.Run("nonce = 1, should pass when nonce mark 0 is set", func(t *testing.T) {

--- a/zetaclient/chains/bitcoin/signer/signer.go
+++ b/zetaclient/chains/bitcoin/signer/signer.go
@@ -106,11 +106,11 @@ func (signer *Signer) TryProcessOutbound(
 		logs.FieldCctxIndex: cctx.Index,
 		logs.FieldNonce:     params.TssNonce,
 	}
-	signerAddress, err := observer.ZetacoreClient().GetKeys().GetAddress()
+	signerAddress, err := observer.ZetaRepo().GetKeysAddress()
 	if err != nil {
 		return
 	}
-	lf["signer"] = signerAddress.String()
+	lf["signer"] = signerAddress
 	logger := signer.Logger().Std.With().Fields(lf).Logger()
 
 	// query network info to get minRelayFee (typically 1000 satoshis)
@@ -211,14 +211,7 @@ func (signer *Signer) BroadcastOutbound(
 	}
 
 	// add tx to outbound tracker so that all observers know about it
-	zetaHash, err := ob.ZetacoreClient().PostOutboundTracker(ctx, ob.Chain().ChainId, nonce, txHash)
-	if err != nil {
-		logger.Err(err).Msg("unable to add Bitcoin outbound tracker")
-	} else {
-		logger.Info().
-			Str(logs.FieldZetaTx, zetaHash).
-			Msg("add Bitcoin outbound tracker successfully")
-	}
+	_, _ = ob.ZetaRepo().PostOutboundTracker(ctx, logger, nonce, txHash)
 
 	// try including this outbound as early as possible, no need to wait for outbound tracker
 	_, included := ob.TryIncludeOutbound(ctx, cctx, txHash)

--- a/zetaclient/chains/bitcoin/signer/signer_test.go
+++ b/zetaclient/chains/bitcoin/signer/signer_test.go
@@ -22,6 +22,7 @@ import (
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/observer"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/config"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/db"
@@ -373,8 +374,10 @@ func (s *testSuite) createObserver(t *testing.T) {
 	baseLogger := base.Logger{Std: logger.Logger, Compliance: logger.Logger}
 
 	// create observer
-	baseObserver, err := base.NewObserver(s.Chain(), params, s.zetacoreClient, s.tss, 100, ts,
-		database, baseLogger, mode.StandardMode)
+	chain := s.Chain()
+	zetaRepo := zrepo.New(s.zetacoreClient, chain, mode.StandardMode)
+	baseObserver, err := base.NewObserver(chain, params, zetaRepo, s.tss, 100, ts, database,
+		baseLogger)
 	require.NoError(t, err)
 
 	s.observer, err = observer.New(baseObserver, s.client, s.Chain())

--- a/zetaclient/chains/evm/observer/inbound.go
+++ b/zetaclient/chains/evm/observer/inbound.go
@@ -36,7 +36,7 @@ import (
 
 // ProcessInboundTrackers observes inbound trackers from zetacore
 func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
-	trackers, err := ob.ZetacoreClient().GetInboundTrackersForChain(ctx, ob.Chain().ChainId)
+	trackers, err := ob.ZetaRepo().GetInboundTrackers(ctx)
 	if err != nil {
 		return err
 	}
@@ -332,9 +332,9 @@ func (ob *Observer) observeZetaSent(
 		}
 
 		const gasLimit = zetacore.PostVoteInboundMessagePassingExecutionGasLimit
-		if _, err = ob.PostVoteInbound(ctx, msg, gasLimit); err != nil {
-			// we have to re-scan from this block next time
-			return beingScanned - 1, errors.Wrap(err, "error posting inbound vote")
+		_, err = ob.ZetaRepo().VoteInbound(ctx, ob.Logger().Inbound, msg, gasLimit)
+		if err != nil {
+			return beingScanned - 1, err // we have to re-scan from this block next time
 		}
 	}
 
@@ -414,10 +414,11 @@ func (ob *Observer) observeERC20Deposited(
 
 		msg := ob.buildInboundVoteMsgForDepositedEvent(event, sender)
 		if msg != nil {
-			_, err = ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+			_, err = ob.ZetaRepo().VoteInbound(ctx, ob.Logger().Inbound,
+				msg, zetacore.PostVoteInboundExecutionGasLimit)
 			if err != nil {
 				// we have to re-scan from this block next time
-				return beingScanned - 1, errors.Wrap(err, "error posting inbound vote")
+				return beingScanned - 1, err
 			}
 		}
 	}
@@ -496,7 +497,11 @@ func (ob *Observer) checkAndVoteInboundTokenZeta(
 		return "", nil
 	}
 	if vote {
-		return ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundMessagePassingExecutionGasLimit)
+		return ob.ZetaRepo().VoteInbound(ctx,
+			ob.Logger().Inbound,
+			msg,
+			zetacore.PostVoteInboundMessagePassingExecutionGasLimit,
+		)
 	}
 
 	return msg.Digest(), nil
@@ -552,7 +557,11 @@ func (ob *Observer) checkAndVoteInboundTokenERC20(
 		return "", nil
 	}
 	if vote {
-		return ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+		return ob.ZetaRepo().VoteInbound(ctx,
+			ob.Logger().Inbound,
+			msg,
+			zetacore.PostVoteInboundExecutionGasLimit,
+		)
 	}
 
 	return msg.Digest(), nil
@@ -593,7 +602,11 @@ func (ob *Observer) checkAndVoteInboundTokenGas(
 		return "", nil
 	}
 	if vote {
-		return ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+		return ob.ZetaRepo().VoteInbound(ctx,
+			ob.Logger().Inbound,
+			msg,
+			zetacore.PostVoteInboundExecutionGasLimit,
+		)
 	}
 
 	return msg.Digest(), nil
@@ -646,7 +659,7 @@ func (ob *Observer) buildInboundVoteMsgForDepositedEvent(
 		ob.Chain().ChainId,
 		"",
 		clienttypes.BytesToEthHex(event.Recipient),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		sdkmath.NewUintFromBigInt(event.Amount),
 		hex.EncodeToString(event.Message),
 		event.Raw.TxHash.Hex(),
@@ -654,7 +667,7 @@ func (ob *Observer) buildInboundVoteMsgForDepositedEvent(
 		1_500_000,
 		coin.CoinType_ERC20,
 		event.Asset.String(),
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		uint64(event.Raw.Index),
 		types.InboundStatus_SUCCESS,
 	)
@@ -718,7 +731,7 @@ func (ob *Observer) buildInboundVoteMsgForZetaSentEvent(
 		event.DestinationGasLimit.Uint64(),
 		coin.CoinType_Zeta,
 		"",
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		uint64(event.Raw.Index),
 		types.InboundStatus_SUCCESS,
 	)
@@ -767,7 +780,7 @@ func (ob *Observer) buildInboundVoteMsgForTokenSentToTSS(
 		ob.Chain().ChainId,
 		sender.Hex(),
 		sender.Hex(),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		sdkmath.NewUintFromBigInt(tx.Value),
 		message,
 		tx.Hash,
@@ -775,7 +788,7 @@ func (ob *Observer) buildInboundVoteMsgForTokenSentToTSS(
 		90_000,
 		coin.CoinType_Gas,
 		"",
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		0, // not a smart contract call
 		types.InboundStatus_SUCCESS,
 	)

--- a/zetaclient/chains/evm/observer/inbound_test.go
+++ b/zetaclient/chains/evm/observer/inbound_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 func Test_CheckAndVoteInboundTokenZeta(t *testing.T) {
@@ -460,7 +462,8 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 				m.On("BlockByNumberCustom", mock.Anything, mock.Anything).Return(block, nil)
 			},
 			mockZetacoreClient: func(m *mocks.ZetacoreClient) {
-				m.On("GetCctxByHash", mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
+				err := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+				m.On("GetCctxByHash", mock.Anything, mock.Anything).Return(nil, err)
 			},
 			errMsg: "",
 		},
@@ -497,7 +500,6 @@ func Test_ObserveTSSReceiveInBlock(t *testing.T) {
 			if tt.mockEVMClient != nil {
 				tt.mockEVMClient(ob.evmMock)
 			}
-
 			if tt.mockZetacoreClient != nil {
 				tt.mockZetacoreClient(ob.zetacore)
 			}

--- a/zetaclient/chains/evm/observer/observer_gas.go
+++ b/zetaclient/chains/evm/observer/observer_gas.go
@@ -34,15 +34,9 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 		return errors.Wrap(err, "unable to get block number")
 	}
 
-	_, err = ob.
-		ZetacoreClient().
-		PostVoteGasPrice(ctx, ob.Chain(), gasPrice.Uint64(), priorityFee, blockNum)
-
-	if err != nil {
-		return errors.Wrap(err, "unable to post vote for gas price")
-	}
-
-	return nil
+	logger := ob.Logger().Chain
+	_, err = ob.ZetaRepo().VoteGasPrice(ctx, logger, gasPrice.Uint64(), priorityFee, blockNum)
+	return err
 }
 
 // DeterminePriorityFee determines the chain priority fee.

--- a/zetaclient/chains/evm/observer/observer_test.go
+++ b/zetaclient/chains/evm/observer/observer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/node/pkg/ptr"
 	"github.com/zeta-chain/node/zetaclient/chains/evm/client"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/keys"
@@ -187,13 +188,12 @@ func Test_NewObserver(t *testing.T) {
 			baseObserver, err := base.NewObserver(
 				chain,
 				tt.chainParams,
-				zetacoreClient,
+				zrepo.New(zetacoreClient, chain, mode.StandardMode),
 				tt.tssSigner,
 				1000,
 				tt.ts,
 				database,
 				tt.logger,
-				mode.StandardMode,
 			)
 			require.NoError(t, err)
 			ob, err := New(baseObserver, tt.evmClient)
@@ -431,8 +431,8 @@ func newTestSuite(t *testing.T, opts ...func(*testSuiteConfig)) *testSuite {
 	log := zerolog.New(zerolog.NewTestWriter(t)).With().Caller().Logger()
 	logger := base.Logger{Std: log, Compliance: log}
 
-	baseObserver, err := base.NewObserver(chain, chainParams, zetacore, tss, 1000, nil, database,
-		logger, mode.StandardMode)
+	baseObserver, err := base.NewObserver(chain, chainParams,
+		zrepo.New(zetacore, chain, mode.StandardMode), tss, 1000, nil, database, logger)
 	require.NoError(t, err)
 
 	ob, err := New(baseObserver, evmMock)

--- a/zetaclient/chains/evm/observer/v2_inbound.go
+++ b/zetaclient/chains/evm/observer/v2_inbound.go
@@ -104,10 +104,14 @@ func (ob *Observer) observeGatewayDeposit(
 			}
 		}
 
-		_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
+		_, err = ob.ZetaRepo().VoteInbound(ctx,
+			ob.Logger().Inbound,
+			&msg,
+			zetacore.PostVoteInboundExecutionGasLimit,
+		)
 		if err != nil {
 			// decrement the last scanned block so we have to re-scan from this block next time
-			return lastScanned - 1, errors.Wrap(err, "error posting vote inbound")
+			return lastScanned - 1, err
 		}
 	}
 
@@ -188,12 +192,12 @@ func (ob *Observer) newDepositInboundVote(event *gatewayevm.GatewayEVMDeposited)
 	}
 
 	return *types.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		event.Sender.Hex(),
 		ob.Chain().ChainId,
 		"",
 		event.Receiver.Hex(),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		sdkmath.NewUintFromBigInt(event.Amount),
 		hex.EncodeToString(event.Payload),
 		event.Raw.TxHash.Hex(),
@@ -247,9 +251,13 @@ func (ob *Observer) observeGatewayCall(
 			Str("message", hex.EncodeToString(event.Payload)).
 			Msg("inbound detected (Call)")
 
-		_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
+		_, err = ob.ZetaRepo().VoteInbound(ctx,
+			ob.Logger().Inbound,
+			&msg,
+			zetacore.PostVoteInboundExecutionGasLimit,
+		)
 		if err != nil {
-			return lastScanned - 1, errors.Wrap(err, "error posting vote inbound")
+			return lastScanned - 1, err
 		}
 	}
 
@@ -320,12 +328,12 @@ func (ob *Observer) parseAndValidateCallEvents(
 // newCallInboundVote creates a MsgVoteInbound message for a Call event
 func (ob *Observer) newCallInboundVote(event *gatewayevm.GatewayEVMCalled) types.MsgVoteInbound {
 	return *types.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		event.Sender.Hex(),
 		ob.Chain().ChainId,
 		"",
 		event.Receiver.Hex(),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		sdkmath.ZeroUint(),
 		hex.EncodeToString(event.Payload),
 		event.Raw.TxHash.Hex(),
@@ -379,10 +387,14 @@ func (ob *Observer) observeGatewayDepositAndCall(
 			Str("message", hex.EncodeToString(event.Payload)).
 			Msg("inbound detected (DepositAndCall)")
 
-		_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
+		_, err = ob.ZetaRepo().VoteInbound(ctx,
+			ob.Logger().Inbound,
+			&msg,
+			zetacore.PostVoteInboundExecutionGasLimit,
+		)
 		if err != nil {
 			// decrement the last scanned block so we have to re-scan from this block next time
-			return lastScanned - 1, errors.Wrap(err, "error posting vote inbound")
+			return lastScanned - 1, err
 		}
 	}
 
@@ -456,12 +468,12 @@ func (ob *Observer) newDepositAndCallInboundVote(event *gatewayevm.GatewayEVMDep
 	coinType := determineCoinType(event.Asset, ob.ChainParams().ZetaTokenContractAddress)
 
 	return *types.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		event.Sender.Hex(),
 		ob.Chain().ChainId,
 		"",
 		event.Receiver.Hex(),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		sdkmath.NewUintFromBigInt(event.Amount),
 		hex.EncodeToString(event.Payload),
 		event.Raw.TxHash.Hex(),

--- a/zetaclient/chains/evm/observer/v2_inbound_tracker.go
+++ b/zetaclient/chains/evm/observer/v2_inbound_tracker.go
@@ -66,7 +66,11 @@ func (ob *Observer) ProcessInboundTrackerV2(
 				return fmt.Errorf("event from inbound tracker %s is not processable", tx.Hash)
 			}
 			msg := ob.newDepositInboundVote(eventDeposit)
-			_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
+			_, err = ob.ZetaRepo().VoteInbound(ctx,
+				ob.Logger().Inbound,
+				&msg,
+				zetacore.PostVoteInboundExecutionGasLimit,
+			)
 			if err != nil || !allowMultipleCalls {
 				return err
 			}
@@ -87,7 +91,11 @@ func (ob *Observer) ProcessInboundTrackerV2(
 				return fmt.Errorf("event from inbound tracker %s is not processable", tx.Hash)
 			}
 			msg := ob.newDepositAndCallInboundVote(eventDepositAndCall)
-			_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
+			_, err = ob.ZetaRepo().VoteInbound(ctx,
+				ob.Logger().Inbound,
+				&msg,
+				zetacore.PostVoteInboundExecutionGasLimit,
+			)
 			if err != nil || !allowMultipleCalls {
 				return err
 			}
@@ -108,7 +116,11 @@ func (ob *Observer) ProcessInboundTrackerV2(
 				return fmt.Errorf("event from inbound tracker %s is not processable", tx.Hash)
 			}
 			msg := ob.newCallInboundVote(eventCall)
-			_, err = ob.PostVoteInbound(ctx, &msg, zetacore.PostVoteInboundExecutionGasLimit)
+			_, err = ob.ZetaRepo().VoteInbound(ctx,
+				ob.Logger().Inbound,
+				&msg,
+				zetacore.PostVoteInboundExecutionGasLimit,
+			)
 			if err != nil || !allowMultipleCalls {
 				return err
 			}

--- a/zetaclient/chains/evm/signer/outbound_tracker_reporter.go
+++ b/zetaclient/chains/evm/signer/outbound_tracker_reporter.go
@@ -18,7 +18,7 @@ import (
 // reportToOutboundTracker reports outboundHash to tracker only when tx receipt is available
 func (signer *Signer) reportToOutboundTracker(
 	ctx context.Context,
-	zetacoreClient zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 	chainID int64,
 	nonce uint64,
 	outboundHash string,
@@ -65,9 +65,9 @@ func (signer *Signer) reportToOutboundTracker(
 			// stop if the CCTX is already finalized for optimization purposes:
 			// 1. all monitoring goroutines should stop and release resources if the CCTX is finalized
 			// 2. especially reduces the lifetime of goroutines that monitor "nonce too low" tx hashes
-			cctx, err := zetacoreClient.GetCctxByNonce(ctx, chainID, nonce)
+			cctx, err := zetaRepo.GetCCTX(ctx, nonce)
 			if err != nil {
-				logger.Err(err).Msg("unable to query CCTX from Zetacore")
+				logger.Err(err).Send()
 			} else if !crosschainkeeper.IsPending(cctx) {
 				logger.Info().Msg("CCTX is already finalized")
 				return nil
@@ -84,13 +84,10 @@ func (signer *Signer) reportToOutboundTracker(
 			}
 
 			// report outbound hash to tracker
-			zetaHash, err := zetacoreClient.PostOutboundTracker(ctx, chainID, nonce, outboundHash)
-			if err != nil {
-				logger.Err(err).Msg("error adding outbound to tracker")
-			} else if zetaHash != "" {
-				logger.Info().Str(logs.FieldZetaTx, zetaHash).Msg("added outbound to tracker")
-			} else {
-				// exit goroutine until the tracker contains the hash (reported by either this or other signers)
+			zhash, err := zetaRepo.PostOutboundTracker(ctx, logger, nonce, outboundHash)
+			if zhash == "" && err == nil {
+				// exit goroutine only when the tracker contains the hash (reported by either this
+				// or other signers)
 				logger.Info().Msg("outbound now exists in tracker")
 				return nil
 			}

--- a/zetaclient/chains/evm/signer/signer_test.go
+++ b/zetaclient/chains/evm/signer/signer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	"github.com/zeta-chain/node/zetaclient/chains/evm/client"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/keys"
 	"github.com/zeta-chain/node/zetaclient/mode"
@@ -150,13 +151,14 @@ func TestSigner_TryProcessOutbound(t *testing.T) {
 		WithKeys(&keys.Keys{}).
 		WithZetaChain().
 		WithPostVoteOutbound("", "")
+	zetaRepo := zrepo.New(client, chains.Ethereum, mode.StandardMode)
 
 	// mock evm client "NonceAt"
 	nonce := uint64(123)
 	evmSigner.evmServer.MockNonceAt(nonce)
 
 	// ACT
-	evmSigner.TryProcessOutbound(ctx, cctx, client, nonce)
+	evmSigner.TryProcessOutbound(ctx, cctx, zetaRepo, nonce)
 
 	// ASSERT
 	// Check if cctx was signed and broadcasted
@@ -190,7 +192,7 @@ func TestSigner_BroadcastOutbound(t *testing.T) {
 			tx,
 			cctx,
 			zerolog.Logger{},
-			mocks.NewZetacoreClient(t),
+			zrepo.New(mocks.NewZetacoreClient(t), chains.Ethereum, mode.StandardMode),
 			txData,
 		)
 

--- a/zetaclient/chains/solana/observer/inbound.go
+++ b/zetaclient/chains/solana/observer/inbound.go
@@ -126,9 +126,13 @@ func (ob *Observer) VoteInboundEvents(ctx context.Context, events []*clienttypes
 	for _, event := range events {
 		msg := ob.BuildInboundVoteMsgFromEvent(event)
 		if msg != nil {
-			_, err := ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+			_, err := ob.ZetaRepo().VoteInbound(ctx,
+				ob.Logger().Inbound,
+				msg,
+				zetacore.PostVoteInboundExecutionGasLimit,
+			)
 			if err != nil {
-				return errors.Wrapf(err, "error PostVoteInbound")
+				return err
 			}
 		}
 	}
@@ -178,12 +182,12 @@ func (ob *Observer) BuildInboundVoteMsgFromEvent(event *clienttypes.InboundEvent
 
 	// create inbound vote message
 	return crosschaintypes.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		event.Sender,
 		event.SenderChainID,
 		event.Sender,
 		event.Receiver,
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		cosmosmath.NewUint(event.Amount),
 		hex.EncodeToString(event.Memo),
 		event.TxHash,

--- a/zetaclient/chains/solana/observer/inbound_test.go
+++ b/zetaclient/chains/solana/observer/inbound_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zeta-chain/node/testutil/sample"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/solana/observer"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/keys"
@@ -43,23 +44,24 @@ func Test_FilterInboundEventAndVote(t *testing.T) {
 	chainParams := sample.ChainParams(chain.ChainId)
 	chainParams.GatewayAddress = testutils.OldSolanaGatewayAddressDevnet
 	zetacoreClient := mocks.NewZetacoreClient(t)
-	zetacoreClient.WithKeys(&keys.Keys{}).WithZetaChain().WithPostVoteInbound("", "")
+	zetacoreClient.
+		WithKeys(&keys.Keys{OperatorAddress: []byte("something")}).
+		WithZetaChain().
+		WithPostVoteInbound("", "")
 
-	zetacoreClient.MockGetCctxByHash(nil)
-	zetacoreClient.WithPostVoteInbound(sample.ZetaIndex(t), mock.Anything)
-	zetacoreClient.MockGetCctxByHash(nil)
+	zetacoreClient.MockGetCctxByHash("anything", nil)
 	zetacoreClient.MockGetBallotByID(mock.Anything, nil)
+	zetacoreClient.WithPostVoteInbound(sample.ZetaIndex(t), mock.Anything)
 
 	baseObserver, err := base.NewObserver(
 		chain,
 		*chainParams,
-		zetacoreClient,
+		zrepo.New(zetacoreClient, chain, mode.StandardMode),
 		nil,
 		1000,
 		nil,
 		database,
 		base.DefaultLogger(),
-		mode.StandardMode,
 	)
 	require.NoError(t, err)
 
@@ -192,13 +194,12 @@ func Test_BuildInboundVoteMsgFromEvent(t *testing.T) {
 	baseObserver, err := base.NewObserver(
 		chain,
 		*params,
-		zetacoreClient,
+		zrepo.New(zetacoreClient, chain, mode.StandardMode),
 		nil,
 		1000,
 		nil,
 		database,
 		base.DefaultLogger(),
-		mode.StandardMode,
 	)
 	require.NoError(t, err)
 

--- a/zetaclient/chains/solana/observer/inbound_tracker.go
+++ b/zetaclient/chains/solana/observer/inbound_tracker.go
@@ -12,7 +12,7 @@ import (
 // ProcessInboundTrackers processes inbound trackers
 func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
 	chainID := ob.Chain().ChainId
-	trackers, err := ob.ZetacoreClient().GetInboundTrackersForChain(ctx, chainID)
+	trackers, err := ob.ZetaRepo().GetInboundTrackers(ctx)
 	if err != nil {
 		return err
 	}

--- a/zetaclient/chains/solana/observer/observer_gas.go
+++ b/zetaclient/chains/solana/observer/observer_gas.go
@@ -54,10 +54,8 @@ func (ob *Observer) PostGasPrice(ctx context.Context) error {
 	medianFee := zetamath.SliceMedianValue(priorityFees, true)
 
 	// there is no Ethereum-like gas price in Solana, we only post priority fee for now
-	_, err = ob.ZetacoreClient().PostVoteGasPrice(ctx, ob.Chain(), 1, medianFee, slot)
-	if err != nil {
-		return errors.Wrapf(err, "PostVoteGasPrice error for chain %d", ob.Chain().ChainId)
-	}
 
-	return nil
+	logger := ob.Logger().Chain
+	_, err = ob.ZetaRepo().VoteGasPrice(ctx, logger, 1, medianFee, slot)
+	return err
 }

--- a/zetaclient/chains/solana/observer/observer_test.go
+++ b/zetaclient/chains/solana/observer/observer_test.go
@@ -43,13 +43,12 @@ func MockSolanaObserver(
 	baseObserver, err := base.NewObserver(
 		chain,
 		chainParams,
-		zetacoreClient,
+		zrepo.New(zetacoreClient, chain, mode.StandardMode),
 		tssSigner,
 		1000,
 		nil,
 		database,
 		base.DefaultLogger(),
-		mode.StandardMode,
 	)
 	require.NoError(t, err)
 

--- a/zetaclient/chains/solana/observer/outbound_test.go
+++ b/zetaclient/chains/solana/observer/outbound_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/interfaces"
 	"github.com/zeta-chain/node/zetaclient/chains/solana/observer"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/mode"
 	"github.com/zeta-chain/node/zetaclient/testutils"
@@ -81,8 +82,8 @@ func createTestObserver(
 	chainParams := sample.ChainParams(chain.ChainId)
 	chainParams.GatewayAddress = GatewayAddressTest
 
-	baseObserver, err := base.NewObserver(chain, *chainParams, nil, tssSigner, 1000, nil, database,
-		logger, mode.StandardMode)
+	baseObserver, err := base.NewObserver(chain, *chainParams,
+		zrepo.New(nil, chain, mode.StandardMode), tssSigner, 1000, nil, database, logger)
 	require.NoError(t, err)
 
 	ob, err := observer.New(baseObserver, solanaClient, chainParams.GatewayAddress)

--- a/zetaclient/chains/solana/signer/outbound_tracker_reporter.go
+++ b/zetaclient/chains/solana/signer/outbound_tracker_reporter.go
@@ -18,7 +18,7 @@ import (
 // it reports tx to outbound tracker only if it's confirmed by the Solana network.
 func (signer *Signer) reportToOutboundTracker(
 	ctx context.Context,
-	zetacoreClient zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 	chainID int64,
 	nonce uint64,
 	txSig sol.Signature,
@@ -82,13 +82,10 @@ func (signer *Signer) reportToOutboundTracker(
 			}
 
 			// report outbound hash to zetacore
-			zetaHash, err := zetacoreClient.PostOutboundTracker(ctx, chainID, nonce, txSig.String())
-			if err != nil {
-				logger.Err(err).Msg("error adding outbound to tracker")
-			} else if zetaHash != "" {
-				logger.Info().Str(logs.FieldZetaTx, zetaHash).Msg("added outbound to tracker")
-			} else {
-				// exit goroutine until the tracker contains the hash (reported by either this or other signers)
+			zhash, err := zetaRepo.PostOutboundTracker(ctx, logger, nonce, txSig.String())
+			if zhash == "" && err == nil {
+				// exit goroutine only when the tracker contains the hash (reported by either this
+				// or other signers)
 				logger.Info().Msg("outbound now exists in tracker")
 				return nil
 			}

--- a/zetaclient/chains/solana/signer/signer.go
+++ b/zetaclient/chains/solana/signer/signer.go
@@ -151,7 +151,7 @@ func (signer *Signer) HasRelayerKey() bool {
 func (signer *Signer) TryProcessOutbound(
 	ctx context.Context,
 	cctx *types.CrossChainTx,
-	zetacoreClient zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 	height uint64,
 ) {
 	outboundID := base.OutboundIDFromCCTX(cctx)
@@ -273,7 +273,7 @@ func (signer *Signer) TryProcessOutbound(
 	}
 
 	// broadcast the signed tx to the Solana network
-	signer.broadcastOutbound(ctx, outbound, chainID, nonce, logger, zetacoreClient)
+	signer.broadcastOutbound(ctx, outbound, chainID, nonce, logger, zetaRepo)
 }
 
 // signTx creates and signs solana tx containing provided instruction with relayer key.
@@ -332,7 +332,7 @@ func (signer *Signer) broadcastOutbound(
 	chainID int64,
 	nonce uint64,
 	logger zerolog.Logger,
-	zetacoreClient zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 ) {
 	tx := outbound.Tx
 	// prepare logger fields
@@ -394,7 +394,7 @@ func (signer *Signer) broadcastOutbound(
 		logger.Info().Fields(lf).Msg("broadcasted Solana outbound successfully")
 
 		// successful broadcast; report to the outbound tracker
-		signer.reportToOutboundTracker(ctx, zetacoreClient, chainID, nonce, txSig, logger)
+		signer.reportToOutboundTracker(ctx, zetaRepo, chainID, nonce, txSig, logger)
 		break
 	}
 }

--- a/zetaclient/chains/solana/solana.go
+++ b/zetaclient/chains/solana/solana.go
@@ -58,9 +58,9 @@ func (s *Solana) Start(ctx context.Context) error {
 		return errors.Wrap(err, "unable to get app from context")
 	}
 
-	newBlockChan, err := s.observer.ZetacoreClient().NewBlockSubscriber(ctx)
+	newBlockChan, err := s.observer.ZetaRepo().WatchNewBlocks(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to create new block subscriber")
+		return err
 	}
 
 	optInboundInterval := scheduler.IntervalUpdater(func() time.Duration {
@@ -147,9 +147,9 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 		needsProcessingCtr = 0
 	)
 
-	cctxList, _, err := s.observer.ZetacoreClient().ListPendingCCTX(ctx, chain)
+	cctxList, err := s.observer.ZetaRepo().GetPendingCCTXs(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to list pending cctx")
+		return err
 	}
 
 	// schedule keysign for each pending cctx
@@ -208,7 +208,7 @@ func (s *Solana) scheduleCCTX(ctx context.Context) error {
 			go s.signer.TryProcessOutbound(
 				ctx,
 				cctx,
-				s.observer.ZetacoreClient(),
+				s.observer.ZetaRepo(),
 				zetaHeight,
 			)
 		}

--- a/zetaclient/chains/sui/observer/inbound.go
+++ b/zetaclient/chains/sui/observer/inbound.go
@@ -79,11 +79,9 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 
 // ProcessInboundTrackers processes trackers for inbound transactions.
 func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
-	chainID := ob.Chain().ChainId
-
-	trackers, err := ob.ZetacoreClient().GetInboundTrackersForChain(ctx, chainID)
+	trackers, err := ob.ZetaRepo().GetInboundTrackers(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to get inbound trackers")
+		return err
 	}
 
 	for _, tracker := range trackers {
@@ -138,9 +136,10 @@ func (ob *Observer) processInboundEvent(
 		return errors.Wrap(err, "unable to construct inbound vote")
 	}
 
-	_, err = ob.PostVoteInbound(ctx, msg, zetacore.PostVoteInboundExecutionGasLimit)
+	logger := ob.Logger().Inbound
+	_, err = ob.ZetaRepo().VoteInbound(ctx, logger, msg, zetacore.PostVoteInboundExecutionGasLimit)
 	if err != nil {
-		return errors.Wrap(err, "unable to post vote inbound")
+		return err
 	}
 
 	return nil
@@ -206,12 +205,12 @@ func (ob *Observer) constructInboundVote(
 	}
 
 	return cctypes.NewMsgVoteInbound(
-		ob.ZetacoreClient().GetKeys().GetOperatorAddress().String(),
+		ob.ZetaRepo().GetOperatorAddress(),
 		deposit.Sender,
 		ob.Chain().ChainId,
 		deposit.Sender,
 		deposit.Receiver.String(),
-		ob.ZetacoreClient().Chain().ChainId,
+		ob.ZetaRepo().ZetaChain().ChainId,
 		deposit.Amount,
 		hex.EncodeToString(deposit.Payload),
 		event.TxHash,

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -8,7 +8,6 @@ import (
 
 	"cosmossdk.io/math"
 	"github.com/block-vision/sui-go-sdk/models"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -19,6 +18,7 @@ import (
 	cctypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/sui/client"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/keys"
@@ -26,6 +26,8 @@ import (
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 	"github.com/zeta-chain/node/zetaclient/testutils/testlog"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 var someArgStub = map[string]any{}
@@ -54,7 +56,7 @@ func TestObserver(t *testing.T) {
 			Return("", nil)
 
 		// ACT
-		err := ts.PostGasPrice(ts.ctx)
+		err := ts.ObserveGasPrice(ts.ctx)
 
 		// ASSERT
 		require.NoError(t, err)
@@ -115,7 +117,9 @@ func TestObserver(t *testing.T) {
 
 		// Given inbound votes catches so we can assert them later
 		ts.CatchInboundVotes()
-		ts.zetaMock.MockGetCctxByHash(errors.New("not found"))
+
+		getCctxByHashErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+		ts.zetaMock.MockGetCctxByHash("", getCctxByHashErr)
 
 		// ACT
 		err := ts.ObserveInbound(ts.ctx)
@@ -241,7 +245,8 @@ func TestObserver(t *testing.T) {
 			}),
 		})
 
-		ts.zetaMock.MockGetCctxByHash(errors.New("not found"))
+		getCctxByHashErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+		ts.zetaMock.MockGetCctxByHash("", getCctxByHashErr)
 
 		// Given votes catcher
 		ts.CatchInboundVotes()
@@ -545,8 +550,9 @@ func newTestSuite(t *testing.T) *testSuite {
 		Compliance: log.Logger,
 	}
 
-	baseObserver, err := base.NewObserver(chain, chainParams, zetacore, tss, 1000, nil, database,
-		logger, mode.StandardMode)
+	zetaRepo := zrepo.New(zetacore, chain, mode.StandardMode)
+	baseObserver, err := base.NewObserver(chain, chainParams, zetaRepo, tss, 1000, nil,
+		database, logger)
 	require.NoError(t, err)
 
 	suiMock := mocks.NewSuiClient(t)

--- a/zetaclient/chains/ton/observer/gas.go
+++ b/zetaclient/chains/ton/observer/gas.go
@@ -2,24 +2,23 @@ package observer
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
 )
 
 // ObserveGasPrice fetches on-chain gas information and reports it to zetacore.
 func (ob *Observer) ObserveGasPrice(ctx context.Context) error {
 	// Gets the latest gas price and block number.
-	gasPrice, blockNumber, err := ob.tonRepo.GetGasPrice(ctx)
+	gasPrice, block, err := ob.tonRepo.GetGasPrice(ctx)
 	if err != nil {
 		return err
 	}
 
-	// There's no concept of priority fee in TON
+	// There's no concept of priority fee in TON.
 	const priorityFee = 0
 
-	_, err = ob.ZetacoreClient().PostVoteGasPrice(ctx, ob.Chain(), gasPrice, priorityFee, blockNumber)
+	logger := ob.Logger().Chain
+	_, err = ob.ZetaRepo().VoteGasPrice(ctx, logger, gasPrice, priorityFee, block)
 	if err != nil {
-		return errors.Wrap(err, "unable to post gas price")
+		return err
 	}
 
 	ob.setLatestGasPrice(gasPrice)

--- a/zetaclient/chains/ton/observer/inbound.go
+++ b/zetaclient/chains/ton/observer/inbound.go
@@ -14,7 +14,6 @@ import (
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/ton/encoder"
-	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/compliance"
 	zetaclientconfig "github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/logs"
@@ -149,12 +148,10 @@ func (ob *Observer) addOutboundTracker(ctx context.Context, tx *toncontracts.Tra
 		return nil
 	}
 
-	chainID := ob.Chain().ChainId
 	nonce := uint64(auth.Seqno)
 	hash := encoder.EncodeTx(tx.Transaction)
 
-	// TODO
-	_, err = ob.ZetacoreClient().PostOutboundTracker(ctx, chainID, nonce, hash)
+	_, err = ob.ZetaRepo().PostOutboundTracker(ctx, logger, nonce, hash)
 
 	return err
 }
@@ -168,9 +165,9 @@ func (ob *Observer) addOutboundTracker(ctx context.Context, tx *toncontracts.Tra
 // It processes each tracker individually (continues executing despite any errors so it does not
 // block other trackers).
 func (ob *Observer) ProcessInboundTrackers(ctx context.Context) error {
-	trackers, err := ob.ZetacoreClient().GetInboundTrackersForChain(ctx, ob.Chain().ChainId)
+	trackers, err := ob.ZetaRepo().GetInboundTrackers(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to get inbound trackers")
+		return err
 	}
 
 	logSkippedTracker := func(hash string, reason string, err error) {
@@ -279,12 +276,15 @@ func (ob *Observer) voteInbound(ctx context.Context, tx *toncontracts.Transactio
 		return nil
 	}
 
-	msg := inbound.intoVoteMessage(ob.ZetacoreClient(), ob.Chain().ChainId)
-	const retryGasLimit = zetacore.PostVoteInboundExecutionGasLimit
+	operatorAddress := ob.ZetaRepo().GetOperatorAddress()
+	senderChain := ob.Chain().ChainId
+	zetaChain := ob.ZetaRepo().ZetaChain().ChainId
 
-	_, err = ob.PostVoteInbound(ctx, msg, retryGasLimit)
+	logger = ob.Logger().Inbound
+	msg := inbound.intoVoteMessage(operatorAddress, senderChain, zetaChain)
+	_, err = ob.ZetaRepo().VoteInbound(ctx, logger, msg, zetacore.PostVoteInboundExecutionGasLimit)
 	if err != nil {
-		return errors.Wrap(err, "unable to vote for inbound transaction")
+		return err
 	}
 
 	return nil
@@ -373,30 +373,30 @@ func (inbound *Inbound) isCompliant() bool {
 }
 
 func (inbound *Inbound) intoVoteMessage(
-	zetacoreClient zrepo.ZetacoreClient, // TODO
+	operatorAddress string,
 	senderChain int64,
+	zetaChain int64,
 ) *types.MsgVoteInbound {
 	const (
-		seqno      = 0  // ton doesn't use sequential block numbers
+		seqno      = 0  // TON does not use sequential block numbers
 		eventIndex = 0  // not applicable for TON
 		asset      = "" // empty for gas coin
 		gasLimit   = zetacore.PostVoteInboundCallOptionsGasLimit
 	)
 
 	var (
-		operatorAddress = zetacoreClient.GetKeys().GetOperatorAddress()
-		inboundHash     = encoder.EncodeTx(inbound.tx.Transaction)
-		sender          = inbound.sender.ToRaw()
-		receiver        = inbound.receiver.Hex()
+		inboundHash = encoder.EncodeTx(inbound.tx.Transaction)
+		sender      = inbound.sender.ToRaw()
+		receiver    = inbound.receiver.Hex()
 	)
 
 	return types.NewMsgVoteInbound(
-		operatorAddress.String(),
+		operatorAddress,
 		sender,
 		senderChain,
 		sender,
 		receiver,
-		zetacoreClient.Chain().ChainId,
+		zetaChain,
 		inbound.amount,
 		hex.EncodeToString(inbound.message),
 		inboundHash,

--- a/zetaclient/chains/ton/observer/observer.go
+++ b/zetaclient/chains/ton/observer/observer.go
@@ -9,7 +9,6 @@ import (
 	toncontracts "github.com/zeta-chain/node/pkg/contracts/ton"
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/ton/repo"
-	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 )
 
 const outboundsCacheSize = 1024
@@ -18,8 +17,7 @@ const outboundsCacheSize = 1024
 type Observer struct {
 	*base.Observer
 
-	tonRepo  *repo.TONRepo
-	zetaRepo *zrepo.ZetaRepo
+	tonRepo *repo.TONRepo
 
 	gateway *toncontracts.Gateway // used to parse transactions
 
@@ -50,13 +48,9 @@ func New(baseObserver *base.Observer,
 
 	baseObserver.LoadLastTxScanned()
 
-	client := baseObserver.ZetacoreClient()
-	chain := baseObserver.Chain()
-	zetaRepo := zrepo.New(client, chain)
 	return &Observer{
 		Observer:  baseObserver,
 		tonRepo:   tonRepo,
-		zetaRepo:  zetaRepo,
 		gateway:   gateway,
 		outbounds: outbounds,
 	}, nil

--- a/zetaclient/chains/ton/signer/signer.go
+++ b/zetaclient/chains/ton/signer/signer.go
@@ -58,14 +58,14 @@ func New(baseSigner *base.Signer, tonClient TONClient, gateway *toncontracts.Gat
 func (s *Signer) TryProcessOutbound(
 	ctx context.Context,
 	cctx *cctypes.CrossChainTx,
-	zetacoreClient zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 	zetaBlockHeight uint64,
 ) {
 	outboundID := base.OutboundIDFromCCTX(cctx)
 	s.MarkOutbound(outboundID, true)
 	defer s.MarkOutbound(outboundID, false)
 
-	outcome, err := s.processOutbound(ctx, cctx, zetacoreClient, zetaBlockHeight)
+	outcome, err := s.processOutbound(ctx, cctx, zetaRepo, zetaBlockHeight)
 
 	logger := s.Logger().Std.With().
 		Str(logs.FieldOutboundID, outboundID).
@@ -90,7 +90,7 @@ func (s *Signer) TryProcessOutbound(
 func (s *Signer) processOutbound(
 	ctx context.Context,
 	cctx *cctypes.CrossChainTx,
-	zetacoreClient zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 	zetaHeight uint64,
 ) (Outcome, error) {
 	// TODO: note that *InboundParams* are use used on purpose due to legacy reasons.
@@ -139,7 +139,7 @@ func (s *Signer) processOutbound(
 
 	// it's okay to run this in the same goroutine
 	// because TryProcessOutbound method should be called in a goroutine
-	err = s.trackOutbound(ctx, zetacoreClient, outbound, gwState)
+	err = s.trackOutbound(ctx, zetaRepo, outbound, gwState)
 	if err != nil {
 		return Fail, errors.Wrap(err, "unable to track outbound")
 	}

--- a/zetaclient/chains/ton/signer/signer_test.go
+++ b/zetaclient/chains/ton/signer/signer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zeta-chain/node/zetaclient/chains/base"
 	"github.com/zeta-chain/node/zetaclient/chains/ton/encoder"
 	"github.com/zeta-chain/node/zetaclient/chains/ton/rpc"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/keys"
 	"github.com/zeta-chain/node/zetaclient/mode"
 	"github.com/zeta-chain/node/zetaclient/testutils"
@@ -105,8 +106,8 @@ func TestSigner(t *testing.T) {
 	)
 
 	// ACT
-	signer.TryProcessOutbound(ts.ctx, cctx1, ts.zetacore, zetaHeight)
-	signer.TryProcessOutbound(ts.ctx, cctx2, ts.zetacore, zetaHeight)
+	signer.TryProcessOutbound(ts.ctx, cctx1, ts.zetaRepo, zetaHeight)
+	signer.TryProcessOutbound(ts.ctx, cctx2, ts.zetaRepo, zetaHeight)
 
 	// ASSERT
 	// Make sure signer send the tx the chain AND published the outbound tracker
@@ -132,6 +133,7 @@ type testSuite struct {
 	rpc *mocks.TONRPC
 
 	zetacore *mocks.ZetacoreClient
+	zetaRepo *zrepo.ZetaRepo
 	tss      *mocks.TSS
 
 	gw         *toncontracts.Gateway
@@ -173,6 +175,7 @@ func newTestSuite(t *testing.T) *testSuite {
 		rpc: rpc,
 
 		zetacore: zetacore,
+		zetaRepo: zrepo.New(zetacore, chain, mode.StandardMode),
 		tss:      tss,
 
 		gw:         toncontracts.NewGateway(gwAccountID),

--- a/zetaclient/chains/ton/signer/tracker.go
+++ b/zetaclient/chains/ton/signer/tracker.go
@@ -23,7 +23,7 @@ import (
 // Note that another zetaclient observers that scrolls Gateway's txs can publish this tracker concurrently.
 func (s *Signer) trackOutbound(
 	ctx context.Context,
-	zetacore zrepo.ZetacoreClient,
+	zetaRepo *zrepo.ZetaRepo,
 	outbound outbound,
 	prevState rpc.Account,
 ) error {
@@ -69,12 +69,8 @@ func (s *Signer) trackOutbound(
 		}
 
 		// Note that this method has a check for noop
-		_, err = zetacore.PostOutboundTracker(ctx, chain.ChainId, nonce, txHash)
-		if err != nil {
-			return errors.Wrap(err, "unable to add outbound tracker")
-		}
-
-		return nil
+		_, err = zetaRepo.PostOutboundTracker(ctx, s.Logger().Std, nonce, txHash)
+		return err
 	}
 
 	return errors.Errorf("timeout exceeded (%s)", time.Since(start).String())

--- a/zetaclient/chains/zrepo/client.go
+++ b/zetaclient/chains/zrepo/client.go
@@ -14,11 +14,15 @@ import (
 	fungible "github.com/zeta-chain/node/x/fungible/types"
 	observer "github.com/zeta-chain/node/x/observer/types"
 	keys "github.com/zeta-chain/node/zetaclient/keys/interfaces"
+	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
+
+var _ ZetacoreClient = &zetacore.Client{}
 
 type ChainID = int64
 type Nonce = uint64
 
+// ZetacoreWriter contains the functions that mutate ZetaChain state.
 type ZetacoreWriter interface {
 	PostVoteGasPrice(_ context.Context,
 		_ chains.Chain,
@@ -58,39 +62,17 @@ type ZetacoreWriter interface {
 	) (string, error)
 }
 
-// ZetacoreClient is the client interface that interacts with zetacore.
-//
-//go:generate mockery --name ZetacoreClient --filename zetacore_client.go --case underscore --output ../../testutils/mocks
-type ZetacoreClient interface {
+// ZetacoreClientRepo contains the functions used by ZetaRepo.
+type ZetacoreClientRepo interface {
 	ZetacoreWriter
 
 	Chain() chains.Chain
 
 	GetKeys() keys.ObserverKeys
 
-	GetSupportedChains(context.Context) ([]chains.Chain, error)
-
-	GetAdditionalChains(context.Context) ([]chains.Chain, error)
-
-	GetChainParams(context.Context) ([]*observer.ChainParams, error)
-
-	GetForeignCoinsFromAsset(context.Context, ChainID, eth.Address) (fungible.ForeignCoins, error)
-
-	GetKeyGen(context.Context) (observer.Keygen, error)
-
-	GetTSS(context.Context) (observer.TSS, error)
-	GetTSSHistory(context.Context) ([]observer.TSS, error)
-
-	GetBlockHeight(context.Context) (int64, error)
-
 	ListPendingCCTX(context.Context, chains.Chain) ([]*crosschain.CrossChainTx, uint64, error)
 
-	ListPendingCCTXWithinRateLimit(context.Context,
-	) (*crosschain.QueryListPendingCctxWithinRateLimitResponse, error)
-
-	GetRateLimiterInput(_ context.Context,
-		window int64,
-	) (*crosschain.QueryRateLimiterInputResponse, error)
+	GetForeignCoinsFromAsset(context.Context, ChainID, eth.Address) (fungible.ForeignCoins, error)
 
 	GetPendingNoncesByChain(context.Context, ChainID) (observer.PendingNonces, error)
 
@@ -106,17 +88,47 @@ type ZetacoreClient interface {
 
 	GetInboundTrackersForChain(context.Context, ChainID) ([]crosschain.InboundTracker, error)
 
+	NewBlockSubscriber(context.Context) (chan cometbft.EventDataNewBlock, error)
+
+	GetBTCTSSAddress(context.Context, ChainID) (string, error)
+}
+
+// ZetacoreClient is the client interface that interacts with zetacore.
+//
+// TODO: this should be moved elsewhere, since it is not used by ZetaRepo.
+// See: https://github.com/zeta-chain/node/issues/4300
+//
+//go:generate mockery --name ZetacoreClient --filename zetacore_client.go --case underscore --output ../../testutils/mocks
+type ZetacoreClient interface {
+	ZetacoreClientRepo
+
+	GetSupportedChains(context.Context) ([]chains.Chain, error)
+
+	GetAdditionalChains(context.Context) ([]chains.Chain, error)
+
+	GetChainParams(context.Context) ([]*observer.ChainParams, error)
+
+	GetKeyGen(context.Context) (observer.Keygen, error)
+
+	GetTSS(context.Context) (observer.TSS, error)
+	GetTSSHistory(context.Context) ([]observer.TSS, error)
+
+	GetBlockHeight(context.Context) (int64, error)
+
+	ListPendingCCTXWithinRateLimit(context.Context,
+	) (*crosschain.QueryListPendingCctxWithinRateLimitResponse, error)
+
+	GetRateLimiterInput(_ context.Context,
+		window int64,
+	) (*crosschain.QueryRateLimiterInputResponse, error)
+
 	GetCrosschainFlags(context.Context) (observer.CrosschainFlags, error)
 	GetRateLimiterFlags(context.Context) (crosschain.RateLimiterFlags, error)
 	GetOperationalFlags(context.Context) (observer.OperationalFlags, error)
 
 	GetObserverList(context.Context) ([]string, error)
 
-	GetBTCTSSAddress(context.Context, ChainID) (string, error)
-
 	GetZetaHotKeyBalance(context.Context) (cosmosmath.Int, error)
 
 	GetUpgradePlan(context.Context) (*upgrade.Plan, error)
-
-	NewBlockSubscriber(context.Context) (chan cometbft.EventDataNewBlock, error)
 }

--- a/zetaclient/chains/zrepo/dry.go
+++ b/zetaclient/chains/zrepo/dry.go
@@ -1,4 +1,0 @@
-package zrepo
-
-// TODO coming up in the next PRs.
-type DryZetaRepo struct{}

--- a/zetaclient/chains/zrepo/errors.go
+++ b/zetaclient/chains/zrepo/errors.go
@@ -1,17 +1,42 @@
 package zrepo
 
-import "errors"
-
-var (
-	ErrClient = errors.New("zetacore client error")
-
-	ErrClientGetCCTXByNonce      = errors.New("failed to get CCTX by nonce from zetacore")
-	ErrClientGetOutboundTrackers = errors.New("failed to get outbound trackers from zetacore")
-	ErrClientPostVoteOutbound    = errors.New("failed to post outbound vote with zetacore")
+import (
+	"errors"
+	"fmt"
 )
 
-// newClientError joins the ErrClient error with a description error (ErrClient...) and an inner
-// client error.
-func newClientError(err, inner error) error {
-	return errors.Join(ErrClient, err, inner)
+var (
+	ErrNotRPCError = errors.New("not a RPC error")
+
+	ErrClientGetCCTXByHash = errors.New("failed to get CCTX by hash")
+	ErrClientGetBallotByID = errors.New("failed to get ballot by ID")
+)
+
+var (
+	ErrClient = errors.New("error calling a zetacore client function")
+
+	ErrClientGetBTCTSSAddress        = errors.New("failed to get BTC TSS address")
+	ErrClientGetCCTX                 = errors.New("failed to get CCTX for nonce")
+	ErrClientGetInboundTrackers      = errors.New("failed to get inbound trackers")
+	ErrClientGetOutboundTrackers     = errors.New("failed to get outbound trackers")
+	ErrClientGetPendingCCTXs         = errors.New("failed to get pending CCTXs")
+	ErrClientGetPendingNonces        = errors.New("failed to get pending nonces")
+	ErrClientGetForeignCoinsForAsset = errors.New("failed to get foreign coins for asset")
+
+	ErrClientPostOutboundTracker = errors.New("failed to post outbound tracker")
+	ErrClientVoteGasPrice        = errors.New("failed to post gas price vote")
+	ErrClientVoteInbound         = errors.New("failed to post inbound vote")
+	ErrClientVoteOutbound        = errors.New("failed to post outbound vote")
+
+	ErrClientNewBlockSubscriber = errors.New("failed to create new block subscriber")
+)
+
+var (
+	ErrGetKeysAddress = errors.New("failed to get address for the observer's keys")
+)
+
+// newClientError joins the ErrClient error with an outer error (ErrClient...) and the actual
+// inner client error.
+func newClientError(outer, inner error) error {
+	return fmt.Errorf("%w (%w): %w", ErrClient, outer, inner)
 }

--- a/zetaclient/chains/zrepo/zrepo.go
+++ b/zetaclient/chains/zrepo/zrepo.go
@@ -1,35 +1,85 @@
 // Package zrepo provides an abstraction layer for interactions with the zetacore client.
+//
+// The functions inside this module return very descriptive errors.
+// There is no need to wrap these errors with "failed to..." messages.
 package zrepo
 
 import (
 	"context"
+	"fmt"
+
+	cometbft "github.com/cometbft/cometbft/types"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/rs/zerolog"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/zeta-chain/node/pkg/chains"
-	"github.com/zeta-chain/node/x/crosschain/types"
+	cc "github.com/zeta-chain/node/x/crosschain/types"
+	fungible "github.com/zeta-chain/node/x/fungible/types"
+	observer "github.com/zeta-chain/node/x/observer/types"
+	"github.com/zeta-chain/node/zetaclient/logs"
+	"github.com/zeta-chain/node/zetaclient/mode"
+	"github.com/zeta-chain/node/zetaclient/zetacore"
 )
 
 // ZetaRepo implements the Repository pattern by wrapping a zetacore client.
 // Each chain module must instantiate its own ZetaRepo.
 type ZetaRepo struct {
-	client ZetacoreClient
+	client ZetacoreClientRepo
 
 	connectedChain chains.Chain
+
+	clientMode mode.ClientMode
 }
 
 // New constructs a new ZetaRepo object.
-func New(client ZetacoreClient, connectedChain chains.Chain) *ZetaRepo {
-	return &ZetaRepo{client, connectedChain}
+func New(client ZetacoreClient, connectedChain chains.Chain, clientMode mode.ClientMode) *ZetaRepo {
+	return &ZetaRepo{client, connectedChain, clientMode}
 }
 
-func (repo *ZetaRepo) GetCCTX(ctx context.Context, nonce uint64) (*types.CrossChainTx, error) {
+// ------------------------------------------------------------------------------------------------
+// Getters
+// ------------------------------------------------------------------------------------------------
+
+func (repo *ZetaRepo) ZetaChain() chains.Chain {
+	return repo.client.Chain()
+}
+
+func (repo *ZetaRepo) GetCCTX(ctx context.Context, nonce uint64) (*cc.CrossChainTx, error) {
 	cctx, err := repo.client.GetCctxByNonce(ctx, repo.connectedChain.ChainId, nonce)
 	if err != nil {
-		return nil, newClientError(ErrClientGetCCTXByNonce, err)
+		outerErr := fmt.Errorf("%w %d", ErrClientGetCCTX, nonce)
+		return nil, newClientError(outerErr, err)
 	}
 	return cctx, nil
 }
 
-func (repo *ZetaRepo) GetOutboundTrackers(ctx context.Context) ([]types.OutboundTracker, error) {
+func (repo *ZetaRepo) GetPendingCCTXs(ctx context.Context) ([]*cc.CrossChainTx, error) {
+	cctxs, _, err := repo.client.ListPendingCCTX(ctx, repo.connectedChain)
+	if err != nil {
+		return nil, newClientError(ErrClientGetPendingCCTXs, err)
+	}
+	return cctxs, nil
+}
+
+func (repo *ZetaRepo) GetPendingNonces(ctx context.Context) (*observer.PendingNonces, error) {
+	nonces, err := repo.client.GetPendingNoncesByChain(ctx, repo.connectedChain.ChainId)
+	if err != nil {
+		return nil, newClientError(ErrClientGetPendingNonces, err)
+	}
+	return &nonces, nil
+}
+
+func (repo *ZetaRepo) GetInboundTrackers(ctx context.Context) ([]cc.InboundTracker, error) {
+	trackers, err := repo.client.GetInboundTrackersForChain(ctx, repo.connectedChain.ChainId)
+	if err != nil {
+		return nil, newClientError(ErrClientGetInboundTrackers, err)
+	}
+	return trackers, nil
+}
+
+func (repo *ZetaRepo) GetOutboundTrackers(ctx context.Context) ([]cc.OutboundTracker, error) {
 	trackers, err := repo.client.GetOutboundTrackers(ctx, repo.connectedChain.ChainId)
 	if err != nil {
 		return nil, newClientError(ErrClientGetOutboundTrackers, err)
@@ -37,16 +87,260 @@ func (repo *ZetaRepo) GetOutboundTrackers(ctx context.Context) ([]types.Outbound
 	return trackers, nil
 }
 
+// TODO: We should probably move this to the TSS repository.
+// See: https://github.com/zeta-chain/node/issues/4304
+func (repo *ZetaRepo) GetBTCTSSAddress(ctx context.Context) (string, error) {
+	address, err := repo.client.GetBTCTSSAddress(ctx, repo.connectedChain.ChainId)
+	if err != nil {
+		chainID := repo.connectedChain.ChainId
+		outerErr := fmt.Errorf("%w for chain %d", ErrClientGetBTCTSSAddress, chainID)
+		return "", newClientError(outerErr, err)
+	}
+	return address, nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// Voting & Posting Trackers
+// ------------------------------------------------------------------------------------------------
+
+// PostOutboundTracker posts an outbound tracker.
+// It returns the hash of the associated ZetaChain transaction.
+func (repo *ZetaRepo) PostOutboundTracker(ctx context.Context, logger zerolog.Logger,
+	nonce uint64,
+	txHash string,
+) (string, error) {
+	// Does not post outbound trackers in dry mode.
+	if repo.clientMode.IsDryMode() {
+		logger.Info().Stringer(logs.FieldMode, mode.DryMode).Msg("skipping outbound tracker")
+		return "", nil
+	}
+
+	zhash, err := repo.client.PostOutboundTracker(ctx, repo.connectedChain.ChainId, nonce, txHash)
+	if err != nil {
+		err = newClientError(ErrClientPostOutboundTracker, err)
+		logger.Error().Err(err).Send()
+		return "", err
+	}
+
+	if zhash == "" {
+		logger.Info().Msg("outbound tracker already exists")
+	} else {
+		logger.Info().Str(logs.FieldZetaTx, zhash).Msg("added outbound tracker")
+	}
+
+	return zhash, nil
+}
+
+// VoteGasPrice votes on gas prices.
+// It returns the hash of the vote transaction.
+func (repo *ZetaRepo) VoteGasPrice(ctx context.Context, logger zerolog.Logger,
+	gasPrice uint64,
+	priorityFee uint64,
+	block uint64,
+) (string, error) {
+	// Does not vote in dry mode.
+	if repo.clientMode.IsDryMode() {
+		logger.Info().Stringer(logs.FieldMode, mode.DryMode).Msg("skipping gas price vote")
+		return "", nil
+	}
+
+	zhash, err := repo.client.PostVoteGasPrice(ctx, repo.connectedChain, gasPrice, priorityFee, block)
+	if err != nil {
+		err = newClientError(ErrClientVoteGasPrice, err)
+		logger.Error().Err(err).Send()
+		return "", err
+	}
+	return zhash, nil
+}
+
+// VoteInbound votes on an inbound.
+// It skips invalid messages and tries to vote on the ballot even if the inbound already has a CCTX.
+// It returns the index of the ballot.
+func (repo *ZetaRepo) VoteInbound(ctx context.Context, logger zerolog.Logger,
+	msg *cc.MsgVoteInbound,
+	retryGasLimit uint64,
+) (string, error) {
+	logger = logger.With().
+		Str(logs.FieldTx, msg.InboundHash).
+		Stringer(logs.FieldCoinType, msg.CoinType).
+		Stringer("confirmation_mode", msg.ConfirmationMode).
+		Logger()
+
+	{
+		// A CCTX is created after an inbound ballot is finalized.
+		// - If the CCTX already exists, we try voting if the finalized ballot is still present.
+		// - If the CCTX exists but the ballot does not exist, we do not vote.
+
+		cctxIndex := msg.Digest()
+
+		cctxExists, err := repo.cctxExists(ctx, cctxIndex)
+		if err != nil {
+			return "", err
+		}
+
+		if cctxExists {
+			ballotExists, err := repo.ballotExists(ctx, cctxIndex)
+			if err != nil {
+				return "", err
+			}
+
+			if !ballotExists {
+				logger.Info().Msg("not voting on inbound; CCTX exists but the ballot does not")
+				return cctxIndex, nil
+			}
+		}
+	}
+
+	// Validates the message to avoid unnecessary retries.
+	if err := msg.ValidateBasic(); err != nil {
+		logger.Warn().Err(err).Msg("invalid vote-inbound message")
+		return "", nil
+	}
+
+	// Does not vote in dry mode.
+	if repo.clientMode.IsDryMode() {
+		logger.Info().Stringer(logs.FieldMode, mode.DryMode).Msg("skipping inbound vote")
+		return "", nil
+	}
+
+	// Post vote to zetacore.
+	const gasLimit = zetacore.PostVoteInboundGasLimit
+	zhash, ballot, err := repo.client.PostVoteInbound(ctx, gasLimit, retryGasLimit, msg)
+	if err != nil {
+		err = newClientError(ErrClientVoteInbound, err)
+		logger.Error().Err(err).Send()
+		return "", err
+	}
+
+	logger = logger.With().Str(logs.FieldBallotIndex, ballot).Logger()
+	if zhash == "" {
+		logger.Info().Msg("already voted on the inbound")
+	} else {
+		logger.Info().Str(logs.FieldZetaTx, zhash).Msg("posted inbound vote")
+	}
+
+	return ballot, nil
+}
+
 // VoteOutbound votes on an outbound.
-// It returns the hash of the transaction and the index of the ballot.
-func (repo *ZetaRepo) VoteOutbound(ctx context.Context,
+// It returns the hash of the vote transaction and the index of the ballot.
+func (repo *ZetaRepo) VoteOutbound(ctx context.Context, logger zerolog.Logger,
 	gasLimit uint64,
 	retryGasLimit uint64,
-	msg *types.MsgVoteOutbound,
+	msg *cc.MsgVoteOutbound,
 ) (string, string, error) {
-	hash, ballot, err := repo.client.PostVoteOutbound(ctx, gasLimit, retryGasLimit, msg)
-	if err != nil {
-		return "", "", newClientError(ErrClientPostVoteOutbound, err)
+	// Does not vote in dry mode.
+	if repo.clientMode.IsDryMode() {
+		logger.Info().Stringer(logs.FieldMode, mode.DryMode).Msg("skipping outbound vote")
+		return "", "", nil
 	}
-	return hash, ballot, nil
+
+	zhash, ballot, err := repo.client.PostVoteOutbound(ctx, gasLimit, retryGasLimit, msg)
+	if err != nil {
+		err = newClientError(ErrClientVoteOutbound, err)
+		logger.Error().Err(err).Send()
+		return "", "", err
+	}
+
+	logger = logger.With().Str(logs.FieldBallotIndex, ballot).Logger()
+	if zhash == "" {
+		logger.Info().Msg("already voted on the outbound")
+	} else {
+		logger.Info().Str(logs.FieldZetaTx, zhash).Msg("posted outbound vote")
+	}
+
+	return zhash, ballot, nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// Misc.
+// ------------------------------------------------------------------------------------------------
+
+// WatchNewBlocks subscribes to new block events.
+func (repo *ZetaRepo) WatchNewBlocks(ctx context.Context) (chan cometbft.EventDataNewBlock, error) {
+	ch, err := repo.client.NewBlockSubscriber(ctx)
+	if err != nil {
+		return nil, newClientError(ErrClientNewBlockSubscriber, err)
+	}
+	return ch, nil
+}
+
+// TODO: This function seems out of place.
+// See: https://github.com/zeta-chain/node/issues/4304
+func (repo *ZetaRepo) GetKeysAddress() (string, error) {
+	address, err := repo.client.GetKeys().GetAddress()
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrGetKeysAddress, err)
+	}
+	return address.String(), nil
+}
+
+// TODO: This function seems out of place.
+// See: https://github.com/zeta-chain/node/issues/4304
+func (repo *ZetaRepo) GetOperatorAddress() string {
+	return repo.client.GetKeys().GetOperatorAddress().String()
+}
+
+func (repo *ZetaRepo) GetForeignCoinsFromAsset(ctx context.Context,
+	asset string,
+) (*fungible.ForeignCoins, error) {
+	chainID := repo.connectedChain.ChainId
+	address := ethcommon.HexToAddress(asset)
+	coins, err := repo.client.GetForeignCoinsFromAsset(ctx, chainID, address)
+	if err != nil {
+		outerErr := fmt.Errorf("%w %s", ErrClientGetForeignCoinsForAsset, asset)
+		return nil, newClientError(outerErr, err)
+	}
+	return &coins, nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// Auxiliary functions
+// ------------------------------------------------------------------------------------------------
+
+// checkCode returns nil if the error is a GRPC error with the given code.
+//
+// We pass code as a parameter because:
+// - GetBallotByID returns NotFound when it does not find a ballot.
+// - GetCctxByHash returns InvalidArgument when it does not find a CCTX (instead of NotFound).
+func checkCode(err error, code grpccodes.Code) error {
+	status, ok := grpcstatus.FromError(err) // get the GRPC status from the error
+	if !ok {
+		return fmt.Errorf("%w: %w", ErrNotRPCError, err) // fail if it is not a GRPC error
+	}
+
+	if status.Code() != code {
+		return err // fail if it is a different code
+	}
+
+	return nil
+}
+
+// exists is the generic function used by cctxExists and ballotExists to check for CCTXs and
+// ballots.
+func exists[T any](ctx context.Context,
+	hashOrID string, // hash of a CCTX or the ID of a ballot
+	f func(context.Context, string) (*T, error), // client function
+	code grpccodes.Code, // code that gets returned by the client if the entity does not exist
+	outerErr error, // error that will be returned if the client fails
+) (bool, error) {
+	res, err := f(ctx, hashOrID)
+	if err != nil {
+		err = checkCode(err, code)
+		if err != nil {
+			return false, newClientError(outerErr, err)
+		}
+		return false, nil
+	}
+	return res != nil, nil
+}
+
+func (repo *ZetaRepo) cctxExists(ctx context.Context, hash string) (bool, error) {
+	f := repo.client.GetCctxByHash
+	return exists(ctx, hash, f, grpccodes.InvalidArgument, ErrClientGetCCTXByHash)
+}
+
+func (repo *ZetaRepo) ballotExists(ctx context.Context, id string) (bool, error) {
+	f := repo.client.GetBallotByID
+	return exists(ctx, id, f, grpccodes.NotFound, ErrClientGetBallotByID)
 }

--- a/zetaclient/chains/zrepo/zrepo_test.go
+++ b/zetaclient/chains/zrepo/zrepo_test.go
@@ -1,0 +1,338 @@
+package zrepo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/coin"
+	"github.com/zeta-chain/node/testutil/sample"
+	crosschain "github.com/zeta-chain/node/x/crosschain/types"
+	observer "github.com/zeta-chain/node/x/observer/types"
+	"github.com/zeta-chain/node/zetaclient/mode"
+	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
+)
+
+func TestDryMode(t *testing.T) {
+	t.Run("PostOutboundTracker", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.DryMode)
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+		const nonce = 1234
+		const txHash = "some hash"
+
+		zhash, err := repo.PostOutboundTracker(context.Background(), logger, nonce, txHash)
+		require.NoError(t, err)
+		require.Empty(t, zhash)
+		require.Contains(t, buffer.String(), "skipping outbound tracker")
+	})
+
+	t.Run("VoteGasPrice", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.DryMode)
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+		const gasPrice = 100000
+		const priorityFee = 200
+		const block = 12345
+
+		zhash, err := repo.VoteGasPrice(context.Background(), logger, gasPrice, priorityFee, block)
+		require.NoError(t, err)
+		require.Empty(t, zhash)
+		require.Contains(t, buffer.String(), "skipping gas price vote")
+	})
+
+	t.Run("VoteInbound", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.DryMode)
+
+		cctxNotFoundErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+		sourceChainID := chains.Ethereum.ChainId
+		targetChainID := chains.ZetaChainMainnet.ChainId
+		voteInboundMsg := sample.InboundVote(coin.CoinType_Gas, sourceChainID, targetChainID)
+		const retryGasLimit = 100000
+
+		client.MockGetCctxByHash("", cctxNotFoundErr)
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+
+		ballot, err := repo.VoteInbound(context.Background(), logger, &voteInboundMsg, retryGasLimit)
+		require.NoError(t, err)
+		require.Empty(t, ballot)
+		require.Contains(t, buffer.String(), "skipping inbound vote")
+	})
+
+	t.Run("VoteOutbound", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.DryMode)
+
+		ctx := context.Background()
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+		const gasLimit = 10000
+		const retryGasLimit = 100000
+		msg := sample.OutboundVote(t)
+
+		zhash, ballot, err := repo.VoteOutbound(ctx, logger, gasLimit, retryGasLimit, &msg)
+		require.NoError(t, err)
+		require.Empty(t, zhash)
+		require.Empty(t, ballot)
+		require.Contains(t, buffer.String(), "skipping outbound vote")
+	})
+}
+
+func TestVoteInbound(t *testing.T) {
+	cctxNotFoundErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+	ballotNotFoundErr := grpcstatus.Error(grpccodes.NotFound, "anything")
+	sourceChainID := chains.Ethereum.ChainId
+	targetChainID := chains.ZetaChainMainnet.ChainId
+	msg := sample.InboundVote(coin.CoinType_Gas, sourceChainID, targetChainID)
+	const retryGasLimit = 100000
+
+	t.Run("ok", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.StandardMode)
+
+		mockBallot := "some ballot"
+
+		client.MockGetCctxByHash("", cctxNotFoundErr)
+		client.WithPostVoteInbound(sample.ZetaIndex(t), mockBallot)
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+
+		ballot, err := repo.VoteInbound(context.Background(), logger, &msg, retryGasLimit)
+		require.NoError(t, err)
+		require.Equal(t, mockBallot, ballot)
+		require.Contains(t, buffer.String(), "posted inbound vote")
+		client.AssertNumberOfCalls(t, "PostVoteInbound", 1)
+	})
+
+	t.Run("already voted", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.StandardMode)
+
+		mockBallot := "some ballot"
+
+		client.MockGetCctxByHash("", cctxNotFoundErr)
+		client.WithPostVoteInbound("", mockBallot)
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+
+		ballot, err := repo.VoteInbound(context.Background(), logger, &msg, retryGasLimit)
+		require.NoError(t, err)
+		require.Equal(t, mockBallot, ballot)
+		require.Contains(t, buffer.String(), "already voted on the inbound")
+		client.AssertNumberOfCalls(t, "PostVoteInbound", 1)
+	})
+
+	t.Run("invalid input message", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.StandardMode)
+
+		client.MockGetCctxByHash("", cctxNotFoundErr)
+
+		msg := msg                                                       // copying
+		msg.Message = strings.Repeat("1", crosschain.MaxMessageLength+1) // long mock message
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+
+		ballot, err := repo.VoteInbound(context.Background(), logger, &msg, retryGasLimit)
+		require.NoError(t, err)
+		require.Equal(t, "", ballot)
+		require.Contains(t, buffer.String(), "invalid vote-inbound message")
+	})
+
+	t.Run("CCTX already exists but the ballot does not", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.StandardMode)
+
+		client.MockGetCctxByHash("anything", nil)
+		client.MockGetBallotByID(msg.Digest(), ballotNotFoundErr)
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+
+		ballot, err := repo.VoteInbound(context.Background(), logger, &msg, retryGasLimit)
+		require.NoError(t, err)
+		require.Equal(t, ballot, msg.Digest())
+		require.Contains(t, buffer.String(), "not voting on inbound; CCTX exists but the ballot does not")
+	})
+
+	t.Run("vote on finalized ballot", func(t *testing.T) {
+		client := mocks.NewZetacoreClient(t)
+		repo := New(client, chains.Ethereum, mode.StandardMode)
+
+		client.MockGetCctxByHash("anything", nil)
+		client.MockGetBallotByID(msg.Digest(), nil)
+		client.WithPostVoteInbound(sample.ZetaIndex(t), msg.Digest())
+
+		var buffer bytes.Buffer
+		logger := zerolog.New(&buffer)
+
+		ballot, err := repo.VoteInbound(context.Background(), logger, &msg, retryGasLimit)
+		require.NoError(t, err)
+		require.Equal(t, ballot, msg.Digest())
+		require.Contains(t, buffer.String(), "posted inbound vote")
+		client.AssertNumberOfCalls(t, "PostVoteInbound", 1)
+	})
+}
+
+// ------------------------------------------------------------------------------------------------
+// Tests of auxiliary functions
+// ------------------------------------------------------------------------------------------------
+
+func TestCheckCode(t *testing.T) {
+	notFoundErr := grpcstatus.Error(grpccodes.NotFound, "anything")
+	invalidErr := errors.New("not a GRPC error")
+
+	testCases := []struct {
+		name         string
+		err          error
+		code         grpccodes.Code
+		expectedErrs []error
+	}{{
+		name:         "same code",
+		err:          notFoundErr,
+		code:         grpccodes.NotFound,
+		expectedErrs: nil,
+	}, {
+		name:         "different code",
+		err:          notFoundErr,
+		code:         grpccodes.InvalidArgument,
+		expectedErrs: []error{notFoundErr},
+	}, {
+		name:         "invalid error",
+		err:          invalidErr,
+		code:         grpccodes.InvalidArgument,
+		expectedErrs: []error{ErrNotRPCError, invalidErr},
+	}}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := checkCode(testCase.err, testCase.code)
+			for _, expectedErr := range testCase.expectedErrs {
+				require.ErrorIs(t, err, expectedErr)
+			}
+		})
+	}
+}
+
+// TestExists tests the cctxExists and ballotExists functions (and the exists function implicitly).
+func TestExists(t *testing.T) {
+	client := mocks.NewZetacoreClient(t)
+	repo := New(client, chains.Ethereum, mode.StandardMode)
+
+	invalidErr := errors.New("not a valid GRPC error")
+
+	const validHash1 = "this hash belongs to a CCTX"
+	const validHash2 = "this hash belongs to a CCTX, but the client does not return the CCTX"
+	const invalidHash1 = "this hash does not belong to a CCTX, and it triggers a valid error"
+	const invalidHash2 = "this hash does not belong to a CCTX, and it triggers an invalid error"
+	validCCTXErr := grpcstatus.Error(grpccodes.InvalidArgument, "a valid GRPC error (CCTX)")
+	cctx := &crosschain.CrossChainTx{}
+	client.
+		On("GetCctxByHash", mock.Anything, validHash1).Return(cctx, nil).
+		On("GetCctxByHash", mock.Anything, validHash2).Return(nil, validCCTXErr).
+		On("GetCctxByHash", mock.Anything, invalidHash1).Return(nil, validCCTXErr).
+		On("GetCctxByHash", mock.Anything, invalidHash2).Return(nil, invalidErr)
+
+	const validID1 = "this ID belongs to a ballot"
+	const validID2 = "this ID belongs to a ballot, but the client does not return the ballot"
+	const invalidID1 = "this ID does not belong to a ballot, and it triggers a valid error"
+	const invalidID2 = "this ID does not belong to a ballot, and it triggers an invalid error"
+	validIDErr := grpcstatus.Error(grpccodes.NotFound, "a valid GRPC error (ID)")
+	ballot := &observer.QueryBallotByIdentifierResponse{}
+	client.
+		On("GetBallotByID", mock.Anything, validID1).Return(ballot, nil).
+		On("GetBallotByID", mock.Anything, validID2).Return(nil, validIDErr).
+		On("GetBallotByID", mock.Anything, invalidID1).Return(nil, validIDErr).
+		On("GetBallotByID", mock.Anything, invalidID2).Return(nil, invalidErr)
+
+	testCases := []struct {
+		name           string
+		hash           string
+		id             string
+		expectedExists bool
+		expectedErrs   []error
+	}{{
+		name:           "CCTX exists",
+		hash:           validHash1,
+		expectedExists: true,
+		expectedErrs:   nil,
+	}, {
+		name:           "CCTX does not exist",
+		hash:           invalidHash1,
+		expectedExists: false,
+		expectedErrs:   nil,
+	}, {
+		name:           "client does not return the CCTX",
+		hash:           validHash2,
+		expectedExists: false,
+		expectedErrs:   nil,
+	}, {
+		name:           "client error (GetCCTXByHash)",
+		hash:           invalidHash2,
+		expectedExists: false,
+		expectedErrs:   []error{ErrClient, ErrClientGetCCTXByHash, invalidErr},
+	}, {
+		name:           "ballot exists",
+		id:             validID1,
+		expectedExists: true,
+		expectedErrs:   nil,
+	}, {
+		name:           "ballot does not exist",
+		id:             invalidID1,
+		expectedExists: false,
+		expectedErrs:   nil,
+	}, {
+		name:           "client does not return the ballot",
+		id:             validID2,
+		expectedExists: false,
+		expectedErrs:   nil,
+	}, {
+		name:           "client error (GetBallotByID)",
+		id:             invalidID2,
+		expectedExists: false,
+		expectedErrs:   []error{ErrClient, ErrClientGetBallotByID, invalidErr},
+	}}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require := require.New(t)
+			if testCase.hash != "" && testCase.id != "" {
+				panic("invalid test case")
+			}
+
+			var exists bool
+			var err error
+			if testCase.hash != "" {
+				exists, err = repo.cctxExists(context.Background(), testCase.hash)
+			} else if testCase.id != "" {
+				exists, err = repo.ballotExists(context.Background(), testCase.id)
+			} else {
+				panic("unreachable")
+			}
+
+			require.Equal(testCase.expectedExists, exists)
+			for _, expectedErr := range testCase.expectedErrs {
+				require.ErrorIs(err, expectedErr)
+			}
+		})
+	}
+}

--- a/zetaclient/mode/mode.go
+++ b/zetaclient/mode/mode.go
@@ -1,3 +1,4 @@
+// Package mode lists the execution modes for the zetaclient.
 package mode
 
 import "fmt"
@@ -5,8 +6,27 @@ import "fmt"
 type ClientMode uint8
 
 const (
+	// StandardMode represents the standard execution mode for the zetaclient.
+	//
+	// An observer-signer in standard mode observes transactions from ZetaChain, signs them, and
+	// relays them to the appropriate connected chains. Symmetrically, it observes transactions from
+	// the connected chains and relay them to ZetaChain.
 	StandardMode ClientMode = iota
+
+	// DryMode represents the read-only execution mode for the zetaclient.
+	//
+	// An observer-signer in dry-mode only observes the transactions from ZetaChain and the
+	// connected chains, without signing them or otherwise mutating the state of the ZetaChain or
+	// the state of the connected chains.
 	DryMode
+
+	// ChaosMode represents the chaos-testing execution mode for the zetaclient.
+	//
+	// An observer-signer in chaos-mode works as if in standard mode, but function calls that
+	// interact with outside resources (mainly ZetaChain, connected chains, and other nodes) may
+	// intentionally fail.
+	//
+	// We use ChaosMode to replicate unstable environments for testing.
 	ChaosMode
 )
 
@@ -21,4 +41,8 @@ func (mode ClientMode) String() string {
 	default:
 		return fmt.Sprintf("invalid mode: %d", mode)
 	}
+}
+
+func (mode ClientMode) IsDryMode() bool {
+	return mode == DryMode
 }

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -33,6 +33,7 @@ import (
 	tonrepo "github.com/zeta-chain/node/zetaclient/chains/ton/repo"
 	tonclient "github.com/zeta-chain/node/zetaclient/chains/ton/rpc"
 	tonsigner "github.com/zeta-chain/node/zetaclient/chains/ton/signer"
+	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	zctx "github.com/zeta-chain/node/zetaclient/context"
 	"github.com/zeta-chain/node/zetaclient/db"
 	"github.com/zeta-chain/node/zetaclient/keys"
@@ -69,7 +70,7 @@ func (oc *Orchestrator) bootstrapBitcoin(ctx context.Context, chain zctx.Chain) 
 		dbName   = btcDatabaseFileName(*rawChain)
 	)
 
-	baseObserver, err := oc.newBaseObserver(chain, dbName, mode.StandardMode)
+	baseObserver, err := oc.newBaseObserver(chain, dbName)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base observer")
 	}
@@ -107,7 +108,7 @@ func (oc *Orchestrator) bootstrapEVM(ctx context.Context, chain zctx.Chain) (*ev
 	}
 	var evmClient evm.Client = standardEvmClient
 
-	baseObserver, err := oc.newBaseObserver(chain, chain.Name(), mode.StandardMode)
+	baseObserver, err := oc.newBaseObserver(chain, chain.Name())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base observer")
 	}
@@ -153,7 +154,7 @@ func (oc *Orchestrator) bootstrapSolana(ctx context.Context, chain zctx.Chain) (
 		return nil, errors.Wrap(errSkipChain, "unable to find solana config")
 	}
 
-	baseObserver, err := oc.newBaseObserver(chain, chain.Name(), mode.StandardMode)
+	baseObserver, err := oc.newBaseObserver(chain, chain.Name())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base observer")
 	}
@@ -215,7 +216,7 @@ func (oc *Orchestrator) bootstrapSui(ctx context.Context, chain zctx.Chain) (*su
 	standardSuiClient := suiclient.New(cfg.Endpoint)
 	var suiClient sui.Client = standardSuiClient
 
-	baseObserver, err := oc.newBaseObserver(chain, chain.Name(), mode.StandardMode)
+	baseObserver, err := oc.newBaseObserver(chain, chain.Name())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base observer")
 	}
@@ -267,7 +268,7 @@ func (oc *Orchestrator) bootstrapTON(ctx context.Context, chain zctx.Chain) (*to
 	standardTonClient := tonclient.New(cfg.Endpoint, chain.ID(), tonclient.WithHTTPClient(rpcClient))
 	var tonClient ton.Client = standardTonClient
 
-	baseObserver, err := oc.newBaseObserver(chain, chain.Name(), mode.StandardMode)
+	baseObserver, err := oc.newBaseObserver(chain, chain.Name())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base observer")
 	}
@@ -286,7 +287,6 @@ func (oc *Orchestrator) bootstrapTON(ctx context.Context, chain zctx.Chain) (*to
 func (oc *Orchestrator) newBaseObserver(
 	chain zctx.Chain,
 	dbName string,
-	clientMode mode.ClientMode,
 ) (*base.Observer, error) {
 	var (
 		rawChain       = chain.RawChain()
@@ -303,16 +303,17 @@ func (oc *Orchestrator) newBaseObserver(
 		blocksCacheSize = btcBlocksPerDay
 	}
 
+	zetaRepo := zrepo.New(oc.deps.Zetacore, *rawChain, mode.StandardMode)
+
 	return base.NewObserver(
 		*rawChain,
 		*rawChainParams,
-		oc.deps.Zetacore,
+		zetaRepo,
 		oc.deps.TSS,
 		blocksCacheSize,
 		oc.deps.Telemetry,
 		database,
 		oc.logger.base,
-		clientMode,
 	)
 }
 

--- a/zetaclient/testutils/mocks/zetacore_client_opts.go
+++ b/zetaclient/testutils/mocks/zetacore_client_opts.go
@@ -65,8 +65,12 @@ func (_m *ZetacoreClient) WithRateLimiterFlags(flags *crosschaintypes.RateLimite
 	return _m
 }
 
-func (_m *ZetacoreClient) MockGetCctxByHash(err error) *ZetacoreClient {
-	_m.On("GetCctxByHash", mock.Anything, mock.Anything).Return(nil, err)
+func (_m *ZetacoreClient) MockGetCctxByHash(cctxIndex string, err error) *ZetacoreClient {
+	var cctx *crosschaintypes.CrossChainTx
+	if cctxIndex != "" {
+		cctx = &crosschaintypes.CrossChainTx{Index: cctxIndex}
+	}
+	_m.On("GetCctxByHash", mock.Anything, mock.Anything).Return(cctx, err)
 	return _m
 }
 

--- a/zetaclient/zetacore/client.go
+++ b/zetaclient/zetacore/client.go
@@ -22,13 +22,10 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/fanout"
 	zetacorerpc "github.com/zeta-chain/node/pkg/rpc"
-	"github.com/zeta-chain/node/zetaclient/chains/zrepo"
 	"github.com/zeta-chain/node/zetaclient/config"
 	keyinterfaces "github.com/zeta-chain/node/zetaclient/keys/interfaces"
 	"github.com/zeta-chain/node/zetaclient/logs"
 )
-
-var _ zrepo.ZetacoreClient = &Client{}
 
 // Client is the client to send tx to zetacore
 type Client struct {


### PR DESCRIPTION
# Description
- Finish `ZetaRepo` to include `ZetacoreClient` functions that are relevant to the observer-signers.
    - Move `VoteInbound` method from the base observer to `ZetaRepo`.
    - Refactor `VoteInbound` so it does not ignore client errors from `GetCctxByHash`.
    - Refactor `VoteInbound` so it does not ignore client errors from `GetBallotByID`.
    - Add more tests for `VoteInbound`.
    - Standardize how errors are returned and logged for most `ZetaRepo` functions.
    - Methods do not need `chainID` parameters anymore.
- Add `clientMode` flag to `ZetaRepo`.
    - Make `Vote*` and `PostOutboundTracker` methods do nothing in dry-mode.
    - Add tests for dry-mode `ZetaRepo`.
- Remove `ZetacoreClient` from the base observer (only `ZetaRepo` from now on).

Closes #4302.

# How Has This Been Tested?
- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [x] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified core interactions behind a new repository, streamlining block watching, CCTX/trackers retrieval, and voting (inbound/outbound/gas price) across Bitcoin, EVM, Solana, Sui, and TON.
  - Observer constructors now accept the repository; logging and error propagation simplified.
  - Renamed Sui gas price method to ObserveGasPrice.
- Tests
  - Updated test suites to the new repository pattern and error expectations.
- Documentation
  - Changelog updated under “Refactor”; no functional behavior changes intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->