### PR TITLE
fix: skip stale block events in all CCTX schedulers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@ The `zetacored` binary must be upgraded to trigger chain parameters data migrati
 * [4509](https://github.com/zeta-chain/node/pull/4509) - use outbound schedule interval in sui cctx scheduling
 * [4514](https://github.com/zeta-chain/node/pull/4514) - use Zeta height as a factor to calculate the EVM chain artificial height for TSS keysign
 * [4513](https://github.com/zeta-chain/node/pull/4513) - use `outbound_schedule_interval` and `outbound_schedule_lookahead` in ton cctx scheduling
+* [4516](https://github.com/zeta-chain/node/pull/4516) - skip stale events in the Zeta block subscription channel
 
 ### Tests
 

--- a/zetaclient/chains/base/signer_batch_sign.go
+++ b/zetaclient/chains/base/signer_batch_sign.go
@@ -25,9 +25,9 @@ const (
 	collectBatchRetries = 2
 )
 
-// IsStaleBlockEvent checks if the block event is stale and returns (zeta_height, is_stale, error).
-func (s *Signer) IsStaleBlockEvent(ctx context.Context, zetaRepo *zrepo.ZetaRepo) (int64, bool, error) {
-	zetaBlock, _, err := scheduler.BlockFromContextWithDelay(ctx)
+// CheckBlockEvent checks if the block event is stale and returns (zeta_height, is_stale, error).
+func (s *Signer) CheckBlockEvent(ctx context.Context, zetaRepo *zrepo.ZetaRepo) (int64, bool, error) {
+	zetaBlock, delay, err := scheduler.BlockFromContextWithDelay(ctx)
 	if err != nil {
 		return 0, false, errors.Wrap(err, "unable to get block event from context")
 	}
@@ -48,6 +48,9 @@ func (s *Signer) IsStaleBlockEvent(ctx context.Context, zetaRepo *zrepo.ZetaRepo
 			Msg("stale block event")
 		return zetaHeight, true, nil
 	}
+
+	// if the event is not stale, it applies the keysign delay configured in operational flags
+	time.Sleep(delay)
 
 	return zetaHeight, false, nil
 }

--- a/zetaclient/chains/base/signer_batch_sign_test.go
+++ b/zetaclient/chains/base/signer_batch_sign_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
 )
 
-func Test_IsStaleBlockEvent(t *testing.T) {
+func Test_CheckBlockEvent(t *testing.T) {
 	tests := []struct {
 		name                string
 		eventHeight         int64
@@ -97,7 +97,7 @@ func Test_IsStaleBlockEvent(t *testing.T) {
 			}
 
 			// ACT
-			height, isStale, err := signer.IsStaleBlockEvent(ctx, zetaRepo)
+			height, isStale, err := signer.CheckBlockEvent(ctx, zetaRepo)
 
 			// ASSERT
 			if tc.errorMsg != "" {

--- a/zetaclient/chains/evm/evm.go
+++ b/zetaclient/chains/evm/evm.go
@@ -114,8 +114,8 @@ func (e *EVM) group() scheduler.Group {
 // scheduleCCTX schedules outbound transactions on each ZetaChain block.
 func (e *EVM) scheduleCCTX(ctx context.Context) error {
 	// skip stale block event if any
-	if _, stale, err := e.signer.IsStaleBlockEvent(ctx, e.observer.ZetaRepo()); err != nil {
-		return errors.Wrap(err, "unable to check block event")
+	if _, stale, err := e.signer.CheckBlockEvent(ctx, e.observer.ZetaRepo()); err != nil {
+		return errors.Wrap(err, "unable to check stale block event")
 	} else if stale {
 		return nil
 	}
@@ -193,9 +193,9 @@ func (e *EVM) scheduleKeysign(ctx context.Context) error {
 	zetaRepo := e.observer.ZetaRepo()
 
 	// skip stale block event if any
-	zetaHeight, stale, err := s.IsStaleBlockEvent(ctx, zetaRepo)
+	zetaHeight, stale, err := s.CheckBlockEvent(ctx, zetaRepo)
 	if err != nil {
-		return errors.Wrap(err, "unable to check block event")
+		return errors.Wrap(err, "unable to check stale block event")
 	} else if stale {
 		return nil
 	}

--- a/zetaclient/chains/sui/sui.go
+++ b/zetaclient/chains/sui/sui.go
@@ -103,18 +103,21 @@ func (s *Sui) group() scheduler.Group {
 
 // scheduleCCTX schedules outbound cross-chain transactions.
 func (s *Sui) scheduleCCTX(ctx context.Context) error {
+	zetaRepo := s.observer.ZetaRepo()
+
+	// skip stale block event in channel if any
+	blockHeight, stale, err := s.signer.CheckBlockEvent(ctx, zetaRepo)
+	if err != nil {
+		return errors.Wrap(err, "unable to check stale block event")
+	} else if stale {
+		return nil
+	}
+
 	if err := s.updateChainParams(ctx); err != nil {
 		return errors.Wrap(err, "unable to update chain params")
 	}
 
-	zetaBlock, delay, err := scheduler.BlockFromContextWithDelay(ctx)
-	if err != nil {
-		return errors.Wrap(err, "unable to get zeta block from context")
-	}
-
-	time.Sleep(delay)
-
-	cctxList, err := s.observer.ZetaRepo().GetPendingCCTXs(ctx)
+	cctxList, err := zetaRepo.GetPendingCCTXs(ctx)
 	if err != nil {
 		return err
 	}
@@ -126,7 +129,7 @@ func (s *Sui) scheduleCCTX(ctx context.Context) error {
 
 	var (
 		// #nosec G115 always in range
-		zetaHeight = uint64(zetaBlock.Block.Height)
+		zetaHeight = uint64(blockHeight)
 		chainID    = s.observer.Chain().ChainId
 
 		// #nosec G115 positive


### PR DESCRIPTION
# Description

This PR replaces [4516](https://github.com/zeta-chain/node/pull/4516) to target `main` branch.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented stale block event detection and skipping in the Zeta block subscription channel to optimize processing and prevent redundant operations across blockchain networks.

* **Refactor**
  * Updated block event handling mechanisms across all blockchain implementations with improved repository access consolidation, adjusted control flow, and enhanced delay management for better consistency and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->