### PR TITLE
fix: tighten MtA proof bounds in tss-lib (backport v37)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -414,7 +414,7 @@ replace (
 replace (
 	// https://github.com/zeta-chain/tss-lib/tree/threshold-dep-updates
 	// which is a fork of https://github.com/threshold-network/tss-lib
-	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
+	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20260422170350-637906ded5ac
 
 	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20250821154530-f0addce1e5ac
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0

--- a/go.sum
+++ b/go.sum
@@ -1971,8 +1971,8 @@ github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88
 github.com/zeta-chain/protocol-contracts-solana/go-idl v0.0.0-20250409230544-d88f214f6f46/go.mod h1:DcDY828o773soiU/h0XpC+naxitrIMFVZqEvq/EJxMA=
 github.com/zeta-chain/solana-go v0.0.0-20250919220552-6800a0427762 h1:KaubBEpJe4qE51FlacXuC0GMuEjopTnW3ttzUikvw54=
 github.com/zeta-chain/solana-go v0.0.0-20250919220552-6800a0427762/go.mod h1:l/qqqIN6qJJPtxW/G1PF4JtcE3Zg2vD2EliZrr9Gn5k=
-github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901 h1:9whtN5fjYHfk4yXIuAsYP2EHxImwDWDVUOnZJ2pfL3w=
-github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901/go.mod h1:d2iTC62s9JwKiCMPhcDDXbIZmuzAyJ4lwso0H5QyRbk=
+github.com/zeta-chain/tss-lib v0.0.0-20260422170350-637906ded5ac h1:yJLwkls4gWxmU5rc0kiJ2op9RsPuuNcuJcZJPBfL+XI=
+github.com/zeta-chain/tss-lib v0.0.0-20260422170350-637906ded5ac/go.mod h1:d2iTC62s9JwKiCMPhcDDXbIZmuzAyJ4lwso0H5QyRbk=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=
 github.com/zondax/hid v0.9.2/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.14.3 h1:wEpJt2CEcBJ428md/5MgSLsXLBos98sBOyxNmCjfUCw=


### PR DESCRIPTION
## Summary
- Bump tss-lib to include https://github.com/zeta-chain/tss-lib/pull/15