### PR TITLE
fix(crosschain): reject paused zrc20 v2 inbounds

### DIFF
--- a/x/crosschain/keeper/v2_zevm_inbound.go
+++ b/x/crosschain/keeper/v2_zevm_inbound.go
@@ -265,6 +265,13 @@ func (k Keeper) getZRC20InboundDetails(
 		ctx.Logger().Info(fmt.Sprintf("cannot find foreign coin associated to the zrc20 address %s", zrc20.Hex()))
 		return InboundDetails{}, nil
 	}
+	if foreignCoin.Paused {
+		return InboundDetails{}, errorsmod.Wrapf(
+			fungibletypes.ErrPausedZRC20,
+			"zrc20 %s is paused",
+			zrc20.Hex(),
+		)
+	}
 
 	receiverChain, found := k.zetaObserverKeeper.GetSupportedChainFromChainID(ctx, foreignCoin.ForeignChainId)
 	if !found {

--- a/x/crosschain/keeper/v2_zevm_inbound_test.go
+++ b/x/crosschain/keeper/v2_zevm_inbound_test.go
@@ -265,7 +265,7 @@ func TestKeeper_GetErc20InboundDetails(t *testing.T) {
 
 		fungibleMock := keepertest.GetCrosschainFungibleMock(t, k)
 		foreignCoin := fungibletypes.ForeignCoins{
-			Zrc20ContractAddress: sample.EthAddress().Hex(),
+			Zrc20ContractAddress: zrc20.Hex(),
 			Asset:                "USDT",
 			ForeignChainId:       1,
 			CoinType:             coin.CoinType_ERC20,
@@ -362,7 +362,7 @@ func TestKeeper_GetErc20InboundDetails(t *testing.T) {
 
 		fungibleMock := keepertest.GetCrosschainFungibleMock(t, k)
 		foreignCoin := fungibletypes.ForeignCoins{
-			Zrc20ContractAddress: sample.EthAddress().Hex(),
+			Zrc20ContractAddress: zrc20.Hex(),
 			Asset:                "USDT",
 			ForeignChainId:       1,
 			CoinType:             coin.CoinType_ERC20,

--- a/x/crosschain/keeper/v2_zevm_inbound_test.go
+++ b/x/crosschain/keeper/v2_zevm_inbound_test.go
@@ -254,6 +254,35 @@ func TestKeeper_GetErc20InboundDetails(t *testing.T) {
 		require.Empty(t, result)
 	})
 
+	t.Run("fail when foreign coin is paused", func(t *testing.T) {
+		// ARRANGE
+		k, ctx, _, _ := keepertest.CrosschainKeeperWithMocks(t, keepertest.CrosschainMockOptions{
+			UseFungibleMock: true,
+		})
+
+		zrc20 := sample.EthAddress()
+		callEvent := false
+
+		fungibleMock := keepertest.GetCrosschainFungibleMock(t, k)
+		foreignCoin := fungibletypes.ForeignCoins{
+			Zrc20ContractAddress: sample.EthAddress().Hex(),
+			Asset:                "USDT",
+			ForeignChainId:       1,
+			CoinType:             coin.CoinType_ERC20,
+			Paused:               true,
+		}
+		fungibleMock.On("GetForeignCoins", ctx, zrc20.Hex()).Return(foreignCoin, true)
+
+		// ACT
+		result, err := k.GetERC20InboundDetails(ctx, zrc20, callEvent)
+
+		// ASSERT
+		require.Error(t, err)
+		require.ErrorIs(t, err, fungibletypes.ErrPausedZRC20)
+		require.Contains(t, err.Error(), "zrc20 "+zrc20.Hex()+" is paused")
+		require.Empty(t, result)
+	})
+
 	t.Run("fail when chain is not supported", func(t *testing.T) {
 		// ARRANGE
 		k, ctx, _, _ := keepertest.CrosschainKeeperWithMocks(t, keepertest.CrosschainMockOptions{
@@ -320,6 +349,35 @@ func TestKeeper_GetErc20InboundDetails(t *testing.T) {
 		// ASSERT
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "gas limit query failed")
+	})
+
+	t.Run("fail when foreign coin is paused for call event", func(t *testing.T) {
+		// ARRANGE
+		k, ctx, _, _ := keepertest.CrosschainKeeperWithMocks(t, keepertest.CrosschainMockOptions{
+			UseFungibleMock: true,
+		})
+
+		zrc20 := sample.EthAddress()
+		callEvent := true
+
+		fungibleMock := keepertest.GetCrosschainFungibleMock(t, k)
+		foreignCoin := fungibletypes.ForeignCoins{
+			Zrc20ContractAddress: sample.EthAddress().Hex(),
+			Asset:                "USDT",
+			ForeignChainId:       1,
+			CoinType:             coin.CoinType_ERC20,
+			Paused:               true,
+		}
+		fungibleMock.On("GetForeignCoins", ctx, zrc20.Hex()).Return(foreignCoin, true)
+
+		// ACT
+		result, err := k.GetERC20InboundDetails(ctx, zrc20, callEvent)
+
+		// ASSERT
+		require.Error(t, err)
+		require.ErrorIs(t, err, fungibletypes.ErrPausedZRC20)
+		require.Contains(t, err.Error(), "zrc20 "+zrc20.Hex()+" is paused")
+		require.Empty(t, result)
 	})
 
 	t.Run("success with call event (NoAssetCall)", func(t *testing.T) {


### PR DESCRIPTION
Closes #4585

## Summary
- reject GatewayZEVM V2 ZRC20 inbound details when the matching foreign coin is paused
- apply the same paused check before classifying call events as `NoAssetCall`
- add regression coverage for paused withdrawal-style and call-event inbound detail parsing

## Tests
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./x/crosschain/keeper"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit paused-coin guard in the V2 ZEVM inbound path: `getZRC20InboundDetails` now checks `foreignCoin.Paused` and returns `ErrPausedZRC20` before any further processing, causing the EVM transaction to be atomically reverted via the `PostTxProcessing` hook. Two regression test cases cover both the withdrawal and call-event code paths.

- **Core fix** (`v2_zevm_inbound.go`): a 7-line guard after the `GetForeignCoins` look-up rejects paused ZRC20 inbounds before chain-lookup or gas-limit queries are executed.
- **Tests** (`v2_zevm_inbound_test.go`): two new sub-tests verify that `ErrPausedZRC20` is returned (and wraps correctly) for both `callEvent=false` and `callEvent=true`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the paused-coin guard is placed correctly before any downstream chain or gas-limit lookups, and the EVM transaction reverts atomically so no ZRC20 tokens are burned on rejection.

The production change is a small, well-scoped guard that follows the existing error-propagation contract. Tests cover both the withdrawal and call-event paths. The only gaps are a missing structured log entry for the paused case (parity with the ZETA-disabled branch) and two test fixtures that use a mismatched Zrc20ContractAddress; neither affects correctness.

No files require special attention; both changed files are straightforward.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| x/crosschain/keeper/v2_zevm_inbound.go | Adds a paused-coin check in getZRC20InboundDetails; logic is correct and error propagates cleanly to revert the EVM tx. Missing a structured log at the point of detection (parity with the ErrZetaThroughGateway case). |
| x/crosschain/keeper/v2_zevm_inbound_test.go | Two new paused-coin test cases cover both withdrawal and call-event paths; minor: foreignCoin.Zrc20ContractAddress in both tests is a fresh random address that differs from the zrc20 input, inconsistent with production data shape but does not affect test correctness. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GatewayZEVM as GatewayZEVM Contract
    participant Hook as PostTxProcessing Hook
    participant V2 as ProcessZEVMInboundV2
    participant ZRC20Details as getZRC20InboundDetails
    participant Fungible as FungibleKeeper

    GatewayZEVM->>Hook: emit Withdrawal/Call event
    Hook->>V2: ProcessZEVMInboundV2(log)
    V2->>ZRC20Details: getZRC20InboundDetails(zrc20, callEvent)
    ZRC20Details->>Fungible: GetForeignCoins(zrc20)
    Fungible-->>ZRC20Details: foreignCoin, found

    alt foreign coin not found
        ZRC20Details-->>V2: "InboundDetails{}, nil"
    else "foreignCoin.Paused == true NEW"
        ZRC20Details-->>V2: ErrPausedZRC20
        V2-->>Hook: ErrInvalidWithdrawalEvent
        Hook-->>GatewayZEVM: error, EVM tx reverted atomically
    else coin active
        ZRC20Details->>Fungible: GetSupportedChain + QueryGasLimit
        ZRC20Details-->>V2: InboundDetails filled
        V2->>V2: validateOutbound + NewWithdrawal/CallInbound
        V2->>V2: ValidateInbound, CCTX created
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `x/crosschain/keeper/v2_zevm_inbound.go`, line 91-104 ([link](https://github.com/zeta-chain/node/blob/9ee66a64d2a6b31bf96102d6c523e2135bb60f39/x/crosschain/keeper/v2_zevm_inbound.go#L91-L104)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> When `ErrZetaThroughGateway` is returned, `ProcessZEVMInboundV2` emits a structured `ctx.Logger().Info` message before propagating the error. The new `ErrPausedZRC20` path gets no equivalent treatment, making it harder to distinguish a paused-coin revert from other `ErrInvalidWithdrawalEvent` causes in node logs. A parallel branch here matches the existing observability pattern.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: x/crosschain/keeper/v2_zevm_inbound.go
   Line: 91-104

   Comment:
   When `ErrZetaThroughGateway` is returned, `ProcessZEVMInboundV2` emits a structured `ctx.Logger().Info` message before propagating the error. The new `ErrPausedZRC20` path gets no equivalent treatment, making it harder to distinguish a paused-coin revert from other `ErrInvalidWithdrawalEvent` causes in node logs. A parallel branch here matches the existing observability pattern.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
x/crosschain/keeper/v2_zevm_inbound_test.go:257-273
In both new paused-coin tests, `foreignCoin.Zrc20ContractAddress` is a freshly-sampled random address that differs from the `zrc20` variable passed as input. In production, `GetForeignCoins(ctx, zrc20.Hex())` returns the coin whose `Zrc20ContractAddress` equals `zrc20.Hex()`. Using `zrc20.Hex()` for this field aligns the test fixture with the real data shape, making it immediately clear to a reader that the coin belongs to the same address under test.

```suggestion
	t.Run("fail when foreign coin is paused", func(t *testing.T) {
		// ARRANGE
		k, ctx, _, _ := keepertest.CrosschainKeeperWithMocks(t, keepertest.CrosschainMockOptions{
			UseFungibleMock: true,
		})

		zrc20 := sample.EthAddress()
		callEvent := false

		fungibleMock := keepertest.GetCrosschainFungibleMock(t, k)
		foreignCoin := fungibletypes.ForeignCoins{
			Zrc20ContractAddress: zrc20.Hex(),
			Asset:                "USDT",
			ForeignChainId:       1,
			CoinType:             coin.CoinType_ERC20,
			Paused:               true,
		}
```

### Issue 2 of 3
x/crosschain/keeper/v2_zevm_inbound.go:91-104
When `ErrZetaThroughGateway` is returned, `ProcessZEVMInboundV2` emits a structured `ctx.Logger().Info` message before propagating the error. The new `ErrPausedZRC20` path gets no equivalent treatment, making it harder to distinguish a paused-coin revert from other `ErrInvalidWithdrawalEvent` causes in node logs. A parallel branch here matches the existing observability pattern.

```suggestion
		if err != nil {
			// Log when V2 ZETA withdrawal is ignored due to disabled flag
			if errorsmod.IsOf(err, types.ErrZetaThroughGateway) {
				ctx.Logger().Info(
					"V2 ZETA withdrawal ignored: V2 ZETA flows are disabled",
					"tx_hash", log.TxHash.Hex(),
					"coin_type", coin.CoinType_Zeta.String(),
				)
			}
			if errorsmod.IsOf(err, fungibletypes.ErrPausedZRC20) {
				ctx.Logger().Info(
					"V2 ZRC20 withdrawal rejected: ZRC20 is paused",
					"tx_hash", log.TxHash.Hex(),
					"error", err.Error(),
				)
			}
			return errorsmod.Wrapf(
				types.ErrInvalidWithdrawalEvent,
				"failed to parse inbound details for withdraw: %v", err,
			)
		}
```

### Issue 3 of 3
x/crosschain/keeper/v2_zevm_inbound_test.go:354-370
Same `Zrc20ContractAddress` mismatch in the call-event paused test. Using `zrc20.Hex()` matches the real data shape where `GetForeignCoins(zrc20.Hex())` returns a coin whose own `Zrc20ContractAddress` equals the lookup key.

```suggestion
	t.Run("fail when foreign coin is paused for call event", func(t *testing.T) {
		// ARRANGE
		k, ctx, _, _ := keepertest.CrosschainKeeperWithMocks(t, keepertest.CrosschainMockOptions{
			UseFungibleMock: true,
		})

		zrc20 := sample.EthAddress()
		callEvent := true

		fungibleMock := keepertest.GetCrosschainFungibleMock(t, k)
		foreignCoin := fungibletypes.ForeignCoins{
			Zrc20ContractAddress: zrc20.Hex(),
			Asset:                "USDT",
			ForeignChainId:       1,
			CoinType:             coin.CoinType_ERC20,
			Paused:               true,
		}
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(crosschain): reject paused zrc20 v2 ..."](https://github.com/zeta-chain/node/commit/9ee66a64d2a6b31bf96102d6c523e2135bb60f39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31979873)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->