### PR TITLE
fix(zetaclient): snapshot telemetry peer data

### DIFF
--- a/zetaclient/metrics/telemetry.go
+++ b/zetaclient/metrics/telemetry.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/libp2p/go-libp2p/core/peer"
+	multiaddr "github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -89,7 +90,11 @@ func copyPingRTT(rtt map[peer.ID]int64) map[peer.ID]int64 {
 }
 
 func copyConnectedPeers(peers []peer.AddrInfo) []peer.AddrInfo {
-	return append([]peer.AddrInfo(nil), peers...)
+	peersCopy := append([]peer.AddrInfo(nil), peers...)
+	for i := range peersCopy {
+		peersCopy[i].Addrs = append([]multiaddr.Multiaddr(nil), peersCopy[i].Addrs...)
+	}
+	return peersCopy
 }
 
 // SetP2PID sets p2pid

--- a/zetaclient/metrics/telemetry.go
+++ b/zetaclient/metrics/telemetry.go
@@ -90,9 +90,17 @@ func copyPingRTT(rtt map[peer.ID]int64) map[peer.ID]int64 {
 }
 
 func copyConnectedPeers(peers []peer.AddrInfo) []peer.AddrInfo {
-	peersCopy := append([]peer.AddrInfo(nil), peers...)
-	for i := range peersCopy {
-		peersCopy[i].Addrs = append([]multiaddr.Multiaddr(nil), peersCopy[i].Addrs...)
+	if peers == nil {
+		return nil
+	}
+
+	peersCopy := make([]peer.AddrInfo, len(peers))
+	for i, peerInfo := range peers {
+		peersCopy[i].ID = peerInfo.ID
+		if peerInfo.Addrs != nil {
+			peersCopy[i].Addrs = make([]multiaddr.Multiaddr, len(peerInfo.Addrs))
+			copy(peersCopy[i].Addrs, peerInfo.Addrs)
+		}
 	}
 	return peersCopy
 }

--- a/zetaclient/metrics/telemetry.go
+++ b/zetaclient/metrics/telemetry.go
@@ -59,25 +59,37 @@ func NewTelemetryServer() *TelemetryServer {
 func (t *TelemetryServer) SetPingRTT(rtt map[peer.ID]int64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.rtt = rtt
+	t.rtt = copyPingRTT(rtt)
 }
 
 func (t *TelemetryServer) GetPingRTT() map[peer.ID]int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.rtt
+	return copyPingRTT(t.rtt)
 }
 
 func (t *TelemetryServer) SetConnectedPeers(peers []peer.AddrInfo) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.connectedPeers = peers
+	t.connectedPeers = copyConnectedPeers(peers)
 }
 
 func (t *TelemetryServer) GetConnectedPeers() []peer.AddrInfo {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.connectedPeers
+	return copyConnectedPeers(t.connectedPeers)
+}
+
+func copyPingRTT(rtt map[peer.ID]int64) map[peer.ID]int64 {
+	rttCopy := make(map[peer.ID]int64, len(rtt))
+	for peerID, duration := range rtt {
+		rttCopy[peerID] = duration
+	}
+	return rttCopy
+}
+
+func copyConnectedPeers(peers []peer.AddrInfo) []peer.AddrInfo {
+	return append([]peer.AddrInfo(nil), peers...)
 }
 
 // SetP2PID sets p2pid

--- a/zetaclient/metrics/telemetry_test.go
+++ b/zetaclient/metrics/telemetry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	maddr "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,14 +28,21 @@ func TestTelemetryServerCopiesConnectedPeers(t *testing.T) {
 	peerA := peer.ID("peer-a")
 	peerB := peer.ID("peer-b")
 	peerC := peer.ID("peer-c")
+	addrA := maddr.StringCast("/ip4/127.0.0.1/tcp/1111")
+	addrB := maddr.StringCast("/ip4/127.0.0.1/tcp/2222")
+	addrC := maddr.StringCast("/ip4/127.0.0.1/tcp/3333")
 
-	peers := []peer.AddrInfo{{ID: peerA}}
+	peers := []peer.AddrInfo{{ID: peerA, Addrs: []maddr.Multiaddr{addrA}}}
 	telemetry.SetConnectedPeers(peers)
 
 	peers[0].ID = peerB
+	peers[0].Addrs[0] = addrB
 	require.Equal(t, peerA, telemetry.GetConnectedPeers()[0].ID)
+	require.Equal(t, addrA, telemetry.GetConnectedPeers()[0].Addrs[0])
 
 	snapshot := telemetry.GetConnectedPeers()
 	snapshot[0].ID = peerC
+	snapshot[0].Addrs[0] = addrC
 	require.Equal(t, peerA, telemetry.GetConnectedPeers()[0].ID)
+	require.Equal(t, addrA, telemetry.GetConnectedPeers()[0].Addrs[0])
 }

--- a/zetaclient/metrics/telemetry_test.go
+++ b/zetaclient/metrics/telemetry_test.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemetryServerCopiesPingRTT(t *testing.T) {
+	telemetry := NewTelemetryServer()
+	peerID := peer.ID("peer-a")
+
+	rtt := map[peer.ID]int64{peerID: 10}
+	telemetry.SetPingRTT(rtt)
+
+	rtt[peerID] = 20
+	require.Equal(t, int64(10), telemetry.GetPingRTT()[peerID])
+
+	snapshot := telemetry.GetPingRTT()
+	snapshot[peerID] = 30
+	require.Equal(t, int64(10), telemetry.GetPingRTT()[peerID])
+}
+
+func TestTelemetryServerCopiesConnectedPeers(t *testing.T) {
+	telemetry := NewTelemetryServer()
+	peerA := peer.ID("peer-a")
+	peerB := peer.ID("peer-b")
+	peerC := peer.ID("peer-c")
+
+	peers := []peer.AddrInfo{{ID: peerA}}
+	telemetry.SetConnectedPeers(peers)
+
+	peers[0].ID = peerB
+	require.Equal(t, peerA, telemetry.GetConnectedPeers()[0].ID)
+
+	snapshot := telemetry.GetConnectedPeers()
+	snapshot[0].ID = peerC
+	require.Equal(t, peerA, telemetry.GetConnectedPeers()[0].ID)
+}

--- a/zetaclient/tss/healthcheck.go
+++ b/zetaclient/tss/healthcheck.go
@@ -43,14 +43,14 @@ func HealthcheckWorker(ctx context.Context, server *tss.Server, p HealthcheckPro
 
 	// Ping & collect round trip time
 	var (
-		host    = server.GetP2PHost()
-		pingRTT = make(map[peer.ID]int64)
-		mu      = sync.Mutex{}
+		host = server.GetP2PHost()
+		mu   = sync.Mutex{}
 	)
 
 	const pingTimeout = 5 * time.Second
 
 	pinger := func(ctx context.Context, _ *ticker.Ticker) error {
+		pingRTT := make(map[peer.ID]int64)
 		var wg sync.WaitGroup
 		for _, peerID := range p.WhitelistPeers {
 			if peerID == host.ID() {

--- a/zetaclient/tss/healthcheck.go
+++ b/zetaclient/tss/healthcheck.go
@@ -42,15 +42,13 @@ func HealthcheckWorker(ctx context.Context, server *tss.Server, p HealthcheckPro
 	logger = logger.With().Str(logs.FieldModule, logs.ModNameTssHealthCheck).Logger()
 
 	// Ping & collect round trip time
-	var (
-		host = server.GetP2PHost()
-		mu   = sync.Mutex{}
-	)
+	host := server.GetP2PHost()
 
 	const pingTimeout = 5 * time.Second
 
 	pinger := func(ctx context.Context, _ *ticker.Ticker) error {
 		pingRTT := make(map[peer.ID]int64)
+		mu := sync.Mutex{}
 		var wg sync.WaitGroup
 		for _, peerID := range p.WhitelistPeers {
 			if peerID == host.ID() {


### PR DESCRIPTION
Closes #4582

## Summary
- allocate a fresh ping RTT map for each TSS healthcheck tick before handing it to telemetry
- copy ping RTT maps and connected peer slices on telemetry set/get so HTTP handlers never iterate shared mutable data
- add regression coverage proving telemetry snapshots cannot be mutated by callers

## Tests
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./zetaclient/metrics ./zetaclient/tss"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data-race in the TSS healthcheck by allocating a fresh `pingRTT` map on every tick, and adds defensive copy-on-set/copy-on-get semantics to `TelemetryServer` so HTTP handlers never iterate shared mutable data.

- **`healthcheck.go`**: `pingRTT` is now declared inside the `pinger` closure, giving each tick its own isolated map and eliminating the cross-tick write race where goroutines from a previous tick could still be updating the map handed to telemetry.
- **`telemetry.go`**: `SetPingRTT`/`GetPingRTT` and `SetConnectedPeers`/`GetConnectedPeers` now copy on every call via `copyPingRTT` and `copyConnectedPeers`, ensuring callers cannot alias internal state; note that `copyConnectedPeers` is a shallow struct copy, so `AddrInfo.Addrs` sub-slices still share their backing array.
- **`telemetry_test.go`**: New regression tests verify both set-time and get-time isolation for the rtt map and the peers slice.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core race condition is correctly fixed and the copy semantics are sound for all current callers.

The changes correctly address the cross-tick data race and HTTP-handler aliasing. The only residual gap is that copyConnectedPeers leaves AddrInfo.Addrs sub-slices sharing their backing arrays, which is harmless for the read-only HTTP handlers today but is an incomplete isolation guarantee relative to the PR's stated intent.

zetaclient/metrics/telemetry.go — specifically the copyConnectedPeers shallow-copy behavior around AddrInfo.Addrs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/metrics/telemetry.go | Adds deep-copy helpers on Set/Get for rtt map and connectedPeers slice; shallow copy of AddrInfo.Addrs slice is noted but safe for current usage. |
| zetaclient/metrics/telemetry_test.go | New regression tests verifying set-isolation and get-isolation for both rtt map and connectedPeers slice; tests are correct but do not cover AddrInfo.Addrs mutation. |
| zetaclient/tss/healthcheck.go | pingRTT map moved inside pinger closure so each tick gets a fresh map; fixes cross-tick data race; mu remains in outer scope which is harmless but slightly confusing. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
zetaclient/metrics/telemetry.go:91-93
`peer.AddrInfo` has an `Addrs []Multiaddr` slice field that is not deep-copied here. `append([]peer.AddrInfo(nil), peers...)` copies each struct by value, so `ID` is isolated correctly, but the `Addrs` slice header in every copied element still shares the same backing array as the original. If any caller replaces an element in `snapshot[i].Addrs`, that change writes through to the stored slice. For the current HTTP-handler read pattern this is harmless, but it leaves the isolation guarantee incomplete compared to the intent of the rest of this PR.

### Issue 2 of 2
zetaclient/tss/healthcheck.go:44-48
`mu` is now only used inside `pinger` to guard concurrent goroutine writes to the per-invocation `pingRTT` map. Since `pingRTT` is local to each closure call, `mu` no longer needs to live in the outer scope — moving it inside `pinger` would make the ownership clear and avoid the appearance that it protects shared state across ticks. If the ticker ever ran overlapping invocations, the shared `mu` would also impose false contention between two independent ping rounds.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(zetaclient): snapshot telemetry peer..."](https://github.com/zeta-chain/node/commit/8abeda607f9b92854bd8eba031c85f17e9f838af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31980618)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->