### PR TITLE
chore: fix comment formatting and typos across codebase

### DIFF
--- a/x/crosschain/keeper/gas_payment.go
+++ b/x/crosschain/keeper/gas_payment.go
@@ -32,7 +32,7 @@ type ChainGasParams struct {
 
 // PayGasAndUpdateCctx updates the outbound tx with the new amount after paying the gas fee
 // **Caller should feed temporary ctx into this function**
-// chainID is the outbound chain chain id , this can be receiver chain for regular transactions and sender-chain to reverted transactions
+// chainID is the outbound chain id , this can be receiver chain for regular transactions and sender-chain to reverted transactions
 func (k Keeper) PayGasAndUpdateCctx(
 	ctx sdk.Context,
 	chainID int64,

--- a/x/fungible/keeper/evm.go
+++ b/x/fungible/keeper/evm.go
@@ -388,7 +388,7 @@ func (k Keeper) CallDepositAndCall(ctx sdk.Context,
 }
 
 // CallOnReceiveZevmConnector calls the onReceive function of the ZevmConnector contract
-// Before calling it mints the zetaValue tokens to the fungible module , and this amount is then provided as value to the onReceive function
+// Before calling it mints the zetaValue tokens to the fungible module, and this amount is then provided as value to the onReceive function
 // The onReceive function will then wrap this native zeta into WZETA and call the onReceive function of the destination contract specified by the destinationAddress
 func (k Keeper) CallOnReceiveZevmConnector(ctx sdk.Context,
 	zetaTxSenderAddress []byte,
@@ -440,7 +440,7 @@ func (k Keeper) CallOnReceiveZevmConnector(ctx sdk.Context,
 }
 
 // CallOnRevertZevmConnector calls the onRevert function of the ZevmConnector contract
-// Before calling it mints the remainingZetaValue tokens to the fungible module , and this amount is then provided as value to the onRevert function
+// Before calling it mints the remainingZetaValue tokens to the fungible module, and this amount is then provided as value to the onRevert function
 // The onRevert function will then wrap this native zeta into WZETA and call the onRevert function of the contract specified by the zetaTxSenderAddress
 // Note the destination address is the original destination address of the transaction and not the current destination .
 func (k Keeper) CallOnRevertZevmConnector(ctx sdk.Context,


### PR DESCRIPTION
# Description

fix comment formatting and typos across codebase


# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [x] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [x] Tested via GitHub Actions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes comment-only fixes across three files — correcting duplicate words, extra spaces before commas, \"ZRC4\" → \"ZRC20\" label references, and minor grammar. No functional code is changed.

- The `VoteOutbound` doc comment in `msg_server_vote_outbound.go` now reads as an incomplete sentence (missing verb) after `is minted` was removed.
- `BalanceOfZRC4` and `TotalSupplyZRC4` in `evm.go` have their godoc lines updated to reference `ZRC20` while the function names still say `ZRC4`, violating Go's naming convention for doc comments.
- A pre-existing `\"into to account\"` typo in `DepositZRC20`'s comment was not fixed despite a similar fix being made in `DepositZeta`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — comment-only changes with no functional impact, minor remaining comment quality issues.

All changes are cosmetic (comments only), so there is zero risk of runtime regression. The score is held to 4 rather than 5 due to three P2 comment-quality issues introduced or missed by this PR: an incomplete sentence, a godoc name mismatch, and an unfixed typo.

x/fungible/keeper/evm.go (godoc name mismatch for BalanceOfZRC4/TotalSupplyZRC4, missed "into to" typo) and x/crosschain/keeper/msg_server_vote_outbound.go (incomplete sentence)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/crosschain/keeper/gas_payment.go | Single comment fix: removed duplicate "chain" word and extra space before comma — clean and correct. |
| x/crosschain/keeper/msg_server_vote_outbound.go | Two comment fixes: punctuation/spacing improvements in refundUnusedGas are good, but the VoteOutbound doc comment now has a missing verb after removing "is minted". |
| x/fungible/keeper/evm.go | Several comment fixes are good, but BalanceOfZRC4 and TotalSupplyZRC4 godoc names were changed to "ZRC20" while the function names remain "ZRC4", and a "into to" typo in DepositZRC20 was missed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Fix comment formatting & typos] --> B[gas_payment.go]
    A --> C[msg_server_vote_outbound.go]
    A --> D[evm.go]

    B --> B1["✅ 'chain chain id ,' → 'chain id,'"]

    C --> C1["✅ Punctuation fixes in refundUnusedGas"]
    C --> C2["⚠️ VoteOutbound doc: removed 'is minted' → incomplete sentence"]

    D --> D1["✅ 'ZRC4' → 'ZRC20' in DepositZRC20 comment"]
    D --> D2["✅ 'and account' → 'an account' in DepositZeta"]
    D --> D3["✅ Trailing space before comma fixes"]
    D --> D4["✅ 'Marshall' → 'Marshal'"]
    D --> D5["⚠️ BalanceOfZRC4/TotalSupplyZRC4 godoc names now say 'ZRC20'"]
    D --> D6["⚠️ 'into to account' typo still present in DepositZRC20"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
x/crosschain/keeper/msg_server_vote_outbound.go:28-30
**Incomplete sentence after removing "is minted"**

The edit removed `is minted` to avoid the awkward repetition, but the resulting sentence now lacks a main verb — "the difference between zeta burned and minted by the bank module and deposited into the module account" is a noun phrase with no predicate. Consider restoring the verb with a cleaner rewrite.

```suggestion
// If the observation is successful, the difference between zeta burned
// and minted is deposited into the module
// account by the bank module.
```

### Issue 2 of 3
x/fungible/keeper/evm.go:622-623
**Godoc comment name doesn't match function name**

Go's convention is that a doc comment must begin with the exact name of the symbol it documents so that `go doc` and IDEs can associate it correctly. Changing the comment to `BalanceOfZRC20` while the function is still named `BalanceOfZRC4` creates a mismatch — the same issue exists one function below for `TotalSupplyZRC4` (comment now reads `TotalSupplyZRC20`). Either revert the comment names to match the functions, or rename the functions themselves.

```suggestion
// BalanceOfZRC4 queries an account's balance for a given ZRC20 contract
func (k Keeper) BalanceOfZRC4(
```

### Issue 3 of 3
x/fungible/keeper/evm.go:245
**Missed typo: "into to" should be "into an"**

The PR fixed a similar "and" → "an" typo in `DepositZeta` but left `DepositZRC20` with the same malformed phrase.

```suggestion
// DepositZRC20 deposits ZRC20 tokens into an account;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix comment formatting and typos ..."](https://github.com/zeta-chain/node/commit/3d9d8fb2e07b1513530d504b9a6fe8e1927a0bc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30594158)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved inline code documentation across keeper modules for clarity and consistency.

* **Chores**
  * Minor formatting refinements in error handling paths.

**Note:** This release contains internal code improvements with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->