### PR TITLE
fix: return default threshold  if the MempoolCongestionThreshold is not set

### DIFF
--- a/zetaclient/config/types.go
+++ b/zetaclient/config/types.go
@@ -248,6 +248,9 @@ func (c Config) GetMaxBaseFee() int64 {
 func (c Config) GetMempoolCongestionThreshold() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	if c.MempoolCongestionThreshold == 0 {
+		return DefaultMempoolCongestionThreshold
+	}
 	return c.MempoolCongestionThreshold
 }
 


### PR DESCRIPTION
# Description

Return the default threshold if the MempoolCongestionThreshold is not set. 

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> GetMempoolCongestionThreshold now returns the default value when the configured threshold is zero.
> 
> - **Config**:
>   - `GetMempoolCongestionThreshold` now falls back to `DefaultMempoolCongestionThreshold` when `MempoolCongestionThreshold` is `0` in `zetaclient/config/types.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62f8a91f2c753a8cae4f6c7b779f11764cc285dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The mempool congestion threshold now falls back to a sensible default when the configured value is unset (0), avoiding unintended zero-value behavior.
  - Improves reliability of congestion detection and more predictable transaction handling under load.
  - Enhances overall stability without changing external APIs. No action needed unless you want to set a custom threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->