### PR TITLE
fix: add AllowInsecureUnlock guard to eth_sign and eth_signTypedData

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ The `zetacored` binary must be upgraded to trigger chain parameters data migrati
 
 ### Fixes
 
+* [4562](https://github.com/zeta-chain/node/pull/4562) - add AllowInsecureUnlock guard to eth_sign and eth_signTypedData
 * [4403](https://github.com/zeta-chain/node/pull/4403) - load Sui inbound cursors from database for all supported packages
 * [4401](https://github.com/zeta-chain/node/pull/4401) - retry Sui inbound when the inbound vote RPC failed
 * [4414](https://github.com/zeta-chain/node/pull/4414) - fix example package deployment by removing gateway object reference

--- a/rpc/backend/sign_tx.go
+++ b/rpc/backend/sign_tx.go
@@ -124,7 +124,7 @@ func (b *Backend) SendTransaction(args evmtypes.TransactionArgs) (common.Hash, e
 func (b *Backend) Sign(address common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
 	if !b.Cfg.JSONRPC.AllowInsecureUnlock {
 		b.Logger.Debug("account unlock with HTTP access is forbidden")
-		return nil, fmt.Errorf("account unlock with HTTP access is forbidden")
+		return nil, errors.New("account unlock with HTTP access is forbidden")
 	}
 
 	from := sdk.AccAddress(address.Bytes())

--- a/rpc/backend/sign_tx.go
+++ b/rpc/backend/sign_tx.go
@@ -122,6 +122,11 @@ func (b *Backend) SendTransaction(args evmtypes.TransactionArgs) (common.Hash, e
 
 // Sign signs the provided data using the private key of address via Geth's signature standard.
 func (b *Backend) Sign(address common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
+	if !b.Cfg.JSONRPC.AllowInsecureUnlock {
+		b.Logger.Debug("account unlock with HTTP access is forbidden")
+		return nil, fmt.Errorf("account unlock with HTTP access is forbidden")
+	}
+
 	from := sdk.AccAddress(address.Bytes())
 
 	_, err := b.ClientCtx.Keyring.KeyByAddress(from)
@@ -143,6 +148,11 @@ func (b *Backend) Sign(address common.Address, data hexutil.Bytes) (hexutil.Byte
 
 // SignTypedData signs EIP-712 conformant typed data
 func (b *Backend) SignTypedData(address common.Address, typedData apitypes.TypedData) (hexutil.Bytes, error) {
+	if !b.Cfg.JSONRPC.AllowInsecureUnlock {
+		b.Logger.Debug("account unlock with HTTP access is forbidden")
+		return nil, fmt.Errorf("account unlock with HTTP access is forbidden")
+	}
+
 	from := sdk.AccAddress(address.Bytes())
 
 	_, err := b.ClientCtx.Keyring.KeyByAddress(from)

--- a/rpc/backend/sign_tx.go
+++ b/rpc/backend/sign_tx.go
@@ -150,7 +150,7 @@ func (b *Backend) Sign(address common.Address, data hexutil.Bytes) (hexutil.Byte
 func (b *Backend) SignTypedData(address common.Address, typedData apitypes.TypedData) (hexutil.Bytes, error) {
 	if !b.Cfg.JSONRPC.AllowInsecureUnlock {
 		b.Logger.Debug("account unlock with HTTP access is forbidden")
-		return nil, fmt.Errorf("account unlock with HTTP access is forbidden")
+		return nil, errors.New("account unlock with HTTP access is forbidden")
 	}
 
 	from := sdk.AccAddress(address.Bytes())

--- a/rpc/backend/sign_tx_test.go
+++ b/rpc/backend/sign_tx_test.go
@@ -154,6 +154,15 @@ func (s *TestSuite) TestSign() {
 		expPass      bool
 	}{
 		{
+			"fail - insecure unlock not allowed",
+			func() {
+				s.backend.Cfg.JSONRPC.AllowInsecureUnlock = false
+			},
+			from,
+			nil,
+			false,
+		},
+		{
 			"fail - can't find key in Keyring",
 			func() {},
 			from,
@@ -204,6 +213,15 @@ func (s *TestSuite) TestSignTypedData() {
 		inputTypedData apitypes.TypedData
 		expPass        bool
 	}{
+		{
+			"fail - insecure unlock not allowed",
+			func() {
+				s.backend.Cfg.JSONRPC.AllowInsecureUnlock = false
+			},
+			from,
+			apitypes.TypedData{},
+			false,
+		},
 		{
 			"fail - can't find key in Keyring",
 			func() {},


### PR DESCRIPTION
## Summary

- Add `AllowInsecureUnlock` check to `Sign()` and `SignTypedData()` in `rpc/backend/sign_tx.go`, consistent with the existing guard in `SendTransaction()`
- When `json-rpc.allow-insecure-unlock=false`, these methods now correctly reject signing requests instead of acting as an open signing oracle
- Add test cases verifying both methods reject requests when insecure unlock is disabled

## Test plan

- [x] `go test -tags=test ./rpc/backend/... -run TestBackendTestSuite/TestSign` — all pass including new guard test
- [x] `go test -tags=test ./rpc/backend/... -run TestBackendTestSuite/TestSignTypedData` — all pass including new guard test
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signing RPC behavior to hard-fail when `json-rpc.allow-insecure-unlock` is disabled, which is security-sensitive and could break clients that relied on the previous permissive behavior.
> 
> **Overview**
> **Prevents the JSON-RPC server from acting as an open signing oracle.** `Sign` (`eth_sign`) and `SignTypedData` (`eth_signTypedData`) now enforce the `Cfg.JSONRPC.AllowInsecureUnlock` gate, returning an error when insecure unlock is disabled (matching `SendTransaction`).
> 
> Tests are extended to cover the new rejection path for both signing methods when `AllowInsecureUnlock=false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8ea64168a0db21321a5c8e42db6ade6fc6c5ac7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a security gap where `eth_sign` (`Sign()`) and `eth_signTypedData` (`SignTypedData()`) were acting as open signing oracles even when `json-rpc.allow-insecure-unlock=false`, while `SendTransaction()` already had the guard in place. The fix adds the missing `AllowInsecureUnlock` check to both methods, making all three functions consistent in their access control.

- `Sign()` and `SignTypedData()` in `rpc/backend/sign_tx.go` now return early with an error when `AllowInsecureUnlock=false`, before any keyring access.
- New test cases in `sign_tx_test.go` verify the reject-when-disabled behavior for both methods; test isolation is correct since `SetupTest()` resets the flag to `true` before each case.
- The default value of `AllowInsecureUnlock` remains `true` (defined in `server/config/config.go`), meaning the change is non-breaking for existing deployments. Operators who had already set the flag to `false` will now correctly have `eth_sign` and `eth_signTypedData` blocked.
- Minor: `fmt.Errorf` is used without format verbs in the new error returns — `errors.New` would be more idiomatic, and is consistent with standard Go best practices.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, targeted security hardening with no functional side effects for default configurations.
- The change is a straightforward two-location guard addition that mirrors an already-proven pattern in `SendTransaction()`. Tests are well-structured and correctly isolated. No existing behavior is altered for the default (`AllowInsecureUnlock=true`) configuration. The only finding is a minor `fmt.Errorf`→`errors.New` style suggestion.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| rpc/backend/sign_tx.go | Adds `AllowInsecureUnlock` guard to `Sign()` and `SignTypedData()`, making them consistent with the existing guard in `SendTransaction()`. The guard is correctly placed before any keyring access, and the error message matches the existing pattern. Only a minor style note: `fmt.Errorf` without format verbs could be `errors.New`. |
| rpc/backend/sign_tx_test.go | Adds test cases for both `Sign` and `SignTypedData` verifying rejection when `AllowInsecureUnlock=false`. Tests are correctly placed as the first case in each suite so they run with a fresh `SetupTest()` reset (which sets `AllowInsecureUnlock=true`) before being overridden by `registerMock()`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as JSON-RPC Client
    participant Backend as Backend

    Note over Backend: AllowInsecureUnlock guard (NEW in Sign & SignTypedData)

    Client->>Backend: eth_sign / eth_signTypedData
    alt AllowInsecureUnlock = false
        Backend-->>Client: error: "account unlock with HTTP access is forbidden"
    else AllowInsecureUnlock = true
        Backend->>Backend: Keyring.KeyByAddress(from)
        alt key not found
            Backend-->>Client: error: ErrNoMatch
        else key found
            Backend->>Backend: Keyring.SignByAddress(from, data)
            Backend-->>Client: signature (hexutil.Bytes)
        end
    end

    Client->>Backend: eth_sendTransaction
    alt AllowInsecureUnlock = false
        Backend-->>Client: error: "account unlock with HTTP access is forbidden"
    else AllowInsecureUnlock = true
        Backend->>Backend: sign + broadcast tx
        Backend-->>Client: txHash
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: rpc/backend/sign_tx.go
Line: 127

Comment:
**Use `errors.New` instead of `fmt.Errorf`**

`fmt.Errorf` is used here without any format verbs, so `errors.New` is more idiomatic and avoids the minor overhead of format string parsing. The same applies to the equivalent line in `SignTypedData` (line 153) and the pre-existing pattern in `SendTransaction` (line 26).

```suggestion
		return nil, errors.New("account unlock with HTTP access is forbidden")
```

You would also need to add `"errors"` to the import block (it's already imported in the file), and can remove `fmt` if it's no longer used elsewhere. Since `fmt` is still used in other error returns, only the call sites need updating.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: rpc/backend/sign_tx.go
Line: 153

Comment:
**Use `errors.New` instead of `fmt.Errorf`**

Same as above — no format verbs are used, so `errors.New` would be more idiomatic.

```suggestion
		return nil, errors.New("account unlock with HTTP access is forbidden")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add AllowInsecureUnlock guard to et..."](https://github.com/zeta-chain/node/commit/d8ea64168a0db21321a5c8e42db6ade6fc6c5ac7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26229104)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by preventing account unlocking over HTTP when insecure unlock is disabled. The system now returns an error for unlock requests that violate the security configuration.

* **Tests**
  * Added test cases to verify signing operations properly fail when insecure unlock is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->