### PR TITLE
fix(sui): cancel on withdraw build errors

### DIFF
--- a/pkg/contracts/sui/withdraw_and_call.go
+++ b/pkg/contracts/sui/withdraw_and_call.go
@@ -1,7 +1,6 @@
 package sui
 
 import (
-	"fmt"
 	"slices"
 	"strconv"
 
@@ -82,17 +81,17 @@ func (d WithdrawAndCallPTB) TxNonce() uint64 {
 func ExtractInitialSharedVersion(objData models.SuiObjectData) (uint64, error) {
 	owner, ok := objData.Owner.(map[string]any)
 	if !ok {
-		return 0, fmt.Errorf("invalid object owner type %T", objData.Owner)
+		return 0, errors.Wrapf(ErrInvalidPayload, "invalid object owner type %T", objData.Owner)
 	}
 
 	shared, ok := owner["Shared"]
 	if !ok {
-		return 0, fmt.Errorf("missing shared object")
+		return 0, errors.Wrap(ErrInvalidPayload, "missing shared object")
 	}
 
 	sharedMap, ok := shared.(map[string]any)
 	if !ok {
-		return 0, fmt.Errorf("invalid shared object type %T", shared)
+		return 0, errors.Wrapf(ErrInvalidPayload, "invalid shared object type %T", shared)
 	}
 
 	return extractInteger[uint64](sharedMap, "initial_shared_version")

--- a/pkg/contracts/sui/withdraw_and_call_test.go
+++ b/pkg/contracts/sui/withdraw_and_call_test.go
@@ -30,6 +30,7 @@ func Test_ExtractInitialSharedVersion(t *testing.T) {
 		objData     models.SuiObjectData
 		wantVersion uint64
 		errMsg      string
+		errIs       error
 	}{
 		{
 			name: "successful extraction",
@@ -49,6 +50,7 @@ func Test_ExtractInitialSharedVersion(t *testing.T) {
 			},
 			wantVersion: 0,
 			errMsg:      "invalid object owner type string",
+			errIs:       ErrInvalidPayload,
 		},
 		{
 			name: "missing shared object",
@@ -59,6 +61,7 @@ func Test_ExtractInitialSharedVersion(t *testing.T) {
 			},
 			wantVersion: 0,
 			errMsg:      "missing shared object",
+			errIs:       ErrInvalidPayload,
 		},
 		{
 			name: "invalid shared object type",
@@ -69,6 +72,7 @@ func Test_ExtractInitialSharedVersion(t *testing.T) {
 			},
 			wantVersion: 0,
 			errMsg:      "invalid shared object type string",
+			errIs:       ErrInvalidPayload,
 		},
 	}
 
@@ -78,6 +82,9 @@ func Test_ExtractInitialSharedVersion(t *testing.T) {
 			if tt.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errMsg)
+				if tt.errIs != nil {
+					require.ErrorIs(t, err, tt.errIs)
+				}
 				return
 			}
 

--- a/zetaclient/chains/sui/signer/signer_test.go
+++ b/zetaclient/chains/sui/signer/signer_test.go
@@ -360,6 +360,32 @@ func TestSigner(t *testing.T) {
 	})
 }
 
+func TestSigner_BroadcastWithdrawalWithFallback(t *testing.T) {
+	t.Run("cancels on generic withdraw build error", func(t *testing.T) {
+		ts := newTestSuite(t)
+
+		withdrawTxBuilder := func(context.Context) (models.TxnMetaData, string, error) {
+			return models.TxnMetaData{}, "", fmt.Errorf("invalid type argument")
+		}
+
+		cancelTxBytes := base64.StdEncoding.EncodeToString([]byte("cancel_tx_bytes"))
+		cancelTxBuilder := func(context.Context) (models.TxnMetaData, string, error) {
+			return models.TxnMetaData{TxBytes: cancelTxBytes}, "cancel_signature", nil
+		}
+
+		const cancelDigest = "0xCancelTransactionBlockDigest"
+		ts.MockExec(func(req models.SuiExecuteTransactionBlockRequest) {
+			require.Equal(t, cancelTxBytes, req.TxBytes)
+			require.Equal(t, []string{"cancel_signature"}, req.Signature)
+		}, cancelDigest)
+
+		digest, err := ts.Signer.broadcastWithdrawalWithFallback(ts.Ctx, withdrawTxBuilder, cancelTxBuilder)
+
+		require.NoError(t, err)
+		require.Equal(t, cancelDigest, digest)
+	})
+}
+
 type testSuite struct {
 	t   *testing.T
 	Ctx context.Context

--- a/zetaclient/chains/sui/signer/signer_test.go
+++ b/zetaclient/chains/sui/signer/signer_test.go
@@ -361,11 +361,11 @@ func TestSigner(t *testing.T) {
 }
 
 func TestSigner_BroadcastWithdrawalWithFallback(t *testing.T) {
-	t.Run("cancels on generic withdraw build error", func(t *testing.T) {
+	t.Run("cancels on invalid payload build error", func(t *testing.T) {
 		ts := newTestSuite(t)
 
 		withdrawTxBuilder := func(context.Context) (models.TxnMetaData, string, error) {
-			return models.TxnMetaData{}, "", fmt.Errorf("invalid type argument")
+			return models.TxnMetaData{}, "", fmt.Errorf("%w: invalid type argument", sui.ErrInvalidPayload)
 		}
 
 		cancelTxBytes := base64.StdEncoding.EncodeToString([]byte("cancel_tx_bytes"))
@@ -383,6 +383,24 @@ func TestSigner_BroadcastWithdrawalWithFallback(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, cancelDigest, digest)
+	})
+
+	t.Run("does not cancel on generic withdraw build error", func(t *testing.T) {
+		ts := newTestSuite(t)
+
+		withdrawTxBuilder := func(context.Context) (models.TxnMetaData, string, error) {
+			return models.TxnMetaData{}, "", fmt.Errorf("temporary rpc error")
+		}
+
+		cancelTxBuilder := func(context.Context) (models.TxnMetaData, string, error) {
+			t.Fatal("cancel tx builder should not be called for retryable build errors")
+			return models.TxnMetaData{}, "", nil
+		}
+
+		digest, err := ts.Signer.broadcastWithdrawalWithFallback(ts.Ctx, withdrawTxBuilder, cancelTxBuilder)
+
+		require.Empty(t, digest)
+		require.ErrorContains(t, err, "unable to build withdraw tx")
 	})
 }
 

--- a/zetaclient/chains/sui/signer/signer_tx.go
+++ b/zetaclient/chains/sui/signer/signer_tx.go
@@ -282,8 +282,7 @@ func (s *Signer) broadcastWithdrawalWithFallback(
 		logger.Info().Err(err).Msg("cancelling tx due to wrong object ownership")
 		return s.broadcastCancelTx(ctx, cancelTxBuilder)
 	case err != nil:
-		logger.Info().Err(err).Msg("cancelling tx due to withdraw tx build error")
-		return s.broadcastCancelTx(ctx, cancelTxBuilder)
+		return "", errors.Wrap(err, "unable to build withdraw tx")
 	}
 
 	req := models.SuiExecuteTransactionBlockRequest{

--- a/zetaclient/chains/sui/signer/signer_tx.go
+++ b/zetaclient/chains/sui/signer/signer_tx.go
@@ -282,7 +282,8 @@ func (s *Signer) broadcastWithdrawalWithFallback(
 		logger.Info().Err(err).Msg("cancelling tx due to wrong object ownership")
 		return s.broadcastCancelTx(ctx, cancelTxBuilder)
 	case err != nil:
-		return "", errors.Wrap(err, "unable to build withdraw tx")
+		logger.Info().Err(err).Msg("cancelling tx due to withdraw tx build error")
+		return s.broadcastCancelTx(ctx, cancelTxBuilder)
 	}
 
 	req := models.SuiExecuteTransactionBlockRequest{

--- a/zetaclient/chains/sui/signer/withdraw_and_call.go
+++ b/zetaclient/chains/sui/signer/withdraw_and_call.go
@@ -57,7 +57,7 @@ func (args withdrawAndCallPTBArgs) onCallTypeArgs() ([]sui.TypeTag, error) {
 	for _, typeArg := range typeArgsStr {
 		typeStruct, err := zetasui.TypeTagFromString(typeArg)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid type argument %s", typeArg)
+			return nil, errors.Wrapf(zetasui.ErrInvalidPayload, "invalid type argument %s: %s", typeArg, err)
 		}
 		onCallTypeArgs = append(onCallTypeArgs, sui.TypeTag{Struct: &typeStruct})
 	}

--- a/zetaclient/chains/sui/signer/withdraw_and_call_test.go
+++ b/zetaclient/chains/sui/signer/withdraw_and_call_test.go
@@ -56,6 +56,7 @@ func Test_withdrawAndCallPTB(t *testing.T) {
 		name   string
 		args   withdrawAndCallPTBArgs
 		errMsg string
+		errIs  error
 	}{
 		{
 			name: "successful withdraw and call",
@@ -130,6 +131,7 @@ func Test_withdrawAndCallPTB(t *testing.T) {
 				return args
 			}(),
 			errMsg: "invalid type argument",
+			errIs:  zetasui.ErrInvalidPayload,
 		},
 	}
 
@@ -139,6 +141,9 @@ func Test_withdrawAndCallPTB(t *testing.T) {
 
 			if tt.errMsg != "" {
 				require.ErrorContains(t, err, tt.errMsg)
+				if tt.errIs != nil {
+					require.ErrorIs(t, err, tt.errIs)
+				}
 				return
 			}
 


### PR DESCRIPTION
Closes #4578

## Summary
- route generic withdraw transaction build errors through the Sui cancel transaction fallback
- keep the existing dedicated logging for invalid payload and object ownership errors
- add regression coverage proving a generic build error broadcasts the cancel tx and returns its digest

## Tests
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./zetaclient/chains/sui/signer"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Routes all generic `buildWithdrawal` errors through the existing Sui cancel-transaction fallback (`broadcastCancelTx`), matching the behavior already in place for `ErrInvalidPayload` and `ErrObjectOwnership`. A new unit test verifies the cancel path is taken and the correct digest is returned.

- `signer_tx.go`: The `case err != nil` branch in `broadcastWithdrawalWithFallback` now logs and calls `broadcastCancelTx` instead of returning the error; this is a one-line change to the switch statement.
- `signer_test.go`: `TestSigner_BroadcastWithdrawalWithFallback` is added with a single sub-test that injects a failing withdraw builder and asserts the cancel transaction is broadcast and its digest returned.

<h3>Confidence Score: 3/5</h3>

The change is a one-liner in a critical path that makes withdrawal cancellation irreversible on any build error, including transient RPC failures — worth a careful second look before merging.

The withdraw builder can fail for transient reasons (RPC timeout, momentary connectivity loss in MoveCall or object-ref lookups). Under the old code those errors bubbled up and the scheduler retried. Under the new code the same transient failure immediately broadcasts an increase_nonce transaction, permanently consuming the nonce and cancelling the user's withdrawal. The test covers only the deterministic 'invalid type argument' case; there is no coverage or safeguard for the transient-failure scenario.

zetaclient/chains/sui/signer/signer_tx.go — specifically the generic error branch in broadcastWithdrawalWithFallback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/sui/signer/signer_tx.go | Changed generic build-error branch from returning an error (retryable) to calling broadcastCancelTx (irreversible nonce increment); transient RPC errors during buildWithdrawal now permanently cancel the withdrawal. |
| zetaclient/chains/sui/signer/signer_test.go | Adds a focused regression test for the new cancel-on-generic-build-error path; the mock is correct and the assertions cover both the cancel tx bytes and the returned digest. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[broadcastWithdrawalWithFallback] --> B[withdrawTxBuilder ctx]
    B --> C{err?}
    C -- ErrInvalidPayload --> D[log: invalid payload
broadcastCancelTx]
    C -- ErrObjectOwnership --> E[log: wrong ownership
broadcastCancelTx]
    C -- any other error
 was: return error --> F[log: build error
broadcastCancelTx]
    C -- nil --> G[SuiExecuteTransactionBlock]
    G --> H{effects.Status}
    H -- Success --> I[return digest]
    H -- Retryable abort --> J[return error for retry]
    H -- Other failure --> K[sleep 2s
broadcastCancelTx]
    D --> L[increase_nonce on-chain]
    E --> L
    F --> L
    K --> L
    L --> M[return cancel digest]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
zetaclient/chains/sui/signer/signer_tx.go:284-286
**Transient build errors now trigger irreversible cancel**

The generic `err != nil` branch now calls `broadcastCancelTx`, which broadcasts an `increase_nonce` transaction that permanently consumes the withdrawal nonce. Any transient error during `buildWithdrawal` — for example a `MoveCall` RPC timeout, a temporary `getWithdrawCapIDCached` miss, or a `getWithdrawAndCallObjectRefs` network failure — will now permanently cancel the withdrawal instead of bubbling the error back to the scheduler for a retry. The existing `ErrInvalidPayload` / `ErrObjectOwnership` branches already cover the known deterministic cases; the remaining errors are a mix of deterministic (e.g. invalid gas price, unsupported coin type) and genuinely transient (RPC connectivity). Consider distinguishing the two categories — or at minimum wrapping the specific Sui-type-argument error as a new sentinel — so that transient failures can still surface as retryable errors.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sui): cancel on withdraw build error..."](https://github.com/zeta-chain/node/commit/1c0af77aef679adab1f4c497fffe7950dd1be2ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31987199)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->