### PR TITLE
fix(zetaclient): respect DisableTssBlockScan in Bitcoin observer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * [4557](https://github.com/zeta-chain/node/pull/4557) - reject Solana transactions with nil metadata instead of treating as successful
 * [4561](https://github.com/zeta-chain/node/pull/4561) - add signet to BTC client `resolveParams` to fix e2e `unknown chain params` error
 * [4569](https://github.com/zeta-chain/node/pull/4569) - tighten MtA proof bounds in tss-lib to fix Alpha-Rays / TSSHOCK vulnerability
+* [4597](https://github.com/zeta-chain/node/pull/4597) - respect `DisableTssBlockScan` in Bitcoin observer to align inbound observation behavior with EVM observer
 
 ### Tests
 

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -26,6 +26,13 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		return err
 	}
 
+	// Bitcoin's only inbound mechanism is direct transfers to the TSS address.
+	// When DisableTssBlockScan is true, skip all inbound scanning so new deposits
+	// are not observed (outbound/withdrawal processing is unaffected).
+	if ob.ChainParams().DisableTssBlockScan {
+		return nil
+	}
+
 	// get fee rate multiplier
 	feeRateMultiplier, err := ob.ChainParams().GasPriceMultiplier.Float64()
 	if err != nil {

--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -30,6 +30,7 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 	// When DisableTssBlockScan is true, skip all inbound scanning so new deposits
 	// are not observed (outbound/withdrawal processing is unaffected).
 	if ob.ChainParams().DisableTssBlockScan {
+		ob.Logger().Sampled.Info().Msg("skip inbound observation: DisableTssBlockScan is true")
 		return nil
 	}
 

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -143,6 +143,22 @@ func TestAvgFeeRateBlock828440Errors(t *testing.T) {
 	})
 }
 
+func Test_ObserveInbound_DisableTssBlockScan(t *testing.T) {
+	chain := chains.BitcoinMainnet
+	ob := newTestSuite(t, chain)
+
+	// flip the chain param to disable inbound scanning
+	chainParams := ob.ChainParams()
+	chainParams.DisableTssBlockScan = true
+	ob.SetChainParams(chainParams)
+
+	// ObserveInbound should return early without scanning any block.
+	// We intentionally do NOT mock GetBlockHash/GetBlockVerbose — if scanning
+	// were attempted, the mock client would fail the test on unexpected calls.
+	err := ob.ObserveInbound(ob.ctx)
+	require.NoError(t, err)
+}
+
 func Test_GetInboundVoteFromBtcEvent(t *testing.T) {
 	r := sample.Rand()
 

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -159,6 +159,27 @@ func Test_ObserveInbound_DisableTssBlockScan(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_ObserveInboundTrackers_DisableTssBlockScan(t *testing.T) {
+	chain := chains.BitcoinMainnet
+	ob := newTestSuite(t, chain)
+
+	chainParams := ob.ChainParams()
+	chainParams.DisableTssBlockScan = true
+	ob.SetChainParams(chainParams)
+
+	// Even with trackers present, observeInboundTrackers should return early.
+	// We intentionally do NOT mock GetRawTransactionVerbose/GetBlockVerbose —
+	// if processing were attempted, the mock client would fail on unexpected calls.
+	trackers := []crosschaintypes.InboundTracker{
+		{ChainId: chain.ChainId, TxHash: "abc"},
+	}
+	err := ob.observeInboundTrackers(ob.ctx, trackers, false)
+	require.NoError(t, err)
+
+	err = ob.observeInboundTrackers(ob.ctx, trackers, true)
+	require.NoError(t, err)
+}
+
 func Test_GetInboundVoteFromBtcEvent(t *testing.T) {
 	r := sample.Rand()
 

--- a/zetaclient/chains/bitcoin/observer/inbound_tracker.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_tracker.go
@@ -48,6 +48,10 @@ func (ob *Observer) observeInboundTrackers(
 	// deposits referenced by external or internal trackers are not voted on
 	// (outbound/withdrawal processing is unaffected).
 	if ob.ChainParams().DisableTssBlockScan {
+		ob.Logger().Sampled.Info().
+			Bool("is_internal", isInternal).
+			Int("tracker_count", len(trackers)).
+			Msg("skip inbound tracker processing: DisableTssBlockScan is true")
 		return nil
 	}
 

--- a/zetaclient/chains/bitcoin/observer/inbound_tracker.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_tracker.go
@@ -43,6 +43,14 @@ func (ob *Observer) observeInboundTrackers(
 	trackers []types.InboundTracker,
 	isInternal bool,
 ) error {
+	// Bitcoin's only inbound mechanism is direct transfers to the TSS address.
+	// When DisableTssBlockScan is true, skip inbound tracker processing so new
+	// deposits referenced by external or internal trackers are not voted on
+	// (outbound/withdrawal processing is unaffected).
+	if ob.ChainParams().DisableTssBlockScan {
+		return nil
+	}
+
 	// take at most MaxInternalTrackersPerScan for each scan
 	if len(trackers) > config.MaxInboundTrackersPerScan {
 		trackers = trackers[:config.MaxInboundTrackersPerScan]


### PR DESCRIPTION
# Description

Align the Bitcoin observer with the EVM observer (zetaclient/chains/evm/observer/inbound.go:190), which already honors ChainParams.DisableTssBlockScan to skip TSS-address block scanning.

Bitcoin's only inbound mechanism is direct transfers to the TSS address, so this flag effectively provides operators a per-chain inbound observation pause for Bitcoin, with no effect on the outbound/withdrawal flow.

Notes:
- updateLastBlock still runs so node health monitoring is unaffected
- LastBlockScanned does not advance while the flag is true; flipping it back to false will resume scanning from the last scanned block (re-scanning the pause window)
- Toggling this flag requires coordinated zetaclient rollout across observers to avoid ballot finalization issues during the rollout window

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Bitcoin inbound processing behavior by short-circuiting both block scanning and tracker-based voting when `DisableTssBlockScan` is enabled; misconfiguration could pause deposit observation and delay inbound finalization.
> 
> **Overview**
> Bitcoin observer now **respects `ChainParams.DisableTssBlockScan`** by returning early from `ObserveInbound` (after `updateLastBlock`) and from `observeInboundTrackers`, effectively pausing all inbound deposit detection/voting while leaving outbound processing untouched.
> 
> Adds unit tests asserting that enabling the flag results in no RPC scanning/processing calls for both block-range scanning and inbound-tracker handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f011b7aa66c9a42fd0fe478c493a3fc3bf229ad4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the Bitcoin observer with the EVM observer by honoring `ChainParams.DisableTssBlockScan`, short-circuiting `ObserveInbound` (after `updateLastBlock`) and `observeInboundTrackers` when the flag is set. Since Bitcoin's only inbound mechanism is direct TSS transfers, the flag acts as a full per-chain inbound pause without touching outbound/withdrawal processing.

- **`inbound.go`**: Guard is placed after `updateLastBlock` so chain-tip health monitoring continues; `LastBlockScanned` does not advance while paused, enabling clean resume-from-last-scanned when the flag is cleared.
- **`inbound_tracker.go`**: Both external (`ProcessInboundTrackers`) and internal (`ProcessInternalTrackers`) tracker paths respect the flag, preventing ballot submission for any tracker discovered during the pause window.
- **`inbound_test.go`**: Two negative-pattern unit tests confirm no RPC scanning or voting occurs when the flag is enabled; the testify mock client would panic on any unexpected call, making the guard genuinely enforced by the test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard is correctly placed after health-monitoring, logging is in place, and tests enforce the early-return path.

The change is a targeted, well-scoped guard that mirrors existing EVM observer behavior. The flag position (after updateLastBlock, before any scanning) is correct, the sampled log makes the skip observable in production, and the unit tests use testify mock panics to enforce that no RPC calls are made when the flag is active. No existing code paths are modified; the only risk is the operational concern already documented in the PR description about coordinated rollout.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/bitcoin/observer/inbound.go | Adds a DisableTssBlockScan guard after updateLastBlock in ObserveInbound, correctly mirroring the EVM observer pattern while using a sampled logger to signal the skip. |
| zetaclient/chains/bitcoin/observer/inbound_tracker.go | Adds a DisableTssBlockScan guard at the top of observeInboundTrackers, halting both external and internal tracker voting when the flag is set; logs include tracker_count and is_internal for observability. |
| zetaclient/chains/bitcoin/observer/inbound_test.go | Adds two unit tests verifying early-return behavior when DisableTssBlockScan is true; newTestSuite already mocks GetBlockCount so updateLastBlock succeeds, and unmocked RPC methods would panic on unexpected calls — an effective negative-test pattern. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ObserveInbound called] --> B[updateLastBlock\nhealth monitoring continues]
    B --> C{DisableTssBlockScan?}
    C -- true --> D[Log sampled info\nreturn nil]
    C -- false --> E[Fetch fee rate\nGet scan ranges]
    E --> F[observeInboundInBlockRange\nSafe blocks]
    F --> G[SaveLastBlockScanned]
    E --> H[observeInboundInBlockRange\nFast blocks]

    I[ProcessInboundTrackers called] --> J[GetInboundTrackers from ZetaRepo]
    J --> K[observeInboundTrackers\nisInternal=false]
    K --> L{DisableTssBlockScan?}
    L -- true --> M[Log sampled info\nreturn nil]
    L -- false --> N[CheckReceiptAndPostVoteForBtcTxHash\nfor each tracker]

    O[ProcessInternalTrackers called] --> P[GetInboundInternalTrackers]
    P --> Q[observeInboundTrackers\nisInternal=true]
    Q --> L
```

<sub>Reviews (2): Last reviewed commit: ["changelog"](https://github.com/zeta-chain/node/commit/0afb07ebede0d647d8a8fc8d2c0f4631f3c04a41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32719725)</sub>

<!-- /greptile_comment -->