### PR TITLE
fix(zetaclient): recover ton and sui signer panics

### DIFF
--- a/zetaclient/chains/sui/signer/signer.go
+++ b/zetaclient/chains/sui/signer/signer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/block-vision/sui-go-sdk/models"
 	suiptb "github.com/pattonkan/sui-go/sui"
@@ -92,14 +93,25 @@ func New(baseSigner *base.Signer,
 
 // ProcessCCTX schedules outbound cross-chain transaction.
 // Build --> Sign --> Broadcast --(async)--> Wait for execution --> PostOutboundTracker
-func (s *Signer) ProcessCCTX(ctx context.Context, cctx *cctypes.CrossChainTx, zetaHeight uint64) error {
+func (s *Signer) ProcessCCTX(ctx context.Context, cctx *cctypes.CrossChainTx, zetaHeight uint64) (err error) {
 	var (
 		outboundID = base.OutboundIDFromCCTX(cctx)
 		nonce      = cctx.GetCurrentOutboundParam().TssNonce
 	)
 
 	s.MarkOutbound(outboundID, true)
-	defer func() { s.MarkOutbound(outboundID, false) }()
+	defer func() {
+		s.MarkOutbound(outboundID, false)
+		if r := recover(); r != nil {
+			s.Logger().Std.Error().
+				Str(logs.FieldCctxIndex, cctx.Index).
+				Str(logs.FieldOutboundID, outboundID).
+				Interface("panic", r).
+				Str("stack_trace", string(debug.Stack())).
+				Msg("caught panic error")
+			err = errors.Errorf("caught panic during outbound processing: %v", r)
+		}
+	}()
 
 	// prepare logger
 	logger := s.Logger().Std.With().Uint64(logs.FieldNonce, nonce).Logger()

--- a/zetaclient/chains/sui/signer/signer.go
+++ b/zetaclient/chains/sui/signer/signer.go
@@ -102,12 +102,13 @@ func (s *Signer) ProcessCCTX(ctx context.Context, cctx *cctypes.CrossChainTx, ze
 	s.MarkOutbound(outboundID, true)
 	defer func() {
 		s.MarkOutbound(outboundID, false)
+		panicStack := debug.Stack()
 		if r := recover(); r != nil {
 			s.Logger().Std.Error().
 				Str(logs.FieldCctxIndex, cctx.Index).
 				Str(logs.FieldOutboundID, outboundID).
 				Interface("panic", r).
-				Str("stack_trace", string(debug.Stack())).
+				Str("stack_trace", string(panicStack)).
 				Msg("caught panic error")
 			err = errors.Errorf("caught panic during outbound processing: %v", r)
 		}

--- a/zetaclient/chains/sui/signer/signer_test.go
+++ b/zetaclient/chains/sui/signer/signer_test.go
@@ -358,6 +358,41 @@ func TestSigner(t *testing.T) {
 
 		require.Eventually(t, wait, 5*time.Second, 100*time.Millisecond)
 	})
+
+	t.Run("ProcessCCTX recovers panic", func(t *testing.T) {
+		// ARRANGE
+		ts := newTestSuite(t)
+
+		const zetaHeight = 1000
+
+		nonce := uint64(123)
+		receiver := "0xdecb47015beebed053c19ef48fe4d722fa3870f567133d235ebe3a70da7b0000"
+
+		cctx := sample.CrossChainTxV2(t, "0xABC123")
+		cctx.InboundParams = nil
+		cctx.OutboundParams = []*cc.OutboundParams{{
+			Receiver:        receiver,
+			ReceiverChainId: ts.Chain.ChainId,
+			CoinType:        coin.CoinType_Gas,
+			Amount:          math.NewUint(100_000),
+			TssNonce:        nonce,
+			GasPrice:        "1000",
+			CallOptions: &cc.CallOptions{
+				GasLimit: 42,
+			},
+		}}
+		outboundID := base.OutboundIDFromCCTX(cctx)
+
+		ts.MockGatewayNonce(nonce)
+		ts.MockWithdrawCapID("0xWithdrawCapID")
+
+		// ACT
+		err := ts.Signer.ProcessCCTX(ts.Ctx, cctx, zetaHeight)
+
+		// ASSERT
+		require.ErrorContains(t, err, "caught panic during outbound processing")
+		require.False(t, ts.Signer.IsOutboundActive(outboundID))
+	})
 }
 
 type testSuite struct {

--- a/zetaclient/chains/ton/signer/signer.go
+++ b/zetaclient/chains/ton/signer/signer.go
@@ -67,12 +67,13 @@ func (s *Signer) TryProcessOutbound(
 	s.MarkOutbound(outboundID, true)
 	defer func() {
 		s.MarkOutbound(outboundID, false)
+		panicStack := debug.Stack()
 		if r := recover(); r != nil {
 			s.Logger().Std.Error().
 				Str(logs.FieldCctxIndex, cctx.Index).
 				Str(logs.FieldOutboundID, outboundID).
 				Interface("panic", r).
-				Str("stack_trace", string(debug.Stack())).
+				Str("stack_trace", string(panicStack)).
 				Msg("caught panic error")
 		}
 	}()

--- a/zetaclient/chains/ton/signer/signer.go
+++ b/zetaclient/chains/ton/signer/signer.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"context"
+	"runtime/debug"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -64,7 +65,17 @@ func (s *Signer) TryProcessOutbound(
 ) {
 	outboundID := base.OutboundIDFromCCTX(cctx)
 	s.MarkOutbound(outboundID, true)
-	defer s.MarkOutbound(outboundID, false)
+	defer func() {
+		s.MarkOutbound(outboundID, false)
+		if r := recover(); r != nil {
+			s.Logger().Std.Error().
+				Str(logs.FieldCctxIndex, cctx.Index).
+				Str(logs.FieldOutboundID, outboundID).
+				Interface("panic", r).
+				Str("stack_trace", string(debug.Stack())).
+				Msg("caught panic error")
+		}
+	}()
 
 	outcome, err := s.processOutbound(ctx, cctx, zetaRepo, zetaBlockHeight)
 

--- a/zetaclient/chains/ton/signer/signer_test.go
+++ b/zetaclient/chains/ton/signer/signer_test.go
@@ -64,6 +64,26 @@ func TestDrySigner(t *testing.T) {
 	require.Len(t, ts.trackerBag, 0)
 }
 
+func TestSigner_TryProcessOutboundRecoversPanic(t *testing.T) {
+	ts := newTestSuite(t)
+
+	const nonce uint64 = 2
+	cctx := sample.CrossChainTx(t, "panic")
+	cctx.InboundParams = nil
+	cctx.OutboundParams = []*cc.OutboundParams{{
+		ReceiverChainId: ts.chain.ChainId,
+		TssNonce:        nonce,
+	}}
+	outboundID := base.OutboundIDFromCCTX(cctx)
+
+	signer := New(ts.baseSigner, ts.rpc, ts.gw)
+
+	require.NotPanics(t, func() {
+		signer.TryProcessOutbound(ts.ctx, cctx, ts.zetaRepo, 0)
+	})
+	require.False(t, signer.IsOutboundActive(outboundID))
+}
+
 func testSigner(t *testing.T, ts *testSuite, nonce uint64) (ton.Transaction, ton.Transaction) {
 	// Given TON signer
 	signer := New(ts.baseSigner, ts.rpc, ts.gw)


### PR DESCRIPTION
Refs #1949

## Summary
- add panic recovery to TON outbound processing, matching the pattern used by EVM/BTC/Solana signers
- add panic recovery to Sui ProcessCCTX while returning an error to the caller
- keep outbound active markers cleared after recovered panics
- add regression coverage for panic recovery paths

## Tests
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./zetaclient/chains/ton/signer"
- docker run --rm -v "${repo}:/workspace" -v zeta-go-cache:/go/pkg/mod --workdir /workspace golang:1.23 sh -c "go test -tags pebbledb,ledger,test ./zetaclient/chains/sui/signer"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds panic recovery to the TON `TryProcessOutbound` and Sui `ProcessCCTX` signers, matching the pattern already used by EVM and Solana signers, and ensures the outbound active marker is always cleared after a recovered panic.

- **TON** (`signer.go`): Wraps the existing `defer s.MarkOutbound(outboundID, false)` into an anonymous function that additionally calls `recover()` and logs the panic with a stack trace; the function returns nothing so the panic is silently swallowed after logging.
- **Sui** (`signer.go`): Converts `ProcessCCTX` to use a named return `err`, adds the same recovery pattern, and sets `err` to a descriptive error value on panic so callers see a non-nil error instead of a silent void.
- Both changes include regression tests that verify the active marker is cleared and (for Sui) that a descriptive error is returned.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are additive panic recovery wrappers that don't alter any business logic.

The core change is low-risk: wrap existing function bodies in a deferred recovery that clears the active marker and logs/returns the panic. The debug.Stack() field captured after recover() will reflect the deferred function's stack rather than the actual panic site, reducing its diagnostic value — but this is a pre-existing pattern in the EVM signer. The implementation, named-return handling in Sui, and test coverage are all correct.

No files require special attention; the production signer files are the most significant changes and look correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/sui/signer/signer.go | Adds panic recovery to ProcessCCTX using a named return err and a single defer that clears the active marker then calls recover(); matches EVM/Solana pattern but debug.Stack() is captured after recover, so the logged stack won't show the panic site |
| zetaclient/chains/ton/signer/signer.go | Adds panic recovery to TryProcessOutbound via the same defer pattern; correct fire-and-forget semantics (void return), stack trace has same post-recover capture limitation |
| zetaclient/chains/sui/signer/signer_test.go | Adds ProcessCCTX recovers panic sub-test: triggers nil-pointer panic via InboundParams = nil, asserts error contains expected message and active marker is cleared |
| zetaclient/chains/ton/signer/signer_test.go | Adds TestSigner_TryProcessOutboundRecoversPanic: uses require.NotPanics to verify recovery and checks IsOutboundActive is false after the call |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Orchestrator
    participant TON_Sui_Signer
    participant processOutbound

    Orchestrator->>TON_Sui_Signer: TryProcessOutbound / ProcessCCTX
    TON_Sui_Signer->>TON_Sui_Signer: MarkOutbound(id, true)
    TON_Sui_Signer->>TON_Sui_Signer: register defer [MarkOutbound(false) + recover()]

    TON_Sui_Signer->>processOutbound: call processOutbound / internal logic

    alt normal execution
        processOutbound-->>TON_Sui_Signer: outcome, err
        TON_Sui_Signer->>TON_Sui_Signer: defer runs: MarkOutbound(id, false)
        TON_Sui_Signer->>TON_Sui_Signer: recover() nil (no panic)
        TON_Sui_Signer-->>Orchestrator: return (nil or error)
    else panic occurs
        processOutbound--xTON_Sui_Signer: panic!
        TON_Sui_Signer->>TON_Sui_Signer: defer runs: MarkOutbound(id, false)
        TON_Sui_Signer->>TON_Sui_Signer: recover() panic value
        TON_Sui_Signer->>TON_Sui_Signer: log error + stack_trace
        Note over TON_Sui_Signer: Sui: set named return err / TON: void (log only)
        TON_Sui_Signer-->>Orchestrator: return (Sui: error / TON: void)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
zetaclient/chains/sui/signer/signer.go:110
**`debug.Stack()` called after `recover()` — panic site stack is lost**

Once `recover()` is called in a deferred function the Go runtime considers the panic resolved and unwinds the call stack to the deferred function's frame. Any subsequent call to `debug.Stack()` returns the current (deferred) goroutine stack, not the stack at the panic origin. The logged `stack_trace` field will point to the defer wrapper rather than the line that panicked, making post-incident analysis significantly harder. The same pattern exists in the EVM signer (`evm/signer/signer.go:276`), so this is a pre-existing footgun being replicated here. Consider capturing the stack trace before `recover()` or accepting that the field's value has limited diagnostic use.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(zetaclient): recover ton and sui sig..."](https://github.com/zeta-chain/node/commit/2816956a715e69d645f4b1ffa6e575d0ae8e87b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31994102)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in Sui and TON chain transaction processors with robust recovery mechanisms that capture and log detailed diagnostic information when unexpected errors occur during processing, ensuring proper cleanup and maintaining system stability.

* **Tests**
  * Added comprehensive test coverage for error recovery scenarios in transaction processing workflows across Sui and TON blockchain chains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeta-chain/node/pull/4594)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->