### PR TITLE
fix(sui): process multiple gateway events per tx

### DIFF
--- a/zetaclient/chains/sui/observer/inbound.go
+++ b/zetaclient/chains/sui/observer/inbound.go
@@ -169,11 +169,6 @@ func (ob *Observer) processInboundEvent(
 		return nil
 	case err != nil:
 		return errors.Wrap(err, "unable to parse event")
-	case event.EventIndex != 0:
-		// Is it possible to have multiple events per tx?
-		// e.g. contract "A" calls Gateway multiple times in a single tx (deposit to multiple accounts)
-		// most likely not, so let's explicitly fail to prevent undefined behavior.
-		return errors.Errorf("unexpected event index %d for tx %s", event.EventIndex, event.TxHash)
 	}
 
 	if tx == nil {

--- a/zetaclient/chains/sui/observer/inbound.go
+++ b/zetaclient/chains/sui/observer/inbound.go
@@ -70,10 +70,12 @@ func (ob *Observer) observeGatewayInbound(ctx context.Context, packageID string)
 		Int("events", len(events)).
 		Msg("processing inbound events")
 
+	txCache := make(map[string]*models.SuiTransactionBlockResponse)
+
 	for _, event := range events {
 		// Note: we can make this concurrent if needed.
 		// Let's revisit later
-		err := ob.processInboundEvent(ctx, event, nil, false, false)
+		err := ob.processInboundEvent(ctx, event, nil, txCache, false, false)
 
 		switch {
 		case errors.Is(err, errTxNotFound),
@@ -159,6 +161,7 @@ func (ob *Observer) processInboundEvent(
 	ctx context.Context,
 	raw models.SuiEventResponse,
 	tx *models.SuiTransactionBlockResponse,
+	txCache map[string]*models.SuiTransactionBlockResponse,
 	fromTracker bool,
 	isInternalTracker bool,
 ) error {
@@ -169,6 +172,12 @@ func (ob *Observer) processInboundEvent(
 		return nil
 	case err != nil:
 		return errors.Wrap(err, "unable to parse event")
+	}
+
+	if tx == nil && txCache != nil {
+		if cached, ok := txCache[event.TxHash]; ok {
+			tx = cached
+		}
 	}
 
 	if tx == nil {
@@ -182,6 +191,9 @@ func (ob *Observer) processInboundEvent(
 		}
 
 		tx = &txFresh
+		if txCache != nil {
+			txCache[event.TxHash] = tx
+		}
 	}
 
 	msg, err := ob.constructInboundVote(event, *tx)
@@ -221,7 +233,7 @@ func (ob *Observer) processInboundTracker(ctx context.Context, tracker cctypes.I
 	}
 
 	for _, event := range tx.Events {
-		if err := ob.processInboundEvent(ctx, event, &tx, true, isInternal); err != nil {
+		if err := ob.processInboundEvent(ctx, event, &tx, nil, true, isInternal); err != nil {
 			return errors.Wrapf(err, "unable to process inbound event %s", event.Id.EventSeq)
 		}
 	}

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -276,6 +276,64 @@ func TestObserver(t *testing.T) {
 		require.Empty(t, ts.inboundVotesBag)
 	})
 
+	t.Run("ObserveInbound handles multiple gateway events in the same tx", func(t *testing.T) {
+		// ARRANGE
+		ts := newTestSuite(t)
+		packageID := ts.gateway.PackageID()
+		txHash := "TX_MULTI_EVENT"
+
+		evmBob := sample.EthAddress()
+		evmAlice := sample.EthAddress()
+
+		expectedQuery := client.EventQuery{
+			PackageID: packageID,
+			Module:    sui.GatewayModule,
+			Cursor:    "",
+			Limit:     client.DefaultEventsLimit,
+		}
+
+		events := []models.SuiEventResponse{
+			ts.SampleEventWithSeq(packageID, txHash, "0", string(sui.DepositEvent), map[string]any{
+				"coin_type": string(sui.SUI),
+				"amount":    "200",
+				"sender":    "SUI_BOB",
+				"receiver":  evmBob.String(),
+			}),
+			ts.SampleEventWithSeq(packageID, txHash, "1", string(sui.DepositAndCallEvent), map[string]any{
+				"coin_type": string(sui.SUI),
+				"amount":    "300",
+				"sender":    "SUI_ALICE",
+				"receiver":  evmAlice.String(),
+				"payload":   preparePayload([]byte{1, 2, 3}),
+			}),
+		}
+
+		ts.suiMock.On("QueryModuleEvents", mock.Anything, expectedQuery).Return(events, "", nil)
+		ts.OnGetTx(txHash, "10000", true, false, nil)
+		ts.OnGetTx(txHash, "10000", true, false, nil)
+
+		getCctxByHashErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+		ts.zetaMock.MockGetCctxByHash("", getCctxByHashErr)
+		ts.CatchInboundVotes()
+
+		// ACT
+		err := ts.ObserveInbound(ts.ctx)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.Equal(t, "TX_MULTI_EVENT,1", ts.GetAuxString(packageID))
+		require.Len(t, ts.inboundVotesBag, 2)
+
+		require.Equal(t, uint64(0), ts.inboundVotesBag[0].EventIndex)
+		require.Equal(t, evmBob.String(), ts.inboundVotesBag[0].Receiver)
+		require.Equal(t, math.NewUint(200), ts.inboundVotesBag[0].Amount)
+
+		require.Equal(t, uint64(1), ts.inboundVotesBag[1].EventIndex)
+		require.Equal(t, evmAlice.String(), ts.inboundVotesBag[1].Receiver)
+		require.Equal(t, math.NewUint(300), ts.inboundVotesBag[1].Amount)
+		require.Equal(t, "010203", ts.inboundVotesBag[1].Message)
+	})
+
 	t.Run("ObserveInbound restricted address", func(t *testing.T) {
 		// ARRANGE
 		ts := newTestSuite(t)
@@ -385,6 +443,57 @@ func TestObserver(t *testing.T) {
 		require.Equal(t, false, vote.IsCrossChainCall)
 		require.Equal(t, math.NewUint(1000), vote.Amount)
 		require.Equal(t, evmAlice.String(), vote.Receiver)
+	})
+
+	t.Run("ProcessInboundTrackers handles multiple gateway events in the same tx", func(t *testing.T) {
+		// ARRANGE
+		ts := newTestSuite(t)
+		packageID := ts.gateway.PackageID()
+		txHash := "TX_TRACKER_MULTI_EVENT"
+		chainID := ts.Chain().ChainId
+
+		trackers := []cctypes.InboundTracker{
+			{
+				ChainId:  chainID,
+				TxHash:   txHash,
+				CoinType: coin.CoinType_Gas,
+			},
+		}
+		ts.zetaMock.On("GetInboundTrackersForChain", mock.Anything, chainID).Return(trackers, nil)
+
+		evmBob := sample.EthAddress()
+		evmAlice := sample.EthAddress()
+		ts.OnGetTx(txHash, "15000", true, true, []models.SuiEventResponse{
+			ts.SampleEventWithSeq(packageID, txHash, "0", string(sui.DepositEvent), map[string]any{
+				"coin_type": string(sui.SUI),
+				"amount":    "1000",
+				"sender":    "SUI_BOB",
+				"receiver":  evmBob.String(),
+			}),
+			ts.SampleEventWithSeq(packageID, txHash, "1", string(sui.DepositEvent), map[string]any{
+				"coin_type": string(sui.SUI),
+				"amount":    "2000",
+				"sender":    "SUI_ALICE",
+				"receiver":  evmAlice.String(),
+			}),
+		})
+
+		getCctxByHashErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
+		ts.zetaMock.MockGetCctxByHash("", getCctxByHashErr)
+		ts.CatchInboundVotes()
+
+		// ACT
+		err := ts.ProcessInboundTrackers(ts.ctx)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.Len(t, ts.inboundVotesBag, 2)
+		require.Equal(t, uint64(0), ts.inboundVotesBag[0].EventIndex)
+		require.Equal(t, evmBob.String(), ts.inboundVotesBag[0].Receiver)
+		require.Equal(t, math.NewUint(1000), ts.inboundVotesBag[0].Amount)
+		require.Equal(t, uint64(1), ts.inboundVotesBag[1].EventIndex)
+		require.Equal(t, evmAlice.String(), ts.inboundVotesBag[1].Receiver)
+		require.Equal(t, math.NewUint(2000), ts.inboundVotesBag[1].Amount)
 	})
 
 	t.Run("ProcessOutboundTrackers", func(t *testing.T) {
@@ -804,12 +913,22 @@ func newTestSuite(t *testing.T, opts ...func(*testSuiteConfig)) *testSuite {
 }
 
 func (ts *testSuite) SampleEvent(packageID, txHash, event string, kv map[string]any) models.SuiEventResponse {
+	return ts.SampleEventWithSeq(packageID, txHash, "0", event, kv)
+}
+
+func (ts *testSuite) SampleEventWithSeq(
+	packageID,
+	txHash,
+	eventSeq,
+	event string,
+	kv map[string]any,
+) models.SuiEventResponse {
 	eventType := fmt.Sprintf("%s::%s::%s", packageID, sui.GatewayModule, event)
 
 	return models.SuiEventResponse{
 		Id: models.EventId{
 			TxDigest: txHash,
-			EventSeq: "0",
+			EventSeq: eventSeq,
 		},
 		PackageId:         packageID,
 		TransactionModule: "gateway",

--- a/zetaclient/chains/sui/observer/observer_test.go
+++ b/zetaclient/chains/sui/observer/observer_test.go
@@ -310,7 +310,6 @@ func TestObserver(t *testing.T) {
 
 		ts.suiMock.On("QueryModuleEvents", mock.Anything, expectedQuery).Return(events, "", nil)
 		ts.OnGetTx(txHash, "10000", true, false, nil)
-		ts.OnGetTx(txHash, "10000", true, false, nil)
 
 		getCctxByHashErr := grpcstatus.Error(grpccodes.InvalidArgument, "anything")
 		ts.zetaMock.MockGetCctxByHash("", getCctxByHashErr)


### PR DESCRIPTION
## Summary
- allow Sui inbound observer to process Gateway events with non-zero event indexes
- keep each Gateway event mapped to its own inbound vote using the existing EventIndex field
- cover both block-scan and inbound-tracker recovery paths for multiple events in one Sui transaction

## Tests
- go test -tags pebbledb,ledger,test ./zetaclient/chains/sui/observer

Closes #4584

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Sui inbound observer to correctly handle transactions that emit more than one gateway event (e.g. a contract depositing to multiple accounts in a single PTB). Previously a hard guard rejected any event whose `EventIndex` was non-zero, which silently skipped all but the first event in such transactions.

- Removes the `event.EventIndex != 0` early-return in `processInboundEvent`, allowing every gateway event in a transaction to be parsed, validated, and voted on independently using its own `EventIndex`.
- Adds test coverage for the block-scan (`ObserveInbound`) and recovery (`ProcessInboundTrackers`) paths, verifying that two distinct inbound votes are produced with the correct receiver, amount, and event index for a two-event transaction.
- Introduces `SampleEventWithSeq` test helper to construct mock events with an arbitrary sequence number.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is focused, cursor advancement and vote idempotency are handled correctly, and both recovery paths are covered by tests.

The production change is a five-line deletion of a guard that blocked multi-event transactions. Cursor management, compliance skipping, and errTxNotFound/errVoteInbound retry semantics all continue to work correctly for the multi-event case. The one non-critical concern is that the block-scan path issues a redundant SuiGetTransactionBlock call per event for the same digest; the test even hard-codes two identical OnGetTx registrations for the same hash, confirming the behaviour is present but benign at current scale.

No files require special attention; inbound.go is the only production change and it is small and well-tested.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| zetaclient/chains/sui/observer/inbound.go | Removes the guard that rejected events with EventIndex != 0, enabling correct processing of multiple gateway events per transaction in both block-scan and tracker paths. |
| zetaclient/chains/sui/observer/observer_test.go | Adds two new integration-style test cases for multi-event transactions covering both ObserveInbound and ProcessInboundTrackers, and introduces SampleEventWithSeq helper to construct events with a configurable sequence number. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Observer
    participant SuiRPC
    participant ZetaCore

    Note over Observer: Block-scan path (ObserveInbound)
    Observer->>SuiRPC: QueryModuleEvents(cursor)
    SuiRPC-->>Observer: "[Event{TxA, seq=0}, Event{TxA, seq=1}, ...]"

    loop for each event
        Observer->>SuiRPC: SuiGetTransactionBlock(TxA)
        SuiRPC-->>Observer: tx (checkpoint, effects)
        Observer->>ZetaCore: "VoteInbound(TxA, EventIndex=N)"
        Observer->>Observer: setCursor(packageID, event.Id)
    end

    Note over Observer: Tracker path (ProcessInboundTrackers)
    Observer->>SuiRPC: "SuiGetTransactionBlock(TxA, ShowEvents=true)"
    SuiRPC-->>Observer: "tx with Events[seq=0, seq=1]"

    loop for each tx.Event
        Observer->>ZetaCore: "VoteInbound(TxA, EventIndex=N)"
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `zetaclient/chains/sui/observer/inbound.go`, line 73-102 ([link](https://github.com/zeta-chain/node/blob/914c6f6c9e00503ea2a8c707d60a4d958a15c237/zetaclient/chains/sui/observer/inbound.go#L73-L102)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicate RPC call per event for same tx in block-scan path**

   When a single transaction emits N gateway events, `observeGatewayInbound` will call `SuiGetTransactionBlock` once per event (N times in total), even though all events share the same `TxDigest`. The test explicitly registers `OnGetTx` twice for the same hash (`ts.OnGetTx(txHash, "10000", true, false, nil)` × 2) confirming the current behavior.

   Under normal operation this is just wasteful, but it becomes a concern at scale when the same tx produces many events and the RPC node is rate-limited or has latency. Consider caching the fetched `*models.SuiTransactionBlockResponse` by `TxDigest` within the scan loop (a simple `map[string]*tx` is enough) and passing the cached value to `processInboundEvent` on subsequent events for the same digest.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: zetaclient/chains/sui/observer/inbound.go
   Line: 73-102

   Comment:
   **Duplicate RPC call per event for same tx in block-scan path**

   When a single transaction emits N gateway events, `observeGatewayInbound` will call `SuiGetTransactionBlock` once per event (N times in total), even though all events share the same `TxDigest`. The test explicitly registers `OnGetTx` twice for the same hash (`ts.OnGetTx(txHash, "10000", true, false, nil)` × 2) confirming the current behavior.

   Under normal operation this is just wasteful, but it becomes a concern at scale when the same tx produces many events and the RPC node is rate-limited or has latency. Consider caching the fetched `*models.SuiTransactionBlockResponse` by `TxDigest` within the scan loop (a simple `map[string]*tx` is enough) and passing the cached value to `processInboundEvent` on subsequent events for the same digest.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
zetaclient/chains/sui/observer/inbound.go:73-102
**Duplicate RPC call per event for same tx in block-scan path**

When a single transaction emits N gateway events, `observeGatewayInbound` will call `SuiGetTransactionBlock` once per event (N times in total), even though all events share the same `TxDigest`. The test explicitly registers `OnGetTx` twice for the same hash (`ts.OnGetTx(txHash, "10000", true, false, nil)` × 2) confirming the current behavior.

Under normal operation this is just wasteful, but it becomes a concern at scale when the same tx produces many events and the RPC node is rate-limited or has latency. Consider caching the fetched `*models.SuiTransactionBlockResponse` by `TxDigest` within the scan loop (a simple `map[string]*tx` is enough) and passing the cached value to `processInboundEvent` on subsequent events for the same digest.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sui): process multiple gateway event..."](https://github.com/zeta-chain/node/commit/914c6f6c9e00503ea2a8c707d60a4d958a15c237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32000866)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized inbound event processing for the Sui chain by implementing per-scan transaction caching, reducing redundant RPC calls when multiple events reference the same transaction.

* **Tests**
  * Expanded test coverage to verify proper handling of multiple gateway events within a single transaction on the Sui chain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeta-chain/node/pull/4596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->