### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/contrib/rpctest/main.go
+++ b/contrib/rpctest/main.go
@@ -27,10 +27,10 @@ var (
 )
 
 type Request struct {
-	Jsonrpc string        `json:"jsonrpc"`
-	Method  string        `json:"method"`
-	Params  []interface{} `json:"params"`
-	ID      int           `json:"id"`
+	Jsonrpc string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+	ID      int    `json:"id"`
 }
 
 type Response struct {
@@ -82,7 +82,7 @@ func main() {
 		HTTPClient: &http.Client{},
 	}
 	resp := client.EthGetBlockByNumber(bnUint64, false)
-	var jsonObject map[string]interface{}
+	var jsonObject map[string]any
 	if resp.Error != nil {
 		fmt.Printf("Error: %s (code %d)\n", resp.Error.Message, resp.Error.Code)
 		panic(resp.Error.Message)
@@ -92,7 +92,7 @@ func main() {
 		panic(err)
 	}
 
-	txs, ok := jsonObject["transactions"].([]interface{})
+	txs, ok := jsonObject["transactions"].([]any)
 	if !ok || len(txs) != 1 {
 		panic("Wrong number of txs")
 	}
@@ -164,7 +164,7 @@ func main() {
 		fmt.Printf("Error: %s (code %d)\n", receipt2.Error.Message, receipt2.Error.Code)
 		panic(tx.Error.Message)
 	}
-	jsonObject = make(map[string]interface{})
+	jsonObject = make(map[string]any)
 	err = json.Unmarshal(receipt2.Result, &jsonObject)
 	if err != nil {
 		panic(err)
@@ -266,7 +266,7 @@ func (c *EthClient) EthGetBlockByNumber(blockNum uint64, verbose bool) *Response
 	req := &Request{
 		Jsonrpc: "2.0",
 		Method:  "eth_getBlockByNumber",
-		Params: []interface{}{
+		Params: []any{
 			hexBlockNum,
 			verbose,
 		},
@@ -309,7 +309,7 @@ func (c *EthClient) EthGetTransactionReceipt(txhash string) *Response {
 	req := &Request{
 		Jsonrpc: "2.0",
 		Method:  "eth_getTransactionReceipt",
-		Params: []interface{}{
+		Params: []any{
 			txhash,
 		},
 		ID: 1,

--- a/pkg/chains/address.go
+++ b/pkg/chains/address.go
@@ -41,7 +41,7 @@ func (addr Address) String() string {
 	return string(addr)
 }
 
-func ConvertRecoverToError(r interface{}) error {
+func ConvertRecoverToError(r any) error {
 	switch x := r.(type) {
 	case string:
 		return errors.New(x)

--- a/pkg/contracts/solana/idl.go
+++ b/pkg/contracts/solana/idl.go
@@ -41,8 +41,8 @@ type Seed struct {
 }
 
 type Arg struct {
-	Name string      `json:"name"`
-	Type interface{} `json:"type"`
+	Name string `json:"name"`
+	Type any    `json:"type"`
 }
 
 type Error struct {
@@ -62,6 +62,6 @@ type TypeField struct {
 }
 
 type Field struct {
-	Name string      `json:"name"`
-	Type interface{} `json:"type"`
+	Name string `json:"name"`
+	Type any    `json:"type"`
 }

--- a/pkg/errgroup/errgroup.go
+++ b/pkg/errgroup/errgroup.go
@@ -88,7 +88,7 @@ func (g *Group) Go(f func() error) {
 //			err := fromPanicValue(recover())
 //			// log or otherwise use err
 //		}()
-func fromPanicValue(i interface{}) error {
+func fromPanicValue(i any) error {
 	switch value := i.(type) {
 	case nil:
 		return nil

--- a/pkg/proofs/ethereum/proof.go
+++ b/pkg/proofs/ethereum/proof.go
@@ -116,7 +116,7 @@ type Trie struct {
 }
 
 var encodeBufferPool = sync.Pool{
-	New: func() interface{} { return new(bytes.Buffer) },
+	New: func() any { return new(bytes.Buffer) },
 }
 
 func encodeForDerive(list types.DerivableList, i int, buf *bytes.Buffer) []byte {


### PR DESCRIPTION
# Description


This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code type annotations to align with current Go standards, with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->