### PR TITLE
feat: add dry-mode to EVM

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@ Also EnableSolanaAddressLookupTable feature flag should be set.
 * [4313](https://github.com/zeta-chain/node/pull/4313) - add dry-mode to Sui and add client wrappers to Sui and TON
 * [4317](https://github.com/zeta-chain/node/pull/4317) - add dry-mode to Solana
 * [4325](https://github.com/zeta-chain/node/pull/4325) - add dry-mode to Bitcoin
+* [4326](https://github.com/zeta-chain/node/pull/4326) - add dry-mode to EVM
 
 ### Tests
 

--- a/zetaclient/chains/evm/observer/observer.go
+++ b/zetaclient/chains/evm/observer/observer.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	ethbind "github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	eth "github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
@@ -24,13 +24,28 @@ import (
 	"github.com/zeta-chain/node/zetaclient/metrics"
 )
 
-// EVMClient is the interface for the EVM RPC client
+// EVMClient is the interface for the EVM RPC client.
+//
+// This interface contains functions from go-ethereum's bind.ContractBackend.
+// We are intentionally not embedding ContractBackend in EVMClient because we want to make it
+// explicit and clear which methods are part of EVMClient.
 //
 //go:generate mockery --name EVMClient --filename evm_client.go --case underscore --output ../../../testutils/mocks
 type EVMClient interface {
-	ethbind.ContractBackend
-
+	PendingCodeAt(context.Context, ethcommon.Address) ([]byte, error)
+	PendingNonceAt(context.Context, ethcommon.Address) (uint64, error)
+	SubscribeFilterLogs(context.Context, ethereum.FilterQuery, chan<- eth.Log) (ethereum.Subscription, error)
+	EstimateGas(context.Context, ethereum.CallMsg) (uint64, error)
+	CodeAt(_ context.Context, contract ethcommon.Address, blockNumber *big.Int) ([]byte, error)
+	CallContract(_ context.Context, _ ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	// This is a mutating function that does not get called when zetaclient is in dry-mode.
 	SendTransaction(context.Context, *eth.Transaction) error
+
+	HealthCheck(ctx context.Context) (time.Time, error)
+
+	FilterLogs(context.Context, ethereum.FilterQuery) ([]eth.Log, error)
+
+	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 
 	SuggestGasPrice(context.Context) (*big.Int, error)
 
@@ -45,14 +60,6 @@ type EVMClient interface {
 	TransactionByHashCustom(context.Context, string) (*client.Transaction, error)
 
 	TransactionReceipt(context.Context, ethcommon.Hash) (*eth.Receipt, error)
-
-	TransactionSender(_ context.Context,
-		_ *eth.Transaction,
-		block ethcommon.Hash,
-		index uint,
-	) (ethcommon.Address, error)
-
-	HealthCheck(ctx context.Context) (time.Time, error)
 }
 
 // Observer is the observer for evm chains

--- a/zetaclient/dry/dry.go
+++ b/zetaclient/dry/dry.go
@@ -14,10 +14,12 @@ import (
 	suimodel "github.com/block-vision/sui-go-sdk/models"
 	btcchainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
 	btcwire "github.com/btcsuite/btcd/wire"
+	eth "github.com/ethereum/go-ethereum/core/types"
 	sol "github.com/gagliardetto/solana-go"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
 
 	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
+	"github.com/zeta-chain/node/zetaclient/chains/evm"
 	"github.com/zeta-chain/node/zetaclient/chains/solana"
 	"github.com/zeta-chain/node/zetaclient/chains/sui"
 	"github.com/zeta-chain/node/zetaclient/chains/ton"
@@ -48,8 +50,17 @@ func (*BitcoinClient) SendRawTransaction(context.Context,
 // EVM
 // ------------------------------------------------------------------------------------------------
 
-// TODO
-// See: https://github.com/zeta-chain/node/issues/4231
+type EVMClient struct {
+	evm.Client
+}
+
+func WrapEVMClient(client evm.Client) *EVMClient {
+	return &EVMClient{Client: client}
+}
+
+func (*EVMClient) SendTransaction(context.Context, *eth.Transaction) error {
+	panic(MsgUnreachable)
+}
 
 // ------------------------------------------------------------------------------------------------
 // Solana

--- a/zetaclient/orchestrator/bootstrap.go
+++ b/zetaclient/orchestrator/bootstrap.go
@@ -119,6 +119,9 @@ func (oc *Orchestrator) bootstrapEVM(ctx context.Context, chain zctx.Chain) (*ev
 		return nil, errors.Wrapf(err, "unable to create evm client (%s)", cfg.Endpoint)
 	}
 	var evmClient evm.Client = standardEvmClient
+	if clientMode.IsDryMode() {
+		evmClient = dry.WrapEVMClient(evmClient)
+	}
 
 	baseObserver, err := oc.newBaseObserver(clientMode, chain, chain.Name())
 	if err != nil {

--- a/zetaclient/testutils/mocks/evm_client.go
+++ b/zetaclient/testutils/mocks/evm_client.go
@@ -82,9 +82,9 @@ func (_m *EVMClient) BlockNumber(_a0 context.Context) (uint64, error) {
 	return r0, r1
 }
 
-// CallContract provides a mock function with given fields: ctx, call, blockNumber
-func (_m *EVMClient) CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	ret := _m.Called(ctx, call, blockNumber)
+// CallContract provides a mock function with given fields: _a0, _a1, blockNumber
+func (_m *EVMClient) CallContract(_a0 context.Context, _a1 ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	ret := _m.Called(_a0, _a1, blockNumber)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CallContract")
@@ -93,10 +93,10 @@ func (_m *EVMClient) CallContract(ctx context.Context, call ethereum.CallMsg, bl
 	var r0 []byte
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.CallMsg, *big.Int) ([]byte, error)); ok {
-		return rf(ctx, call, blockNumber)
+		return rf(_a0, _a1, blockNumber)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.CallMsg, *big.Int) []byte); ok {
-		r0 = rf(ctx, call, blockNumber)
+		r0 = rf(_a0, _a1, blockNumber)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -104,7 +104,7 @@ func (_m *EVMClient) CallContract(ctx context.Context, call ethereum.CallMsg, bl
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, ethereum.CallMsg, *big.Int) error); ok {
-		r1 = rf(ctx, call, blockNumber)
+		r1 = rf(_a0, _a1, blockNumber)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -112,9 +112,9 @@ func (_m *EVMClient) CallContract(ctx context.Context, call ethereum.CallMsg, bl
 	return r0, r1
 }
 
-// CodeAt provides a mock function with given fields: ctx, contract, blockNumber
-func (_m *EVMClient) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
-	ret := _m.Called(ctx, contract, blockNumber)
+// CodeAt provides a mock function with given fields: _a0, contract, blockNumber
+func (_m *EVMClient) CodeAt(_a0 context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
+	ret := _m.Called(_a0, contract, blockNumber)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CodeAt")
@@ -123,10 +123,10 @@ func (_m *EVMClient) CodeAt(ctx context.Context, contract common.Address, blockN
 	var r0 []byte
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, common.Address, *big.Int) ([]byte, error)); ok {
-		return rf(ctx, contract, blockNumber)
+		return rf(_a0, contract, blockNumber)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, common.Address, *big.Int) []byte); ok {
-		r0 = rf(ctx, contract, blockNumber)
+		r0 = rf(_a0, contract, blockNumber)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -134,7 +134,7 @@ func (_m *EVMClient) CodeAt(ctx context.Context, contract common.Address, blockN
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, common.Address, *big.Int) error); ok {
-		r1 = rf(ctx, contract, blockNumber)
+		r1 = rf(_a0, contract, blockNumber)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -142,9 +142,9 @@ func (_m *EVMClient) CodeAt(ctx context.Context, contract common.Address, blockN
 	return r0, r1
 }
 
-// EstimateGas provides a mock function with given fields: ctx, call
-func (_m *EVMClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
-	ret := _m.Called(ctx, call)
+// EstimateGas provides a mock function with given fields: _a0, _a1
+func (_m *EVMClient) EstimateGas(_a0 context.Context, _a1 ethereum.CallMsg) (uint64, error) {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for EstimateGas")
@@ -153,16 +153,16 @@ func (_m *EVMClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (ui
 	var r0 uint64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.CallMsg) (uint64, error)); ok {
-		return rf(ctx, call)
+		return rf(_a0, _a1)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.CallMsg) uint64); ok {
-		r0 = rf(ctx, call)
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, ethereum.CallMsg) error); ok {
-		r1 = rf(ctx, call)
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -170,9 +170,9 @@ func (_m *EVMClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (ui
 	return r0, r1
 }
 
-// FilterLogs provides a mock function with given fields: ctx, q
-func (_m *EVMClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
-	ret := _m.Called(ctx, q)
+// FilterLogs provides a mock function with given fields: _a0, _a1
+func (_m *EVMClient) FilterLogs(_a0 context.Context, _a1 ethereum.FilterQuery) ([]types.Log, error) {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FilterLogs")
@@ -181,10 +181,10 @@ func (_m *EVMClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]
 	var r0 []types.Log
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.FilterQuery) ([]types.Log, error)); ok {
-		return rf(ctx, q)
+		return rf(_a0, _a1)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.FilterQuery) []types.Log); ok {
-		r0 = rf(ctx, q)
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]types.Log)
@@ -192,7 +192,7 @@ func (_m *EVMClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, ethereum.FilterQuery) error); ok {
-		r1 = rf(ctx, q)
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -258,9 +258,9 @@ func (_m *EVMClient) HealthCheck(ctx context.Context) (time.Time, error) {
 	return r0, r1
 }
 
-// PendingCodeAt provides a mock function with given fields: ctx, account
-func (_m *EVMClient) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
-	ret := _m.Called(ctx, account)
+// PendingCodeAt provides a mock function with given fields: _a0, _a1
+func (_m *EVMClient) PendingCodeAt(_a0 context.Context, _a1 common.Address) ([]byte, error) {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PendingCodeAt")
@@ -269,10 +269,10 @@ func (_m *EVMClient) PendingCodeAt(ctx context.Context, account common.Address) 
 	var r0 []byte
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, common.Address) ([]byte, error)); ok {
-		return rf(ctx, account)
+		return rf(_a0, _a1)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, common.Address) []byte); ok {
-		r0 = rf(ctx, account)
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -280,7 +280,7 @@ func (_m *EVMClient) PendingCodeAt(ctx context.Context, account common.Address) 
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, common.Address) error); ok {
-		r1 = rf(ctx, account)
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -288,9 +288,9 @@ func (_m *EVMClient) PendingCodeAt(ctx context.Context, account common.Address) 
 	return r0, r1
 }
 
-// PendingNonceAt provides a mock function with given fields: ctx, account
-func (_m *EVMClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
-	ret := _m.Called(ctx, account)
+// PendingNonceAt provides a mock function with given fields: _a0, _a1
+func (_m *EVMClient) PendingNonceAt(_a0 context.Context, _a1 common.Address) (uint64, error) {
+	ret := _m.Called(_a0, _a1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PendingNonceAt")
@@ -299,16 +299,16 @@ func (_m *EVMClient) PendingNonceAt(ctx context.Context, account common.Address)
 	var r0 uint64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, common.Address) (uint64, error)); ok {
-		return rf(ctx, account)
+		return rf(_a0, _a1)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, common.Address) uint64); ok {
-		r0 = rf(ctx, account)
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, common.Address) error); ok {
-		r1 = rf(ctx, account)
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -334,9 +334,9 @@ func (_m *EVMClient) SendTransaction(_a0 context.Context, _a1 *types.Transaction
 	return r0
 }
 
-// SubscribeFilterLogs provides a mock function with given fields: ctx, q, ch
-func (_m *EVMClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
-	ret := _m.Called(ctx, q, ch)
+// SubscribeFilterLogs provides a mock function with given fields: _a0, _a1, _a2
+func (_m *EVMClient) SubscribeFilterLogs(_a0 context.Context, _a1 ethereum.FilterQuery, _a2 chan<- types.Log) (ethereum.Subscription, error) {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SubscribeFilterLogs")
@@ -345,10 +345,10 @@ func (_m *EVMClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQ
 	var r0 ethereum.Subscription
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.FilterQuery, chan<- types.Log) (ethereum.Subscription, error)); ok {
-		return rf(ctx, q, ch)
+		return rf(_a0, _a1, _a2)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, ethereum.FilterQuery, chan<- types.Log) ethereum.Subscription); ok {
-		r0 = rf(ctx, q, ch)
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ethereum.Subscription)
@@ -356,7 +356,7 @@ func (_m *EVMClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQ
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, ethereum.FilterQuery, chan<- types.Log) error); ok {
-		r1 = rf(ctx, q, ch)
+		r1 = rf(_a0, _a1, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -514,36 +514,6 @@ func (_m *EVMClient) TransactionReceipt(_a0 context.Context, _a1 common.Hash) (*
 
 	if rf, ok := ret.Get(1).(func(context.Context, common.Hash) error); ok {
 		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// TransactionSender provides a mock function with given fields: _a0, _a1, block, index
-func (_m *EVMClient) TransactionSender(_a0 context.Context, _a1 *types.Transaction, block common.Hash, index uint) (common.Address, error) {
-	ret := _m.Called(_a0, _a1, block, index)
-
-	if len(ret) == 0 {
-		panic("no return value specified for TransactionSender")
-	}
-
-	var r0 common.Address
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *types.Transaction, common.Hash, uint) (common.Address, error)); ok {
-		return rf(_a0, _a1, block, index)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *types.Transaction, common.Hash, uint) common.Address); ok {
-		r0 = rf(_a0, _a1, block, index)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(common.Address)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *types.Transaction, common.Hash, uint) error); ok {
-		r1 = rf(_a0, _a1, block, index)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
# Description
Closes #4231.

# How Has This Been Tested?
- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dry mode for EVM, allowing runs without broadcasting transactions. Outbound processing is skipped with clear logs when enabled. No behavioral changes in normal mode.

* **Documentation**
  * Updated changelog with a new entry for dry mode.

* **Tests**
  * Updated test mocks to align with the revised EVM client interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->