### PR TITLE
ci: remove upgrade tests from merge queue ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -167,8 +167,6 @@ jobs:
             } else if (context.eventName === 'merge_group') {
               // default mergequeue tests
               core.setOutput('DEFAULT_TESTS', true);
-              core.setOutput('UPGRADE_TESTS', true);
-              core.setOutput('ADMIN_UPGRADE_TESTS', true);
 
               // conditional tests based on PR labels
               const commit_message = context.payload.merge_group.head_commit.message;


### PR DESCRIPTION
# Description

Remove the upgrade test.
Currently some instability in the tests prevent PRs to be easily merged, in addition this test is not necessary as we're no longer pushing consensus breaking changes to `develop`

A zetaclient upgrade test will be implementated for the next release
