### PR TITLE
fix(zetaclient): backport respect DisableTssBlockScan in Bitcoin observer 

### DIFF
--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -30,6 +30,14 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		return err
 	}
 
+	// Bitcoin's only inbound mechanism is direct transfers to the TSS address.
+	// When DisableTssBlockScan is true, skip all inbound scanning so new deposits
+	// are not observed (outbound/withdrawal processing is unaffected).
+	if ob.ChainParams().DisableTssBlockScan {
+		ob.Logger().Sampled.Info().Msg("skip inbound observation: DisableTssBlockScan is true")
+		return nil
+	}
+
 	// scan SAFE confirmed blocks
 	startBlockSafe, endBlockSafe := ob.GetScanRangeInboundSafe(config.MaxBlocksPerScan)
 	if startBlockSafe < endBlockSafe {

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -148,6 +148,43 @@ func TestAvgFeeRateBlock828440Errors(t *testing.T) {
 	})
 }
 
+func Test_ObserveInbound_DisableTssBlockScan(t *testing.T) {
+	chain := chains.BitcoinMainnet
+	ob := newTestSuite(t, chain)
+
+	// flip the chain param to disable inbound scanning
+	chainParams := ob.ChainParams()
+	chainParams.DisableTssBlockScan = true
+	ob.SetChainParams(chainParams)
+
+	// ObserveInbound should return early without scanning any block.
+	// We intentionally do NOT mock GetBlockHash/GetBlockVerbose — if scanning
+	// were attempted, the mock client would fail the test on unexpected calls.
+	err := ob.ObserveInbound(ob.ctx)
+	require.NoError(t, err)
+}
+
+func Test_ObserveInboundTrackers_DisableTssBlockScan(t *testing.T) {
+	chain := chains.BitcoinMainnet
+	ob := newTestSuite(t, chain)
+
+	chainParams := ob.ChainParams()
+	chainParams.DisableTssBlockScan = true
+	ob.SetChainParams(chainParams)
+
+	// Even with trackers present, observeInboundTrackers should return early.
+	// We intentionally do NOT mock GetRawTransactionVerbose/GetBlockVerbose —
+	// if processing were attempted, the mock client would fail on unexpected calls.
+	trackers := []crosschaintypes.InboundTracker{
+		{ChainId: chain.ChainId, TxHash: "abc"},
+	}
+	err := ob.observeInboundTrackers(ob.ctx, trackers, false)
+	require.NoError(t, err)
+
+	err = ob.observeInboundTrackers(ob.ctx, trackers, true)
+	require.NoError(t, err)
+}
+
 func Test_GetInboundVoteFromBtcEvent(t *testing.T) {
 	r := sample.Rand()
 

--- a/zetaclient/chains/bitcoin/observer/inbound_tracker.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_tracker.go
@@ -43,6 +43,18 @@ func (ob *Observer) observeInboundTrackers(
 	trackers []types.InboundTracker,
 	isInternal bool,
 ) error {
+	// Bitcoin's only inbound mechanism is direct transfers to the TSS address.
+	// When DisableTssBlockScan is true, skip inbound tracker processing so new
+	// deposits referenced by external or internal trackers are not voted on
+	// (outbound/withdrawal processing is unaffected).
+	if ob.ChainParams().DisableTssBlockScan {
+		ob.Logger().Sampled.Info().
+			Bool("is_internal", isInternal).
+			Int("tracker_count", len(trackers)).
+			Msg("skip inbound tracker processing: DisableTssBlockScan is true")
+		return nil
+	}
+
 	// take at most MaxInternalTrackersPerScan for each scan
 	if len(trackers) > config.MaxInboundTrackersPerScan {
 		trackers = trackers[:config.MaxInboundTrackersPerScan]


### PR DESCRIPTION
original PR https://github.com/zeta-chain/node/pull/4597
# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes to conditionally suppress Bitcoin inbound detection and voting; a mis-set `DisableTssBlockScan` could cause missed deposits, though it is gated behind an explicit chain parameter flag.
> 
> **Overview**
> **Respects `DisableTssBlockScan` in the Bitcoin observer.** When this chain parameter is enabled, `ObserveInbound` now returns early and performs no block-range inbound scanning.
> 
> Inbound tracker processing (`observeInboundTrackers`) is also short-circuited under the same flag (with additional sampled logging), preventing votes on tracker-referenced deposits. Unit tests were added to ensure both paths return without attempting any Bitcoin RPC calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a7597d77ad708f0dddccbd261fc4aec5450cb9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `DisableTssBlockScan` guard to the Bitcoin observer's inbound scanning path, mirroring the check that already exists in the EVM observer. Since Bitcoin has no smart-contract-based inbounds — all deposits go directly to the TSS address — the flag correctly short-circuits the entire inbound observation loop rather than just part of it.

- `inbound.go`: Early return after `updateLastBlock` when `DisableTssBlockScan` is set, so the chain-tip pointer stays fresh but block scanning stops.
- `inbound_tracker.go`: Same guard added to `observeInboundTrackers`, preventing both external and internal tracker votes from being processed.
- `inbound_test.go`: Two focused unit tests verify the early-return paths without requiring any RPC mock setup for the scan operations.

<h3>Confidence Score: 5/5</h3>

The change is a narrow, additive guard; it cannot break existing scan paths and has direct test coverage.

Both changed functions gain a clear early-return guarded by the existing chain parameter, with no mutation to downstream logic. The updateLastBlock call is preserved before the guard in ObserveInbound, keeping chain-tip tracking alive even when scanning is disabled, which is the correct trade-off for a clean resume once the flag is cleared. Tests confirm no RPC calls are made when the flag is set.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/bitcoin/observer/inbound.go | Adds DisableTssBlockScan early-return after updateLastBlock; placement is correct and consistent with keeping chain-tip tracking alive. |
| zetaclient/chains/bitcoin/observer/inbound_tracker.go | Adds DisableTssBlockScan guard to observeInboundTrackers, correctly skipping both external and internal tracker voting with structured logging. |
| zetaclient/chains/bitcoin/observer/inbound_test.go | Two new tests cover the early-return behaviour for ObserveInbound and observeInboundTrackers; GetBlockCount is safely handled by the existing Maybe() mock in newTestSuite. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ObserveInbound called] --> B[updateLastBlock]
    B --> C{DisableTssBlockScan?}
    C -- Yes --> D[log sampled info & return nil]
    C -- No --> E[GetScanRangeInboundSafe]
    E --> F[observeInboundInBlockRange SAFE]
    F --> G[SaveLastBlockScanned]
    G --> H[GetScanRangeInboundFast]
    H --> I[observeInboundInBlockRange FAST]
    I --> J[return nil]

    K[ProcessInboundTrackers / ProcessInternalTrackers] --> L[observeInboundTrackers]
    L --> M{DisableTssBlockScan?}
    M -- Yes --> N[log sampled info & return nil]
    M -- No --> O[truncate trackers at MaxInboundTrackersPerScan]
    O --> P[CheckReceiptAndPostVoteForBtcTxHash per tracker]
    P --> Q[return nil]
```

<sub>Reviews (1): Last reviewed commit: ["fix(zetaclient): respect DisableTssBlock..."](https://github.com/zeta-chain/node/commit/92a7597d77ad708f0dddccbd261fc4aec5450cb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32928521)</sub>

<!-- /greptile_comment -->