### PR TITLE
fix(crosschain): protect gas payment swaps

### DIFF
--- a/testutil/keeper/crosschain.go
+++ b/testutil/keeper/crosschain.go
@@ -380,7 +380,7 @@ func MockPayGasAndUpdateCCTX(
 		Return(ethcommon.Address{}, nil).Once()
 	m.On("CallZRC20Approve", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Once()
-	m.On("CallUniswapV2RouterSwapExactTokensForTokens", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	m.On("CallUniswapV2RouterSwapExactTokensForTokens", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return([]*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(1000)}, nil).
 		Once()
 	m.On("CallZRC20Burn", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).

--- a/testutil/keeper/mocks/crosschain/fungible.go
+++ b/testutil/keeper/mocks/crosschain/fungible.go
@@ -26,9 +26,9 @@ type CrosschainFungibleKeeper struct {
 	mock.Mock
 }
 
-// CallUniswapV2RouterSwapExactETHForToken provides a mock function with given fields: ctx, sender, to, amountIn, outZRC4, noEthereumTxEvent
-func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactETHForToken(ctx types.Context, sender common.Address, to common.Address, amountIn *big.Int, outZRC4 common.Address, noEthereumTxEvent bool) ([]*big.Int, error) {
-	ret := _m.Called(ctx, sender, to, amountIn, outZRC4, noEthereumTxEvent)
+// CallUniswapV2RouterSwapExactETHForToken provides a mock function with given fields: ctx, sender, to, amountIn, amountOutMin, outZRC4, noEthereumTxEvent
+func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactETHForToken(ctx types.Context, sender common.Address, to common.Address, amountIn *big.Int, amountOutMin *big.Int, outZRC4 common.Address, noEthereumTxEvent bool) ([]*big.Int, error) {
+	ret := _m.Called(ctx, sender, to, amountIn, amountOutMin, outZRC4, noEthereumTxEvent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CallUniswapV2RouterSwapExactETHForToken")
@@ -36,19 +36,19 @@ func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactETHForToken(ctx 
 
 	var r0 []*big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, common.Address, bool) ([]*big.Int, error)); ok {
-		return rf(ctx, sender, to, amountIn, outZRC4, noEthereumTxEvent)
+	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, *big.Int, common.Address, bool) ([]*big.Int, error)); ok {
+		return rf(ctx, sender, to, amountIn, amountOutMin, outZRC4, noEthereumTxEvent)
 	}
-	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, common.Address, bool) []*big.Int); ok {
-		r0 = rf(ctx, sender, to, amountIn, outZRC4, noEthereumTxEvent)
+	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, *big.Int, common.Address, bool) []*big.Int); ok {
+		r0 = rf(ctx, sender, to, amountIn, amountOutMin, outZRC4, noEthereumTxEvent)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*big.Int)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(types.Context, common.Address, common.Address, *big.Int, common.Address, bool) error); ok {
-		r1 = rf(ctx, sender, to, amountIn, outZRC4, noEthereumTxEvent)
+	if rf, ok := ret.Get(1).(func(types.Context, common.Address, common.Address, *big.Int, *big.Int, common.Address, bool) error); ok {
+		r1 = rf(ctx, sender, to, amountIn, amountOutMin, outZRC4, noEthereumTxEvent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,9 +56,9 @@ func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactETHForToken(ctx 
 	return r0, r1
 }
 
-// CallUniswapV2RouterSwapExactTokensForTokens provides a mock function with given fields: ctx, sender, to, amountIn, inZRC4, outZRC4, noEthereumTxEvent
-func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactTokensForTokens(ctx types.Context, sender common.Address, to common.Address, amountIn *big.Int, inZRC4 common.Address, outZRC4 common.Address, noEthereumTxEvent bool) ([]*big.Int, error) {
-	ret := _m.Called(ctx, sender, to, amountIn, inZRC4, outZRC4, noEthereumTxEvent)
+// CallUniswapV2RouterSwapExactTokensForTokens provides a mock function with given fields: ctx, sender, to, amountIn, amountOutMin, inZRC4, outZRC4, noEthereumTxEvent
+func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactTokensForTokens(ctx types.Context, sender common.Address, to common.Address, amountIn *big.Int, amountOutMin *big.Int, inZRC4 common.Address, outZRC4 common.Address, noEthereumTxEvent bool) ([]*big.Int, error) {
+	ret := _m.Called(ctx, sender, to, amountIn, amountOutMin, inZRC4, outZRC4, noEthereumTxEvent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CallUniswapV2RouterSwapExactTokensForTokens")
@@ -66,19 +66,19 @@ func (_m *CrosschainFungibleKeeper) CallUniswapV2RouterSwapExactTokensForTokens(
 
 	var r0 []*big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, common.Address, common.Address, bool) ([]*big.Int, error)); ok {
-		return rf(ctx, sender, to, amountIn, inZRC4, outZRC4, noEthereumTxEvent)
+	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, *big.Int, common.Address, common.Address, bool) ([]*big.Int, error)); ok {
+		return rf(ctx, sender, to, amountIn, amountOutMin, inZRC4, outZRC4, noEthereumTxEvent)
 	}
-	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, common.Address, common.Address, bool) []*big.Int); ok {
-		r0 = rf(ctx, sender, to, amountIn, inZRC4, outZRC4, noEthereumTxEvent)
+	if rf, ok := ret.Get(0).(func(types.Context, common.Address, common.Address, *big.Int, *big.Int, common.Address, common.Address, bool) []*big.Int); ok {
+		r0 = rf(ctx, sender, to, amountIn, amountOutMin, inZRC4, outZRC4, noEthereumTxEvent)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*big.Int)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(types.Context, common.Address, common.Address, *big.Int, common.Address, common.Address, bool) error); ok {
-		r1 = rf(ctx, sender, to, amountIn, inZRC4, outZRC4, noEthereumTxEvent)
+	if rf, ok := ret.Get(1).(func(types.Context, common.Address, common.Address, *big.Int, *big.Int, common.Address, common.Address, bool) error); ok {
+		r1 = rf(ctx, sender, to, amountIn, amountOutMin, inZRC4, outZRC4, noEthereumTxEvent)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/x/crosschain/keeper/gas_payment.go
+++ b/x/crosschain/keeper/gas_payment.go
@@ -40,6 +40,8 @@ func gasPaymentAmountOutMin(amountOut *big.Int) *big.Int {
 		return big.NewInt(0)
 	}
 
+	// The swap minimum catches severe EVM-level slippage. Callers still require the full
+	// expected gas fee after the swap so CCTX accounting remains exact.
 	amountOutMin := new(big.Int).Mul(amountOut, big.NewInt(gasPaymentBpsDenominator-gasPaymentSwapSlippageBps))
 	return amountOutMin.Div(amountOutMin, big.NewInt(gasPaymentBpsDenominator))
 }

--- a/x/crosschain/keeper/gas_payment.go
+++ b/x/crosschain/keeper/gas_payment.go
@@ -30,6 +30,20 @@ type ChainGasParams struct {
 	ProtocolFlatFee sdkmath.Uint
 }
 
+const (
+	gasPaymentSwapSlippageBps = 500
+	gasPaymentBpsDenominator  = 10_000
+)
+
+func gasPaymentAmountOutMin(amountOut *big.Int) *big.Int {
+	if amountOut == nil || amountOut.Sign() <= 0 {
+		return big.NewInt(0)
+	}
+
+	amountOutMin := new(big.Int).Mul(amountOut, big.NewInt(gasPaymentBpsDenominator-gasPaymentSwapSlippageBps))
+	return amountOutMin.Div(amountOutMin, big.NewInt(gasPaymentBpsDenominator))
+}
+
 // PayGasAndUpdateCctx updates the outbound tx with the new amount after paying the gas fee
 // **Caller should feed temporary ctx into this function**
 // chainID is the outbound chain chain id , this can be receiver chain for regular transactions and sender-chain to reverted transactions
@@ -274,6 +288,7 @@ func (k Keeper) PayGasInERC20AndUpdateCctx(
 		types.ModuleAddressEVM,
 		types.ModuleAddressEVM,
 		feeInZRC20,
+		gasPaymentAmountOutMin(outTxGasFee.BigInt()),
 		zrc20,
 		gas.GasZRC20,
 		noEthereumTxEvent,
@@ -423,6 +438,7 @@ func (k Keeper) PayGasInZetaAndUpdateCctx(
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			outTxGasFeeInZeta,
+			gasPaymentAmountOutMin(outTxGasFee.BigInt()),
 			gasZRC20,
 			noEthereumTxEvent,
 		)
@@ -441,6 +457,15 @@ func (k Keeper) PayGasInZetaAndUpdateCctx(
 
 		// FIXME: investigate small mismatches between amounts[1] and outTxGasFee
 		// https://github.com/zeta-chain/node/issues/1303
+		if amounts[1].Cmp(outTxGasFee.BigInt()) == -1 {
+			return cosmoserrors.Wrapf(
+				types.ErrInvalidGasAmount,
+				"gas obtained for burn (%s) is lower than gas fee(%s)",
+				amounts[1],
+				outTxGasFee,
+			)
+		}
+
 		err = k.fungibleKeeper.CallZRC20Burn(ctx, types.ModuleAddressEVM, gasZRC20, amounts[1], noEthereumTxEvent)
 		if err != nil {
 			return cosmoserrors.Wrap(err, "PayGasInZetaAndUpdateCctx: unable to CallZRC20Burn")

--- a/x/crosschain/types/expected_keepers.go
+++ b/x/crosschain/types/expected_keepers.go
@@ -179,6 +179,7 @@ type FungibleKeeper interface {
 		sender ethcommon.Address,
 		to ethcommon.Address,
 		amountIn *big.Int,
+		amountOutMin *big.Int,
 		inZRC4,
 		outZRC4 ethcommon.Address,
 		noEthereumTxEvent bool,
@@ -188,6 +189,7 @@ type FungibleKeeper interface {
 		sender ethcommon.Address,
 		to ethcommon.Address,
 		amountIn *big.Int,
+		amountOutMin *big.Int,
 		outZRC4 ethcommon.Address,
 		noEthereumTxEvent bool,
 	) ([]*big.Int, error)

--- a/x/fungible/keeper/system_contract.go
+++ b/x/fungible/keeper/system_contract.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	cosmoserrors "cosmossdk.io/errors"
 	"cosmossdk.io/store/prefix"
@@ -15,6 +16,16 @@ import (
 	"github.com/zeta-chain/node/pkg/contracts/uniswap/v2-periphery/contracts/uniswapv2router02.sol"
 	"github.com/zeta-chain/node/x/fungible/types"
 )
+
+const uniswapV2SwapDeadline = 30 * time.Minute
+
+func uniswapV2Deadline(ctx sdk.Context) *big.Int {
+	deadline := ctx.BlockTime().Add(uniswapV2SwapDeadline).Unix()
+	if deadline < 0 {
+		deadline = int64(uniswapV2SwapDeadline.Seconds())
+	}
+	return big.NewInt(deadline)
+}
 
 // SetSystemContract set system contract in the store
 func (k Keeper) SetSystemContract(ctx sdk.Context, sytemContract types.SystemContract) {
@@ -344,6 +355,7 @@ func (k *Keeper) CallUniswapV2RouterSwapExactTokensForTokens(
 	sender ethcommon.Address,
 	to ethcommon.Address,
 	amountIn *big.Int,
+	amountOutMin *big.Int,
 	inZRC4,
 	outZRC4 ethcommon.Address,
 	noEthereumTxEvent bool,
@@ -379,10 +391,10 @@ func (k *Keeper) CallUniswapV2RouterSwapExactTokensForTokens(
 		noEthereumTxEvent,
 		"swapExactTokensForTokens",
 		amountIn,
-		BigIntZero,
+		amountOutMin,
 		[]ethcommon.Address{inZRC4, wzetaAddr, outZRC4},
 		to,
-		big.NewInt(1e17),
+		uniswapV2Deadline(ctx),
 	)
 	if err != nil {
 		return nil, cosmoserrors.Wrapf(
@@ -468,6 +480,7 @@ func (k *Keeper) CallUniswapV2RouterSwapExactETHForToken(
 	sender ethcommon.Address,
 	to ethcommon.Address,
 	amountIn *big.Int,
+	amountOutMin *big.Int,
 	outZRC4 ethcommon.Address,
 	noEthereumTxEvent bool,
 ) ([]*big.Int, error) {
@@ -497,10 +510,10 @@ func (k *Keeper) CallUniswapV2RouterSwapExactETHForToken(
 		true,
 		noEthereumTxEvent,
 		"swapExactETHForTokens",
-		BigIntZero,
+		amountOutMin,
 		[]ethcommon.Address{wzetaAddr, outZRC4},
 		to,
-		big.NewInt(1e17),
+		uniswapV2Deadline(ctx),
 	)
 	if err != nil {
 		return nil, cosmoserrors.Wrapf(

--- a/x/fungible/keeper/system_contract.go
+++ b/x/fungible/keeper/system_contract.go
@@ -17,12 +17,19 @@ import (
 	"github.com/zeta-chain/node/x/fungible/types"
 )
 
-const uniswapV2SwapDeadline = 30 * time.Minute
+const (
+	uniswapV2SwapDeadline           = 30 * time.Minute
+	uniswapV2FallbackDeadline int64 = 100_000_000_000_000_000
+)
 
 func uniswapV2Deadline(ctx sdk.Context) *big.Int {
+	if ctx.BlockTime().IsZero() {
+		return big.NewInt(uniswapV2FallbackDeadline)
+	}
+
 	deadline := ctx.BlockTime().Add(uniswapV2SwapDeadline).Unix()
 	if deadline < 0 {
-		deadline = int64(uniswapV2SwapDeadline.Seconds())
+		deadline = uniswapV2FallbackDeadline
 	}
 	return big.NewInt(deadline)
 }

--- a/x/fungible/keeper/system_contract_internal_test.go
+++ b/x/fungible/keeper/system_contract_internal_test.go
@@ -1,0 +1,22 @@
+package keeper
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniswapV2Deadline(t *testing.T) {
+	t.Run("uses block time when available", func(t *testing.T) {
+		blockTime := time.Unix(1_700_000_000, 0).UTC()
+		ctx := sdk.Context{}.WithBlockTime(blockTime)
+
+		require.Equal(t, blockTime.Add(uniswapV2SwapDeadline).Unix(), uniswapV2Deadline(ctx).Int64())
+	})
+
+	t.Run("uses far future fallback for zero block time", func(t *testing.T) {
+		require.Equal(t, uniswapV2FallbackDeadline, uniswapV2Deadline(sdk.Context{}).Int64())
+	})
+}

--- a/x/fungible/keeper/system_contract_test.go
+++ b/x/fungible/keeper/system_contract_test.go
@@ -389,6 +389,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactETHForToken(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			true,
 		)
@@ -419,6 +420,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactETHForToken(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			amountToSwap,
+			tokenAmount,
 			zrc20,
 			true,
 		)
@@ -426,6 +428,24 @@ func TestKeeper_CallUniswapV2RouterSwapExactETHForToken(t *testing.T) {
 
 		require.Equal(t, 2, len(amounts))
 		require.Equal(t, tokenAmount, amounts[1])
+
+		err = sdkk.BankKeeper.MintCoins(
+			ctx,
+			types.ModuleName,
+			sdk.NewCoins(sdk.NewCoin("azeta", sdkmath.NewIntFromBigInt(amountToSwap))),
+		)
+		require.NoError(t, err)
+
+		_, err = k.CallUniswapV2RouterSwapExactETHForToken(
+			ctx,
+			types.ModuleAddressEVM,
+			types.ModuleAddressEVM,
+			amountToSwap,
+			new(big.Int).Add(tokenAmount, big.NewInt(1)),
+			zrc20,
+			true,
+		)
+		require.ErrorIs(t, err, types.ErrContractCall)
 	})
 
 	t.Run("should fail if missing zeta balance", func(t *testing.T) {
@@ -445,6 +465,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactETHForToken(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			amountToSwap,
+			big.NewInt(0),
 			zrc20,
 			true,
 		)
@@ -466,6 +487,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactETHForToken(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			true,
 		)
@@ -487,6 +509,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactETHForToken(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			true,
 		)
@@ -501,7 +524,7 @@ func TestKeeper_CallUniswapV2RouterSwapEthForExactToken(t *testing.T) {
 
 		// fail if no system contract
 		_, err := k.CallUniswapV2RouterSwapExactETHForToken(
-			ctx, types.ModuleAddressEVM, types.ModuleAddressEVM, big.NewInt(1), sample.EthAddress(), true)
+			ctx, types.ModuleAddressEVM, types.ModuleAddressEVM, big.NewInt(1), big.NewInt(0), sample.EthAddress(), true)
 		require.ErrorIs(t, err, types.ErrStateVariableNotFound)
 	})
 
@@ -752,6 +775,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			sample.EthAddress(),
 			true,
@@ -770,6 +794,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			sample.EthAddress(),
 			true,
@@ -800,10 +825,33 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 		)
 
 		amounts, err := k.CallUniswapV2RouterSwapExactTokensForTokens(
-			ctx, types.ModuleAddressEVM, types.ModuleAddressEVM, amountToSwap, inzrc20, outzrc20, true)
+			ctx, types.ModuleAddressEVM, types.ModuleAddressEVM, amountToSwap, tokenAmount, inzrc20, outzrc20, true)
 		require.NoError(t, err)
 		require.Equal(t, 3, len(amounts))
 		require.Equal(t, amounts[2], tokenAmount)
+
+		_, err = k.DepositZRC20(ctx, inzrc20, types.ModuleAddressEVM, amountToSwap)
+		require.NoError(t, err)
+		k.CallZRC20Approve(
+			ctx,
+			types.ModuleAddressEVM,
+			inzrc20,
+			router,
+			amountToSwap,
+			false,
+		)
+
+		_, err = k.CallUniswapV2RouterSwapExactTokensForTokens(
+			ctx,
+			types.ModuleAddressEVM,
+			types.ModuleAddressEVM,
+			amountToSwap,
+			new(big.Int).Add(tokenAmount, big.NewInt(1)),
+			inzrc20,
+			outzrc20,
+			true,
+		)
+		require.ErrorIs(t, err, types.ErrContractCall)
 	})
 
 	t.Run("should fail if missing tokens balance", func(t *testing.T) {
@@ -828,6 +876,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			amountToSwap,
+			big.NewInt(0),
 			inzrc20,
 			outzrc20,
 			true,
@@ -845,6 +894,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			sample.EthAddress(),
 			true,
@@ -863,6 +913,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			sample.EthAddress(),
 			true,
@@ -880,6 +931,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			sample.EthAddress(),
 			true,
@@ -898,6 +950,7 @@ func TestKeeper_CallUniswapV2RouterSwapExactTokensForTokens(t *testing.T) {
 			types.ModuleAddressEVM,
 			types.ModuleAddressEVM,
 			big.NewInt(1),
+			big.NewInt(0),
 			sample.EthAddress(),
 			sample.EthAddress(),
 			true,


### PR DESCRIPTION
## Summary
- add amountOutMin slippage protection for gas payment Uniswap swaps
- replace the effectively unbounded router deadline with a 30 minute deadline
- verify ZETA gas swaps receive enough gas ZRC20 before burning

## Tests
- go test -tags pebbledb,ledger,test ./x/fungible/keeper ./x/crosschain/keeper

Closes #4565

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens gas-payment Uniswap swaps on ZetaChain by adding slippage protection (`amountOutMin` at 5% below expected output), replacing the effectively infinite `1e17` deadline with a 30-minute block-time-relative deadline, and adding a new post-swap verification for the ZETA gas path to confirm at least `outTxGasFee` gas ZRC20 was received before burning.

- **Slippage guard**: `gasPaymentAmountOutMin` (95% of expected) is passed to both `swapExactTokensForTokens` and `swapExactETHForTokens` as `amountOutMin`; the ERC20 path also gains this guard (the post-swap check was already present).
- **ZETA path new check**: A strict `amounts[1] < outTxGasFee` guard is added before `CallZRC20Burn` in `PayGasInZetaAndUpdateCctx`, consistent with the existing ERC20 path behaviour.
- **Deadline fix**: `uniswapV2Deadline` replaces the 3-billion-year hardcoded value with a proper `blockTime + 30 min` computation across both swap helpers.

<h3>Confidence Score: 4/5</h3>

The core changes are correct and close a real vulnerability; the new protections are consistent across both payment paths and covered by new integration tests.

The `uniswapV2Deadline` fallback lands on Unix timestamp 1800 (January 1970) when block time is zero, silently breaking all swaps in that edge case. The `amountOutMin` at 95% and the post-swap check at 100% have mismatched thresholds that are undocumented, which could mislead future maintainers. Neither concern affects the production happy path.

x/fungible/keeper/system_contract.go (deadline fallback) and x/crosschain/keeper/gas_payment.go (dual-threshold design)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/crosschain/keeper/gas_payment.go | Adds slippage protection (5% amountOutMin) for ERC20 and ZETA gas swaps, and adds a new strict post-swap check for the ZETA path; the dual-threshold design (95% EVM guard + 100% Cosmos check) is intentional but undocumented. |
| x/fungible/keeper/system_contract.go | Replaces hardcoded `1e17` deadline and zero amountOutMin with a proper 30-minute block-time-relative deadline and caller-supplied amountOutMin; the negative-deadline fallback resolves to Unix timestamp 1800, which would fail all swaps in zero-time test contexts. |
| x/fungible/keeper/system_contract_test.go | Test signatures updated for the new amountOutMin parameter; new sub-cases added to verify that exceeding amountOutMin causes ErrContractCall for both swap variants. |
| x/crosschain/types/expected_keepers.go | Interface signatures for both Uniswap swap helpers updated to include the new amountOutMin parameter. |
| testutil/keeper/mocks/crosschain/fungible.go | Auto-generated mock correctly regenerated to reflect the new amountOutMin parameter in both swap functions. |
| testutil/keeper/crosschain.go | Mock setup for PayGasAndUpdateCCTX updated to add an extra mock.Anything arg matching the new amountOutMin parameter. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
x/fungible/keeper/system_contract.go:22-28
**Fallback deadline produces an always-expired timestamp**

When `ctx.BlockTime()` is zero (the Go zero-value `time.Time{}`), `ctx.BlockTime().Add(30 * time.Minute).Unix()` is a large negative number, triggering the fallback. The fallback sets `deadline = int64(uniswapV2SwapDeadline.Seconds())` which is `1800` — Unix timestamp January 1, 1970, 00:30 UTC. Any Uniswap call carrying this value will immediately revert with `UniswapV2Router: EXPIRED`, since `block.timestamp > 1800` in every real or non-trivial test context. The intent of the fallback appears to be "use a safe default when the block time is unavailable," but the value chosen is the opposite of safe.

### Issue 2 of 2
x/crosschain/keeper/gas_payment.go:38-45
**`amountOutMin` at 95% is superseded by the 100% post-swap checks**

`gasPaymentAmountOutMin` allows up to 5% slippage at the EVM level, but both gas payment paths immediately follow the swap with a strict check (`amounts[x].Cmp(outTxGasFee.BigInt()) == -1`) that requires 100% of the expected output. Any swap output in the 95–100% range passes the EVM guard but is rejected by the Cosmos-level check, making the 5% tolerance effectively unreachable. A comment explaining this dual-layer design (EVM guard stops catastrophic slippage; Cosmos check enforces accounting exactness and reverts cleanly) would help future readers understand why the thresholds are intentionally mismatched, and prevent someone from "fixing" the `amountOutMin` to 100% while silently losing the EVM-level protection.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(crosschain): protect gas payment swa..."](https://github.com/zeta-chain/node/commit/f2377e9ceda87e4b1ea0c81ad6b0a0b9046e7c91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31997697)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->