### PR TITLE
fix: skip forged non-protocol logs in v1 outbound parsers

### DIFF
--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -307,6 +307,9 @@ func parseAndCheckZetaEvent(
 		// try parsing ZetaReceived event
 		received, err := connector.ZetaConnectorNonEthFilterer.ParseZetaReceived(*vLog)
 		if err == nil {
+			if vLog.Address != connectorAddr {
+				continue
+			}
 			err = common.ValidateEvmTxLog(vLog, connectorAddr, receipt.TxHash.Hex(), common.TopicsZetaReceived)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "error validating ZetaReceived event")
@@ -328,6 +331,9 @@ func parseAndCheckZetaEvent(
 		// try parsing ZetaReverted event
 		reverted, err := connector.ZetaConnectorNonEthFilterer.ParseZetaReverted(*vLog)
 		if err == nil {
+			if vLog.Address != connectorAddr {
+				continue
+			}
 			err = common.ValidateEvmTxLog(vLog, connectorAddr, receipt.TxHash.Hex(), common.TopicsZetaReverted)
 			if err != nil {
 				return nil, nil, errors.Wrap(err, "error validating ZetaReverted event")
@@ -364,6 +370,9 @@ func parseAndCheckWithdrawnEvent(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := custody.ParseWithdrawn(*vLog)
 		if err == nil {
+			if vLog.Address != custodyAddr {
+				continue
+			}
 			err = common.ValidateEvmTxLog(vLog, custodyAddr, receipt.TxHash.Hex(), common.TopicsWithdrawn)
 			if err != nil {
 				return nil, errors.Wrap(err, "error validating Withdrawn event")

--- a/zetaclient/chains/evm/observer/outbound_test.go
+++ b/zetaclient/chains/evm/observer/outbound_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
@@ -217,13 +218,24 @@ func Test_ParseZetaReceived(t *testing.T) {
 		require.NotNil(t, receivedLog)
 		require.Nil(t, revertedLog)
 	})
-	t.Run("should fail on connector address mismatch", func(t *testing.T) {
+	t.Run("should report no event on connector address mismatch", func(t *testing.T) {
 		// use an arbitrary address to make validation fail
 		fakeConnectorAddress := sample.EthAddress()
 		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, fakeConnectorAddress, connector)
-		require.ErrorContains(t, err, "error validating ZetaReceived event")
+		require.ErrorContains(t, err, "no ZetaReceived/ZetaReverted event")
 		require.Nil(t, revertedLog)
 		require.Nil(t, receivedLog)
+	})
+	t.Run("should skip forged connector log and parse later valid zeta received event", func(t *testing.T) {
+		forgedReceipt := receiptWithPrependedForgedLog(
+			receipt,
+			mustFindZetaReceivedLogIndex(t, receipt, connector),
+			sample.EthAddress(),
+		)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, forgedReceipt, connectorAddress, connector)
+		require.NoError(t, err)
+		require.NotNil(t, receivedLog)
+		require.Nil(t, revertedLog)
 	})
 	t.Run("should fail on receiver address mismatch", func(t *testing.T) {
 		// load cctx and set receiver address to an arbitrary address
@@ -292,13 +304,24 @@ func Test_ParseZetaReverted(t *testing.T) {
 		require.Nil(t, receivedLog)
 		require.NotNil(t, revertedLog)
 	})
-	t.Run("should fail on connector address mismatch", func(t *testing.T) {
+	t.Run("should report no event on connector address mismatch", func(t *testing.T) {
 		// use an arbitrary address to make validation fail
 		fakeConnectorAddress := sample.EthAddress()
 		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, receipt, fakeConnectorAddress, connector)
-		require.ErrorContains(t, err, "error validating ZetaReverted event")
+		require.ErrorContains(t, err, "no ZetaReceived/ZetaReverted event")
 		require.Nil(t, receivedLog)
 		require.Nil(t, revertedLog)
+	})
+	t.Run("should skip forged connector log and parse later valid zeta reverted event", func(t *testing.T) {
+		forgedReceipt := receiptWithPrependedForgedLog(
+			receipt,
+			mustFindZetaRevertedLogIndex(t, receipt, connector),
+			sample.EthAddress(),
+		)
+		receivedLog, revertedLog, err := parseAndCheckZetaEvent(cctx, forgedReceipt, connectorAddress, connector)
+		require.NoError(t, err)
+		require.Nil(t, receivedLog)
+		require.NotNil(t, revertedLog)
 	})
 	t.Run("should fail on receiver address mismatch", func(t *testing.T) {
 		// load cctx and set receiver address to an arbitrary address
@@ -350,12 +373,22 @@ func Test_ParseERC20WithdrawnEvent(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, withdrawn)
 	})
-	t.Run("should fail on erc20 custody address mismatch", func(t *testing.T) {
+	t.Run("should report no event on erc20 custody address mismatch", func(t *testing.T) {
 		// use an arbitrary address to make validation fail
 		fakeCustodyAddress := sample.EthAddress()
 		withdrawn, err := parseAndCheckWithdrawnEvent(cctx, receipt, fakeCustodyAddress, custody)
-		require.ErrorContains(t, err, "error validating Withdrawn event")
+		require.ErrorContains(t, err, "no ERC20 Withdrawn event")
 		require.Nil(t, withdrawn)
+	})
+	t.Run("should skip forged custody log and parse later valid withdrawn event", func(t *testing.T) {
+		forgedReceipt := receiptWithPrependedForgedLog(
+			receipt,
+			mustFindWithdrawnLogIndex(t, receipt, custody),
+			sample.EthAddress(),
+		)
+		withdrawn, err := parseAndCheckWithdrawnEvent(cctx, forgedReceipt, custodyAddress, custody)
+		require.NoError(t, err)
+		require.NotNil(t, withdrawn)
 	})
 	t.Run("should fail on receiver address mismatch", func(t *testing.T) {
 		// load cctx and set receiver address to an arbitrary address
@@ -457,6 +490,87 @@ func Test_FilterTSSOutbound(t *testing.T) {
 		found := ob.isTxConfirmed(outboundNonce)
 		require.False(t, found)
 	})
+}
+
+func receiptWithPrependedForgedLog(
+	receipt *ethtypes.Receipt,
+	logIndex int,
+	forgedAddress ethcommon.Address,
+) *ethtypes.Receipt {
+	clonedReceipt := *receipt
+	clonedLogs := make([]*ethtypes.Log, 0, len(receipt.Logs)+1)
+
+	forgedLog := cloneEVMLog(receipt.Logs[logIndex])
+	forgedLog.Address = forgedAddress
+	clonedLogs = append(clonedLogs, forgedLog)
+
+	for _, log := range receipt.Logs {
+		clonedLogs = append(clonedLogs, cloneEVMLog(log))
+	}
+
+	clonedReceipt.Logs = clonedLogs
+	return &clonedReceipt
+}
+
+func cloneEVMLog(log *ethtypes.Log) *ethtypes.Log {
+	cloned := *log
+	cloned.Topics = append([]ethcommon.Hash(nil), log.Topics...)
+	cloned.Data = append([]byte(nil), log.Data...)
+	return &cloned
+}
+
+func mustFindZetaReceivedLogIndex(
+	t *testing.T,
+	receipt *ethtypes.Receipt,
+	connector *zetaconnector.ZetaConnectorNonEth,
+) int {
+	t.Helper()
+
+	for i, log := range receipt.Logs {
+		event, err := connector.ZetaConnectorNonEthFilterer.ParseZetaReceived(*log)
+		if err == nil && event != nil {
+			return i
+		}
+	}
+
+	t.Fatal("zeta received log not found")
+	return -1
+}
+
+func mustFindZetaRevertedLogIndex(
+	t *testing.T,
+	receipt *ethtypes.Receipt,
+	connector *zetaconnector.ZetaConnectorNonEth,
+) int {
+	t.Helper()
+
+	for i, log := range receipt.Logs {
+		event, err := connector.ZetaConnectorNonEthFilterer.ParseZetaReverted(*log)
+		if err == nil && event != nil {
+			return i
+		}
+	}
+
+	t.Fatal("zeta reverted log not found")
+	return -1
+}
+
+func mustFindWithdrawnLogIndex(
+	t *testing.T,
+	receipt *ethtypes.Receipt,
+	custody *erc20custody.ERC20Custody,
+) int {
+	t.Helper()
+
+	for i, log := range receipt.Logs {
+		event, err := custody.ParseWithdrawn(*log)
+		if err == nil && event != nil {
+			return i
+		}
+	}
+
+	t.Fatal("withdrawn log not found")
+	return -1
 }
 
 // TODO: create mocks for gateway and ERC20Custody and uncomment these tests

--- a/zetaclient/chains/evm/observer/v2_outbound.go
+++ b/zetaclient/chains/evm/observer/v2_outbound.go
@@ -75,6 +75,9 @@ func parseAndCheckGatewayExecuted(
 		if err != nil {
 			continue
 		}
+		if vLog.Address != gatewayAddr {
+			continue
+		}
 		// basic event check
 		if err := common.ValidateEvmTxLog(
 			vLog,
@@ -128,6 +131,9 @@ func parseAndCheckGatewayReverted(
 	for _, vLog := range receipt.Logs {
 		reverted, err := gateway.GatewayEVMFilterer.ParseReverted(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != gatewayAddr {
 			continue
 		}
 		// basic event check
@@ -189,6 +195,9 @@ func parseAndCheckZetaConnectorWithdraw(
 		if err != nil {
 			continue
 		}
+		if vLog.Address != connectorAddr {
+			continue
+		}
 		// basic event check
 		if err := common.ValidateEvmTxLog(
 			vLog,
@@ -238,6 +247,9 @@ func parseAndCheckERC20CustodyWithdraw(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := custody.ERC20CustodyFilterer.ParseWithdrawn(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != custodyAddr {
 			continue
 		}
 		// basic event check
@@ -297,6 +309,9 @@ func parseAndCheckERC20CustodyWithdrawAndCall(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := custody.ERC20CustodyFilterer.ParseWithdrawnAndCalled(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != custodyAddr {
 			continue
 		}
 		// basic event check
@@ -360,6 +375,9 @@ func parseAndZetaConnectorWithdrawAndCall(
 	for _, vLog := range receipt.Logs {
 		withdrawn, err := connector.ZetaConnectorNativeFilterer.ParseWithdrawnAndCalled(*vLog)
 		if err != nil {
+			continue
+		}
+		if vLog.Address != connectorAddr {
 			continue
 		}
 		// basic event check

--- a/zetaclient/chains/evm/observer/v2_outbound_test.go
+++ b/zetaclient/chains/evm/observer/v2_outbound_test.go
@@ -1,0 +1,347 @@
+package observer
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+	"github.com/zeta-chain/protocol-contracts-evm/pkg/erc20custody.sol"
+	"github.com/zeta-chain/protocol-contracts-evm/pkg/gatewayevm.sol"
+	"github.com/zeta-chain/protocol-contracts-evm/pkg/zetaconnectornative.sol"
+
+	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+)
+
+type v2OutboundParser func(
+	cctx *crosschaintypes.CrossChainTx,
+	receipt *ethtypes.Receipt,
+) (*big.Int, chains.ReceiveStatus, error)
+
+func TestV2OutboundParsersSkipForgedLogs(t *testing.T) {
+	txHash := sample.Hash()
+	receiver := sample.EthAddress()
+	asset := sample.EthAddress()
+	amount := big.NewInt(42)
+	payload := []byte{0xde, 0xad, 0xbe, 0xef}
+
+	gatewayAddr := sample.EthAddress()
+	forgedGatewayAddr := sample.EthAddress()
+	connectorAddr := sample.EthAddress()
+	forgedConnectorAddr := sample.EthAddress()
+	custodyAddr := sample.EthAddress()
+	forgedCustodyAddr := sample.EthAddress()
+
+	gateway := mustNewGatewayEVM(t, gatewayAddr)
+	connector := mustNewZetaConnectorNative(t, connectorAddr)
+	custody := mustNewERC20Custody(t, custodyAddr)
+
+	tests := []struct {
+		name    string
+		cctx    *crosschaintypes.CrossChainTx
+		receipt *ethtypes.Receipt
+		parse   v2OutboundParser
+	}{
+		{
+			name: "parseAndCheckGatewayExecuted",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeGatewayExecutedLog(t, forgedGatewayAddr, txHash, receiver, amount, payload),
+				makeGatewayExecutedLog(t, gatewayAddr, txHash, receiver, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckGatewayExecuted(cctx, receipt, gatewayAddr, gateway)
+			},
+		},
+		{
+			name: "parseAndCheckGatewayReverted",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeGatewayRevertedLog(t, forgedGatewayAddr, txHash, receiver, asset, amount, payload),
+				makeGatewayRevertedLog(t, gatewayAddr, txHash, receiver, asset, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckGatewayReverted(cctx, receipt, gatewayAddr, gateway)
+			},
+		},
+		{
+			name: "parseAndCheckZetaConnectorWithdraw",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeZetaConnectorWithdrawLog(t, forgedConnectorAddr, txHash, receiver, amount),
+				makeZetaConnectorWithdrawLog(t, connectorAddr, txHash, receiver, amount),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckZetaConnectorWithdraw(cctx, receipt, connectorAddr, connector)
+			},
+		},
+		{
+			name: "parseAndCheckERC20CustodyWithdraw",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeERC20CustodyWithdrawLog(t, forgedCustodyAddr, txHash, receiver, asset, amount),
+				makeERC20CustodyWithdrawLog(t, custodyAddr, txHash, receiver, asset, amount),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckERC20CustodyWithdraw(cctx, receipt, custodyAddr, custody)
+			},
+		},
+		{
+			name: "parseAndCheckERC20CustodyWithdrawAndCall",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeERC20CustodyWithdrawAndCallLog(t, forgedCustodyAddr, txHash, receiver, asset, amount, payload),
+				makeERC20CustodyWithdrawAndCallLog(t, custodyAddr, txHash, receiver, asset, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndCheckERC20CustodyWithdrawAndCall(cctx, receipt, custodyAddr, custody)
+			},
+		},
+		{
+			name: "parseAndZetaConnectorWithdrawAndCall",
+			cctx: newV2OutboundCCTX(t, receiver, asset, amount, payload),
+			receipt: newReceipt(
+				txHash,
+				makeZetaConnectorWithdrawAndCallLog(t, forgedConnectorAddr, txHash, receiver, amount, payload),
+				makeZetaConnectorWithdrawAndCallLog(t, connectorAddr, txHash, receiver, amount, payload),
+			),
+			parse: func(cctx *crosschaintypes.CrossChainTx, receipt *ethtypes.Receipt) (*big.Int, chains.ReceiveStatus, error) {
+				return parseAndZetaConnectorWithdrawAndCall(cctx, receipt, connectorAddr, connector)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAmount, gotStatus, err := tt.parse(tt.cctx, tt.receipt)
+			require.NoError(t, err)
+			require.Equal(t, chains.ReceiveStatus_success, gotStatus)
+			require.Zero(t, gotAmount.Cmp(amount))
+		})
+	}
+}
+
+func newV2OutboundCCTX(
+	t *testing.T,
+	receiver ethcommon.Address,
+	asset ethcommon.Address,
+	amount *big.Int,
+	payload []byte,
+) *crosschaintypes.CrossChainTx {
+	t.Helper()
+
+	cctx := sample.CrossChainTxV2(t, "issue-4567")
+	cctx.InboundParams = &crosschaintypes.InboundParams{Asset: asset.Hex()}
+	cctx.OutboundParams = []*crosschaintypes.OutboundParams{{
+		Receiver:    receiver.Hex(),
+		Amount:      sdkmath.NewUintFromBigInt(amount),
+		CallOptions: &crosschaintypes.CallOptions{},
+	}}
+	cctx.RelayedMessage = hex.EncodeToString(payload)
+
+	return cctx
+}
+
+func newReceipt(txHash ethcommon.Hash, logs ...*ethtypes.Log) *ethtypes.Receipt {
+	return &ethtypes.Receipt{
+		Status: ethtypes.ReceiptStatusSuccessful,
+		TxHash: txHash,
+		Logs:   logs,
+	}
+}
+
+func makeGatewayExecutedLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	destination ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustGatewayABI(t).Events["Executed"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(destination)}, amount, data)
+}
+
+func makeGatewayRevertedLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	token ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustGatewayABI(t).Events["Reverted"]
+	return newEventLog(
+		t,
+		emitter,
+		txHash,
+		event,
+		[]ethcommon.Hash{addressTopic(to), addressTopic(token)},
+		amount,
+		data,
+		gatewayevm.RevertContext{
+			Sender:        sample.EthAddress(),
+			Asset:         token,
+			Amount:        amount,
+			RevertMessage: data,
+		},
+	)
+}
+
+func makeZetaConnectorWithdrawLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	amount *big.Int,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustZetaConnectorNativeABI(t).Events["Withdrawn"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to)}, amount)
+}
+
+func makeERC20CustodyWithdrawLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	token ethcommon.Address,
+	amount *big.Int,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustERC20CustodyABI(t).Events["Withdrawn"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to), addressTopic(token)}, amount)
+}
+
+func makeERC20CustodyWithdrawAndCallLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	token ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustERC20CustodyABI(t).Events["WithdrawnAndCalled"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to), addressTopic(token)}, amount, data)
+}
+
+func makeZetaConnectorWithdrawAndCallLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	to ethcommon.Address,
+	amount *big.Int,
+	data []byte,
+) *ethtypes.Log {
+	t.Helper()
+
+	event := mustZetaConnectorNativeABI(t).Events["WithdrawnAndCalled"]
+	return newEventLog(t, emitter, txHash, event, []ethcommon.Hash{addressTopic(to)}, amount, data)
+}
+
+func newEventLog(
+	t *testing.T,
+	emitter ethcommon.Address,
+	txHash ethcommon.Hash,
+	event abi.Event,
+	indexedTopics []ethcommon.Hash,
+	nonIndexed ...interface{},
+) *ethtypes.Log {
+	t.Helper()
+
+	data, err := event.Inputs.NonIndexed().Pack(nonIndexed...)
+	require.NoError(t, err)
+
+	topics := []ethcommon.Hash{event.ID}
+	topics = append(topics, indexedTopics...)
+
+	return &ethtypes.Log{
+		Address: emitter,
+		Topics:  topics,
+		Data:    data,
+		TxHash:  txHash,
+	}
+}
+
+func addressTopic(address ethcommon.Address) ethcommon.Hash {
+	return ethcommon.BytesToHash(ethcommon.LeftPadBytes(address.Bytes(), 32))
+}
+
+func mustNewGatewayEVM(t *testing.T, address ethcommon.Address) *gatewayevm.GatewayEVM {
+	t.Helper()
+
+	gateway, err := gatewayevm.NewGatewayEVM(address, &ethclient.Client{})
+	require.NoError(t, err)
+
+	return gateway
+}
+
+func mustNewERC20Custody(t *testing.T, address ethcommon.Address) *erc20custody.ERC20Custody {
+	t.Helper()
+
+	custody, err := erc20custody.NewERC20Custody(address, &ethclient.Client{})
+	require.NoError(t, err)
+
+	return custody
+}
+
+func mustNewZetaConnectorNative(t *testing.T, address ethcommon.Address) *zetaconnectornative.ZetaConnectorNative {
+	t.Helper()
+
+	connector, err := zetaconnectornative.NewZetaConnectorNative(address, &ethclient.Client{})
+	require.NoError(t, err)
+
+	return connector
+}
+
+func mustGatewayABI(t *testing.T) *abi.ABI {
+	t.Helper()
+
+	parsed, err := gatewayevm.GatewayEVMMetaData.GetAbi()
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	return parsed
+}
+
+func mustERC20CustodyABI(t *testing.T) *abi.ABI {
+	t.Helper()
+
+	parsed, err := erc20custody.ERC20CustodyMetaData.GetAbi()
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	return parsed
+}
+
+func mustZetaConnectorNativeABI(t *testing.T) *abi.ABI {
+	t.Helper()
+
+	parsed, err := zetaconnectornative.ZetaConnectorNativeMetaData.GetAbi()
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+
+	return parsed
+}


### PR DESCRIPTION
Follow-up to #4567
Closes #4573 

Root cause:
The legacy v1 outbound parsers iterate receipt logs, attempt ABI parsing, and then validate the parsed log with `ValidateEvmTxLog`. A forged log from a non-protocol contract can still parse successfully if it reuses the same event signature and ABI shape. The old code then returned immediately on emitter-address mismatch, which prevented the parser from reaching the later valid protocol log in the same receipt.

Fix:
For the affected v1 outbound parsers, skip logs whose emitter address does not match the expected protocol contract before calling `ValidateEvmTxLog`. Keep `ValidateEvmTxLog` for candidate protocol logs so removed-log, tx-hash, and topic-count validation behavior remains unchanged.

Affected paths:
- `parseAndCheckZetaEvent`
- `parseAndCheckWithdrawnEvent`

Tests:
- Added forged-first regression coverage for:
  - `ZetaReceived`
  - `ZetaReverted`
  - `Withdrawn`
- Verified the new regression tests fail before the fix with emitter-address mismatch errors.
- Verified the focused v1 parser tests pass after the fix.
- Verified the full `zetaclient/chains/evm/observer` package passes under Go 1.23.9.

Notes:
- Wrong expected contract-address cases now resolve to "no event found" rather than a validation abort, which matches the new skip-and-continue semantics.
- No additional same-pattern outbound paths remain in this observer package after the v1 and v2 fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound receipt parsing used to determine cross-chain receive status/value; while the change is small, it affects core confirmation/voting behavior and could cause missed events if address checks are wrong.
> 
> **Overview**
> Hardens outbound receipt parsing to **ignore forged/non-protocol logs** that reuse protocol event signatures. The v1 parsers (`parseAndCheckZetaEvent`, `parseAndCheckWithdrawnEvent`) and v2 outbound parsers now **skip logs whose `Address` is not the expected contract** before running `ValidateEvmTxLog`, allowing the parser to continue scanning and find the later legitimate protocol log.
> 
> Updates and expands tests to match the new semantics (wrong contract address now yields *“no event found”*), and adds regression coverage that prepends a forged log to real receipts/events to ensure parsing still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2e6d3eb68f8f2b68141bf8994b69e0e8dce95e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a forged-log bypass in the EVM outbound parsers (v1 and v2) where a non-protocol contract emitting an event with the same ABI signature could cause an early validation failure that prevented the parser from reaching the real protocol log later in the receipt. The fix consistently adds an emitter-address check (`vLog.Address != protocolAddr → continue`) immediately after a successful ABI parse and before `ValidateEvmTxLog`, converting the old abort-on-mismatch into a skip-and-continue across all nine affected parsers.

<h3>Confidence Score: 5/5</h3>

Safe to merge; fix is minimal, correctly applied to all affected parsers, and well-covered by new regression tests.

The patch is a narrow, consistent change (one 3-line guard per parser) with no logic regressions. All nine parsers (v1 and v2) receive the same treatment, existing tests are updated to reflect the new semantics, and targeted forged-first tests are added for all affected paths. No P0/P1 findings were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/evm/observer/outbound.go | Adds emitter-address guard before ValidateEvmTxLog in parseAndCheckZetaEvent (ZetaReceived + ZetaReverted) and parseAndCheckWithdrawnEvent, replacing an early-return-on-mismatch pattern with continue-and-skip so the loop can reach a later valid protocol log. |
| zetaclient/chains/evm/observer/v2_outbound.go | Applies the same address-before-validate guard to all six v2 parsers (GatewayExecuted, GatewayReverted, ZetaConnectorWithdraw, ERC20CustodyWithdraw, ERC20CustodyWithdrawAndCall, ZetaConnectorWithdrawAndCall). |
| zetaclient/chains/evm/observer/outbound_test.go | Updates three existing address-mismatch tests to expect 'no event found' errors and adds forged-first regression tests for ZetaReceived, ZetaReverted, and ERC20 Withdrawn; adds helper functions receiptWithPrependedForgedLog, cloneEVMLog, and three mustFind* utilities. |
| zetaclient/chains/evm/observer/v2_outbound_test.go | New test file with a table-driven test covering all six v2 parsers under the forged-first scenario; includes ABI-based log constructors for each event type. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: iterate receipt.Logs] --> B[Try ABI parse]
    B -- parse error --> A
    B -- parse OK --> C{vLog.Address == protocolAddr?}
    C -- No --> A
    C -- Yes --> D[ValidateEvmTxLog\ntx-hash, topic-count, address]
    D -- validation error --> E[Return error]
    D -- OK --> F[Check receiver / amount / index]
    F -- mismatch --> G[Return error]
    F -- match --> H[Return event ✓]
    A -- no logs left --> I[Return 'no event found' error]
```

<sub>Reviews (1): Last reviewed commit: ["fix: skip forged non-protocol v1 outboun..."](https://github.com/zeta-chain/node/commit/bd2e6d3eb68f8f2b68141bf8994b69e0e8dce95e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29520892)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event log validation by filtering receipt events based on their source contract address before processing, ensuring only logs from intended contracts are parsed and preventing issues from unrelated contract emissions.

* **Tests**
  * Added comprehensive test coverage for event parsing scenarios involving mismatched contract addresses and forged logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeta-chain/node/pull/4574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->