### PR TITLE
fix(v37): accept uppercase receiver address in Bitcoin withdrawal

### DIFF
--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
@@ -252,10 +253,20 @@ func (r *E2ERunner) WithdrawBTC(
 		r.ApproveBTCZRC20(r.GatewayZEVMAddr)
 	}
 
+	// convert P2WPKH/P2WSH addresses to uppercase, it should work without issue
+	var receiverStr string
+	switch to.(type) {
+	case *btcutil.AddressWitnessPubKeyHash,
+		*btcutil.AddressWitnessScriptHash:
+		receiverStr = strings.ToUpper(to.EncodeAddress())
+	default:
+		receiverStr = to.EncodeAddress()
+	}
+
 	// withdraw 'amount' of BTC through ZEVM gateway
 	tx, err := r.GatewayZEVM.Withdraw(
 		r.ZEVMAuth,
-		[]byte(to.EncodeAddress()),
+		[]byte(receiverStr),
 		amount,
 		r.BTCZRC20Addr,
 		revertOptions,

--- a/pkg/chains/address_test.go
+++ b/pkg/chains/address_test.go
@@ -2,6 +2,7 @@ package chains
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -156,7 +157,7 @@ func Test_IsBtcAddressSupported_P2TR(t *testing.T) {
 		{
 			// https://mempool.space/tx/259fc21e63e138136c8f19270a0f7ca10039a66a474f91d23a17896f46e677a7
 			name:      "mainnet taproot address",
-			addr:      "bc1p4scddlkkuw9486579autxumxmkvuphm5pz4jvf7f6pdh50p2uzqstawjt9",
+			addr:      strings.ToUpper("bc1p4scddlkkuw9486579autxumxmkvuphm5pz4jvf7f6pdh50p2uzqstawjt9"),
 			chainId:   BitcoinMainnet.ChainId,
 			supported: true,
 		},
@@ -207,7 +208,7 @@ func Test_IsBtcAddressSupported_P2WSH(t *testing.T) {
 		{
 			// https://mempool.space/testnet/tx/78fac3f0d4c0174c88d21c4bb1e23a8f007e890c6d2cfa64c97389ead16c51ed
 			name:      "testnet P2WSH address",
-			addr:      "tb1quhassyrlj43qar0mn0k5sufyp6mazmh2q85lr6ex8ehqfhxpzsksllwrsu",
+			addr:      strings.ToUpper("tb1quhassyrlj43qar0mn0k5sufyp6mazmh2q85lr6ex8ehqfhxpzsksllwrsu"),
 			chainId:   BitcoinTestnet.ChainId,
 			supported: true,
 		},
@@ -256,7 +257,7 @@ func Test_IsBtcAddressSupported_P2WPKH(t *testing.T) {
 		},
 		{
 			name:      "regtest P2WPKH address",
-			addr:      "bcrt1qy9pqmk2pd9sv63g27jt8r657wy0d9uee4x2dt2",
+			addr:      strings.ToUpper("bcrt1qy9pqmk2pd9sv63g27jt8r657wy0d9uee4x2dt2"),
 			chainId:   BitcoinRegtest.ChainId,
 			supported: true,
 		},

--- a/zetaclient/chains/bitcoin/common/tx_script_test.go
+++ b/zetaclient/chains/bitcoin/common/tx_script_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/node/pkg/chains"
@@ -509,10 +510,10 @@ func TestDecodeTSSVout(t *testing.T) {
 		txHash := "259fc21e63e138136c8f19270a0f7ca10039a66a474f91d23a17896f46e677a7"
 		rawResult := testutils.LoadBTCTxRawResult(t, TestDataDir, chain.ChainId, "P2TR", txHash)
 
-		receiverExpected := "bc1p4scddlkkuw9486579autxumxmkvuphm5pz4jvf7f6pdh50p2uzqstawjt9"
+		receiverExpected := addressDecoder(t, "bc1p4scddlkkuw9486579autxumxmkvuphm5pz4jvf7f6pdh50p2uzqstawjt9", chain.ChainId)
 		receiver, amount, err := common.DecodeTSSVout(rawResult.Vout[0], receiverExpected, chain)
 		require.NoError(t, err)
-		require.Equal(t, receiverExpected, receiver)
+		require.Equal(t, receiverExpected.EncodeAddress(), receiver)
 		require.Equal(t, int64(45000), amount)
 	})
 
@@ -521,10 +522,10 @@ func TestDecodeTSSVout(t *testing.T) {
 		txHash := "791bb9d16f7ab05f70a116d18eaf3552faf77b9d5688699a480261424b4f7e53"
 		rawResult := testutils.LoadBTCTxRawResult(t, TestDataDir, chain.ChainId, "P2WSH", txHash)
 
-		receiverExpected := "bc1qqv6pwn470vu0tssdfha4zdk89v3c8ch5lsnyy855k9hcrcv3evequdmjmc"
+		receiverExpected := addressDecoder(t, "bc1qqv6pwn470vu0tssdfha4zdk89v3c8ch5lsnyy855k9hcrcv3evequdmjmc", chain.ChainId)
 		receiver, amount, err := common.DecodeTSSVout(rawResult.Vout[0], receiverExpected, chain)
 		require.NoError(t, err)
-		require.Equal(t, receiverExpected, receiver)
+		require.Equal(t, receiverExpected.EncodeAddress(), receiver)
 		require.Equal(t, int64(36557203), amount)
 	})
 
@@ -533,10 +534,10 @@ func TestDecodeTSSVout(t *testing.T) {
 		txHash := "5d09d232bfe41c7cb831bf53fc2e4029ab33a99087fd5328a2331b52ff2ebe5b"
 		rawResult := testutils.LoadBTCTxRawResult(t, TestDataDir, chain.ChainId, "P2WPKH", txHash)
 
-		receiverExpected := "bc1qaxf82vyzy8y80v000e7t64gpten7gawewzu42y"
+		receiverExpected := addressDecoder(t, "bc1qaxf82vyzy8y80v000e7t64gpten7gawewzu42y", chain.ChainId)
 		receiver, amount, err := common.DecodeTSSVout(rawResult.Vout[0], receiverExpected, chain)
 		require.NoError(t, err)
-		require.Equal(t, receiverExpected, receiver)
+		require.Equal(t, receiverExpected.EncodeAddress(), receiver)
 		require.Equal(t, int64(79938), amount)
 	})
 
@@ -545,10 +546,10 @@ func TestDecodeTSSVout(t *testing.T) {
 		txHash := "fd68c8b4478686ca6f5ae4c28eaab055490650dbdaa6c2c8e380a7e075958a21"
 		rawResult := testutils.LoadBTCTxRawResult(t, TestDataDir, chain.ChainId, "P2SH", txHash)
 
-		receiverExpected := "327z4GyFM8Y8DiYfasGKQWhRK4MvyMSEgE"
+		receiverExpected := addressDecoder(t, "327z4GyFM8Y8DiYfasGKQWhRK4MvyMSEgE", chain.ChainId)
 		receiver, amount, err := common.DecodeTSSVout(rawResult.Vout[0], receiverExpected, chain)
 		require.NoError(t, err)
-		require.Equal(t, receiverExpected, receiver)
+		require.Equal(t, receiverExpected.EncodeAddress(), receiver)
 		require.Equal(t, int64(1003881), amount)
 	})
 
@@ -557,10 +558,10 @@ func TestDecodeTSSVout(t *testing.T) {
 		txHash := "9c741de6e17382b7a9113fc811e3558981a35a360e3d1262a6675892c91322ca"
 		rawResult := testutils.LoadBTCTxRawResult(t, TestDataDir, chain.ChainId, "P2PKH", txHash)
 
-		receiverExpected := "1FueivsE338W2LgifJ25HhTcVJ7CRT8kte"
+		receiverExpected := addressDecoder(t, "1FueivsE338W2LgifJ25HhTcVJ7CRT8kte", chain.ChainId)
 		receiver, amount, err := common.DecodeTSSVout(rawResult.Vout[0], receiverExpected, chain)
 		require.NoError(t, err)
-		require.Equal(t, receiverExpected, receiver)
+		require.Equal(t, receiverExpected.EncodeAddress(), receiver)
 		require.Equal(t, int64(1140000), amount)
 	})
 }
@@ -572,7 +573,7 @@ func TestDecodeTSSVoutErrors(t *testing.T) {
 	txHash := "259fc21e63e138136c8f19270a0f7ca10039a66a474f91d23a17896f46e677a7"
 
 	rawResult := testutils.LoadBTCTxRawResult(t, TestDataDir, chain.ChainId, "P2TR", txHash)
-	receiverExpected := "bc1p4scddlkkuw9486579autxumxmkvuphm5pz4jvf7f6pdh50p2uzqstawjt9"
+	receiverExpected := addressDecoder(t, "bc1p4scddlkkuw9486579autxumxmkvuphm5pz4jvf7f6pdh50p2uzqstawjt9", chain.ChainId)
 
 	t.Run("should return error on invalid amount", func(t *testing.T) {
 		invalidVout := rawResult.Vout[0]
@@ -589,20 +590,6 @@ func TestDecodeTSSVoutErrors(t *testing.T) {
 		invalidChain := chains.Chain{ChainId: 123}
 		receiver, amount, err := common.DecodeTSSVout(invalidVout, receiverExpected, invalidChain)
 		require.ErrorContains(t, err, "error GetBTCChainParams")
-		require.Empty(t, receiver)
-		require.Zero(t, amount)
-	})
-
-	t.Run("should return error when invalid receiver passed", func(t *testing.T) {
-		invalidVout := rawResult.Vout[0]
-		// use testnet params to decode mainnet receiver
-		wrongChain := chains.BitcoinTestnet
-		receiver, amount, err := common.DecodeTSSVout(
-			invalidVout,
-			"bc1qulmx8ej27cj0xe20953cztr2excnmsqvuh0s5c",
-			wrongChain,
-		)
-		require.ErrorContains(t, err, "error decoding receiver")
 		require.Empty(t, receiver)
 		require.Zero(t, amount)
 	})
@@ -698,4 +685,11 @@ func TestDecodeScript(t *testing.T) {
 		require.False(t, isFound)
 		require.Nil(t, memo)
 	})
+}
+
+// addressDecoder decodes a BTC address from a given string and chainID
+func addressDecoder(t *testing.T, addressStr string, chainID int64) btcutil.Address {
+	btcAddress, err := chains.DecodeBtcAddress(addressStr, chainID)
+	require.NoError(t, err)
+	return btcAddress
 }

--- a/zetaclient/chains/bitcoin/observer/outbound.go
+++ b/zetaclient/chains/bitcoin/observer/outbound.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/math"
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/pkg/errors"
 
@@ -444,41 +445,52 @@ func (ob *Observer) checkTSSVout(params *crosschaintypes.OutboundParams, vouts [
 		return fmt.Errorf("checkTSSVout: invalid number of vouts: %d", len(vouts))
 	}
 
-	nonce := params.TssNonce
-	tssAddress := ob.TSSAddressString()
+	// decode cctx receiver address
+	cctxReceiver, err := chains.DecodeBtcAddress(params.Receiver, ob.Chain().ChainId)
+	if err != nil {
+		return errors.Wrapf(err, "error decoding receiver %s", params.Receiver)
+	}
+
+	tssAddress, err := ob.TSS().PubKey().AddressBTC(ob.Chain().ChainId)
+	if err != nil {
+		return errors.Wrapf(err, "error getting TSS address")
+	}
+
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
-		receiverExpected := tssAddress
+		var receiverExpected btcutil.Address = tssAddress
 		if vout.N == 1 {
-			// the 2nd output is the payment to recipient
-			receiverExpected = params.Receiver
+			receiverExpected = cctxReceiver
 		}
+
+		// decode receiver and amount from vout
 		receiverVout, amount, err := common.DecodeTSSVout(vout, receiverExpected, ob.Chain())
 		if err != nil {
 			return err
 		}
+
 		switch vout.N {
 		case 0: // 1st vout: nonce-mark
-			if receiverVout != tssAddress {
+			if receiverVout != tssAddress.EncodeAddress() {
 				return fmt.Errorf(
 					"checkTSSVout: nonce-mark address %s not match TSS address %s",
 					receiverVout,
-					tssAddress,
+					tssAddress.EncodeAddress(),
 				)
 			}
-			if amount != chains.NonceMarkAmount(nonce) {
+			if amount != chains.NonceMarkAmount(params.TssNonce) {
 				return fmt.Errorf(
 					"checkTSSVout: nonce-mark amount %d not match nonce-mark amount %d",
 					amount,
-					chains.NonceMarkAmount(nonce),
+					chains.NonceMarkAmount(params.TssNonce),
 				)
 			}
 		case 1: // 2nd vout: payment to recipient
-			if receiverVout != params.Receiver {
+			if receiverVout != cctxReceiver.EncodeAddress() {
 				return fmt.Errorf(
 					"checkTSSVout: output address %s not match params receiver %s",
 					receiverVout,
-					params.Receiver,
+					cctxReceiver.EncodeAddress(),
 				)
 			}
 			// #nosec G115 always positive
@@ -486,8 +498,12 @@ func (ob *Observer) checkTSSVout(params *crosschaintypes.OutboundParams, vouts [
 				return fmt.Errorf("checkTSSVout: output amount %d not match params amount %d", amount, params.Amount)
 			}
 		case 2: // 3rd vout: change to TSS (optional)
-			if receiverVout != tssAddress {
-				return fmt.Errorf("checkTSSVout: change address %s not match TSS address %s", receiverVout, tssAddress)
+			if receiverVout != tssAddress.EncodeAddress() {
+				return fmt.Errorf(
+					"checkTSSVout: change address %s not match TSS address %s",
+					receiverVout,
+					tssAddress.EncodeAddress(),
+				)
 			}
 		}
 	}
@@ -503,8 +519,12 @@ func (ob *Observer) checkTSSVoutCancelled(params *crosschaintypes.OutboundParams
 		return fmt.Errorf("checkTSSVoutCancelled: invalid number of vouts: %d", len(vouts))
 	}
 
+	tssAddress, err := ob.TSS().PubKey().AddressBTC(ob.Chain().ChainId)
+	if err != nil {
+		return errors.Wrapf(err, "error getting TSS address")
+	}
+
 	nonce := params.TssNonce
-	tssAddress := ob.TSSAddressString()
 	for _, vout := range vouts {
 		// decode receiver and amount from vout
 		receiverVout, amount, err := common.DecodeTSSVout(vout, tssAddress, ob.Chain())
@@ -513,11 +533,11 @@ func (ob *Observer) checkTSSVoutCancelled(params *crosschaintypes.OutboundParams
 		}
 		switch vout.N {
 		case 0: // 1st vout: nonce-mark
-			if receiverVout != tssAddress {
+			if receiverVout != tssAddress.EncodeAddress() {
 				return fmt.Errorf(
 					"checkTSSVoutCancelled: nonce-mark address %s not match TSS address %s",
 					receiverVout,
-					tssAddress,
+					tssAddress.EncodeAddress(),
 				)
 			}
 			if amount != chains.NonceMarkAmount(nonce) {
@@ -528,11 +548,11 @@ func (ob *Observer) checkTSSVoutCancelled(params *crosschaintypes.OutboundParams
 				)
 			}
 		case 1: // 2nd vout: change to TSS (optional)
-			if receiverVout != tssAddress {
+			if receiverVout != tssAddress.EncodeAddress() {
 				return fmt.Errorf(
 					"checkTSSVoutCancelled: change address %s not match TSS address %s",
 					receiverVout,
-					tssAddress,
+					tssAddress.EncodeAddress(),
 				)
 			}
 		}

--- a/zetaclient/chains/bitcoin/observer/outbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/outbound_test.go
@@ -65,6 +65,7 @@ func TestCheckTSSVout(t *testing.T) {
 		err := ob.checkTSSVout(params, rawResult.Vout)
 		require.NoError(t, err)
 	})
+
 	t.Run("should fail if vout length < 2 or > 3", func(t *testing.T) {
 		_, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()
@@ -75,6 +76,7 @@ func TestCheckTSSVout(t *testing.T) {
 		err = ob.checkTSSVout(params, []btcjson.Vout{{}, {}, {}, {}})
 		require.ErrorContains(t, err, "invalid number of vouts")
 	})
+
 	t.Run("should fail on invalid TSS vout", func(t *testing.T) {
 		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()
@@ -84,6 +86,7 @@ func TestCheckTSSVout(t *testing.T) {
 		err := ob.checkTSSVout(params, rawResult.Vout)
 		require.Error(t, err)
 	})
+
 	t.Run("should fail if vout 0 is not to the TSS address", func(t *testing.T) {
 		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()
@@ -93,6 +96,17 @@ func TestCheckTSSVout(t *testing.T) {
 		err := ob.checkTSSVout(params, rawResult.Vout)
 		require.ErrorContains(t, err, "not match TSS address")
 	})
+
+	t.Run("should fail if unable to decode receiver address", func(t *testing.T) {
+		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
+		params := cctx.GetCurrentOutboundParam()
+
+		// invalid receiver address (testnet address, not mainnet)
+		params.Receiver = "tb1q6rufg6myrxurdn0h57d2qhtm9zfmjw2mzcm05q"
+		err := ob.checkTSSVout(params, rawResult.Vout)
+		require.ErrorContains(t, err, "error decoding receiver")
+	})
+
 	t.Run("should fail if vout 0 not match nonce mark", func(t *testing.T) {
 		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()
@@ -102,6 +116,7 @@ func TestCheckTSSVout(t *testing.T) {
 		err := ob.checkTSSVout(params, rawResult.Vout)
 		require.ErrorContains(t, err, "not match nonce-mark amount")
 	})
+
 	t.Run("should fail if vout 1 is not to the receiver address", func(t *testing.T) {
 		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()
@@ -111,6 +126,7 @@ func TestCheckTSSVout(t *testing.T) {
 		err := ob.checkTSSVout(params, rawResult.Vout)
 		require.ErrorContains(t, err, "not match params receiver")
 	})
+
 	t.Run("should fail if vout 1 not match payment amount", func(t *testing.T) {
 		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()
@@ -120,6 +136,7 @@ func TestCheckTSSVout(t *testing.T) {
 		err := ob.checkTSSVout(params, rawResult.Vout)
 		require.ErrorContains(t, err, "not match params amount")
 	})
+
 	t.Run("should fail if vout 2 is not to the TSS address", func(t *testing.T) {
 		rawResult, cctx := testutils.LoadBTCTxRawResultNCctx(t, TestDataDir, chainID, nonce)
 		params := cctx.GetCurrentOutboundParam()


### PR DESCRIPTION
# Description

This PR is a cherry-pick of [4448](https://github.com/zeta-chain/node/pull/4448) but targets `v37`.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Accepts uppercase Bitcoin Bech32 receiver addresses in withdrawals and refactors TSS vout/observer logic to use btcutil.Address, with tests updated accordingly.
> 
> - **Bitcoin E2E**:
>   - Normalize Bech32 receivers: uppercase `P2WPKH/P2WSH` addresses before `GatewayZEVM.Withdraw` in `e2e/runner/bitcoin.go`.
> - **Common (tx_script)**:
>   - Change `DecodeTSSVout` to accept `btcutil.Address` (type-driven decoding); remove internal string decoding; return receiver via `EncodeAddress()`.
> - **Observer**:
>   - In `checkTSSVout`/`checkTSSVoutCancelled`, decode `params.Receiver` to `btcutil.Address`, fetch TSS address as `btcutil.Address`, compare using `EncodeAddress()`; improved error handling for receiver decode.
> - **Tests**:
>   - Update unit tests to pass decoded addresses and compare via `EncodeAddress()`.
>   - Add cases that use uppercase Bech32 inputs and receiver-decode failure paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c522a2715a770dba82775ce3e17a0da6bd24454. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->