### PR TITLE
refactor: use maps.Clone to simplify code

### DIFF
--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"maps"
 	"strings"
 	"sync"
 
@@ -133,12 +134,8 @@ func (c Config) GetAllEVMConfigs() map[int64]EVMConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	// deep copy evm configs
-	copied := make(map[int64]EVMConfig, len(c.EVMChainConfigs))
-	for chainID, evmConfig := range c.EVMChainConfigs {
-		copied[chainID] = evmConfig
-	}
-	return copied
+	// shallow copy evm configs (sufficient for current struct with immutable fields)
+	return maps.Clone(c.EVMChainConfigs)
 }
 
 // GetBTCConfig returns the BTC config for the given chain ID


### PR DESCRIPTION
# Description

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Clone) added in the go1.21 standard library, which can make the code more concise and easy to read.



# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of EVM chain configurations by streamlining the copy process, enhancing reliability and maintainability.
  - Ensures safer duplication of configuration data, reducing the risk of subtle state-sharing issues.
  - No changes to public APIs or expected behavior.
  - No user action required; existing workflows continue to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->