### PR TITLE
chore: fix the inconsistent method names in the comments

### DIFF
--- a/app/eips/eips.go
+++ b/app/eips/eips.go
@@ -11,7 +11,7 @@ var (
 
 // NOTE: copied from cosmos evm to avoid importing evmd
 
-// enable0000 contains the logic to modify the CREATE and CREATE2 opcodes
+// Enable0000 contains the logic to modify the CREATE and CREATE2 opcodes
 // constant gas value.
 func Enable0000(jt *vm.JumpTable) {
 	currentValCreate := jt[vm.CREATE].GetConstantGas()
@@ -21,14 +21,14 @@ func Enable0000(jt *vm.JumpTable) {
 	jt[vm.CREATE2].SetConstantGas(currentValCreate2 * Multiplier)
 }
 
-// enable0001 contains the logic to modify the CALL opcode
+// Enable0001 contains the logic to modify the CALL opcode
 // constant gas value.
 func Enable0001(jt *vm.JumpTable) {
 	currentVal := jt[vm.CALL].GetConstantGas()
 	jt[vm.CALL].SetConstantGas(currentVal * Multiplier)
 }
 
-// enable0002 contains the logic to modify the SSTORE opcode
+// Enable0002 contains the logic to modify the SSTORE opcode
 // constant gas value.
 func Enable0002(jt *vm.JumpTable) {
 	jt[vm.SSTORE].SetConstantGas(SstoreConstantGas)

--- a/cmd/zetatool/chains/solana.go
+++ b/cmd/zetatool/chains/solana.go
@@ -9,7 +9,7 @@ import (
 	clienttypes "github.com/zeta-chain/node/zetaclient/types"
 )
 
-// voteMsgFromSolEvent builds a MsgVoteInbound from an inbound event
+// VoteMsgFromSolEvent builds a MsgVoteInbound from an inbound event
 func VoteMsgFromSolEvent(event *clienttypes.InboundEvent,
 	zetaChainID int64) (*crosschaintypes.MsgVoteInbound, error) {
 	// create inbound vote message

--- a/e2e/runner/e2etest.go
+++ b/e2e/runner/e2etest.go
@@ -160,7 +160,7 @@ func (r *E2ERunner) GetE2ETestsToRunByConfig(
 	return tests, nil
 }
 
-// findE2ETest finds a e2e test by name
+// findE2ETestByName finds a e2e test by name
 func findE2ETestByName(e2eTests []E2ETest, e2eTestName string) (E2ETest, bool) {
 	for _, test := range e2eTests {
 		if test.Name == e2eTestName {

--- a/e2e/runner/require.go
+++ b/e2e/runner/require.go
@@ -26,7 +26,7 @@ func (r *E2ERunner) EnsureNoTrackers() {
 	require.Empty(r, res.OutboundTracker, "there should be no trackers at the end of the test")
 }
 
-// EnsureZeroBalanceAddressZEVM ensures that the balance of the restricted address is zero in the ZEVM
+// EnsureZeroBalanceOnRestrictedAddressZEVM ensures that the balance of the restricted address is zero in the ZEVM
 func (r *E2ERunner) EnsureZeroBalanceOnRestrictedAddressZEVM() {
 	restrictedAddress := ethcommon.HexToAddress(sample.RestrictedEVMAddressTest)
 


### PR DESCRIPTION
# Description

fix the inconsistent method names in the comments

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CREATE2 opcode gas calculation logic
  * Improved internal function and method naming for enhanced code clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->