### PR TITLE
feat: Add action to build & push zetanode image internally

### DIFF
--- a/.github/workflows/publish-zetanode-image-internal.yml
+++ b/.github/workflows/publish-zetanode-image-internal.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   build-and-push:
     runs-on: gcp-athens-runners
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -111,3 +112,10 @@ jobs:
           echo "**Commit**: \`${{ env.NODE_COMMIT }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Image successfully pushed to Google Artifact Registry." >> $GITHUB_STEP_SUMMARY
+      - name: Clean up workspace & Docker images
+        if: always()
+        shell: bash
+        run: |
+          docker rmi zetanode:latest || true
+          docker image prune -f || true
+          sudo rm -rf * || echo "Failed to cleanup workspace"


### PR DESCRIPTION
# Description

Adds a github action to build and publish zetanode image to our registry, and deploy the latest version 

This action helps in testing zetaclient in dryrun mode: https://github.com/zeta-chain/infrastructure/issues/2431

# How Has This Been Tested?

WIP 

- [ ] Tested CCTX in localnet
- [x] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a GitHub Actions workflow to build the zetanode image and push tagged snapshots to Google Artifact Registry for internal/dev use.
> 
> - **CI (GitHub Actions)**:
>   - **New workflow** `/.github/workflows/publish-zetanode-image-internal.yml`:
>     - Triggers on `workflow_dispatch` (optional `ref`) and PRs to `develop`.
>     - Builds Docker image via `make zetanode` on `gcp-athens-runners`.
>     - Authenticates with GCP and configures Docker for `us-docker.pkg.dev`.
>     - Determines `NODE_VERSION` from tags (with v-prefix and patch bump fallback) and captures commit hash.
>     - Pushes image to GAR repository as `latest` and as `${NODE_VERSION}-${NODE_COMMIT_SHORT}`.
>     - Outputs build summary with image, version, and commit details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aea1a0490b4515324091b9e2c1f2f87fb81bfa84. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal deployment infrastructure with automated Docker image building and publishing, including improved version tagging and commit tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->