### PR TITLE
fix: decoding of legacy eth txs from cosmos msgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -415,7 +415,7 @@ replace (
 	// which is a fork of https://github.com/threshold-network/tss-lib
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 
-	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348
+	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20251007152629-6fa9eebae439
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
 )

--- a/go.sum
+++ b/go.sum
@@ -1959,8 +1959,8 @@ github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348 h1:Ta+tRdJ608We92ybjAUrOZ8SwnMP7YJM3v4K7HqT/co=
-github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
+github.com/zeta-chain/evm v0.0.0-20251007152629-6fa9eebae439 h1:Er4T2EjjRHpIPYSkB3y5RMiHHC9D5gj9dvDI2EK6EWQ=
+github.com/zeta-chain/evm v0.0.0-20251007152629-6fa9eebae439/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
 github.com/zeta-chain/go-tss v0.6.3 h1:c/zSEvI0h7MJ+xxu42M58uBdEWrlzfD3NI1kP/FlWBE=

--- a/rpc/backend/blocks.go
+++ b/rpc/backend/blocks.go
@@ -10,6 +10,7 @@ import (
 	cmtypes "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
+	etherminttypes "github.com/cosmos/evm/legacy/evm"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -247,6 +248,73 @@ func (b *Backend) BlockNumberFromTendermintByHash(blockHash common.Hash) (*big.I
 	return big.NewInt(resBlock.Header.Height), nil
 }
 
+// DecodeMsgEthereumTxFromCosmosMsg tries to get MsgEthereumTx from cosmos msg
+// fallback to legacy ethermint MsgEthereumTx if evm cant be parsed
+func (b *Backend) DecodeMsgEthereumTxFromCosmosMsg(msg sdk.Msg) (*evmtypes.MsgEthereumTx, bool) {
+	ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
+	if ok {
+		ethMsg.Hash = ethMsg.AsTransaction().Hash().Hex()
+		return ethMsg, ok
+	}
+
+	// if above fails, try to cast to legacy ethermint type
+	ethMsg2, ok := msg.(*etherminttypes.MsgEthereumTx)
+	if !ok {
+		return nil, false
+	}
+
+	// convert to new evm tx type
+	tx2 := ethMsg2.AsTransaction()
+	acessListTuple := []ethtypes.AccessTuple{}
+	for _, al := range tx2.AccessList() {
+		acessListTuple = append(acessListTuple, ethtypes.AccessTuple{
+			Address:     al.Address,
+			StorageKeys: al.StorageKeys,
+		})
+	}
+
+	accessList := ethtypes.AccessList(acessListTuple)
+	ethMsg = evmtypes.NewTx(&evmtypes.EvmTxArgs{
+		Nonce:     tx2.Nonce(),
+		GasLimit:  tx2.Gas(),
+		Input:     tx2.Data(),
+		GasFeeCap: tx2.GasFeeCap(),
+		GasPrice:  tx2.GasPrice(),
+		ChainID:   tx2.ChainId(),
+		Amount:    tx2.Value(),
+		GasTipCap: tx2.GasFeeCap(),
+		To:        tx2.To(),
+		Accesses:  &accessList,
+	})
+
+	chainId, err := b.ChainID()
+	if err != nil {
+		b.Logger.Error("can't get backend chain id", err.Error())
+		return nil, false
+	}
+	from, err := ethMsg2.GetSender(chainId.ToInt())
+	if err != nil {
+		b.Logger.Error("can't get tx From field", err.Error())
+		return nil, false
+	}
+	ethMsg.From = from.Bytes()
+	ethMsg.Hash = ethMsg2.AsTransaction().Hash().Hex()
+
+	return ethMsg, true
+}
+
+// DecodeMsgEthereumTxFromCosmosTx tries to get MsgEthereumTx from cosmos tx msgs
+func (b *Backend) DecodeMsgEthereumTxFromCosmosTx(tx sdk.Tx) (*evmtypes.MsgEthereumTx, bool) {
+	for _, msg := range tx.GetMsgs() {
+		ethMsg, ok := b.DecodeMsgEthereumTxFromCosmosMsg(msg)
+		if ok {
+			return ethMsg, ok
+		}
+	}
+
+	return nil, false
+}
+
 // EthMsgsFromTendermintBlock returns all real and synthetic MsgEthereumTxs from a
 // Tendermint block. It also ensures consistency over the correct txs indexes
 // across RPC endpoints
@@ -275,14 +343,11 @@ func (b *Backend) EthMsgsFromTendermintBlock(
 		shouldCheckForSyntheticTx := true
 		// if tx can be decoded, try to find MsgEthereumTx inside
 		if err == nil {
-			for _, msg := range tx.GetMsgs() {
-				ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
-				if ok {
-					shouldCheckForSyntheticTx = false
-					ethMsg.Hash = ethMsg.AsTransaction().Hash().Hex()
-					ethMsgs = append(ethMsgs, ethMsg)
-					txsAdditional = append(txsAdditional, nil)
-				}
+			ethMsg, ok := b.DecodeMsgEthereumTxFromCosmosTx(tx)
+			if ok {
+				shouldCheckForSyntheticTx = false
+				ethMsgs = append(ethMsgs, ethMsg)
+				txsAdditional = append(txsAdditional, nil)
 			}
 		} else {
 			b.Logger.Debug("failed to decode transaction in block", "height", block.Height, "error", err.Error())
@@ -435,6 +500,11 @@ func (b *Backend) BlockBloom(blockRes *tmrpctypes.ResultBlockResults) (ethtypes.
 
 		for _, attr := range event.Attributes {
 			if attr.Key == evmtypes.AttributeKeyEthereumBloom {
+				// this is panicing in go-ethereum in case bloom length is greater than max
+				bloomSize := len([]byte(attr.Value))
+				if bloomSize > ethtypes.BloomByteLength {
+					return ethtypes.Bloom{}, errors.New("block bloom greater than max allowed size")
+				}
 				return ethtypes.BytesToBloom([]byte(attr.Value)), nil
 			}
 		}


### PR DESCRIPTION
# Description

evm PR: https://github.com/zeta-chain/evm/pull/15

closes: #4307 

needs testing on live network, locally best i could do is manually replace backend clientctx rpc with url, but can't test things like debug trace endpoints 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions
