### PR TITLE
chore: cherry-pick workflow fixes for legacy release

### DIFF
--- a/.github/workflows/publish-release-legacy.yml
+++ b/.github/workflows/publish-release-legacy.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           make release-snapshot
 
-  publish-release:
+  publish-release-legacy:
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
This PR cherry-picks workflow changes to restore legacy release workflows:

## Cherry-picked commits:
- `ef139a3` - Add legacy workflow file to build zetaclient
- `87800f5` - rename to legacy  
- `7236bbc` - Fix job name to fix dependency graph

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the release workflow and job to legacy variants, updates concurrency and dependencies, and adjusts how the version input is passed to the environment.
> 
> - **CI/CD (GitHub Actions)**:
>   - Rename workflow to `Publish Release Legacy`; update `concurrency.group` to `publish-release-legacy`.
>   - Rename job `publish-release` -> `publish-release-legacy` and update `publish-typescript` to depend on it.
>   - In `Set Version`, read `inputs.version` via `VERSION_INPUT` env and export `GITHUB_TAG_VERSION` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9c0b50f0680ef573d0724a3bd6c166391f5bc2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->