### PR TITLE
fix(zetaclient/v38): also cancel arbitrary calls reaching executeWithERC20

### DIFF
--- a/e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go
@@ -3,6 +3,7 @@ package e2etests
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 	"github.com/zeta-chain/protocol-contracts-evm/pkg/gatewayzevm.sol"
 
@@ -23,18 +24,43 @@ func TestERC20WithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	r.ApproveERC20ZRC20(r.GatewayZEVMAddr)
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
+	revertAddress := r.EVMAddress()
+
 	// perform the withdraw
 	tx := r.ERC20WithdrawAndArbitraryCall(
 		r.TestDAppV2EVMAddr,
 		amount,
 		r.EncodeERC20Call(r.ERC20Addr, amount, payload),
-		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
 	)
+
+	// wait for the withdraw tx to mine on ZEVM (user has paid amount + fees),
+	// then capture the post-payment ERC20-ZRC20 balance.
+	receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+	utils.RequireTxSuccessful(r, receipt)
+	revertBalanceBefore, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
 
 	// wait for the cctx to be mined
 	cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 	r.Logger.CCTX(*cctx, "withdraw")
-	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
 
-	r.AssertTestDAppEVMCalled(true, payload, amount)
+	// V2 arbitrary calls via ERC20Custody.withdrawAndCall route to
+	// gateway.executeWithERC20, which has the same sender==0 arbitrary-call
+	// branch as gateway.execute. The signer cancels these CCTXs (TSS
+	// self-transfer); the observer reports the outbound failed; the CCTX
+	// terminates as Reverted via the standard V2 revert flow; the principal
+	// is refunded to the revert address.
+	utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
+
+	// destination dApp must not have been called
+	r.AssertTestDAppEVMCalled(false, payload, amount)
+
+	// revert address should receive at least the principal back
+	revertBalanceAfter, err := r.ERC20ZRC20.BalanceOf(&bind.CallOpts{}, revertAddress)
+	require.NoError(r, err)
+	require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 }

--- a/e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go
@@ -35,12 +35,16 @@ func TestZetaWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 	)
 
 	if r.IsV2ZETAEnabled() {
-		// V2 ZETA flows enabled: withdraw and call should succeed
+		// V2 ZETA flows enabled: ZetaConnector.withdrawAndCall arbitrary calls
+		// route to GatewayEVM.executeWithERC20's sender==0 arbitrary-call branch
+		// — the same drain shape as GatewayEVM.execute. The signer cancels these
+		// CCTXs (TSS self-transfer); the CCTX terminates as Reverted via the
+		// standard V2 revert flow; the destination dApp must not be invoked.
 		cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 		r.Logger.CCTX(*cctx, "zeta_withdraw_and_arbitrary_call")
-		utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_OutboundMined)
+		utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
-		r.AssertTestDAppEVMCalled(true, payload, amount)
+		r.AssertTestDAppEVMCalled(false, payload, amount)
 	} else {
 		// V2 ZETA flows disabled: tx should revert on GatewayZEVM, no CCTX created
 		utils.EnsureNoCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient)

--- a/e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go
+++ b/e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go
@@ -25,13 +25,20 @@ func TestZetaWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 
 	r.ApproveETHZRC20(r.GatewayZEVMAddr)
 
+	// use a contract as revert recipient so the post-revert balance check
+	// isn't perturbed by gas costs (the revert tx is signed by TSS).
+	revertAddress := r.TestDAppV2ZEVMAddr
+
 	// perform the withdraw
 	tx := r.ZETAWithdrawAndArbitraryCall(
 		r.TestDAppV2EVMAddr,
 		amount,
 		evmChainID,
 		r.EncodeERC20Call(r.ZetaEthAddr, amount, payload),
-		gatewayzevm.RevertOptions{OnRevertGasLimit: big.NewInt(0)},
+		gatewayzevm.RevertOptions{
+			RevertAddress:    revertAddress,
+			OnRevertGasLimit: big.NewInt(0),
+		},
 	)
 
 	if r.IsV2ZETAEnabled() {
@@ -40,11 +47,25 @@ func TestZetaWithdrawAndArbitraryCall(r *runner.E2ERunner, args []string) {
 		// — the same drain shape as GatewayEVM.execute. The signer cancels these
 		// CCTXs (TSS self-transfer); the CCTX terminates as Reverted via the
 		// standard V2 revert flow; the destination dApp must not be invoked.
+
+		// wait for the withdraw tx to mine on ZEVM, then capture the
+		// post-payment ZEVM-coin balance of the revert recipient.
+		receipt := utils.MustWaitForTxReceipt(r.Ctx, r.ZEVMClient, tx, r.Logger, r.ReceiptTimeout)
+		utils.RequireTxSuccessful(r, receipt)
+		revertBalanceBefore, err := r.ZEVMClient.BalanceAt(r.Ctx, revertAddress, nil)
+		require.NoError(r, err)
+
 		cctx := utils.WaitCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient, r.Logger, r.CctxTimeout)
 		r.Logger.CCTX(*cctx, "zeta_withdraw_and_arbitrary_call")
 		utils.RequireCCTXStatus(r, cctx, crosschaintypes.CctxStatus_Reverted)
 
+		// destination dApp must not have been called
 		r.AssertTestDAppEVMCalled(false, payload, amount)
+
+		// revert recipient should receive at least the principal back
+		revertBalanceAfter, err := r.ZEVMClient.BalanceAt(r.Ctx, revertAddress, nil)
+		require.NoError(r, err)
+		require.EqualValues(r, new(big.Int).Add(revertBalanceBefore, amount), revertBalanceAfter)
 	} else {
 		// V2 ZETA flows disabled: tx should revert on GatewayZEVM, no CCTX created
 		utils.EnsureNoCctxMinedByInboundHash(r.Ctx, tx.Hash().Hex(), r.CctxClient)

--- a/zetaclient/chains/evm/common/cctx.go
+++ b/zetaclient/chains/evm/common/cctx.go
@@ -49,13 +49,34 @@ const (
 	OutboundTypeZetaWithdraw
 )
 
-// IsGatewayExecuteOutbound reports whether the outbound type forwards
-// arbitrary calldata through GatewayEVM.execute (signGatewayExecute path).
-// These are the outbound types where MessageContext.Sender = 0x0 grants the
-// destination contract authority over arbitrary calldata, so a CCTX with
-// CallOptions.IsArbitraryCall=true on this path must not be signed.
-func IsGatewayExecuteOutbound(t OutboundType) bool {
-	return t == OutboundTypeCall || t == OutboundTypeGasWithdrawAndCall
+// IsArbitraryCallCancellable reports whether the outbound type, when paired
+// with CallOptions.IsArbitraryCall=true, would produce a TSS-signed call
+// containing MessageContext.Sender == address(0) and thereby reach
+// GatewayEVM's arbitrary-call branch (_executeArbitraryCall) on the
+// destination chain.
+//
+// Three signer entry points translate IsArbitraryCall into a zero sender
+// inside MessageContext (see OutboundData.MessageContext) and pass it into
+// a contract that branches on sender:
+//   - signGatewayExecute → GatewayEVM.execute
+//     reached by OutboundTypeCall and OutboundTypeGasWithdrawAndCall
+//   - signERC20CustodyWithdrawAndCall → ERC20Custody.withdrawAndCall
+//     → GatewayEVM.executeWithERC20
+//     reached by OutboundTypeERC20WithdrawAndCall
+//   - signZetaConnectorWithdrawAndCall → ZetaConnector.withdrawAndCall
+//     → GatewayEVM.executeWithERC20
+//     reached by OutboundTypeZetaWithdrawAndCall
+//
+// All three end at GatewayEVM's arbitrary-call branch, which performs a raw
+// destination.call(data) with msg.sender == GatewayEVM and is not selector-
+// filtered against ERC20 authority (transferFrom / approve / permit). CCTXs
+// with IsArbitraryCall=true on any of these outbound types must be cancelled
+// at the signer rather than relayed to the destination chain.
+func IsArbitraryCallCancellable(t OutboundType) bool {
+	return t == OutboundTypeCall ||
+		t == OutboundTypeGasWithdrawAndCall ||
+		t == OutboundTypeERC20WithdrawAndCall ||
+		t == OutboundTypeZetaWithdrawAndCall
 }
 
 // ParseOutboundTypeFromCCTX returns the outbound type from the CCTX

--- a/zetaclient/chains/evm/common/cctx_test.go
+++ b/zetaclient/chains/evm/common/cctx_test.go
@@ -219,10 +219,12 @@ func TestParseOutboundTypeFromCCTX(t *testing.T) {
 	}
 }
 
-func TestIsGatewayExecuteOutbound(t *testing.T) {
-	gatewayExecuteTypes := map[OutboundType]bool{
-		OutboundTypeCall:               true,
-		OutboundTypeGasWithdrawAndCall: true,
+func TestIsArbitraryCallCancellable(t *testing.T) {
+	cancellableTypes := map[OutboundType]bool{
+		OutboundTypeCall:                 true,
+		OutboundTypeGasWithdrawAndCall:   true,
+		OutboundTypeERC20WithdrawAndCall: true,
+		OutboundTypeZetaWithdrawAndCall:  true,
 	}
 	allTypes := []OutboundType{
 		OutboundTypeUnknown,
@@ -243,7 +245,7 @@ func TestIsGatewayExecuteOutbound(t *testing.T) {
 	for _, ot := range allTypes {
 		ot := ot
 		t.Run(fmt.Sprintf("OutboundType_%d", ot), func(t *testing.T) {
-			require.Equal(t, gatewayExecuteTypes[ot], IsGatewayExecuteOutbound(ot))
+			require.Equal(t, cancellableTypes[ot], IsArbitraryCallCancellable(ot))
 		})
 	}
 }

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -194,8 +194,9 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	// - the CCTX is restricted by compliance, OR
 	// - the CCTX is a V2 arbitrary call (signer refuses to forward arbitrary
 	//   calldata through the destination Gateway)
-	if compliance.IsCCTXRestricted(cctx) || isArbitraryCallCancellation(cctx) {
-		if isArbitraryCallCancellation(cctx) {
+	isArbitraryCancel := isArbitraryCallCancellation(cctx)
+	if compliance.IsCCTXRestricted(cctx) || isArbitraryCancel {
+		if isArbitraryCancel {
 			logger.Warn().
 				Str(logs.FieldCctxIndex, cctx.Index).
 				Stringer(logs.FieldTx, receipt.TxHash).

--- a/zetaclient/chains/evm/observer/outbound.go
+++ b/zetaclient/chains/evm/observer/outbound.go
@@ -195,6 +195,12 @@ func (ob *Observer) VoteOutboundIfConfirmed(
 	// - the CCTX is a V2 arbitrary call (signer refuses to forward arbitrary
 	//   calldata through the destination Gateway)
 	if compliance.IsCCTXRestricted(cctx) || isArbitraryCallCancellation(cctx) {
+		if isArbitraryCallCancellation(cctx) {
+			logger.Warn().
+				Str(logs.FieldCctxIndex, cctx.Index).
+				Stringer(logs.FieldTx, receipt.TxHash).
+				Msg("voting V2 arbitrary-call CCTX as failed (signer-cancelled)")
+		}
 		receiveValue = cctx.GetCurrentOutboundParam().Amount.BigInt()
 		receiveStatus = chains.ReceiveStatus_failed
 		ob.postVoteOutbound(ctx, cctx.Index, receipt, transaction, receiveValue, receiveStatus, nonce, cointype, logger)
@@ -535,18 +541,20 @@ func (ob *Observer) checkConfirmedTx(
 // outbound (mirroring the compliance-restricted cancellation path) to bypass
 // event parsing and trigger the standard V2 revert flow.
 //
-// Only OutboundTypeCall and OutboundTypeGasWithdrawAndCall are cancelled by
-// the signer (see SignOutboundFromCCTXV2). The ERC20- and ZETA-`withdrawAndCall`
-// paths and plain V2 withdraws also have CallOptions.IsArbitraryCall=true on
-// the wire but are not cancelled — they must follow the normal event-parsing
-// path.
+// The signer cancels OutboundTypeCall, OutboundTypeGasWithdrawAndCall,
+// OutboundTypeERC20WithdrawAndCall, and OutboundTypeZetaWithdrawAndCall — all
+// arbitrary-call routes that produce sender == address(0) inside
+// MessageContext and reach GatewayEVM's `_executeArbitraryCall` branch (via
+// GatewayEVM.execute or executeWithERC20). Plain V2 withdraws also carry
+// CallOptions.IsArbitraryCall=true on the wire but are not cancelled — they
+// follow the normal event-parsing path.
 //
 // Deployment note: this predicate decides on CCTX metadata alone, never the
 // receipt. During a rolling zetaclient upgrade where some validators still
-// run the old signer (which forwards the call as GatewayEVM.execute), a
-// new-version observer would mark that successful Executed receipt as
-// failed. To avoid split votes, all validators should upgrade zetaclient as
-// a single coordinated step on this hotfix.
+// run the old signer (which forwards the arbitrary call to the destination
+// Gateway), a new-version observer would mark that successful Executed
+// receipt as failed. To avoid split votes, all validators should upgrade
+// zetaclient as a single coordinated step on this hotfix.
 func isArbitraryCallCancellation(cctx *crosschaintypes.CrossChainTx) bool {
 	// Mirror the signer's V2-only dispatch (SignOutboundFromCCTXV2 is reached
 	// only via signer.go's ProtocolContractVersion == V2 branch). V1 CCTXs do
@@ -562,5 +570,5 @@ func isArbitraryCallCancellation(cctx *crosschaintypes.CrossChainTx) bool {
 	if !outboundParam.CallOptions.IsArbitraryCall {
 		return false
 	}
-	return common.IsGatewayExecuteOutbound(common.ParseOutboundTypeFromCCTX(*cctx))
+	return common.IsArbitraryCallCancellable(common.ParseOutboundTypeFromCCTX(*cctx))
 }

--- a/zetaclient/chains/evm/observer/outbound_test.go
+++ b/zetaclient/chains/evm/observer/outbound_test.go
@@ -704,13 +704,14 @@ func Test_isArbitraryCallCancellation(t *testing.T) {
 		{"authenticated call returns false", build(v2, coin.CoinType_Gas, true, authenticated), false},
 		{"arbitrary gas withdraw and call (Gateway.execute) returns true", build(v2, coin.CoinType_Gas, true, arbitrary), true},
 		{"arbitrary no-asset call (Gateway.execute) returns true", build(v2, coin.CoinType_NoAssetCall, true, arbitrary), true},
+		// ERC20 / Zeta withdrawAndCall arbitrary calls land at
+		// GatewayEVM.executeWithERC20's `_executeArbitraryCall` branch (sender
+		// == address(0)) — same drain shape as GatewayEVM.execute, also cancelled.
+		{"arbitrary erc20 withdraw and call (Custody) returns true", build(v2, coin.CoinType_ERC20, true, arbitrary), true},
+		{"arbitrary zeta withdraw and call (Connector) returns true", build(v2, coin.CoinType_Zeta, true, arbitrary), true},
 		// GatewayZEVM.withdraw() emits isArbitraryCall=true on plain withdraws,
 		// but the signer routes those through SignGasWithdraw — not cancelled.
 		{"plain gas withdraw with arbitrary flag returns false", build(v2, coin.CoinType_Gas, false, arbitrary), false},
-		// Custody / Connector withdrawAndCall paths — destination is invoked
-		// via typed Callable.onCall, not the GatewayEVM.execute drain shape.
-		{"arbitrary erc20 withdraw and call (Custody) returns false", build(v2, coin.CoinType_ERC20, true, arbitrary), false},
-		{"arbitrary zeta withdraw and call (Connector) returns false", build(v2, coin.CoinType_Zeta, true, arbitrary), false},
 		// Defense-in-depth: predicate must mirror the signer's V2-only dispatch.
 		{"V1 cctx with arbitrary flag never cancelled", build(v1, coin.CoinType_Gas, true, arbitrary), false},
 	}

--- a/zetaclient/chains/evm/signer/v2_signer.go
+++ b/zetaclient/chains/evm/signer/v2_signer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/zeta-chain/node/x/crosschain/types"
 	"github.com/zeta-chain/node/zetaclient/chains/evm/common"
+	"github.com/zeta-chain/node/zetaclient/logs"
 )
 
 // SignOutboundFromCCTXV2 signs an outbound transaction from a CCTX with protocol contract v2
@@ -14,20 +15,33 @@ func (signer *Signer) SignOutboundFromCCTXV2(
 	cctx *types.CrossChainTx,
 	outboundData *OutboundData,
 ) (*ethtypes.Transaction, error) {
-	// V2 arbitrary calls that route through GatewayEVM.execute are not signed:
-	// the destination contract and calldata are caller-controlled, so we
-	// cancel via a TSS-to-TSS zero-value self-transfer that consumes the
-	// assigned nonce. This avoids the head-of-line blocking that would occur
-	// if the CCTX were left perpetually unsigned.
+	// V2 arbitrary calls reach GatewayEVM's `_executeArbitraryCall` branch
+	// (sender == address(0)), which performs a raw destination.call(data) with
+	// msg.sender == GatewayEVM. The destination and calldata are caller-
+	// controlled, so we cancel these CCTXs at the signer via a TSS-to-TSS
+	// zero-value self-transfer that consumes the assigned nonce. This avoids
+	// the head-of-line blocking that would occur if the CCTX were left
+	// perpetually unsigned.
 	//
-	// Only OutboundTypeCall and OutboundTypeGasWithdrawAndCall reach
-	// signGatewayExecute. The other arbitrary-call routes
-	// (ERC20Custody.withdrawAndCall, ZetaConnector.withdrawAndCall) constrain
-	// the destination to invoke typed `Callable.onCall` and remain enabled.
-	// Plain withdraws emit `isArbitraryCall=true` from GatewayZEVM.withdraw()
-	// too, but they don't reach signGatewayExecute either.
+	// Three signer entry points produce a sender == 0 MessageContext and
+	// land at the same arbitrary-call branch:
+	//   - signGatewayExecute → GatewayEVM.execute
+	//     (OutboundTypeCall, OutboundTypeGasWithdrawAndCall)
+	//   - signERC20CustodyWithdrawAndCall → GatewayEVM.executeWithERC20
+	//     (OutboundTypeERC20WithdrawAndCall)
+	//   - signZetaConnectorWithdrawAndCall → GatewayEVM.executeWithERC20
+	//     (OutboundTypeZetaWithdrawAndCall)
+	//
+	// Plain withdraws also emit `isArbitraryCall=true` from
+	// GatewayZEVM.withdraw(), but they don't reach any of these entry points.
 	outboundType := common.ParseOutboundTypeFromCCTX(*cctx)
-	if outboundData.callOptions.IsArbitraryCall && common.IsGatewayExecuteOutbound(outboundType) {
+	if outboundData.callOptions.IsArbitraryCall && common.IsArbitraryCallCancellable(outboundType) {
+		signer.Logger().Std.Warn().
+			Str(logs.FieldCctxIndex, cctx.Index).
+			Uint64(logs.FieldNonce, outboundData.nonce).
+			Stringer("destination", outboundData.to).
+			Int("outbound_type", int(outboundType)).
+			Msg("cancelling V2 arbitrary-call CCTX via TSS self-transfer")
 		return signer.SignCancel(outboundData)
 	}
 	switch outboundType {


### PR DESCRIPTION
## Summary

Extends the V2 arbitrary-call cancel guard (merged in #4575) to cover the ERC20 and ZETA `withdrawAndCall` paths, which forward to `GatewayEVM.executeWithERC20` and reach the same `sender==0` arbitrary-call branch as `GatewayEVM.execute`. Also adds warn logs around the cancellation so it's visible in production.

## Why this matters

Before this change, only `GatewayEVM.execute` arbitrary calls were cancelled. `ERC20Custody.withdrawAndCall` and `ZetaConnector.withdrawAndCall` were still signed normally — but those paths forward `MessageContext` straight into `GatewayEVM.executeWithERC20`, which has the same `_executeArbitraryCall` branch that `execute` does. Without this extension, an attacker who triggers an `IsArbitraryCall=true` CCTX with `CoinType=ERC20` (or `Zeta`) could still reach the arbitrary-call branch on the destination gateway.

## Changes

| Area | Change |
|------|--------|
| `common/cctx.go` | Rename `IsGatewayExecuteOutbound` → `IsArbitraryCallCancellable`; expand to cover `OutboundTypeERC20WithdrawAndCall` and `OutboundTypeZetaWithdrawAndCall` |
| `signer/v2_signer.go` | Use new helper; emit warn log on cancellation |
| `observer/outbound.go` | Use new helper; emit warn log on event-parsing bypass |
| `cctx_test.go` | `TestIsArbitraryCallCancellable` enumerates all four cancellable types |
| `outbound_test.go` | Predicate table flips ERC20 + Zeta arbitrary `withdrawAndCall` cases to `true` |
| `e2etests/test_erc20_withdraw_and_arbitrary_call.go` | Now expects `Reverted` with ZRC20 refund to `RevertAddress` |
| `e2etests/test_zeta_withdraw_and_arbitrary_call.go` | V2-enabled branch flipped to `Reverted` (forward compat — V2 ZETA flows are disabled at the contract level on mainnet today) |

## Test plan

- [x] `go build ./zetaclient/... ./e2e/...`
- [x] `go test ./zetaclient/chains/evm/{common,observer,signer}/...`
- [x] `go vet ./zetaclient/chains/evm/... ./e2e/e2etests/...`
- [ ] CI E2E suite green on this branch
- [ ] Bugbot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes signer and observer behavior for V2 cross-chain outbounds by cancelling additional arbitrary-call routes, which is security- and funds-flow critical and could affect outbound processing if misclassified.
> 
> **Overview**
> Extends the V2 arbitrary-call cancellation guard so CCTXs with `CallOptions.IsArbitraryCall=true` are also **signer-cancelled** for `ERC20` and `ZETA` `withdrawAndCall` outbounds that reach `GatewayEVM.executeWithERC20` (in addition to the existing `GatewayEVM.execute` paths).
> 
> Renames/expands the outbound-type predicate to `IsArbitraryCallCancellable`, wires it into both the V2 signer and observer (including new warn logs when voting failed due to signer-cancel), and updates unit/e2e tests to expect **`Reverted`** CCTXs with refund to the configured `RevertAddress` and no destination dApp invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38856c95a5beaac2b3c3626b832764d0832bf074. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends the V2 arbitrary-call cancel guard (from #4575) to cover `ERC20Custody.withdrawAndCall` and `ZetaConnector.withdrawAndCall`, which both forward into `GatewayEVM.executeWithERC20`'s `_executeArbitraryCall` branch with `MessageContext.Sender == address(0)` — the same drain shape as `GatewayEVM.execute`. The changes rename `IsGatewayExecuteOutbound` → `IsArbitraryCallCancellable`, wire the updated predicate into both the V2 signer and observer, add warn logs on cancellation, and update unit + e2e tests to expect `Reverted` CCTXs with refund to the configured `RevertAddress`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are P2 style/test-coverage gaps with no correctness impact on the core cancellation logic.

The predicate expansion, signer guard, observer handler, and unit tests are all consistent and correct. Both P2 findings (double function call in observer, missing refund assertion in Zeta e2e test) are quality issues rather than logic defects. Deployment note about coordinated rollout is important and already documented.

e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go — missing principal-refund balance assertion parallel to the ERC20 test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/evm/common/cctx.go | Renames `IsGatewayExecuteOutbound` → `IsArbitraryCallCancellable` and expands it to include `OutboundTypeERC20WithdrawAndCall` and `OutboundTypeZetaWithdrawAndCall`; logic and docs are correct and exhaustive. |
| zetaclient/chains/evm/signer/v2_signer.go | Uses updated `IsArbitraryCallCancellable` predicate and adds a warn log; the early-return guard before the switch is correctly positioned so ERC20/Zeta non-arbitrary calls still fall through to normal signing paths. |
| zetaclient/chains/evm/observer/outbound.go | Updated to use `IsArbitraryCallCancellable`; adds warn log but calls `isArbitraryCallCancellation` twice in the same block — minor style issue, no correctness impact. |
| e2e/e2etests/test_erc20_withdraw_and_arbitrary_call.go | Correctly adds revert-address setup, balance capture before CCTX processing, Reverted status assertion, dApp-not-called check, and exact principal refund assertion. |
| e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go | Flips V2-enabled branch to expect `Reverted` and dApp not called, but omits the revert-address balance check present in the ERC20 counterpart. |
| zetaclient/chains/evm/common/cctx_test.go | Renames test function and extends the truth table with the two new cancellable types; all allTypes entries are exercised. |
| zetaclient/chains/evm/observer/outbound_test.go | Flips the ERC20 and Zeta arbitrary withdrawAndCall test cases from `false` to `true`; table is consistent with the new predicate. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CCTX PendingOutbound\nIsArbitraryCall=true] --> B{ParseOutboundTypeFromCCTX}

    B --> C[OutboundTypeCall\nOutboundTypeGasWithdrawAndCall]
    B --> D[OutboundTypeERC20WithdrawAndCall\n🆕 now cancellable]
    B --> E[OutboundTypeZetaWithdrawAndCall\n🆕 now cancellable]
    B --> F[Plain withdraw types\nIsArbitraryCall=true on wire\nbut NOT cancellable]

    C --> G{IsArbitraryCallCancellable?}
    D --> G
    E --> G
    F --> H[Normal signing path\nEvent parsing in observer]

    G -- true --> I[Signer: SignCancel\nTSS self-transfer\nWarn log emitted]
    I --> J[Observer: vote failed\nWarn log emitted]
    J --> K[ZetaCore: CCTX → Reverted\nPrincipal refunded to RevertAddress]

    G -- false --> H
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: zetaclient/chains/evm/observer/outbound.go
Line: 197-203

Comment:
**Double call to `isArbitraryCallCancellation`**

`isArbitraryCallCancellation(cctx)` is evaluated twice in the same code block — once in the outer `if` condition and again to gate the warn log. The function parses `ProtocolContractVersion`, dereferences outbound params, and dispatches into `ParseOutboundTypeFromCCTX`, so it does real work each time. Extracting it to a local variable eliminates the redundant evaluation and makes the intent clearer.

```suggestion
	isArbitraryCancel := isArbitraryCallCancellation(cctx)
	if compliance.IsCCTXRestricted(cctx) || isArbitraryCancel {
		if isArbitraryCancel {
			logger.Warn().
				Str(logs.FieldCctxIndex, cctx.Index).
				Stringer(logs.FieldTx, receipt.TxHash).
				Msg("voting V2 arbitrary-call CCTX as failed (signer-cancelled)")
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: e2e/e2etests/test_zeta_withdraw_and_arbitrary_call.go
Line: 37-47

Comment:
**No revert-refund balance check in Zeta path**

The ERC20 test was extended to capture `revertBalanceBefore` and assert `revertBalanceBefore + amount == revertBalanceAfter`, ensuring the principal is actually returned to the revert address. The Zeta test flips the same CCTX expectation to `Reverted` but does not include a corresponding balance check. Without it, a regression where the ZETA principal is silently lost would not be caught by this test.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: also cancel arbitrary calls reachin..."](https://github.com/zeta-chain/node/commit/38856c95a5beaac2b3c3626b832764d0832bf074) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30067649)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->