### PR TITLE
fix: stop ProcessOutboundTrackers from breaking when it finds an error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,10 @@ by calling `updateAdditionalActionFee` admin function.
 
 * [4296](https://github.com/zeta-chain/node/pull/4296) - add zrepo package to zetaclient
 
+### Fixes
+
+* [4305](https://github.com/zeta-chain/node/pull/4305) - stop ProcessOutboundTrackers from breaking when it finds an error
+
 ## v36.0.0
 
 ### Features

--- a/zetaclient/chains/sui/observer/outbound.go
+++ b/zetaclient/chains/sui/observer/outbound.go
@@ -2,7 +2,6 @@ package observer
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"cosmossdk.io/math"
@@ -56,7 +55,9 @@ func (ob *Observer) ProcessOutboundTrackers(ctx context.Context) error {
 
 		cctx, err := ob.ZetaRepo().GetCCTX(ctx, tracker.Nonce)
 		if err != nil {
-			return fmt.Errorf("%w (Sui digest %q)", err, digest)
+			err = errors.Wrapf(err, "Sui digest %q", digest)
+			logger.Error().Err(err).Send()
+			continue // does not block other CCTXs from being processed
 		}
 
 		if err := ob.loadOutboundTx(ctx, cctx, digest); err != nil {


### PR DESCRIPTION
# Description

Bitcoin's, Solana's, and Sui's `ProcessOutboundTrackers` function does not continue to process other outbound trackers when it tries to retrieve an outbound transaction and it finds an error.

# How Has This Been Tested?
- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of outbound transaction processing. A failure on an individual tracker no longer halts the entire batch; remaining trackers continue to be processed.
  * Reduces stalled operations and minimizes delays caused by transient errors, resulting in more reliable and consistent outbound handling for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->