### PR TITLE
fix: wrong error usage for aborted cctx error message

### DIFF
--- a/x/crosschain/keeper/abort.go
+++ b/x/crosschain/keeper/abort.go
@@ -76,7 +76,7 @@ func (k Keeper) ProcessAbort(
 				// this happens if the cctx events are not processed correctly with invalid withdrawals
 				// in this situation we want the CCTX to be reverted, we don't commit the state so the contract call is not persisted
 				// the contract call is considered as reverted
-				messages.ErrorMessageAbort = "failed to process logs for abort: " + err.Error()
+				messages.ErrorMessageAbort = "failed to process logs for abort: " + processLogsErr.Error()
 				cctx.CctxStatus.UpdateStatusAndErrorMessages(types.CctxStatus_Aborted, messages)
 				return
 			}


### PR DESCRIPTION
# Description

Use the correct error in the error message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting in abort operations to display specific failures from log processing instead of generic errors. Users now receive more precise and actionable error information when abort operations encounter issues, enabling better troubleshooting of transaction problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->