### PR TITLE
fix: cancel V2 arbitrary calls in zetaclient signer (backport v37)

### DIFF
--- a/e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go
@@ -3,6 +3,7 @@ package e2etests
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts-evm/pkg/gatewayzevm.sol"
 
@@ -23,18 +24,43 @@ func TestERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
+	revertAddress := r.EVMAddress()
+
 	// perform the withdraw
 	tx := r.ERC20WithdrawAndArbitraryCall(
 		r.TestDAppV2EVMAddr,
 		amount,
 		r.EncodeERC20Call(r.ERC20Addr, amount, payload),
-		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
 	)
+
+	// wait for the withdraw tx to mine on ZEVM (user has paid amount + fees),
+	// then capture the post-payment ERC20-ZRC20 balance.
+	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+	utils.RequireTxSuccessful(r, receipt)
+	revertBalanceBefore, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payload, amount)
+	// V2 arbitrary calls via ERC20Custody.withdrawAndCall route to
+	// gateway.executeWithERC20, which has the same sender==0 arbitrary-call
+	// branch as gateway.execute. The signer cancels these CCTXs (TSS
+	// self-transfer); the observer reports the outbound failed; the CCTX
+	// terminates as Reverted via the standard V2 revert flow; the principal
+	// is refunded to the revert address.
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// destination dApp must not have been called
+	r.AssertTestDAppEVMCalled(false, payload, amount)
+
+	// revert address should receive at least the principal back
+	revertBalanceAfter, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 }

--- a/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts-evm/pkg/gatewayzevm.sol"
 
@@ -54,8 +55,21 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	// withdrawn ZRC20 amount is refunded to the revert address on ZEVM.
 	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-	// the cancelled outbound is a TSS self-transfer with zero value
-	r.EVMVerifyOutboundTransferAmount(cctx.OutboundParams[0].Hash, 0)
+	// the cancelled outbound on-chain must be a TSS self-transfer:
+	// zero value, no calldata, recipient = TSS. Fetching the tx and
+	// inspecting it directly is necessary because Transfer-event-based
+	// helpers can't see a payload-less self-transfer (no logs).
+	require.NotEmpty(r, cctx.OutboundParams, "CCTX must have at least one outbound param")
+	cancelTxHash := ethcommon.HexToHash(cctx.OutboundParams[0].Hash)
+	cancelTx, _, err := r.EVMClient.TransactionByHash(r.Ctx, cancelTxHash)
+	require.NoError(r, err)
+	require.Equal(r, big.NewInt(0).Int64(), cancelTx.Value().Int64(),
+		"cancelled outbound must have zero value")
+	require.Empty(r, cancelTx.Data(),
+		"cancelled outbound must have no calldata")
+	require.NotNil(r, cancelTx.To())
+	require.Equal(r, r.TSSAddress.Hex(), cancelTx.To().Hex(),
+		"cancelled outbound must be sent to TSS (self-transfer)")
 
 	// destination dApp must not have been called
 	r.AssertTestDAppEVMCalled(false, payload, amount)

--- a/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
@@ -23,11 +23,7 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
-	// capture the ZEVM revert recipient's ETH-ZRC20 balance before the
-	// withdraw — the cancelled CCTX should refund the principal here.
 	revertAddress := r.EVMAddress()
-	revertBalanceBefore, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
-	require.NoError(r, err)
 
 	// perform the withdraw
 	tx := r.ETHWithdrawAndArbitraryCall(
@@ -39,6 +35,14 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 			OnRevertGasLimit: big.NewInt(0),
 		},
 	)
+
+	// wait for the withdraw tx to mine on ZEVM (user has now paid amount +
+	// gasFee + protocolFlatFee out of their ETH-ZRC20 balance), then capture
+	// the post-payment balance — the revert refund will add on top of this.
+	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+	utils.RequireTxSuccessful(r, receipt)
+	revertBalanceBefore, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
@@ -56,11 +60,11 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	// destination dApp must not have been called
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 
-	// revert address should receive at least the principal back. The exact
-	// amount also includes a portion of the unused gas-fee leftover (refunded
-	// by RefundUnusedGasFee in the vote handler) but the precise math is
-	// fragile across gas-price/percentage settings, so we assert the lower
-	// bound: balance increase >= principal.
+	// Compared to the post-withdraw balance, the revert refund must add at
+	// least the principal (zetacore's ProcessRevert refunds amount in full).
+	// The exact value also includes a fractional gas-fee leftover refund from
+	// RefundUnusedGasFee, but the precise math is fragile across percentage
+	// settings, so we assert the lower bound only.
 	revertBalanceAfter, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
 	require.NoError(r, err)
 

--- a/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
@@ -3,6 +3,7 @@ package e2etests
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts-evm/pkg/gatewayzevm.sol"
 
@@ -22,18 +23,41 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
+	// capture the ZEVM revert recipient's ETH-ZRC20 balance before the
+	// withdraw — the cancelled CCTX should refund the principal here.
+	revertAddress := r.EVMAddress()
+	revertBalanceBefore, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+
 	// perform the withdraw
 	tx := r.ETHWithdrawAndArbitraryCall(
 		r.TestDAppV2EVMAddr,
 		amount,
 		r.EncodeGasCall(payload),
-		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
 	)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	r.AssertTestDAppEVMCalled(true, payload, amount)
+	// V2 arbitrary calls are cancelled by the signer (TSS self-transfer).
+	// The observer reports the outbound as failed, which routes the CCTX
+	// through the standard V2 revert flow and terminates as Reverted; the
+	// withdrawn ZRC20 amount is refunded to the revert address on ZEVM.
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// the cancelled outbound is a TSS self-transfer with zero value
+	r.EVMVerifyOutboundTransferAmount(cctx.OutboundParams[0].Hash, 0)
+
+	// destination dApp must not have been called
+	r.AssertTestDAppEVMCalled(false, payload, amount)
+
+	// revert address should receive the principal back
+	revertBalanceAfter, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 }

--- a/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_eth_withdraw_and_arbitrary_call.go
@@ -56,8 +56,21 @@ func TestETHWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	// destination dApp must not have been called
 	r.AssertTestDAppEVMCalled(false, payload, amount)
 
-	// revert address should receive the principal back
+	// revert address should receive at least the principal back. The exact
+	// amount also includes a portion of the unused gas-fee leftover (refunded
+	// by RefundUnusedGasFee in the vote handler) but the precise math is
+	// fragile across gas-price/percentage settings, so we assert the lower
+	// bound: balance increase >= principal.
 	revertBalanceAfter, err := r.ETHZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
 	require.NoError(r, err)
-	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
+
+	wantMin := new(big.Int).Add(revertBalanceBefore, amount)
+	require.GreaterOrEqual(
+		r,
+		revertBalanceAfter.Cmp(wantMin),
+		0,
+		"revert address should receive at least the principal: got %s, want >= %s",
+		revertBalanceAfter.String(),
+		wantMin.String(),
+	)
 }

--- a/e2e/e2etests/test_zevm_to_evm_arbitrary_call.go
+++ b/e2e/e2etests/test_zevm_to_evm_arbitrary_call.go
@@ -33,8 +33,12 @@ func TestZEVMToEVMArbitraryCall(r *runner.E2ERunner, args []string) {
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "call")
-	require.Equal(r, crosschaintypes.CctxStatus_OutboundMined, cctx.CctxStatus.Status)
 
-	// check the payload was received on the contract
-	r.AssertTestDAppEVMCalled(true, payload, big.NewInt(0))
+	// V2 arbitrary calls are cancelled by the signer (TSS self-transfer).
+	// The observer reports the outbound as failed, which routes the CCTX
+	// through the standard V2 revert flow and terminates as Reverted.
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// destination dApp must not have been called
+	r.AssertTestDAppEVMCalled(false, payload, big.NewInt(0))
 }

--- a/zetaclient/chains/evm/common/cctx.go
+++ b/zetaclient/chains/evm/common/cctx.go
@@ -49,6 +49,15 @@ const (
 	OutboundTypeZetaWithdraw
 )
 
+// IsGatewayExecuteOutbound reports whether the outbound type forwards
+// arbitrary calldata through GatewayEVM.execute (signGatewayExecute path).
+// These are the outbound types where MessageContext.Sender = 0x0 grants the
+// destination contract authority over arbitrary calldata, so a CCTX with
+// CallOptions.IsArbitraryCall=true on this path must not be signed.
+func IsGatewayExecuteOutbound(t OutboundType) bool {
+	return t == OutboundTypeCall || t == OutboundTypeGasWithdrawAndCall
+}
+
 // ParseOutboundTypeFromCCTX returns the outbound type from the CCTX
 func ParseOutboundTypeFromCCTX(cctx types.CrossChainTx) OutboundType {
 	switch cctx.InboundParams.CoinType {

--- a/zetaclient/chains/evm/common/cctx.go
+++ b/zetaclient/chains/evm/common/cctx.go
@@ -49,13 +49,34 @@ const (
 	OutboundTypeZetaWithdraw
 )
 
-// IsGatewayExecuteOutbound reports whether the outbound type forwards
-// arbitrary calldata through GatewayEVM.execute (signGatewayExecute path).
-// These are the outbound types where MessageContext.Sender = 0x0 grants the
-// destination contract authority over arbitrary calldata, so a CCTX with
-// CallOptions.IsArbitraryCall=true on this path must not be signed.
-func IsGatewayExecuteOutbound(t OutboundType) bool {
-	return t == OutboundTypeCall || t == OutboundTypeGasWithdrawAndCall
+// IsArbitraryCallCancellable reports whether the outbound type, when paired
+// with CallOptions.IsArbitraryCall=true, would produce a TSS-signed call
+// containing MessageContext.Sender == address(0) and thereby reach
+// GatewayEVM's arbitrary-call branch (_executeArbitraryCall) on the
+// destination chain.
+//
+// Three signer entry points translate IsArbitraryCall into a zero sender
+// inside MessageContext (see OutboundData.MessageContext) and pass it into
+// a contract that branches on sender:
+//   - signGatewayExecute → GatewayEVM.execute
+//     reached by OutboundTypeCall and OutboundTypeGasWithdrawAndCall
+//   - signERC20CustodyWithdrawAndCall → ERC20Custody.withdrawAndCall
+//     → GatewayEVM.executeWithERC20
+//     reached by OutboundTypeERC20WithdrawAndCall
+//   - signZetaConnectorWithdrawAndCall → ZetaConnector.withdrawAndCall
+//     → GatewayEVM.executeWithERC20
+//     reached by OutboundTypeZetaWithdrawAndCall
+//
+// All three end at GatewayEVM's arbitrary-call branch, which performs a raw
+// destination.call(data) with msg.sender == GatewayEVM and is not selector-
+// filtered against ERC20 authority (transferFrom / approve / permit). CCTXs
+// with IsArbitraryCall=true on any of these outbound types must be cancelled
+// at the signer rather than relayed to the destination chain.
+func IsArbitraryCallCancellable(t OutboundType) bool {
+	return t == OutboundTypeCall ||
+		t == OutboundTypeGasWithdrawAndCall ||
+		t == OutboundTypeERC20WithdrawAndCall ||
+		t == OutboundTypeZetaWithdrawAndCall
 }
 
 // ParseOutboundTypeFromCCTX returns the outbound type from the CCTX

--- a/zetaclient/chains/evm/common/cctx_test.go
+++ b/zetaclient/chains/evm/common/cctx_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -214,6 +215,35 @@ func TestParseOutboundTypeFromCCTX(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ParseOutboundTypeFromCCTX(tt.cctx)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsGatewayExecuteOutbound(t *testing.T) {
+	gatewayExecuteTypes := map[OutboundType]bool{
+		OutboundTypeCall:               true,
+		OutboundTypeGasWithdrawAndCall: true,
+	}
+	allTypes := []OutboundType{
+		OutboundTypeUnknown,
+		OutboundTypeGasWithdraw,
+		OutboundTypeERC20Withdraw,
+		OutboundTypeGasWithdrawAndCall,
+		OutboundTypeERC20WithdrawAndCall,
+		OutboundTypeCall,
+		OutboundTypeGasWithdrawRevert,
+		OutboundTypeGasWithdrawRevertAndCallOnRevert,
+		OutboundTypeERC20WithdrawRevert,
+		OutboundTypeERC20WithdrawRevertAndCallOnRevert,
+		OutboundTypeZetaWithdrawRevertAndCallOnRevert,
+		OutboundTypeZetaWithdrawRevert,
+		OutboundTypeZetaWithdrawAndCall,
+		OutboundTypeZetaWithdraw,
+	}
+	for _, ot := range allTypes {
+		ot := ot
+		t.Run(fmt.Sprintf("OutboundType_%d", ot), func(t *testing.T) {
+			require.Equal(t, gatewayExecuteTypes[ot], IsGatewayExecuteOutbound(ot))
 		})
 	}
 }

--- a/zetaclient/chains/evm/common/cctx_test.go
+++ b/zetaclient/chains/evm/common/cctx_test.go
@@ -219,10 +219,15 @@ func TestParseOutboundTypeFromCCTX(t *testing.T) {
 	}
 }
 
-func TestIsGatewayExecuteOutbound(t *testing.T) {
-	gatewayExecuteTypes := map[OutboundType]bool{
-		OutboundTypeCall:               true,
-		OutboundTypeGasWithdrawAndCall: true,
+func TestIsArbitraryCallCancellable(t *testing.T) {
+	// All outbound types that route to a signer that translates
+	// IsArbitraryCall=true into MessageContext.Sender=0x0 and lands at
+	// GatewayEVM's arbitrary-call branch (via execute or executeWithERC20).
+	cancellableTypes := map[OutboundType]bool{
+		OutboundTypeCall:                 true,
+		OutboundTypeGasWithdrawAndCall:   true,
+		OutboundTypeERC20WithdrawAndCall: true,
+		OutboundTypeZetaWithdrawAndCall:  true,
 	}
 	allTypes := []OutboundType{
 		OutboundTypeUnknown,
@@ -243,7 +248,7 @@ func TestIsGatewayExecuteOutbound(t *testing.T) {
 	for _, ot := range allTypes {
 		ot := ot
 		t.Run(fmt.Sprintf("OutboundType_%d", ot), func(t *testing.T) {
-			require.Equal(t, gatewayExecuteTypes[ot], IsGatewayExecuteOutbound(ot))
+			require.Equal(t, cancellableTypes[ot], IsArbitraryCallCancellable(ot))
 		})
 	}
 }

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -181,7 +181,12 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	// cancelled transaction means the outbound is failed
 	// - set amount to CCTX's amount to bypass amount check in zetacore
 	// - set status to failed to revert the CCTX in zetacore
-	if compliance.IsCCTXRestricted(cctx) {
+	// CCTXs are cancelled via SignCancel (TSS self-transfer) when:
+	// - the CCTX is restricted by compliance, OR
+	// - the CCTX is a V2 arbitrary call routing through GatewayEVM.execute
+	//   (the signer refuses to forward arbitrary calldata through the
+	//   destination Gateway).
+	if compliance.IsCCTXRestricted(cctx) || isArbitraryCallCancellation(cctx) {
 		receiveValue = cctx.GetCurrentOutboundParam().Amount.BigInt()
 		receiveStatus = chains.ReceiveStatus_failed
 		ob.postVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
@@ -514,4 +519,33 @@ func (ob *Observer) checkConfirmedTx(
 	}
 
 	return receipt, transaction, true
+}
+
+// isArbitraryCallCancellation returns true if the outbound CCTX is a V2
+// arbitrary call that the signer cancels via SignOutboundFromCCTXV2 (TSS
+// self-transfer). The observer must treat the resulting receipt as a failed
+// outbound (mirroring the compliance-restricted cancellation path) to bypass
+// event parsing and trigger the standard V2 revert flow.
+//
+// Only OutboundTypeCall and OutboundTypeGasWithdrawAndCall are cancelled by
+// the signer (see SignOutboundFromCCTXV2). The ERC20-`withdrawAndCall` path
+// and plain V2 withdraws also have CallOptions.IsArbitraryCall=true on the
+// wire but are not cancelled — they must follow the normal event-parsing
+// path.
+func isArbitraryCallCancellation(cctx *crosschaintypes.CrossChainTx) bool {
+	// Mirror the signer's V2-only dispatch (SignOutboundFromCCTXV2 is reached
+	// only via signer.go's ProtocolContractVersion == V2 branch). V1 CCTXs do
+	// not populate CallOptions today, but gate on the version explicitly so
+	// the predicate is symmetric with the signer.
+	if cctx.ProtocolContractVersion != crosschaintypes.ProtocolContractVersion_V2 {
+		return false
+	}
+	outboundParam := cctx.GetCurrentOutboundParam()
+	if outboundParam == nil || outboundParam.CallOptions == nil {
+		return false
+	}
+	if !outboundParam.CallOptions.IsArbitraryCall {
+		return false
+	}
+	return common.IsGatewayExecuteOutbound(common.ParseOutboundTypeFromCCTX(*cctx))
 }

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -183,11 +183,11 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	// - set status to failed to revert the CCTX in zetacore
 	// CCTXs are cancelled via SignCancel (TSS self-transfer) when:
 	// - the CCTX is restricted by compliance, OR
-	// - the CCTX is a V2 arbitrary call routing through GatewayEVM.execute
-	//   (the signer refuses to forward arbitrary calldata through the
-	//   destination Gateway).
-	if compliance.IsCCTXRestricted(cctx) || isArbitraryCallCancellation(cctx) {
-		if isArbitraryCallCancellation(cctx) {
+	// - the CCTX is a V2 arbitrary call (signer refuses to forward arbitrary
+	//   calldata through the destination Gateway)
+	isArbitraryCancel := isArbitraryCallCancellation(cctx)
+	if compliance.IsCCTXRestricted(cctx) || isArbitraryCancel {
+		if isArbitraryCancel {
 			logger.Warn().
 				Str(logs.FieldCctxIndex, cctx.Index).
 				Stringer(logs.FieldTx, receipt.TxHash).

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -187,6 +187,12 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	//   (the signer refuses to forward arbitrary calldata through the
 	//   destination Gateway).
 	if compliance.IsCCTXRestricted(cctx) || isArbitraryCallCancellation(cctx) {
+		if isArbitraryCallCancellation(cctx) {
+			logger.Warn().
+				Str(logs.FieldCctxIndex, cctx.Index).
+				Stringer(logs.FieldTx, receipt.TxHash).
+				Msg("voting V2 arbitrary-call CCTX as failed (signer-cancelled)")
+		}
 		receiveValue = cctx.GetCurrentOutboundParam().Amount.BigInt()
 		receiveStatus = chains.ReceiveStatus_failed
 		ob.postVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -532,6 +532,13 @@ func (ob *Observer) checkConfirmedTx(
 // and plain V2 withdraws also have CallOptions.IsArbitraryCall=true on the
 // wire but are not cancelled — they must follow the normal event-parsing
 // path.
+//
+// Deployment note: this predicate decides on CCTX metadata alone, never the
+// receipt. During a rolling zetaclient upgrade where some validators still
+// run the old signer (which forwards the call as GatewayEVM.execute), a
+// new-version observer would mark that successful Executed receipt as
+// failed. To avoid split votes, all validators should upgrade zetaclient as
+// a single coordinated step on this hotfix.
 func isArbitraryCallCancellation(cctx *crosschaintypes.CrossChainTx) bool {
 	// Mirror the signer's V2-only dispatch (SignOutboundFromCCTXV2 is reached
 	// only via signer.go's ProtocolContractVersion == V2 branch). V1 CCTXs do

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -533,11 +533,12 @@ func (ob *Observer) checkConfirmedTx(
 // outbound (mirroring the compliance-restricted cancellation path) to bypass
 // event parsing and trigger the standard V2 revert flow.
 //
-// Only OutboundTypeCall and OutboundTypeGasWithdrawAndCall are cancelled by
-// the signer (see SignOutboundFromCCTXV2). The ERC20-`withdrawAndCall` path
-// and plain V2 withdraws also have CallOptions.IsArbitraryCall=true on the
-// wire but are not cancelled — they must follow the normal event-parsing
-// path.
+// IsArbitraryCallCancellable enumerates the outbound types cancelled by the
+// signer (Call / GasWithdrawAndCall via signGatewayExecute, plus
+// ERC20WithdrawAndCall and ZetaWithdrawAndCall via the asset-handler relay
+// to GatewayEVM.executeWithERC20). Plain V2 withdraws also have
+// IsArbitraryCall=true on the wire per protocol-contracts semantics but are
+// not cancelled — they follow the normal event-parsing path.
 //
 // Deployment note: this predicate decides on CCTX metadata alone, never the
 // receipt. During a rolling zetaclient upgrade where some validators still
@@ -560,5 +561,5 @@ func isArbitraryCallCancellation(cctx *crosschaintypes.CrossChainTx) bool {
 	if !outboundParam.CallOptions.IsArbitraryCall {
 		return false
 	}
-	return common.IsGatewayExecuteOutbound(common.ParseOutboundTypeFromCCTX(*cctx))
+	return common.IsArbitraryCallCancellable(common.ParseOutboundTypeFromCCTX(*cctx))
 }

--- a/zetaclient/chains/evm/observer/outbound_test.go
+++ b/zetaclient/chains/evm/observer/outbound_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zeta-chain/node/pkg/chains"
 	"github.com/zeta-chain/node/pkg/coin"
 	"github.com/zeta-chain/node/testutil/sample"
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/config"
 	"github.com/zeta-chain/node/zetaclient/testutils"
 	"github.com/zeta-chain/node/zetaclient/testutils/mocks"
@@ -73,6 +74,31 @@ func Test_IsOutboundProcessed(t *testing.T) {
 		config.SetRestrictedAddressesFromConfig(cfg)
 
 		// post outbound vote
+		continueKeysign, err := ob.VoteOutboundIfConfirmed(ctx, cctx)
+		require.NoError(t, err)
+		require.False(t, continueKeysign)
+	})
+	t.Run("should post vote and return true on V2 arbitrary call cancellation", func(t *testing.T) {
+		// Mirror the signer's SignOutboundFromCCTXV2 cancel path: only
+		// OutboundTypeCall and OutboundTypeGasWithdrawAndCall are cancelled.
+		// Build a OutboundTypeGasWithdrawAndCall CCTX with IsArbitraryCall=true
+		// so the observer bypass fires and votes the outbound as failed without
+		// parsing Gateway events.
+		cctx := testutils.LoadCctxByNonce(t, chainID, nonce)
+		cctx.ProtocolContractVersion = crosschaintypes.ProtocolContractVersion_V2
+		cctx.InboundParams.CoinType = coin.CoinType_Gas
+		cctx.InboundParams.IsCrossChainCall = true
+		cctx.CctxStatus.Status = crosschaintypes.CctxStatus_PendingOutbound
+		cctx.GetCurrentOutboundParam().CallOptions = &crosschaintypes.CallOptions{
+			GasLimit:        100_000,
+			IsArbitraryCall: true,
+		}
+
+		// create evm observer and set outbound and receipt
+		ob := newTestSuite(t)
+		ob.setTxNReceipt(nonce, receipt, outbound)
+
+		// post outbound vote — bypass should fire regardless of receipt contents
 		continueKeysign, err := ob.VoteOutboundIfConfirmed(ctx, cctx)
 		require.NoError(t, err)
 		require.False(t, continueKeysign)
@@ -646,3 +672,50 @@ func Test_FilterTSSOutbound(t *testing.T) {
 //		require.Equal(t, chains.ReceiveStatus_failed, status)
 //	})
 //}
+
+func Test_isArbitraryCallCancellation(t *testing.T) {
+	build := func(
+		version crosschaintypes.ProtocolContractVersion,
+		coinType coin.CoinType,
+		isCrossChainCall bool,
+		callOptions *crosschaintypes.CallOptions,
+	) *crosschaintypes.CrossChainTx {
+		return &crosschaintypes.CrossChainTx{
+			ProtocolContractVersion: version,
+			InboundParams: &crosschaintypes.InboundParams{
+				CoinType:         coinType,
+				IsCrossChainCall: isCrossChainCall,
+			},
+			CctxStatus:     &crosschaintypes.Status{Status: crosschaintypes.CctxStatus_PendingOutbound},
+			OutboundParams: []*crosschaintypes.OutboundParams{{CallOptions: callOptions}},
+		}
+	}
+	v2 := crosschaintypes.ProtocolContractVersion_V2
+	v1 := crosschaintypes.ProtocolContractVersion_V1
+	arbitrary := &crosschaintypes.CallOptions{IsArbitraryCall: true}
+	authenticated := &crosschaintypes.CallOptions{IsArbitraryCall: false}
+
+	tests := []struct {
+		name     string
+		cctx     *crosschaintypes.CrossChainTx
+		expected bool
+	}{
+		{"nil call options returns false", build(v2, coin.CoinType_Gas, true, nil), false},
+		{"authenticated call returns false", build(v2, coin.CoinType_Gas, true, authenticated), false},
+		{"arbitrary gas withdraw and call (Gateway.execute) returns true", build(v2, coin.CoinType_Gas, true, arbitrary), true},
+		{"arbitrary no-asset call (Gateway.execute) returns true", build(v2, coin.CoinType_NoAssetCall, true, arbitrary), true},
+		// GatewayZEVM.withdraw() emits isArbitraryCall=true on plain withdraws,
+		// but the signer routes those through SignGasWithdraw — not cancelled.
+		{"plain gas withdraw with arbitrary flag returns false", build(v2, coin.CoinType_Gas, false, arbitrary), false},
+		// Custody withdrawAndCall path — destination is invoked via typed
+		// Callable.onCall, not the GatewayEVM.execute drain shape.
+		{"arbitrary erc20 withdraw and call (Custody) returns false", build(v2, coin.CoinType_ERC20, true, arbitrary), false},
+		// Defense-in-depth: predicate must mirror the signer's V2-only dispatch.
+		{"V1 cctx with arbitrary flag never cancelled", build(v1, coin.CoinType_Gas, true, arbitrary), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, isArbitraryCallCancellation(tc.cctx))
+		})
+	}
+}

--- a/zetaclient/chains/evm/observer/outbound_test.go
+++ b/zetaclient/chains/evm/observer/outbound_test.go
@@ -702,14 +702,20 @@ func Test_isArbitraryCallCancellation(t *testing.T) {
 	}{
 		{"nil call options returns false", build(v2, coin.CoinType_Gas, true, nil), false},
 		{"authenticated call returns false", build(v2, coin.CoinType_Gas, true, authenticated), false},
+		// GatewayEVM.execute path (signGatewayExecute):
 		{"arbitrary gas withdraw and call (Gateway.execute) returns true", build(v2, coin.CoinType_Gas, true, arbitrary), true},
 		{"arbitrary no-asset call (Gateway.execute) returns true", build(v2, coin.CoinType_NoAssetCall, true, arbitrary), true},
-		// GatewayZEVM.withdraw() emits isArbitraryCall=true on plain withdraws,
-		// but the signer routes those through SignGasWithdraw — not cancelled.
+		// GatewayEVM.executeWithERC20 path via asset-handler relay:
+		// ERC20Custody.withdrawAndCall and ZetaConnector.withdrawAndCall both
+		// pass MessageContext through to gateway.executeWithERC20, which
+		// branches on sender==0 to _executeArbitraryCall — same drain
+		// primitive as GatewayEVM.execute. Must be cancelled too.
+		{"arbitrary erc20 withdraw and call (Custody → executeWithERC20) returns true", build(v2, coin.CoinType_ERC20, true, arbitrary), true},
+		{"arbitrary zeta withdraw and call (Connector → executeWithERC20) returns true", build(v2, coin.CoinType_Zeta, true, arbitrary), true},
+		// Plain withdraws emit isArbitraryCall=true on the wire (GatewayZEVM
+		// semantics for "no authenticated sender") but don't reach any of the
+		// MessageContext-passing signers — not cancelled.
 		{"plain gas withdraw with arbitrary flag returns false", build(v2, coin.CoinType_Gas, false, arbitrary), false},
-		// Custody withdrawAndCall path — destination is invoked via typed
-		// Callable.onCall, not the GatewayEVM.execute drain shape.
-		{"arbitrary erc20 withdraw and call (Custody) returns false", build(v2, coin.CoinType_ERC20, true, arbitrary), false},
 		// Defense-in-depth: predicate must mirror the signer's V2-only dispatch.
 		{"V1 cctx with arbitrary flag never cancelled", build(v1, coin.CoinType_Gas, true, arbitrary), false},
 	}

--- a/zetaclient/chains/evm/observer/outbound_test.go
+++ b/zetaclient/chains/evm/observer/outbound_test.go
@@ -78,7 +78,7 @@ func Test_IsOutboundProcessed(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, continueKeysign)
 	})
-	t.Run("should post vote and return true on V2 arbitrary call cancellation", func(t *testing.T) {
+	t.Run("should post vote and return false on V2 arbitrary call cancellation", func(t *testing.T) {
 		// Mirror the signer's SignOutboundFromCCTXV2 cancel path: only
 		// OutboundTypeCall and OutboundTypeGasWithdrawAndCall are cancelled.
 		// Build a OutboundTypeGasWithdrawAndCall CCTX with IsArbitraryCall=true

--- a/zetaclient/chains/evm/signer/v2_signer.go
+++ b/zetaclient/chains/evm/signer/v2_signer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/evm/common"
+	"github.com/zeta-chain/node/zetaclient/logs"
 )
 
 // SignOutboundFromCCTXV2 signs an outbound transaction from a CCTX with protocol contract v2
@@ -31,6 +32,12 @@ func (signer *Signer) SignOutboundFromCCTXV2(
 	// `isArbitraryCall=true` from GatewayZEVM.withdraw() too, but they don't
 	// reach signGatewayExecute either.
 	if outboundData.callOptions.IsArbitraryCall && common.IsGatewayExecuteOutbound(outboundType) {
+		signer.Logger().Std.Warn().
+			Str(logs.FieldCctxIndex, cctx.Index).
+			Uint64(logs.FieldNonce, outboundData.nonce).
+			Stringer("destination", outboundData.to).
+			Int("outbound_type", int(outboundType)).
+			Msg("cancelling V2 arbitrary-call CCTX via TSS self-transfer")
 		return signer.SignCancel(ctx, outboundData)
 	}
 	switch outboundType {

--- a/zetaclient/chains/evm/signer/v2_signer.go
+++ b/zetaclient/chains/evm/signer/v2_signer.go
@@ -19,19 +19,23 @@ func (signer *Signer) SignOutboundFromCCTXV2(
 ) (*ethtypes.Transaction, error) {
 	outboundType := common.ParseOutboundTypeFromCCTX(*cctx)
 
-	// V2 arbitrary calls that route through GatewayEVM.execute are not signed:
-	// the destination contract and calldata are caller-controlled, so we
-	// cancel via a TSS-to-TSS zero-value self-transfer that consumes the
-	// assigned nonce. This avoids the head-of-line blocking that would occur
-	// if the CCTX were left perpetually unsigned.
+	// V2 arbitrary calls whose CCTX shape lands at GatewayEVM's arbitrary-call
+	// branch on the destination chain are not signed. The destination contract
+	// and calldata are caller-controlled, so we cancel via a TSS-to-TSS
+	// zero-value self-transfer that consumes the assigned nonce. This avoids
+	// the head-of-line blocking that would occur if the CCTX were left
+	// perpetually unsigned.
 	//
-	// Only OutboundTypeCall and OutboundTypeGasWithdrawAndCall reach
-	// signGatewayExecute. The other arbitrary-call routes
-	// (ERC20Custody.withdrawAndCall) constrain the destination to invoke
-	// typed `Callable.onCall` and remain enabled. Plain withdraws emit
-	// `isArbitraryCall=true` from GatewayZEVM.withdraw() too, but they don't
-	// reach signGatewayExecute either.
-	if outboundData.callOptions.IsArbitraryCall && common.IsGatewayExecuteOutbound(outboundType) {
+	// IsArbitraryCallCancellable enumerates the outbound types whose signer
+	// would otherwise produce MessageContext.Sender=0x0 and pass it into
+	// GatewayEVM.execute (signGatewayExecute) or GatewayEVM.executeWithERC20
+	// (via ERC20Custody.withdrawAndCall / ZetaConnector.withdrawAndCall) —
+	// both of which branch on the zero sender to invoke _executeArbitraryCall.
+	//
+	// Plain withdraws emit `isArbitraryCall=true` from GatewayZEVM.withdraw()
+	// per protocol-contracts semantics ("no authenticated sender"), but they
+	// don't reach any of those entry points and are not cancelled.
+	if outboundData.callOptions.IsArbitraryCall && common.IsArbitraryCallCancellable(outboundType) {
 		signer.Logger().Std.Warn().
 			Str(logs.FieldCctxIndex, cctx.Index).
 			Uint64(logs.FieldNonce, outboundData.nonce).

--- a/zetaclient/chains/evm/signer/v2_signer.go
+++ b/zetaclient/chains/evm/signer/v2_signer.go
@@ -17,6 +17,22 @@ func (signer *Signer) SignOutboundFromCCTXV2(
 	outboundData *OutboundData,
 ) (*ethtypes.Transaction, error) {
 	outboundType := common.ParseOutboundTypeFromCCTX(*cctx)
+
+	// V2 arbitrary calls that route through GatewayEVM.execute are not signed:
+	// the destination contract and calldata are caller-controlled, so we
+	// cancel via a TSS-to-TSS zero-value self-transfer that consumes the
+	// assigned nonce. This avoids the head-of-line blocking that would occur
+	// if the CCTX were left perpetually unsigned.
+	//
+	// Only OutboundTypeCall and OutboundTypeGasWithdrawAndCall reach
+	// signGatewayExecute. The other arbitrary-call routes
+	// (ERC20Custody.withdrawAndCall) constrain the destination to invoke
+	// typed `Callable.onCall` and remain enabled. Plain withdraws emit
+	// `isArbitraryCall=true` from GatewayZEVM.withdraw() too, but they don't
+	// reach signGatewayExecute either.
+	if outboundData.callOptions.IsArbitraryCall && common.IsGatewayExecuteOutbound(outboundType) {
+		return signer.SignCancel(ctx, outboundData)
+	}
 	switch outboundType {
 	case common.OutboundTypeGasWithdraw, common.OutboundTypeGasWithdrawRevert:
 		return signer.SignGasWithdraw(ctx, outboundData)

--- a/zetaclient/chains/evm/signer/v2_signer_test.go
+++ b/zetaclient/chains/evm/signer/v2_signer_test.go
@@ -1,0 +1,100 @@
+package signer
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/coin"
+)
+
+// TestSigner_SignOutboundFromCCTXV2_NoAssetArbitraryCallCancels verifies that
+// a V2 OutboundTypeCall (no-asset call from GatewayZEVM.call) with
+// IsArbitraryCall=true is short-circuited to SignCancel — this is the path
+// the live mainnet drain used.
+func TestSigner_SignOutboundFromCCTXV2_NoAssetArbitraryCallCancels(t *testing.T) {
+	ctx := makeCtx(t)
+	evmSigner := newTestSuite(t)
+
+	// Build a OutboundTypeCall CCTX (CoinType=NoAssetCall, amount=0,
+	// PendingOutbound).
+	cctx := getCCTX(t)
+	cctx.InboundParams.CoinType = coin.CoinType_NoAssetCall
+	cctx.GetCurrentOutboundParam().CoinType = coin.CoinType_NoAssetCall
+	cctx.GetCurrentOutboundParam().Amount = math.ZeroUint()
+
+	txData, skip, err := NewOutboundData(ctx, cctx, 123, zerolog.Logger{})
+	require.False(t, skip)
+	require.NoError(t, err)
+
+	// Force the outbound's call options to request an arbitrary call.
+	txData.callOptions.IsArbitraryCall = true
+
+	tx, err := evmSigner.SignOutboundFromCCTXV2(ctx, cctx, txData)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	// Cancel produces a TSS self-transfer: to == TSS, value == 0, no calldata.
+	verifyTxBodyBasics(t, tx, evmSigner.tss.PubKey().AddressEVM(), txData.nonce, big.NewInt(0))
+	require.Empty(t, tx.Data())
+}
+
+// TestSigner_SignOutboundFromCCTXV2_GasWithdrawAndArbitraryCallCancels verifies
+// that a V2 OutboundTypeGasWithdrawAndCall with IsArbitraryCall=true is
+// short-circuited to SignCancel rather than packed into GatewayEVM.execute.
+func TestSigner_SignOutboundFromCCTXV2_GasWithdrawAndArbitraryCallCancels(t *testing.T) {
+	ctx := makeCtx(t)
+	evmSigner := newTestSuite(t)
+
+	// Build a OutboundTypeGasWithdrawAndCall CCTX (CoinType=Gas with
+	// IsCrossChainCall=true) — the GatewayEVM.execute dispatch path that must
+	// be cancelled when IsArbitraryCall=true.
+	cctx := getCCTX(t)
+	cctx.InboundParams.IsCrossChainCall = true
+
+	txData, skip, err := NewOutboundData(ctx, cctx, 123, zerolog.Logger{})
+	require.False(t, skip)
+	require.NoError(t, err)
+
+	txData.callOptions.IsArbitraryCall = true
+
+	tx, err := evmSigner.SignOutboundFromCCTXV2(ctx, cctx, txData)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	// Cancel produces a TSS self-transfer: to == TSS, value == 0, no calldata.
+	verifyTxBodyBasics(t, tx, evmSigner.tss.PubKey().AddressEVM(), txData.nonce, big.NewInt(0))
+	require.Empty(t, tx.Data())
+}
+
+// TestSigner_SignOutboundFromCCTXV2_PlainWithdrawNotCancelled is a regression
+// guard for the case where GatewayZEVM.withdraw() emits Withdrawn with
+// CallOptions.isArbitraryCall=true even though there is no payload. Plain V2
+// withdraws must NOT be cancelled — they don't reach signGatewayExecute.
+func TestSigner_SignOutboundFromCCTXV2_PlainWithdrawNotCancelled(t *testing.T) {
+	ctx := makeCtx(t)
+	evmSigner := newTestSuite(t)
+
+	// CCTX is OutboundTypeGasWithdraw (CoinType=Gas, IsCrossChainCall=false).
+	cctx := getCCTX(t)
+	require.False(t, cctx.InboundParams.IsCrossChainCall)
+
+	txData, skip, err := NewOutboundData(ctx, cctx, 123, zerolog.Logger{})
+	require.False(t, skip)
+	require.NoError(t, err)
+
+	// Simulate the protocol-contract behavior: GatewayZEVM.withdraw() emits
+	// isArbitraryCall=true on plain withdraws.
+	txData.callOptions.IsArbitraryCall = true
+
+	tx, err := evmSigner.SignOutboundFromCCTXV2(ctx, cctx, txData)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	// Gas withdraw sends to the receiver, not the TSS — i.e. NOT a self-transfer.
+	verifyTxBodyBasics(t, tx, txData.to, txData.nonce, txData.amount)
+	require.NotEqual(t, evmSigner.tss.PubKey().AddressEVM(), *tx.To())
+}


### PR DESCRIPTION
## Summary

Backport of both #4575 and #4580 to `release/zetaclient/v37`.

V2 CCTXs with `CallOptions.IsArbitraryCall=true` whose outbound type is one of:
- `OutboundTypeCall` / `OutboundTypeGasWithdrawAndCall` → `GatewayEVM.execute`
- `OutboundTypeERC20WithdrawAndCall` → `ERC20Custody.withdrawAndCall` → `GatewayEVM.executeWithERC20`
- `OutboundTypeZetaWithdrawAndCall` → `ZetaConnector.withdrawAndCall` → `GatewayEVM.executeWithERC20`

…are short-circuited to a TSS self-transfer (`SignCancel`) in the signer, and the observer treats those receipts as failed outbounds to trigger the standard V2 revert flow rather than parsing gateway events. All four outbound types reach the same `sender == address(0)` branch (`_executeArbitraryCall`) on the destination gateway, so they are cancelled as one group.

## Changes

| Area | Change |
|------|--------|
| `common/cctx.go` | New `IsArbitraryCallCancellable` helper enumerating the four cancellable types |
| `signer/v2_signer.go` | Short-circuit to `SignCancel` for arbitrary calls on cancellable outbound types; warn log on cancellation |
| `observer/outbound.go` | New `isArbitraryCallCancellation` predicate mirroring the signer; warn log on event-parsing bypass |
| `cctx_test.go`, `outbound_test.go`, `v2_signer_test.go` | Unit coverage for all four cancellable types and the predicate |
| `e2etests/test_eth_withdraw_and_arbitrary_call.go` | Expects `Reverted` with principal refund |
| `e2etests/test_erc20_withdraw_and_arbitrary_call.go` | Expects `Reverted` with ZRC20 refund to `RevertAddress` |
| `e2etests/test_zevm_to_evm_arbitrary_call.go` | Expects `Reverted`, asserts dApp not invoked |

## Test plan

- [x] `go build ./zetaclient/... ./e2e/...`
- [x] `go test ./zetaclient/chains/evm/{common,observer,signer}/...`
- [x] `go vet ./zetaclient/chains/evm/... ./e2e/e2etests/...`
- [ ] CI E2E suite green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)