### PR TITLE
fix(observer): cap ballots pagination limit

### DIFF
--- a/x/observer/keeper/grpc_query_ballot.go
+++ b/x/observer/keeper/grpc_query_ballot.go
@@ -13,6 +13,8 @@ import (
 	"github.com/zeta-chain/node/x/observer/types"
 )
 
+const maxBallotsPageLimit = 1000
+
 func (k Keeper) HasVoted(goCtx context.Context, req *types.QueryHasVotedRequest) (*types.QueryHasVotedResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
@@ -73,6 +75,9 @@ func (k Keeper) Ballots(goCtx context.Context, req *types.QueryBallotsRequest) (
 
 	if req.Pagination == nil {
 		req.Pagination = &query.PageRequest{}
+	}
+	if req.Pagination.Limit > maxBallotsPageLimit {
+		req.Pagination.Limit = maxBallotsPageLimit
 	}
 
 	pageRes, err := query.Paginate(ballotStore, req.Pagination, func(_ []byte, value []byte) error {

--- a/x/observer/keeper/grpc_query_ballot.go
+++ b/x/observer/keeper/grpc_query_ballot.go
@@ -76,6 +76,8 @@ func (k Keeper) Ballots(goCtx context.Context, req *types.QueryBallotsRequest) (
 	if req.Pagination == nil {
 		req.Pagination = &query.PageRequest{}
 	}
+	// A zero limit preserves the Cosmos SDK default page size, which is below
+	// maxBallotsPageLimit. Only explicit oversized limits are capped here.
 	if req.Pagination.Limit > maxBallotsPageLimit {
 		req.Pagination.Limit = maxBallotsPageLimit
 	}

--- a/x/observer/keeper/grpc_query_ballot_test.go
+++ b/x/observer/keeper/grpc_query_ballot_test.go
@@ -255,6 +255,33 @@ func TestKeeper_BallotByIdentifier(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res.Ballots, 10)
 	})
+
+	t.Run("should cap excessive pagination limit", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
+		wctx := sdk.WrapSDKContext(ctx)
+		numOfBallots := 1001
+
+		for i := 0; i < numOfBallots; i++ {
+			ballot := types.Ballot{
+				BallotIdentifier:     fmt.Sprintf("index-%d", i),
+				VoterList:            []string{sample.AccAddress()},
+				Votes:                []types.VoteType{types.VoteType_SuccessObservation},
+				BallotStatus:         types.BallotStatus_BallotInProgress,
+				BallotCreationHeight: 1,
+				BallotThreshold:      sdkmath.LegacyMustNewDecFromStr("0.5"),
+			}
+			k.SetBallot(ctx, &ballot)
+		}
+
+		res, err := k.Ballots(wctx, &types.QueryBallotsRequest{
+			Pagination: &query.PageRequest{
+				Limit: 1_000_000,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Ballots, 1000)
+		require.NotEmpty(t, res.Pagination.NextKey)
+	})
 }
 
 func TestKeeper_Ballots(t *testing.T) {

--- a/x/observer/keeper/grpc_query_ballot_test.go
+++ b/x/observer/keeper/grpc_query_ballot_test.go
@@ -204,6 +204,55 @@ func TestKeeper_BallotByIdentifier(t *testing.T) {
 		}, res)
 	})
 
+}
+
+func TestKeeper_Ballots(t *testing.T) {
+	t.Run("should error if req is nil", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
+		wctx := sdk.WrapSDKContext(ctx)
+
+		res, err := k.Ballots(wctx, nil)
+		require.Nil(t, res)
+		require.Error(t, err)
+	})
+
+	t.Run("should return empty list if no ballots", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
+		wctx := sdk.WrapSDKContext(ctx)
+
+		res, err := k.Ballots(wctx, &types.QueryBallotsRequest{})
+		require.NoError(t, err)
+		require.Empty(t, res.Ballots)
+	})
+
+	t.Run("should return all ballots", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.ObserverKeeper(t)
+		wctx := sdk.WrapSDKContext(ctx)
+
+		ballots := make([]types.Ballot, 10)
+		for i := 0; i < 10; i++ {
+			ballot := types.Ballot{
+				BallotIdentifier:     fmt.Sprintf("index-%d", i),
+				VoterList:            []string{sample.AccAddress()},
+				Votes:                []types.VoteType{types.VoteType_SuccessObservation},
+				BallotStatus:         types.BallotStatus_BallotInProgress,
+				BallotCreationHeight: 1 + int64(i),
+				BallotThreshold:      sdkmath.LegacyMustNewDecFromStr("0.5"),
+			}
+			k.SetBallot(ctx, &ballot)
+			ballots[i] = ballot
+		}
+
+		res, err := k.Ballots(wctx, &types.QueryBallotsRequest{})
+		require.NoError(t, err)
+		require.ElementsMatch(t, ballots, res.Ballots)
+
+		firstBallotCreationHeight := res.Ballots[0].BallotCreationHeight
+		for _, ballot := range res.Ballots {
+			require.GreaterOrEqual(t, ballot.BallotCreationHeight, firstBallotCreationHeight)
+		}
+	})
+
 	t.Run("should return 100 ballots if more exist and limit is not provided", func(t *testing.T) {
 		k, ctx, _, _ := keepertest.ObserverKeeper(t)
 		wctx := sdk.WrapSDKContext(ctx)
@@ -281,53 +330,5 @@ func TestKeeper_BallotByIdentifier(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res.Ballots, 1000)
 		require.NotEmpty(t, res.Pagination.NextKey)
-	})
-}
-
-func TestKeeper_Ballots(t *testing.T) {
-	t.Run("should error if req is nil", func(t *testing.T) {
-		k, ctx, _, _ := keepertest.ObserverKeeper(t)
-		wctx := sdk.WrapSDKContext(ctx)
-
-		res, err := k.Ballots(wctx, nil)
-		require.Nil(t, res)
-		require.Error(t, err)
-	})
-
-	t.Run("should return empty list if no ballots", func(t *testing.T) {
-		k, ctx, _, _ := keepertest.ObserverKeeper(t)
-		wctx := sdk.WrapSDKContext(ctx)
-
-		res, err := k.Ballots(wctx, &types.QueryBallotsRequest{})
-		require.NoError(t, err)
-		require.Empty(t, res.Ballots)
-	})
-
-	t.Run("should return all ballots", func(t *testing.T) {
-		k, ctx, _, _ := keepertest.ObserverKeeper(t)
-		wctx := sdk.WrapSDKContext(ctx)
-
-		ballots := make([]types.Ballot, 10)
-		for i := 0; i < 10; i++ {
-			ballot := types.Ballot{
-				BallotIdentifier:     fmt.Sprintf("index-%d", i),
-				VoterList:            []string{sample.AccAddress()},
-				Votes:                []types.VoteType{types.VoteType_SuccessObservation},
-				BallotStatus:         types.BallotStatus_BallotInProgress,
-				BallotCreationHeight: 1 + int64(i),
-				BallotThreshold:      sdkmath.LegacyMustNewDecFromStr("0.5"),
-			}
-			k.SetBallot(ctx, &ballot)
-			ballots[i] = ballot
-		}
-
-		res, err := k.Ballots(wctx, &types.QueryBallotsRequest{})
-		require.NoError(t, err)
-		require.ElementsMatch(t, ballots, res.Ballots)
-
-		firstBallotCreationHeight := res.Ballots[0].BallotCreationHeight
-		for _, ballot := range res.Ballots {
-			require.GreaterOrEqual(t, ballot.BallotCreationHeight, firstBallotCreationHeight)
-		}
 	})
 }


### PR DESCRIPTION
Closes #4568

## Summary
- cap `Ballots` pagination requests at 1000 entries server-side
- preserve the existing default pagination behavior when no limit is supplied
- add regression coverage for excessive pagination limits and next-page continuation

## Tests
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./x/observer/keeper"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps the `Ballots` gRPC query's pagination limit at 1000 server-side to prevent unbounded store scans from arbitrarily large client-supplied limits. The implementation is straightforward and the core clamping logic is correct.

- **`grpc_query_ballot.go`**: Introduces `maxBallotsPageLimit = 1000` and silently clamps `req.Pagination.Limit` before calling `query.Paginate`, preserving the existing SDK default-100 behavior when no limit is supplied.
- **`grpc_query_ballot_test.go`**: Adds a regression test for the cap, but it is placed inside `TestKeeper_BallotByIdentifier` instead of `TestKeeper_Ballots`, meaning `-run TestKeeper_Ballots` will not execute the new case.

<h3>Confidence Score: 3/5</h3>

The guard itself works correctly, but the regression test is wired to the wrong parent test function and will be skipped when running targeted Ballots tests.

The regression test added to cover this change is nested inside TestKeeper_BallotByIdentifier rather than TestKeeper_Ballots, so a developer running -run TestKeeper_Ballots would never execute it. The production guard is sound, but the misplaced test means the cap could silently regress without failing CI if tests are run by name.

The new sub-test in grpc_query_ballot_test.go needs to be moved into TestKeeper_Ballots to be reachable by targeted test runs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/observer/keeper/grpc_query_ballot.go | Adds `maxBallotsPageLimit = 1000` constant and clamps `req.Pagination.Limit` before passing to `query.Paginate`; logic is correct but the `Limit=0` path relies implicitly on the Cosmos SDK's internal `DefaultLimit` (100) never exceeding the cap. |
| x/observer/keeper/grpc_query_ballot_test.go | Adds regression test for the cap, but the test is nested inside `TestKeeper_BallotByIdentifier` instead of `TestKeeper_Ballots`, so running `-run TestKeeper_Ballots` will not execute it. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client calls Ballots RPC] --> B{req == nil?}
    B -- Yes --> C[Return InvalidArgument error]
    B -- No --> D{req.Pagination == nil?}
    D -- Yes --> E[Initialize empty PageRequest\nLimit = 0]
    D -- No --> F[Use provided PageRequest]
    E --> G{Limit > 1000?}
    F --> G
    G -- Yes --> H[Clamp Limit to 1000]
    G -- No --> I[Keep Limit as-is\n0 → SDK default 100]
    H --> J[query.Paginate]
    I --> J
    J --> K[Sort ballots by BallotCreationHeight]
    K --> L[Return ballots + NextKey if more remain]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
x/observer/keeper/grpc_query_ballot_test.go:259-284
**Test placed in wrong parent function**

This sub-test is nested inside `TestKeeper_BallotByIdentifier` even though it exercises `k.Ballots(...)`, not `k.BallotByIdentifier(...)`. It belongs in `TestKeeper_Ballots` (line 287+). As written, running `go test -run TestKeeper_Ballots` will never execute this case, silently leaving the cap regression uncovered when developers target that specific test function.

### Issue 2 of 2
x/observer/keeper/grpc_query_ballot.go:76-81
**`Limit = 0` silently bypasses the cap**

When a caller sets `Limit` to 0 (the zero value, i.e. no explicit limit is provided in the `PageRequest`), the check `req.Pagination.Limit > maxBallotsPageLimit` is false and the Cosmos SDK `query.Paginate` falls back to its own `DefaultLimit` of 100. This is fine in practice today, but if the SDK's `DefaultLimit` is ever raised above 1000, callers that omit `Limit` would start receiving more entries than intended without triggering this guard. A defensive lower bound check (e.g. also capping when `Limit == 0`) or a comment noting the SDK default assumption would make the intent explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observer): cap ballots pagination li..."](https://github.com/zeta-chain/node/commit/68d63b4559c8ba6289e5f2a12b42f30ac774c48f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31986464)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->