### PR TITLE
fix(crosschain): guard revert gas limit conversion

### DIFF
--- a/x/crosschain/keeper/cctx_utils.go
+++ b/x/crosschain/keeper/cctx_utils.go
@@ -22,7 +22,7 @@ func gasLimitUint64(gasLimit sdkmath.Uint) (uint64, error) {
 
 func gasLimitBigIntUint64(gasLimit *big.Int) (uint64, error) {
 	if gasLimit == nil || gasLimit.Sign() < 0 || gasLimit.BitLen() > 64 {
-		return 0, cosmoserrors.Wrap(types.ErrInvalidGasLimit, "gas limit exceeds uint64 range")
+		return 0, cosmoserrors.Wrap(types.ErrInvalidGasLimit, "gas limit is invalid or exceeds uint64 range")
 	}
 	return gasLimit.Uint64(), nil
 }

--- a/x/crosschain/keeper/cctx_utils.go
+++ b/x/crosschain/keeper/cctx_utils.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"math/big"
 	"sort"
 
 	cosmoserrors "cosmossdk.io/errors"
@@ -14,6 +15,17 @@ import (
 	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 )
+
+func gasLimitUint64(gasLimit sdkmath.Uint) (uint64, error) {
+	return gasLimitBigIntUint64(gasLimit.BigInt())
+}
+
+func gasLimitBigIntUint64(gasLimit *big.Int) (uint64, error) {
+	if gasLimit == nil || gasLimit.Sign() < 0 || gasLimit.BitLen() > 64 {
+		return 0, cosmoserrors.Wrap(types.ErrInvalidGasLimit, "gas limit exceeds uint64 range")
+	}
+	return gasLimit.Uint64(), nil
+}
 
 // SetObserverOutboundInfo sets the CCTX outbound nonce to the next available nonce for the TSS address, and updates the nonce of blockchain state.
 // It also updates the PendingNonces that is used to track the unfulfilled outbound txs.
@@ -69,7 +81,7 @@ func (k Keeper) GetRevertGasLimit(ctx sdk.Context, cctx types.CrossChainTx) (uin
 	// with V2 protocol, reverts on connected chains can eventually call a onRevert function which can require a higher gas limit
 	if cctx.ProtocolContractVersion == types.ProtocolContractVersion_V2 && cctx.RevertOptions.CallOnRevert &&
 		!cctx.RevertOptions.RevertGasLimit.IsZero() {
-		return cctx.RevertOptions.RevertGasLimit.Uint64(), nil
+		return gasLimitUint64(cctx.RevertOptions.RevertGasLimit)
 	}
 
 	if cctx.InboundParams == nil {
@@ -86,7 +98,7 @@ func (k Keeper) GetRevertGasLimit(ctx sdk.Context, cctx types.CrossChainTx) (uin
 		if err != nil {
 			return 0, errors.Wrap(fungibletypes.ErrContractCall, err.Error())
 		}
-		return gasLimit.Uint64(), nil
+		return gasLimitBigIntUint64(gasLimit)
 	} else if cctx.InboundParams.CoinType == coin.CoinType_ERC20 {
 		// get the gas limit of the associated asset
 		fc, found := k.fungibleKeeper.GetForeignCoinFromAsset(
@@ -101,7 +113,7 @@ func (k Keeper) GetRevertGasLimit(ctx sdk.Context, cctx types.CrossChainTx) (uin
 		if err != nil {
 			return 0, errors.Wrap(fungibletypes.ErrContractCall, err.Error())
 		}
-		return gasLimit.Uint64(), nil
+		return gasLimitBigIntUint64(gasLimit)
 	}
 
 	return 0, nil

--- a/x/crosschain/keeper/cctx_utils_test.go
+++ b/x/crosschain/keeper/cctx_utils_test.go
@@ -107,6 +107,57 @@ func TestGetRevertGasLimit(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrInvalidGasLimit)
 	})
 
+	t.Run("should fail if gas coin query gas limit exceeds uint64", func(t *testing.T) {
+		k, ctx, sdkk, zk := keepertest.CrosschainKeeper(t)
+		k.GetAuthKeeper().GetModuleAccount(ctx, fungibletypes.ModuleName)
+
+		chainID := getValidEthChainID()
+		deploySystemContracts(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper)
+		gas := setupGasCoin(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper, chainID, "foo", "FOO")
+
+		_, err := zk.FungibleKeeper.UpdateZRC20GasLimit(ctx, gas, new(big.Int).Lsh(big.NewInt(1), 64))
+		require.NoError(t, err)
+
+		_, err = k.GetRevertGasLimit(ctx, types.CrossChainTx{
+			InboundParams: &types.InboundParams{
+				CoinType:      coin.CoinType_Gas,
+				SenderChainId: chainID,
+			},
+		})
+		require.ErrorIs(t, err, types.ErrInvalidGasLimit)
+	})
+
+	t.Run("should fail if erc20 query gas limit exceeds uint64", func(t *testing.T) {
+		k, ctx, sdkk, zk := keepertest.CrosschainKeeper(t)
+		k.GetAuthKeeper().GetModuleAccount(ctx, fungibletypes.ModuleName)
+
+		chainID := getValidEthChainID()
+		deploySystemContracts(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper)
+		asset := sample.EthAddress().String()
+		zrc20Addr := deployZRC20(
+			t,
+			ctx,
+			zk.FungibleKeeper,
+			sdkk.EvmKeeper,
+			chainID,
+			"bar",
+			asset,
+			"bar",
+		)
+
+		_, err := zk.FungibleKeeper.UpdateZRC20GasLimit(ctx, zrc20Addr, new(big.Int).Lsh(big.NewInt(1), 64))
+		require.NoError(t, err)
+
+		_, err = k.GetRevertGasLimit(ctx, types.CrossChainTx{
+			InboundParams: &types.InboundParams{
+				CoinType:      coin.CoinType_ERC20,
+				SenderChainId: chainID,
+				Asset:         asset,
+			},
+		})
+		require.ErrorIs(t, err, types.ErrInvalidGasLimit)
+	})
+
 	t.Run("should fail if no gas coin found", func(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 

--- a/x/crosschain/keeper/cctx_utils_test.go
+++ b/x/crosschain/keeper/cctx_utils_test.go
@@ -93,6 +93,20 @@ func TestGetRevertGasLimit(t *testing.T) {
 		require.Equal(t, uint64(42), gasLimit)
 	})
 
+	t.Run("should fail if revert gas limit exceeds uint64", func(t *testing.T) {
+		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
+		overflowGasLimit := sdkmath.NewUintFromBigInt(new(big.Int).Lsh(big.NewInt(1), 64))
+
+		_, err := k.GetRevertGasLimit(ctx, types.CrossChainTx{
+			ProtocolContractVersion: types.ProtocolContractVersion_V2,
+			RevertOptions: types.RevertOptions{
+				CallOnRevert:   true,
+				RevertGasLimit: overflowGasLimit,
+			},
+		})
+		require.ErrorIs(t, err, types.ErrInvalidGasLimit)
+	})
+
 	t.Run("should fail if no gas coin found", func(t *testing.T) {
 		k, ctx, _, _ := keepertest.CrosschainKeeper(t)
 

--- a/x/crosschain/keeper/gas_payment.go
+++ b/x/crosschain/keeper/gas_payment.go
@@ -126,6 +126,10 @@ func (k Keeper) PayGasNativeAndUpdateCctx(
 		!cctx.RevertOptions.RevertGasLimit.IsZero() {
 		gas.GasLimit = cctx.RevertOptions.RevertGasLimit
 	}
+	callGasLimit, err := gasLimitUint64(gas.GasLimit)
+	if err != nil {
+		return err
+	}
 
 	// calculate the final gas fee
 	gasFee := gas.GasLimit.Mul(gas.GasPrice)
@@ -149,7 +153,7 @@ func (k Keeper) PayGasNativeAndUpdateCctx(
 
 	// update cctx
 	cctx.GetCurrentOutboundParam().Amount = newAmount
-	cctx.GetCurrentOutboundParam().CallOptions.GasLimit = gas.GasLimit.Uint64()
+	cctx.GetCurrentOutboundParam().CallOptions.GasLimit = callGasLimit
 	cctx.GetCurrentOutboundParam().GasPrice = gas.GasPrice.String()
 	cctx.GetCurrentOutboundParam().GasPriorityFee = gas.PriorityFee.String()
 
@@ -193,6 +197,10 @@ func (k Keeper) PayGasInERC20AndUpdateCctx(
 	if cctx.ProtocolContractVersion == types.ProtocolContractVersion_V2 && cctx.RevertOptions.CallOnRevert &&
 		!cctx.RevertOptions.RevertGasLimit.IsZero() {
 		gas.GasLimit = cctx.RevertOptions.RevertGasLimit
+	}
+	callGasLimit, err := gasLimitUint64(gas.GasLimit)
+	if err != nil {
+		return err
 	}
 
 	gasFee := gas.GasLimit.Mul(gas.GasPrice)
@@ -312,7 +320,7 @@ func (k Keeper) PayGasInERC20AndUpdateCctx(
 
 	// update cctx
 	cctx.GetCurrentOutboundParam().Amount = newAmount
-	cctx.GetCurrentOutboundParam().CallOptions.GasLimit = gas.GasLimit.Uint64()
+	cctx.GetCurrentOutboundParam().CallOptions.GasLimit = callGasLimit
 	cctx.GetCurrentOutboundParam().GasPrice = gas.GasPrice.String()
 	cctx.GetCurrentOutboundParam().GasPriorityFee = gas.PriorityFee.String()
 

--- a/x/crosschain/keeper/gas_payment_test.go
+++ b/x/crosschain/keeper/gas_payment_test.go
@@ -71,6 +71,46 @@ func TestKeeper_PayGasNativeAndUpdateCctx(t *testing.T) {
 		require.Equal(t, "2", cctx.GetCurrentOutboundParam().GasPrice)
 	})
 
+	t.Run("should fail if v2 revert gas limit exceeds uint64", func(t *testing.T) {
+		k, ctx, sdkk, zk := testkeeper.CrosschainKeeper(t)
+		k.GetAuthKeeper().GetModuleAccount(ctx, fungibletypes.ModuleName)
+
+		chainID := getValidEthChainID()
+		setSupportedChain(ctx, zk, chainID)
+
+		deploySystemContracts(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper)
+		zrc20 := setupGasCoin(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper, chainID, "foobar", "foobar")
+
+		_, err := zk.FungibleKeeper.UpdateZRC20ProtocolFlatFee(ctx, zrc20, big.NewInt(withdrawFee))
+		require.NoError(t, err)
+
+		k.SetGasPrice(ctx, types.GasPrice{
+			ChainId:     chainID,
+			MedianIndex: 0,
+			Prices:      []uint64{gasPrice},
+		})
+
+		cctx := types.CrossChainTx{
+			ProtocolContractVersion: types.ProtocolContractVersion_V2,
+			RevertOptions: types.RevertOptions{
+				CallOnRevert:   true,
+				RevertGasLimit: math.NewUintFromBigInt(new(big.Int).Lsh(big.NewInt(1), 64)),
+			},
+			InboundParams: &types.InboundParams{
+				CoinType: coin.CoinType_Gas,
+			},
+			OutboundParams: []*types.OutboundParams{
+				{
+					ReceiverChainId: chainID,
+					CallOptions:     &types.CallOptions{},
+				},
+			},
+		}
+
+		err = k.PayGasNativeAndUpdateCctx(ctx, chainID, &cctx, math.NewUint(inputAmount))
+		require.ErrorIs(t, err, types.ErrInvalidGasLimit)
+	})
+
 	t.Run("should fail if not coin type gas", func(t *testing.T) {
 		k, ctx, _, _ := testkeeper.CrosschainKeeper(t)
 		chainID := getValidEthChainID()
@@ -233,6 +273,46 @@ func TestKeeper_PayGasInERC20AndUpdateCctx(t *testing.T) {
 		require.Equal(t, inputAmount-expectedInZRC20.Uint64(), cctx.GetCurrentOutboundParam().Amount.Uint64())
 		require.Equal(t, uint64(21_000), cctx.GetCurrentOutboundParam().CallOptions.GasLimit)
 		require.Equal(t, "2", cctx.GetCurrentOutboundParam().GasPrice)
+	})
+
+	t.Run("should fail if v2 erc20 revert gas limit exceeds uint64", func(t *testing.T) {
+		k, ctx, sdkk, zk := testkeeper.CrosschainKeeper(t)
+		k.GetAuthKeeper().GetModuleAccount(ctx, fungibletypes.ModuleName)
+
+		chainID := getValidEthChainID()
+		setSupportedChain(ctx, zk, chainID)
+
+		deploySystemContracts(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper)
+		gasZRC20 := setupGasCoin(t, ctx, zk.FungibleKeeper, sdkk.EvmKeeper, chainID, "foo", "foo")
+
+		_, err := zk.FungibleKeeper.UpdateZRC20ProtocolFlatFee(ctx, gasZRC20, big.NewInt(withdrawFee))
+		require.NoError(t, err)
+
+		k.SetGasPrice(ctx, types.GasPrice{
+			ChainId:     chainID,
+			MedianIndex: 0,
+			Prices:      []uint64{gasPrice},
+		})
+
+		cctx := types.CrossChainTx{
+			ProtocolContractVersion: types.ProtocolContractVersion_V2,
+			RevertOptions: types.RevertOptions{
+				CallOnRevert:   true,
+				RevertGasLimit: math.NewUintFromBigInt(new(big.Int).Lsh(big.NewInt(1), 64)),
+			},
+			InboundParams: &types.InboundParams{
+				CoinType: coin.CoinType_ERC20,
+			},
+			OutboundParams: []*types.OutboundParams{
+				{
+					ReceiverChainId: chainID,
+					CallOptions:     &types.CallOptions{},
+				},
+			},
+		}
+
+		err = k.PayGasInERC20AndUpdateCctx(ctx, chainID, &cctx, math.NewUint(inputAmount), false)
+		require.ErrorIs(t, err, types.ErrInvalidGasLimit)
 	})
 
 	t.Run("should fail if not coin type erc20", func(t *testing.T) {


### PR DESCRIPTION
Closes #4564

## Summary
- add a checked gas-limit-to-uint64 conversion helper
- return ErrInvalidGasLimit instead of panicking when revert gas limits exceed uint64
- apply the guard to GetRevertGasLimit and gas payment paths that populate outbound call options
- add regression coverage for oversized V2 revert gas limits

## Tests
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./x/crosschain/keeper"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR guards the revert-gas-limit-to-`uint64` conversion that previously called `.Uint64()` directly on an unbounded `sdkmath.Uint`, which would silently truncate or panic if the value exceeded 2^64−1. Two new helper functions (`gasLimitUint64` / `gasLimitBigIntUint64`) validate the value with a `BitLen() > 64` check and return `ErrInvalidGasLimit` on overflow.

- Adds `gasLimitUint64` / `gasLimitBigIntUint64` helpers and applies them in `GetRevertGasLimit` (V2 revert, Gas-coin, and ERC20 paths) and in the V2 revert-override branches of `PayGasNativeAndUpdateCctx` and `PayGasInERC20AndUpdateCctx`.
- `PayGasInZetaAndUpdateCctx` is correctly left unchanged; it reads `CallOptions.GasLimit` which is already a `uint64`, so no overflow is possible there.
- Three new regression tests cover the overflow scenario in each affected function.

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped, replaces direct unsafe `.Uint64()` calls with a validated helper, and all three affected code paths now have matching regression tests. The boundary logic (`BitLen() > 64`) correctly allows all values from 0 to 2^64−1 and rejects anything ≥ 2^64.

The guard is implemented correctly and the test suite covers the introduced overflow path in each modified function. The only observation is a cosmetic inaccuracy in the error message for nil/negative inputs, which does not affect runtime correctness.

No files require special attention. The `gasLimitBigIntUint64` helper in `cctx_utils.go` is the core of the change and its logic is sound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/crosschain/keeper/cctx_utils.go | Adds gasLimitUint64/gasLimitBigIntUint64 helpers with correct BitLen guard; applies them in GetRevertGasLimit for V2 revert, Gas coin, and ERC20 coin paths |
| x/crosschain/keeper/gas_payment.go | Applies gasLimitUint64 guard in PayGasNativeAndUpdateCctx and PayGasInERC20AndUpdateCctx immediately after the V2 revert gas limit override; PayGasInZetaAndUpdateCctx correctly omitted since it reads gas limit from the already-uint64 CallOptions.GasLimit field |
| x/crosschain/keeper/cctx_utils_test.go | Adds regression test for GetRevertGasLimit rejecting a 2^64 overflow gas limit; covers the V2 CallOnRevert path |
| x/crosschain/keeper/gas_payment_test.go | Adds regression tests for PayGasNativeAndUpdateCctx and PayGasInERC20AndUpdateCctx with a 2^64 V2 revert gas limit; setup correctly deploys system contracts so failure happens at the guard, not earlier |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PayGasNative / PayGasInERC20] --> B[ChainGasParams]
    B --> C{V2 + CallOnRevert\n+ non-zero RevertGasLimit?}
    C -- Yes --> D[gas.GasLimit = RevertGasLimit]
    C -- No --> E[gas.GasLimit from ChainGasParams]
    D --> F[gasLimitUint64\ngasLimit.BitLen > 64?]
    E --> F
    F -- overflow --> G[return ErrInvalidGasLimit]
    F -- ok --> H[callGasLimit uint64]
    H --> I[Calculate gasFee\ngas.GasLimit x gas.GasPrice]
    I --> J[Set CallOptions.GasLimit = callGasLimit]

    K[GetRevertGasLimit] --> L{V2 + CallOnRevert\n+ non-zero RevertGasLimit?}
    L -- Yes --> M[gasLimitUint64\nRevertGasLimit]
    M -- overflow --> N[return ErrInvalidGasLimit]
    M -- ok --> O[return uint64]
    L -- No --> P[QueryGasLimit from ZRC20]
    P --> Q[gasLimitBigIntUint64\ngasLimit.BitLen > 64?]
    Q -- overflow --> R[return ErrInvalidGasLimit]
    Q -- ok --> S[return uint64]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
x/crosschain/keeper/cctx_utils.go:24-26
The error message `"gas limit exceeds uint64 range"` is inaccurate when `gasLimit` is `nil` or negative — both cases trigger the same message. A nil gas limit returned from a ZRC20 contract query or a sign error would surface as "exceeds uint64 range" in logs/errors, making triage harder. A more general description covers all branches correctly.

```suggestion
	if gasLimit == nil || gasLimit.Sign() < 0 || gasLimit.BitLen() > 64 {
		return 0, cosmoserrors.Wrap(types.ErrInvalidGasLimit, "gas limit is invalid or exceeds uint64 range")
	}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(crosschain): guard revert gas limit ..."](https://github.com/zeta-chain/node/commit/1a46082360e7c0e6df5c0054e13da0ffda80ee53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31990714)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->