### PR TITLE
chore(zetaclient): demote ChainParams enumeration noise to debug

### DIFF
--- a/zetaclient/context/app.go
+++ b/zetaclient/context/app.go
@@ -250,10 +250,12 @@ func (a *AppContext) updateChainRegistry(
 			Msg("chain list changed at the runtime")
 	}
 
-	// Log warn if somehow chain doesn't chainParam
+	// Log if a chain in the registry lacks chainParams. Debug-level because this
+	// fires on every UpdateAppContext tick for every such chain — high-volume
+	// enumeration noise, not an actionable warning.
 	for _, chainID := range freshChainIDs {
 		if _, ok := freshChainParams[chainID]; !ok && !isZeta(chainID) {
-			a.logger.Warn().
+			a.logger.Debug().
 				Int64("chain_id", chainID).
 				Msg("chain does not have according ChainParams present; skipping")
 		}

--- a/zetaclient/orchestrator/contextupdater.go
+++ b/zetaclient/orchestrator/contextupdater.go
@@ -88,7 +88,10 @@ func UpdateAppContext(ctx context.Context, app *zctx.AppContext, zc ZetacoreClie
 		cp := chainParams[i]
 
 		if !cp.IsSupported {
-			logger.Warn().
+			// Debug-level: this fires every UpdateAppContext tick for every
+			// unsupported chain in the registry — pure config-driven enumeration,
+			// not an actionable warning.
+			logger.Debug().
 				Int64(logs.FieldChain, cp.ChainId).
 				Msg("skipping unsupported chain")
 			continue


### PR DESCRIPTION
## Summary
- Demote two log lines from `Warn` to `Debug`:
  - `skipping unsupported chain` (`zetaclient/orchestrator/contextupdater.go`)
  - `chain does not have according ChainParams present; skipping` (`zetaclient/context/app.go`)

## Why
Both fire on every `UpdateAppContext` tick for every chain in the registry — config-driven enumeration over a mostly-static chain list, not runtime warnings. In Datadog over the last 7d these accounted for ~4M warn lines/wk across the fleet (`skipping unsupported chain` alone: 3,103/day per client). Real `Warn`s in this code path are preserved: chain list changes at runtime, deleted chains, invalid chain params with an error, mempool congestion.

## Test plan
- [x] `go test ./zetaclient/context/... ./zetaclient/orchestrator/...` — all pass
- [x] `go build ./zetaclient/...`
- [ ] After merge & deploy: confirm `service:zetaclientd status:warn @msg:"skipping unsupported chain"` drops to ~0 in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no behavior or control-flow impact; operational alerts that still use Warn remain in place.
> 
> **Overview**
> Reduces **zetaclient** log noise by demoting two recurring enumeration messages from **`Warn`** to **`Debug`**: `skipping unsupported chain` in `contextupdater.go` and `chain does not have according ChainParams present; skipping` in `app.go`.
> 
> Both run on every **`UpdateAppContext`** tick for chains that are expected to be skipped (unsupported or missing params), so they were inflating fleet warn volume without signaling new failures. Comments document that intent; **real** warns in this path (runtime chain list changes, deleted chains, invalid chain params, mempool congestion) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c9bf40156e742a7e1745d2602822ef770feb88. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging severity for chain parameter and unsupported chain enumeration events during update cycles to reduce log verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR demotes two log lines from `Warn` to `Debug` level in the zetaclient's chain-params enumeration path to reduce high-volume log noise in production. The change is well-scoped and preserves all actionable `Warn`-level logs in the same code paths.

- In `zetaclient/orchestrator/contextupdater.go`, the `"skipping unsupported chain"` message is demoted to `Debug` since it fires on every `UpdateAppContext` tick for each unsupported chain in the registry.
- In `zetaclient/context/app.go`, the `"chain does not have according ChainParams present; skipping"` message is similarly demoted; genuine runtime warnings (chain list changes, invalid params with errors) remain at `Warn`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only changes are log level demotions with no effect on business logic or control flow.

Both changed lines are pure observability adjustments: `.Warn()` becomes `.Debug()` with no surrounding logic touched. Actionable warnings in the same code paths (chain list runtime changes, invalid param validation errors) remain at `Warn`. The added comments accurately explain the rationale.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/orchestrator/contextupdater.go | Demotes `"skipping unsupported chain"` from Warn to Debug with an explanatory comment; no logic changes. |
| zetaclient/context/app.go | Demotes `"chain does not have according ChainParams present; skipping"` from Warn to Debug with an explanatory comment; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UpdateAppContext tick] --> B[Fetch chainParams from ZetaCore]
    B --> C{For each ChainParam}
    C --> D{IsSupported?}
    D -- No --> E[logger.Debug: 'skipping unsupported chain']
    D -- Yes --> F{IsZetaChain?}
    E --> C
    F -- Yes --> C
    F -- No --> G{Validate params}
    G -- Error --> H[logger.Warn: 'skipping invalid chain parameters']
    G -- OK --> I[Add to freshParams]
    H --> C
    I --> C
    C --> J[updateChainRegistry]
    J --> K{Chain list changed?}
    K -- Yes --> L[logger.Warn: 'chain list changed at runtime']
    K --> M{Each chain has ChainParams?}
    M -- Missing & not Zeta --> N[logger.Debug: 'chain does not have ChainParams; skipping']
    M --> O[Update registry]
```

<sub>Reviews (1): Last reviewed commit: ["chore(zetaclient): demote ChainParams en..."](https://github.com/zeta-chain/node/commit/a0c9bf40156e742a7e1745d2602822ef770feb88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36323377)</sub>

<!-- /greptile_comment -->