### PR TITLE
fix(zetaclient): backport respect DisableTssBlockScan in Bitcoin observer

### DIFF
--- a/zetaclient/chains/bitcoin/observer/inbound.go
+++ b/zetaclient/chains/bitcoin/observer/inbound.go
@@ -28,6 +28,14 @@ func (ob *Observer) ObserveInbound(ctx context.Context) error {
 		return err
 	}
 
+	// Bitcoin's only inbound mechanism is direct transfers to the TSS address.
+	// When DisableTssBlockScan is true, skip all inbound scanning so new deposits
+	// are not observed (outbound/withdrawal processing is unaffected).
+	if ob.ChainParams().DisableTssBlockScan {
+		ob.Logger().Sampled.Info().Msg("skip inbound observation: DisableTssBlockScan is true")
+		return nil
+	}
+
 	// get fee rate multiplier
 	feeRateMultiplier, err := ob.ChainParams().GasPriceMultiplier.Float64()
 	if err != nil {

--- a/zetaclient/chains/bitcoin/observer/inbound_test.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_test.go
@@ -146,6 +146,43 @@ func TestAvgFeeRateBlock828440Errors(t *testing.T) {
 	})
 }
 
+func Test_ObserveInbound_DisableTssBlockScan(t *testing.T) {
+	chain := chains.BitcoinMainnet
+	ob := newTestSuite(t, chain)
+
+	// flip the chain param to disable inbound scanning
+	chainParams := ob.ChainParams()
+	chainParams.DisableTssBlockScan = true
+	ob.SetChainParams(chainParams)
+
+	// ObserveInbound should return early without scanning any block.
+	// We intentionally do NOT mock GetBlockHash/GetBlockVerbose — if scanning
+	// were attempted, the mock client would fail the test on unexpected calls.
+	err := ob.ObserveInbound(ob.ctx)
+	require.NoError(t, err)
+}
+
+func Test_ObserveInboundTrackers_DisableTssBlockScan(t *testing.T) {
+	chain := chains.BitcoinMainnet
+	ob := newTestSuite(t, chain)
+
+	chainParams := ob.ChainParams()
+	chainParams.DisableTssBlockScan = true
+	ob.SetChainParams(chainParams)
+
+	// Even with trackers present, observeInboundTrackers should return early.
+	// We intentionally do NOT mock GetRawTransactionVerbose/GetBlockVerbose —
+	// if processing were attempted, the mock client would fail on unexpected calls.
+	trackers := []crosschaintypes.InboundTracker{
+		{ChainId: chain.ChainId, TxHash: "abc"},
+	}
+	err := ob.observeInboundTrackers(ob.ctx, trackers, false)
+	require.NoError(t, err)
+
+	err = ob.observeInboundTrackers(ob.ctx, trackers, true)
+	require.NoError(t, err)
+}
+
 func Test_GetInboundVoteFromBtcEvent(t *testing.T) {
 	r := sample.Rand()
 

--- a/zetaclient/chains/bitcoin/observer/inbound_tracker.go
+++ b/zetaclient/chains/bitcoin/observer/inbound_tracker.go
@@ -43,6 +43,18 @@ func (ob *Observer) observeInboundTrackers(
 	trackers []types.InboundTracker,
 	isInternal bool,
 ) error {
+	// Bitcoin's only inbound mechanism is direct transfers to the TSS address.
+	// When DisableTssBlockScan is true, skip inbound tracker processing so new
+	// deposits referenced by external or internal trackers are not voted on
+	// (outbound/withdrawal processing is unaffected).
+	if ob.ChainParams().DisableTssBlockScan {
+		ob.Logger().Sampled.Info().
+			Bool("is_internal", isInternal).
+			Int("tracker_count", len(trackers)).
+			Msg("skip inbound tracker processing: DisableTssBlockScan is true")
+		return nil
+	}
+
 	// take at most MaxInternalTrackersPerScan for each scan
 	if len(trackers) > config.MaxInboundTrackersPerScan {
 		trackers = trackers[:config.MaxInboundTrackersPerScan]


### PR DESCRIPTION
original PR https://github.com/zeta-chain/node/pull/4597

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [ ] Go unit tests
- [ ] Go integration tests
- [ ] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When `DisableTssBlockScan` is enabled, Bitcoin inbound deposits will no longer be observed/voted on (by design), so misconfiguration could halt deposit processing; changes are otherwise localized with added unit coverage.
> 
> **Overview**
> **Respects `DisableTssBlockScan` for Bitcoin inbound handling.** The Bitcoin observer now returns early from both `ObserveInbound` block-range scanning and `observeInboundTrackers` processing when `ChainParams.DisableTssBlockScan` is true, emitting sampled info logs.
> 
> Adds unit tests asserting that with the flag enabled, neither block scanning nor inbound-tracker processing attempts any Bitcoin RPC calls and the methods exit cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b718ef2e0816a4c96edd6b483d93f99352650df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the `DisableTssBlockScan` guard from the EVM observer to the Bitcoin observer, ensuring that when the flag is set both `ObserveInbound` and `observeInboundTrackers` return early without scanning or voting on inbound transactions.

- `inbound.go`: guard is inserted after `updateLastBlock` (preserving block-height tracking) but before any scanning, matching the intent of the flag.
- `inbound_tracker.go`: guard is inserted at the top of `observeInboundTrackers`, covering both external (`ProcessInboundTrackers`) and internal (`ProcessInternalTrackers`) tracker paths via the shared helper.
- `inbound_test.go`: two new tests confirm the early-return behaviour by relying on testify mock's strict unexpected-call detection.

<h3>Confidence Score: 4/5</h3>

The change is a targeted, minimal flag-check insertion with no impact on outbound processing; safe to merge.

Both guard locations are correct and the logic is straightforward. The only gap is that the public callers ProcessInboundTrackers and ProcessInternalTrackers still perform preliminary network/state work before the guard is reached inside observeInboundTrackers, and neither is covered by a dedicated test. This is a minor quality concern rather than a functional defect.

zetaclient/chains/bitcoin/observer/inbound_test.go — the tests exercise observeInboundTrackers directly but do not cover the public ProcessInboundTrackers and ProcessInternalTrackers entry-points.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/chains/bitcoin/observer/inbound.go | Adds an early-return guard for DisableTssBlockScan after updateLastBlock; consistent with existing EVM pattern |
| zetaclient/chains/bitcoin/observer/inbound_tracker.go | Adds DisableTssBlockScan guard at the top of observeInboundTrackers; covers both external and internal tracker paths |
| zetaclient/chains/bitcoin/observer/inbound_test.go | Adds two tests verifying early-return behaviour; relies on testify mock's strict-call detection but ProcessInboundTrackers/ProcessInternalTrackers callers are not covered |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Scheduler
    participant Observer

    Note over Scheduler,Observer: ObserveInbound path
    Scheduler->>Observer: ObserveInbound(ctx)
    Observer->>Observer: updateLastBlock(ctx)
    alt "DisableTssBlockScan == true"
        Observer-->>Scheduler: return nil (early exit)
    else "DisableTssBlockScan == false"
        Observer->>Observer: observeInboundInBlockRange(...)
        Observer-->>Scheduler: return nil
    end

    Note over Scheduler,Observer: ProcessInboundTrackers path
    Scheduler->>Observer: ProcessInboundTrackers(ctx)
    Observer->>Observer: GetInboundTrackers(ctx)
    Observer->>Observer: observeInboundTrackers(ctx, trackers, false)
    alt "DisableTssBlockScan == true"
        Observer-->>Scheduler: return nil (early exit)
    else "DisableTssBlockScan == false"
        Observer->>Observer: CheckReceiptAndPostVoteForBtcTxHash(...)
        Observer-->>Scheduler: return nil
    end

    Note over Scheduler,Observer: ProcessInternalTrackers path
    Scheduler->>Observer: ProcessInternalTrackers(ctx)
    Observer->>Observer: GetInboundInternalTrackers(ctx)
    Observer->>Observer: observeInboundTrackers(ctx, trackers, true)
    alt "DisableTssBlockScan == true"
        Observer-->>Scheduler: return nil (early exit)
    else "DisableTssBlockScan == false"
        Observer->>Observer: CheckReceiptAndPostVoteForBtcTxHash(...)
        Observer-->>Scheduler: return nil
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
zetaclient/chains/bitcoin/observer/inbound_test.go:149-163
**Test does not cover public callers (`ProcessInboundTrackers` / `ProcessInternalTrackers`)**

The guard lives inside `observeInboundTrackers`, but `ProcessInboundTrackers` still calls `ob.ZetaRepo().GetInboundTrackers(ctx)` and `ProcessInternalTrackers` still calls `ob.GetInboundInternalTrackers` before reaching the guard. Those callers are the ones actually triggered by the scheduler, yet neither is covered by a test here. A test for each public entry-point would confirm the full intended behaviour (and would also catch any future guard-bypass regression if the guard is accidentally moved or removed in a refactor).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(zetaclient): respect DisableTssBlock..."](https://github.com/zeta-chain/node/commit/3b718ef2e0816a4c96edd6b483d93f99352650df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32928570)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->