### PR TITLE
chore: increase upgrade test height

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ endif
 start-upgrade-test: zetanode-upgrade solana
 	@echo "--> Starting upgrade test"
 	export LOCALNET_MODE=upgrade && \
-	export UPGRADE_HEIGHT=240 && \
+	export UPGRADE_HEIGHT=260 && \
  	export USE_ZETAE2E_ANTE=true && \
 	export E2E_ARGS="--test-solana --test-sui" && \
 	cd contrib/localnet/ && $(DOCKER_COMPOSE) --profile upgrade --profile solana --profile sui -f docker-compose-upgrade.yml up -d


### PR DESCRIPTION
# Description

Upgrade tests are failing a lot in the CI because the first tests pass complete after the upgrade height.

This PR increase the height from 240 to 260 to give the time for tests to complete. This is a change we already did on the main branch to fix this problem in the past.
