### PR TITLE
fix(observer): skip forged outbound logs during v2 outbound receipt parsing

### DIFF
--- a/zetaclient/chains/evm/observer/v2_outbound.go
+++ b/zetaclient/chains/evm/observer/v2_outbound.go
@@ -75,6 +75,9 @@ func parseAndCheckGatewayExecuted(
 		if err != nil {
 			continue
 		}
+		if vLog.Address != gatewayAddr {
+			continue
+		}
 		// basic event check
 		if err := common.ValidateEvmTxLog(
 			vLog,
@@ -128,6 +131,9 @@ func parseAndCheckGatewayReverted(
 	for _, vLog := range receipt.Logs {
 		reverted, err := gateway.GatewayEVMFilterer.ParseReverted(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != gatewayAddr {
 			continue
 		}
 		// basic event check
@@ -189,6 +195,9 @@ func parseAndCheckZetaConnectorWithdraw(
 		if err != nil {
 			continue
 		}
+		if vLog.Address != connectorAddr {
+			continue
+		}
 		// basic event check
 		if err := common.ValidateEvmTxLog(
 			vLog,
@@ -238,6 +247,9 @@ func parseAndCheckERC20CustodyWithdraw(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := custody.ERC20CustodyFilterer.ParseWithdrawn(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != custodyAddr {
 			continue
 		}
 		// basic event check
@@ -297,6 +309,9 @@ func parseAndCheckERC20CustodyWithdrawAndCall(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := custody.ERC20CustodyFilterer.ParseWithdrawnAndCalled(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != custodyAddr {
 			continue
 		}
 		// basic event check
@@ -360,6 +375,9 @@ func parseAndZetaConnectorWithdrawAndCall(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := connector.ZetaConnectorNativeFilterer.ParseWithdrawnAndCalled(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != connectorAddr {
 			continue
 		}
 		// basic event check

--- a/zetaclient/chains/evm/observer/v2_outbound_test.go
+++ b/zetaclient/chains/evm/observer/v2_outbound_test.go
@@ -1,0 +1,347 @@
+package observer
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts-evm/pkg/erc20custody.sol"
+	"github.com/zeta-chain/protocol-contracts-evm/pkg/gatewayevm.sol"
+	"github.com/zeta-chain/protocol-contracts-evm/pkg/zetaconnectornative.sol"
+
+	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+type v2OutboundParser func(
+	cctx *crosschaintypes.CrossChainTx,
+	receipt *ethtypes.Receipt,
+) (*big.Int, chains.ReceiveStatus, error)
+
+func TestV2OutboundParsersSkipForgedLogs(t *testing.T) {
+	txHash := sample.Hash()
+	receiver := sample.EthAddress()
+	asset := sample.EthAddress()
+	amount := big.NewInt(42)
+	payload := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	gatewayAddr := sample.EthAddress()
+	forgedGatewayAddr := sample.EthAddress()
+	connectorAddr := sample.EthAddress()
+	forgedConnectorAddr := sample.EthAddress()
+	custodyAddr := sample.EthAddress()
+	forgedCustodyAddr := sample.EthAddress()
+
+	gateway := mustNewGatewayEVM(t, gatewayAddr)
+	connector := mustNewZetaConnectorNative(t, connectorAddr)
+	custody := mustNewERC20Custody(t, custodyAddr)
+
+	tests := []struct {
+		name    string
+		cctx    *crosschaintypes.CrossChainTx
+		receipt *ethtypes.Receipt
+		parse   v2OutboundParser
+	}{
+		{
+			name: "parseAndCheckGatewayExecuted",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeGatewayExecutedLog(t, forgedGatewayAddr, txHash, receiver, amount, payload),
+				makeGatewayExecutedLog(t, gatewayAddr, txHash, receiver, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckGatewayExecuted(cctx, receipt, gatewayAddr, gateway)
+			},
+		},
+		{
+			name: "parseAndCheckGatewayReverted",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeGatewayRevertedLog(t, forgedGatewayAddr, txHash, receiver, asset, amount, payload),
+				makeGatewayRevertedLog(t, gatewayAddr, txHash, receiver, asset, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckGatewayReverted(cctx, receipt, gatewayAddr, gateway)
+			},
+		},
+		{
+			name: "parseAndCheckZetaConnectorWithdraw",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeZetaConnectorWithdrawLog(t, forgedConnectorAddr, txHash, receiver, amount),
+				makeZetaConnectorWithdrawLog(t, connectorAddr, txHash, receiver, amount),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckZetaConnectorWithdraw(cctx, receipt, connectorAddr, connector)
+			},
+		},
+		{
+			name: "parseAndCheckERC20CustodyWithdraw",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeERC20CustodyWithdrawLog(t, forgedCustodyAddr, txHash, receiver, asset, amount),
+				makeERC20CustodyWithdrawLog(t, custodyAddr, txHash, receiver, asset, amount),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckERC20CustodyWithdraw(cctx, receipt, custodyAddr, custody)
+			},
+		},
+		{
+			name: "parseAndCheckERC20CustodyWithdrawAndCall",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeERC20CustodyWithdrawAndCallLog(t, forgedCustodyAddr, txHash, receiver, asset, amount, payload),
+				makeERC20CustodyWithdrawAndCallLog(t, custodyAddr, txHash, receiver, asset, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckERC20CustodyWithdrawAndCall(cctx, receipt, custodyAddr, custody)
+			},
+		},
+		{
+			name: "parseAndZetaConnectorWithdrawAndCall",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeZetaConnectorWithdrawAndCallLog(t, forgedConnectorAddr, txHash, receiver, amount, payload),
+				makeZetaConnectorWithdrawAndCallLog(t, connectorAddr, txHash, receiver, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndZetaConnectorWithdrawAndCall(cctx, receipt, connectorAddr, connector)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAmount, gotStatus, err := tt.parse(tt.cctx, tt.receipt)
+			require.NoError(t, err)
+			require.Equal(t, chains.ReceiveStatus_success, gotStatus)
+			require.Zero(t, gotAmount.Cmp(amount))
+		})
+	}
+}
+
+func newV2OutboundCCTX(
+	t *testing.T,
+	receiver ethcommon.Address,
+	asset ethcommon.Address,
+	amount *big.Int,
+	payload []byte,
+) *crosschaintypes.CrossChainTx {
+	t.Helper()
+
+	cctx := sample.CrossChainTxV2(t, "issue-4567")
+	cctx.InboundParams = &crosschaintypes.InboundParams{Asset: asset.Hex()}
+	cctx.OutboundParams = []*crosschaintypes.OutboundParams{{
+		Receiver:    receiver.Hex(),
+		Amount:      sdkmath.NewUintFromBigInt(amount),
+		CallOptions: &crosschaintypes.CallOptions{},
+	}}
+	cctx.RelayedMessage = hex.EncodeToString(payload)
+
+	return cctx
+}
+
+func newReceipt(txHash ethcommon.Hash, logs ...*ethtypes.Log) *ethtypes.Receipt {
+	return &ethtypes.Receipt{
+		Status: ethtypes.ReceiptStatusSuccessful,
+		TxHash: txHash,
+		Logs:   logs,
+	}
+}
+
+func makeGatewayExecutedLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	destination ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustGatewayABI(t).Events["Executed"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(destination)}, amount, data)
+}
+
+func makeGatewayRevertedLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	token ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustGatewayABI(t).Events["Reverted"]
+	return newEventLog(
+		t,
+		emitter,
+		txHash,
+		event,
+		[]ethcommon.Hash{addressTopic(to), addressTopic(token)},
+		amount,
+		data,
+		gatewayevm.RevertContext{
+			Sender:        sample.EthAddress(),
+			Asset:         token,
+			Amount:        amount,
+			RevertMessage: data,
+		},
+	)
+}
+
+func makeZetaConnectorWithdrawLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	amount *big.Int,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustZetaConnectorNativeABI(t).Events["Withdrawn"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to)}, amount)
+}
+
+func makeERC20CustodyWithdrawLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	token ethcommon.Address,
+	amount *big.Int,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustERC20CustodyABI(t).Events["Withdrawn"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to), addressTopic(token)}, amount)
+}
+
+func makeERC20CustodyWithdrawAndCallLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	token ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustERC20CustodyABI(t).Events["WithdrawnAndCalled"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to), addressTopic(token)}, amount, data)
+}
+
+func makeZetaConnectorWithdrawAndCallLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustZetaConnectorNativeABI(t).Events["WithdrawnAndCalled"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to)}, amount, data)
+}
+
+func newEventLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	event abi.Event,
+	indexedTopics []ethcommon.Hash,
+	nonIndexed ...interface{},
+) *ethtypes.Log {
+	t.Helper()
+
+	data, err := event.Inputs.NonIndexed().Pack(nonIndexed...)
+	require.NoError(t, err)
+
+	topics := []ethcommon.Hash{event.ID}
+	topics = append(topics, indexedTopics...)
+
+	return &ethtypes.Log{
+		Address: emitter,
+		Topics:  topics,
+		Data:    data,
+		TxHash:  txHash,
+	}
+}
+
+func addressTopic(address ethcommon.Address) ethcommon.Hash {
+	return ethcommon.BytesToHash(ethcommon.LeftPadBytes(address.Bytes(), 32))
+}
+
+func mustNewGatewayEVM(t *testing.T, address ethcommon.Address) *gatewayevm.GatewayEVM {
+	t.Helper()
+
+	gateway, err := gatewayevm.NewGatewayEVM(address, &ethclient.Client{})
+	require.NoError(t, err)
+
+	return gateway
+}
+
+func mustNewERC20Custody(t *testing.T, address ethcommon.Address) *erc20custody.ERC20Custody {
+	t.Helper()
+
+	custody, err := erc20custody.NewERC20Custody(address, &ethclient.Client{})
+	require.NoError(t, err)
+
+	return custody
+}
+
+func mustNewZetaConnectorNative(t *testing.T, address ethcommon.Address) *zetaconnectornative.ZetaConnectorNative {
+	t.Helper()
+
+	connector, err := zetaconnectornative.NewZetaConnectorNative(address, &ethclient.Client{})
+	require.NoError(t, err)
+
+	return connector
+}
+
+func mustGatewayABI(t *testing.T) *abi.ABI {
+	t.Helper()
+
+	parsed, err := gatewayevm.GatewayEVMMetaData.GetAbi()
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	return parsed
+}
+
+func mustERC20CustodyABI(t *testing.T) *abi.ABI {
+	t.Helper()
+
+	parsed, err := erc20custody.ERC20CustodyMetaData.GetAbi()
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	return parsed
+}
+
+func mustZetaConnectorNativeABI(t *testing.T) *abi.ABI {
+	t.Helper()
+
+	parsed, err := zetaconnectornative.ZetaConnectorNativeMetaData.GetAbi()
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	return parsed
+}


### PR DESCRIPTION
closes #4567

Root cause:
The v2 outbound parseAndCheck helpers iterate receipt logs and first try to ABI-parse each log. A forged log from a non-protocol contract can still parse successfully if it reuses the same event signature and ABI layout. The old code then called ValidateEvmTxLog and returned immediately on the emitter-address mismatch, which aborted parsing before the real protocol log later in the receipt could be examined.

Fix:
For the six affected v2 outbound parsers, skip logs whose emitter address does not match the expected protocol contract before calling ValidateEvmTxLog. Keep ValidateEvmTxLog in place for candidate protocol logs so removed-log, tx-hash, and topic-count validation behavior remains unchanged.

Affected functions:
- parseAndCheckGatewayExecuted
- parseAndCheckGatewayReverted
- parseAndCheckZetaConnectorWithdraw
- parseAndCheckERC20CustodyWithdraw
- parseAndCheckERC20CustodyWithdrawAndCall
- parseAndZetaConnectorWithdrawAndCall

Tests:
- Added a table-driven regression test that covers all six affected parsers.
- Each case builds a receipt with:
  - a forged same-signature log from the wrong emitter address
  - followed by the valid protocol log
- Verified that the test fails before the fix with log emitter address mismatch errors.
- Verified that the focused regression test passes after the fix.
- Verified that the full zetaclient/chains/evm/observer package passes under Go 1.23.9.

Notes:
- I intentionally did not widen this PR to legacy v1 outbound parsing, although the same pattern still appears there and should likely be fixed separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how outbound receipts are interpreted; incorrect filtering could cause valid protocol events to be missed or misclassified, but the change is narrow and covered by a regression test.
> 
> **Overview**
> Fixes v2 outbound receipt parsing to **skip ABI-decodable but non-protocol (forged) logs** by checking `vLog.Address` matches the expected contract *before* calling `ValidateEvmTxLog`, preventing early failure when a valid protocol log appears later in the receipt.
> 
> Adds a table-driven regression test (`v2_outbound_test.go`) that builds receipts containing a forged same-signature log followed by a valid one, and asserts all six affected parsers return `ReceiveStatus_success` with the expected amount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e608191a15496c9e5f3a803a1be3fd4632d66dc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a log-parsing bug in all six v2 outbound receipt parsers where a forged EVM log (same event signature, wrong emitter address) would cause `ValidateEvmTxLog` to return an address-mismatch error that aborted the loop early, preventing the real protocol log from being processed. The fix adds a `vLog.Address != <protocolAddr>` guard immediately after ABI parsing succeeds so forged logs are silently skipped, and `ValidateEvmTxLog` (which still validates tx-hash and topic-count) is only reached for logs from the expected contract. A comprehensive table-driven regression test covers all six parsers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, correct, and well-tested; no behavioral regressions for the happy path.

All six parsers receive consistent, correctly-placed address guards. The address check comes after ABI-parsing succeeds and before ValidateEvmTxLog, preserving tx-hash and topic-count validation for legitimate protocol logs. The regression test directly reproduces the reported failure condition.

No files require special attention; the analogous v1 parsers are intentionally out of scope and should be addressed in a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/evm/observer/v2_outbound.go | Adds emitter-address guard before ValidateEvmTxLog in all six v2 outbound parsers so forged same-signature logs from non-protocol contracts are skipped rather than halting parsing. |
| zetaclient/chains/evm/observer/v2_outbound_test.go | New table-driven regression test covering all six parsers; each case injects a forged log (wrong emitter, same ABI signature) followed by the real protocol log and asserts parsing succeeds. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: iterate receipt.Logs] --> B[ABI Parse log\ne.g. ParseExecuted]
    B -->|parse error| C[continue to next log]
    B -->|parse ok| D{NEW: vLog.Address\n== protocolAddr?}
    D -->|no - forged emitter| C
    D -->|yes| E[ValidateEvmTxLog\ncheck txHash + topic count]
    E -->|fail| F[return ReceiveStatus_failed]
    E -->|pass| G[Validate fields\nreceiver / amount / data]
    G -->|mismatch| F
    G -->|match| H[return ReceiveStatus_success]
    C --> A
    A -->|no more logs| I[return event not found error]
```

<sub>Reviews (1): Last reviewed commit: ["fix: skip forged non-protocol v2 outboun..."](https://github.com/zeta-chain/node/commit/e608191a15496c9e5f3a803a1be3fd4632d66dc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29517158)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced outbound event validation to verify contract addresses, preventing processing of fraudulent event logs and improving transaction security across all v2 outbound event parsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->