### PR TITLE
chore(ci): increase zetae2e artifact retention to 400 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           name: zetae2e
           path: ~/go/bin/zetae2e
-          retention-days: 90
+          retention-days: 400
       
       - name: Clean Up Workspace
         if: always()


### PR DESCRIPTION
## Summary

- Bumps `zetae2e` artifact retention from 90 → 400 days (GitHub max)
- The mainnet E2E workflow (`zeta-chain/e2e`) downloads this artifact to run tests — at 90 days it expires between release cuts, which broke all mainnet E2E runs starting Apr 24 ([failed run](https://github.com/zeta-chain/e2e/actions/runs/24895332964))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions artifact retention, with no impact to application runtime behavior.
> 
> **Overview**
> Updates the CI workflow to retain the `zetae2e` build artifact for **400 days** (up from 90) to reduce test breakages from artifact expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e52e8c2fe715d931ddeccf820a925e9ef1dfd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `zetae2e` artifact `retention-days` from 90 to 400 in the CI workflow to prevent expiry between release cuts, which caused mainnet E2E runs to fail starting Apr 24. The change is a single-line config update with no logic side-effects.

- GitHub limits `retention-days` to **90 days on public repositories**; 400 days is only available for private/internal repositories. If `zeta-chain/node` is public, this value may be silently clamped (yielding no improvement) or cause the upload step to fail.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the repository is private; needs verification of repo visibility before merging if public.

The change is minimal and addresses a real production breakage. The only concern is a potential GitHub platform constraint on public repos that could make the fix ineffective, but this is a speculative P2 — no code logic is broken by this change.

.github/workflows/ci.yml — confirm `retention-days: 400` is valid for this repository's visibility level.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Single-line change bumping the `zetae2e` artifact `retention-days` from 90 to 400 to prevent expiry between release cuts; 400 days is the GitHub maximum for private repositories but may be silently capped on public repos. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as zeta-chain/node CI
    participant GHA as GitHub Artifact Store
    participant E2E as zeta-chain/e2e workflow

    CI->>GHA: upload-artifact(zetae2e, retention-days=400)
    Note over GHA: Artifact stored for up to 400 days
    E2E->>GHA: download-artifact(zetae2e)
    GHA-->>E2E: zetae2e binary
    E2E->>E2E: Run mainnet E2E tests
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 82

Comment:
**400 days may exceed the GitHub limit for public repositories**

GitHub caps artifact `retention-days` at **90 days for public repositories** and 400 days only for private/internal/enterprise repositories. If `zeta-chain/node` is public, setting `400` here will either be silently clamped back to 90 days (giving no improvement over the previous value) or cause the upload step to error. It's worth confirming the repository visibility before merging — if the repo is public, a higher retention requires either making it private or using a separate private artifact store.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): increase zetae2e artifact ret..."](https://github.com/zeta-chain/node/commit/75e52e8c2fe715d931ddeccf820a925e9ef1dfd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30030397)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended artifact retention period in CI workflow for improved test data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->