### PR TITLE
feat(snapshot): add ZETA snapshot tooling (state export + per-address balance compute)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ download-snapshot:
 	@echo "--> Downloading and caching snapshot..."
 	@python3 contrib/localnet/scripts_python/download_snapshot.py --chain-id $(or $(CHAIN_ID),athens_7001-1) --force
 
+snapshot-export:
+	@echo "--> Exporting $(or $(NETWORK),testnet) snapshot..."
+	@python3 contrib/snapshot/export_snapshot.py --network $(or $(NETWORK),testnet) $(SNAPSHOT_EXPORT_ARGS)
+
 ###############################################################################
 ###                                 Linting            	                    ###
 ###############################################################################

--- a/cmd/zetatool/cli/snapshot.go
+++ b/cmd/zetatool/cli/snapshot.go
@@ -166,8 +166,9 @@ func readPinFile(path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read pin file %q: %w", path, err)
 	}
-	var pins []string
-	for _, line := range strings.Split(string(raw), "\n") {
+	lines := strings.Split(string(raw), "\n")
+	pins := make([]string, 0, len(lines))
+	for _, line := range lines {
 		if i := strings.Index(line, "#"); i >= 0 {
 			line = line[:i]
 		}

--- a/cmd/zetatool/cli/snapshot.go
+++ b/cmd/zetatool/cli/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ const (
 	flagSnapshotOutput      = "output"
 	flagSnapshotChainID     = "chain-id"
 	flagSnapshotPin         = "pin"
+	flagSnapshotPinFile     = "pin-file"
 	flagSnapshotWZeta       = "wzeta"
 	flagSnapshotSupplyCheck = "supply-check"
 
@@ -58,7 +60,9 @@ Outputs into --output:
 	cmd.Flags().
 		StringSlice(flagSnapshotPin, nil, "non-claimable addresses routed to the remainder (repeatable or comma-separated)")
 	cmd.Flags().StringSlice(flagSnapshotWZeta, nil, "alias for --pin: non-claimable contract addresses (e.g. WZETA)")
-	cmd.Flags().Bool(flagSnapshotSupplyCheck, true, "fail on any supply-check mismatch")
+	cmd.Flags().
+		String(flagSnapshotPinFile, "", "file of non-claimable addresses, one per line (# comments; first field per line is the address)")
+	cmd.Flags().Bool(flagSnapshotSupplyCheck, true, "fail on any output check (supply mismatch, unmatched pin)")
 
 	if err := cmd.MarkFlagRequired(flagSnapshotInput); err != nil {
 		panic(err)
@@ -87,9 +91,22 @@ func runSnapshot(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	pinFile, err := cmd.Flags().GetString(flagSnapshotPinFile)
+	if err != nil {
+		return err
+	}
 	supplyCheck, err := cmd.Flags().GetBool(flagSnapshotSupplyCheck)
 	if err != nil {
 		return err
+	}
+
+	pins = append(pins, wzeta...)
+	if pinFile != "" {
+		filePins, err := readPinFile(pinFile)
+		if err != nil {
+			return err
+		}
+		pins = append(pins, filePins...)
 	}
 
 	appState, err := readAppState(input)
@@ -103,7 +120,7 @@ func runSnapshot(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	cfg := snapshot.Config{Denom: snapshot.BaseDenom, Pins: append(pins, wzeta...)}
+	cfg := snapshot.Config{Denom: snapshot.BaseDenom, Pins: pins}
 	res, err := snapshot.Compute(gen, cfg)
 	if err != nil {
 		return err
@@ -137,6 +154,30 @@ func readAppState(path string) (map[string]json.RawMessage, error) {
 		return nil, fmt.Errorf("export json has no app_state")
 	}
 	return doc.AppState, nil
+}
+
+// readPinFile reads non-claimable addresses from a file, one per line, in file
+// order. `#` starts a comment and blank lines are skipped; only the first
+// whitespace-separated field of a line is read, so a TSV whose first column is
+// the address works as-is. Address validity is left to snapshot.Canonical, which
+// names the offending string.
+func readPinFile(path string) ([]string, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- operator-supplied pin file path
+	if err != nil {
+		return nil, fmt.Errorf("read pin file %q: %w", path, err)
+	}
+	var pins []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		if i := strings.Index(line, "#"); i >= 0 {
+			line = line[:i]
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		pins = append(pins, fields[0])
+	}
+	return pins, nil
 }
 
 func writeOutputs(dir string, res *snapshot.Result) error {
@@ -174,8 +215,8 @@ func writeCSV(path string, records [][]string) error {
 	return nil
 }
 
-// runChecks enforces the three supply invariants. When supplyCheck is false the
-// mismatches are reported but do not fail the command.
+// runChecks enforces the three supply invariants plus the pin-match check. When
+// supplyCheck is false the problems are reported but do not fail the command.
 func runChecks(gen *snapshot.Genesis, res *snapshot.Result, dbPath string, supplyCheck bool) error {
 	var problems []string
 
@@ -198,14 +239,23 @@ func runChecks(gen *snapshot.Genesis, res *snapshot.Result, dbPath string, suppl
 		problems = append(problems, fmt.Sprintf("csv total_azeta sum %s != supply %s", csvSum, res.Supply))
 	}
 
+	// (4) every pin matched a holder. A pin that matched nothing is a typo or a
+	// wrong-network pin file, and the books balance either way so the supply
+	// checks above cannot see it.
+	for _, p := range res.Pinned {
+		if p.Azeta.IsZero() {
+			problems = append(problems, fmt.Sprintf("pin %s matched no holder in the export", p.Canonical))
+		}
+	}
+
 	if len(problems) == 0 {
 		return nil
 	}
 	for _, p := range problems {
-		fmt.Fprintf(os.Stderr, "supply check failed: %s\n", p)
+		fmt.Fprintf(os.Stderr, "check failed: %s\n", p)
 	}
 	if supplyCheck {
-		return fmt.Errorf("%d supply check(s) failed", len(problems))
+		return fmt.Errorf("%d check(s) failed", len(problems))
 	}
 	return nil
 }
@@ -254,6 +304,15 @@ func printSummary(cmd *cobra.Command, gen *snapshot.Genesis, res *snapshot.Resul
 	fmt.Fprintf(out, "    staked:        %s\n", res.TotalStaked)
 	fmt.Fprintf(out, "    unbonding:     %s\n", res.TotalUnbonding)
 	fmt.Fprintf(out, "    remainder:     %s\n", res.Remainder)
+	if len(res.Pinned) > 0 {
+		subtotal := sdkmath.ZeroInt()
+		fmt.Fprintln(out, "  pinned (non-claimable):")
+		for _, p := range res.Pinned {
+			fmt.Fprintf(out, "    %s  %s\n", p.Canonical, p.Azeta)
+			subtotal = subtotal.Add(p.Azeta)
+		}
+		fmt.Fprintf(out, "    subtotal:      %s\n", subtotal)
+	}
 	fmt.Fprintf(out, "  total supply:    %s azeta\n", res.Supply)
 	fmt.Fprintf(out, "  SPL cap (9dec):  %s\n", res.SPLCap())
 }

--- a/cmd/zetatool/cli/snapshot.go
+++ b/cmd/zetatool/cli/snapshot.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/spf13/cobra"
+
+	"github.com/zeta-chain/node/app"
+	"github.com/zeta-chain/node/cmd/zetatool/snapshot"
+)
+
+const (
+	flagSnapshotInput       = "input"
+	flagSnapshotOutput      = "output"
+	flagSnapshotChainID     = "chain-id"
+	flagSnapshotPin         = "pin"
+	flagSnapshotWZeta       = "wzeta"
+	flagSnapshotSupplyCheck = "supply-check"
+
+	fileSnapshotDB     = "snapshot_db.csv"
+	fileSnapshotHuman  = "snapshot_human.csv"
+	fileSnapshotSchema = "schema.sql"
+
+	// column index of total_azeta in snapshot_db.csv, used to re-sum the file.
+	dbColTotalAzeta = 5
+)
+
+// NewSnapshotCMD builds the `zetatool snapshot` command: it reads a
+// `zetacored export` genesis and produces a per-address native-ZETA balance
+// list for the ZETA->Solana migration mint.
+func NewSnapshotCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Build a per-address native-ZETA balance snapshot for the Solana migration",
+		Long: `Build the ZETA->Solana migration snapshot (Stage 2) from a zetacored export.
+
+Reads the bank and staking genesis from an export produced with
+--for-zero-height (so withdrawn staking rewards and validator commission are
+already folded into liquid bank balances) and attributes native ZETA to each
+claimable address. Module accounts and any pinned contracts (e.g. WZETA) are
+routed to a single remainder that goes to the migration multisig.
+
+Outputs into --output:
+  snapshot_db.csv    Postgres COPY-ready (raw azeta + 9-decimal SPL amount)
+  schema.sql         matching Postgres table DDL
+  snapshot_human.csv readable audit copy in ZETA units (not published)`,
+		RunE: runSnapshot,
+	}
+
+	cmd.Flags().String(flagSnapshotInput, "", "path to the zetacored export.json (required)")
+	cmd.Flags().String(flagSnapshotOutput, ".", "output directory")
+	cmd.Flags().Uint64(flagSnapshotChainID, 7001, "chain id for the codec (testnet=7001, mainnet=7000)")
+	cmd.Flags().
+		StringSlice(flagSnapshotPin, nil, "non-claimable addresses routed to the remainder (repeatable or comma-separated)")
+	cmd.Flags().StringSlice(flagSnapshotWZeta, nil, "alias for --pin: non-claimable contract addresses (e.g. WZETA)")
+	cmd.Flags().Bool(flagSnapshotSupplyCheck, true, "fail on any supply-check mismatch")
+
+	if err := cmd.MarkFlagRequired(flagSnapshotInput); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+func runSnapshot(cmd *cobra.Command, _ []string) error {
+	input, err := cmd.Flags().GetString(flagSnapshotInput)
+	if err != nil {
+		return err
+	}
+	outputDir, err := cmd.Flags().GetString(flagSnapshotOutput)
+	if err != nil {
+		return err
+	}
+	chainID, err := cmd.Flags().GetUint64(flagSnapshotChainID)
+	if err != nil {
+		return err
+	}
+	pins, err := cmd.Flags().GetStringSlice(flagSnapshotPin)
+	if err != nil {
+		return err
+	}
+	wzeta, err := cmd.Flags().GetStringSlice(flagSnapshotWZeta)
+	if err != nil {
+		return err
+	}
+	supplyCheck, err := cmd.Flags().GetBool(flagSnapshotSupplyCheck)
+	if err != nil {
+		return err
+	}
+
+	appState, err := readAppState(input)
+	if err != nil {
+		return err
+	}
+
+	encodingConfig := app.MakeEncodingConfig(chainID)
+	gen, err := snapshot.ParseAppState(encodingConfig.Codec, appState)
+	if err != nil {
+		return err
+	}
+
+	cfg := snapshot.Config{Denom: snapshot.BaseDenom, Pins: append(pins, wzeta...)}
+	res, err := snapshot.Compute(gen, cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := writeOutputs(outputDir, res); err != nil {
+		return err
+	}
+
+	if err := runChecks(gen, res, filepath.Join(outputDir, fileSnapshotDB), supplyCheck); err != nil {
+		return err
+	}
+
+	printSummary(cmd, gen, res)
+	return nil
+}
+
+// readAppState reads the export file and returns its decoded app_state map.
+func readAppState(path string) (map[string]json.RawMessage, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- operator-supplied export path
+	if err != nil {
+		return nil, fmt.Errorf("read input %q: %w", path, err)
+	}
+	var doc struct {
+		AppState map[string]json.RawMessage `json:"app_state"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("unmarshal export json: %w", err)
+	}
+	if doc.AppState == nil {
+		return nil, fmt.Errorf("export json has no app_state")
+	}
+	return doc.AppState, nil
+}
+
+func writeOutputs(dir string, res *snapshot.Result) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create output dir %q: %w", dir, err)
+	}
+	if err := writeCSV(filepath.Join(dir, fileSnapshotDB), res.DBRecords()); err != nil {
+		return err
+	}
+	if err := writeCSV(filepath.Join(dir, fileSnapshotHuman), res.HumanRecords()); err != nil {
+		return err
+	}
+	schemaPath := filepath.Join(dir, fileSnapshotSchema)
+	if err := os.WriteFile(schemaPath, []byte(snapshot.SchemaSQL), 0o600); err != nil {
+		return fmt.Errorf("write %q: %w", schemaPath, err)
+	}
+	return nil
+}
+
+func writeCSV(path string, records [][]string) error {
+	f, err := os.Create(path) // #nosec G304 -- operator-supplied output dir
+	if err != nil {
+		return fmt.Errorf("create %q: %w", path, err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	if err := w.WriteAll(records); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("flush %q: %w", path, err)
+	}
+	return nil
+}
+
+// runChecks enforces the three supply invariants. When supplyCheck is false the
+// mismatches are reported but do not fail the command.
+func runChecks(gen *snapshot.Genesis, res *snapshot.Result, dbPath string, supplyCheck bool) error {
+	var problems []string
+
+	// (1) every exported bank azeta balance is accounted for
+	if bankSum := snapshot.SumBankDenom(gen, snapshot.BaseDenom); !bankSum.Equal(res.Supply) {
+		problems = append(problems, fmt.Sprintf("bank balances sum %s != supply %s", bankSum, res.Supply))
+	}
+
+	// (2) attributed + remainder == supply (remainder >= 0 is enforced in Compute)
+	if got := res.AttributedTotal().Add(res.Remainder); !got.Equal(res.Supply) {
+		problems = append(problems, fmt.Sprintf("attributed+remainder %s != supply %s", got, res.Supply))
+	}
+
+	// (3) the written CSV re-sums to the supply
+	csvSum, err := sumCSVColumn(dbPath, dbColTotalAzeta)
+	if err != nil {
+		return err
+	}
+	if !csvSum.Equal(res.Supply) {
+		problems = append(problems, fmt.Sprintf("csv total_azeta sum %s != supply %s", csvSum, res.Supply))
+	}
+
+	if len(problems) == 0 {
+		return nil
+	}
+	for _, p := range problems {
+		fmt.Fprintf(os.Stderr, "supply check failed: %s\n", p)
+	}
+	if supplyCheck {
+		return fmt.Errorf("%d supply check(s) failed", len(problems))
+	}
+	return nil
+}
+
+// sumCSVColumn re-reads a written CSV and sums an integer column (skips header).
+func sumCSVColumn(path string, col int) (sdkmath.Int, error) {
+	f, err := os.Open(path) // #nosec G304 -- path we just wrote
+	if err != nil {
+		return sdkmath.Int{}, fmt.Errorf("reopen %q: %w", path, err)
+	}
+	defer f.Close()
+
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return sdkmath.Int{}, fmt.Errorf("read %q: %w", path, err)
+	}
+	total := sdkmath.ZeroInt()
+	for i, row := range rows {
+		if i == 0 {
+			continue
+		}
+		if col >= len(row) {
+			return sdkmath.Int{}, fmt.Errorf("%q row %d has no column %d", path, i, col)
+		}
+		v, ok := sdkmath.NewIntFromString(row[col])
+		if !ok {
+			return sdkmath.Int{}, fmt.Errorf("%q row %d: bad integer %q", path, i, row[col])
+		}
+		total = total.Add(v)
+	}
+	return total, nil
+}
+
+func printSummary(cmd *cobra.Command, gen *snapshot.Genesis, res *snapshot.Result) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "\nZETA->Solana migration snapshot")
+	fmt.Fprintf(out, "  bank balances:   %d\n", len(gen.Bank.Balances))
+	fmt.Fprintf(out, "  validators:      %d\n", len(gen.Staking.Validators))
+	fmt.Fprintf(out, "  claimable accts: %d\n", len(res.Accounts))
+	if res.NonStandard > 0 {
+		fmt.Fprintf(out, "  non-std swept:   %d holder(s), %s azeta -> remainder\n",
+			res.NonStandard, res.NonStandardAzeta)
+	}
+	fmt.Fprintln(out, "  buckets (azeta):")
+	fmt.Fprintf(out, "    liquid:        %s\n", res.TotalLiquid)
+	fmt.Fprintf(out, "    staked:        %s\n", res.TotalStaked)
+	fmt.Fprintf(out, "    unbonding:     %s\n", res.TotalUnbonding)
+	fmt.Fprintf(out, "    remainder:     %s\n", res.Remainder)
+	fmt.Fprintf(out, "  total supply:    %s azeta\n", res.Supply)
+	fmt.Fprintf(out, "  SPL cap (9dec):  %s\n", res.SPLCap())
+}

--- a/cmd/zetatool/cli/snapshot_test.go
+++ b/cmd/zetatool/cli/snapshot_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writePinFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pins.txt")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// TestReadPinFile covers the shapes an operator-supplied pin file takes: a plain
+// list, comment and blank lines, trailing comments, and a TSV whose first column
+// is the address.
+func TestReadPinFile(t *testing.T) {
+	// ARRANGE
+	path := writePinFile(t, `# non-claimable contracts (mainnet)
+# source: eth_getCode over the top holders
+
+0x5f0b1a82749cb4e2278ec87f8bf6b618dc71a8bf  # WZETA, canonical wrapped ZETA
+   0x1840aabe58042e4080e248c7384381cb37178215
+
+0x0fc8f47c5bd1c89b0e2f08bfe72df4ea9dff61aa	680661	TTUV2Native
+zeta1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+`)
+
+	// ACT
+	pins, err := readPinFile(path)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"0x5f0b1a82749cb4e2278ec87f8bf6b618dc71a8bf",
+		"0x1840aabe58042e4080e248c7384381cb37178215",
+		"0x0fc8f47c5bd1c89b0e2f08bfe72df4ea9dff61aa",
+		"zeta1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+	}, pins, "only the first field of each non-comment line, in file order")
+}
+
+func TestReadPinFileCommentsOnly(t *testing.T) {
+	// ARRANGE
+	path := writePinFile(t, "# nothing here\n\n   \n#0xdeadbeef disabled\n")
+
+	// ACT
+	pins, err := readPinFile(path)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Empty(t, pins)
+}
+
+func TestReadPinFileMissing(t *testing.T) {
+	// ARRANGE
+	path := filepath.Join(t.TempDir(), "does-not-exist.txt")
+
+	// ACT
+	_, err := readPinFile(path)
+
+	// ASSERT
+	require.ErrorContains(t, err, "read pin file")
+}
+
+// TestReadPinFileMainnetList asserts the committed mainnet pin list parses to the
+// 16 contract addresses it documents.
+func TestReadPinFileMainnetList(t *testing.T) {
+	// ACT
+	pins, err := readPinFile("../../../contrib/snapshot/pins_mainnet.txt")
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, pins, 16)
+	require.Equal(t, "0x5f0b1a82749cb4e2278ec87f8bf6b618dc71a8bf", pins[0], "WZETA is the largest holder")
+}

--- a/cmd/zetatool/main.go
+++ b/cmd/zetatool/main.go
@@ -21,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(cli.NewApplicationDBStatsCMD())
 	rootCmd.AddCommand(cli.NewTSSBalancesCMD())
 	rootCmd.AddCommand(cli.NewListChainsCMD())
+	rootCmd.AddCommand(cli.NewSnapshotCMD())
 	rootCmd.PersistentFlags().String(config.FlagConfig, "", "custom config file: --config filename.json")
 	rootCmd.PersistentFlags().
 		Bool(config.FlagDebug, false, "enable debug mode, to show more details on why the command might be failing")

--- a/cmd/zetatool/snapshot/address.go
+++ b/cmd/zetatool/snapshot/address.go
@@ -1,0 +1,73 @@
+package snapshot
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+// addressLen is the byte length of a ZetaChain (eth-style) account address.
+const addressLen = 20
+
+// Canonical collapses any address form for the same underlying account to a
+// single key: bech32 zeta1... (account), bech32 zetavaloper1... (validator
+// operator) and 0x hex all reduce to the 20-byte account address as lowercase
+// 0x-prefixed hex. This is what folds a validator's self-delegation and
+// commission into its operator account without double-crediting.
+//
+// Canonical is strict: it errors on anything that is not a 20-byte account
+// address, so it is used for inputs that must be 20-byte (validator operators,
+// pins, module accounts). For bank holders and delegators, use Classify.
+func Canonical(addr string) (string, error) {
+	raw, err := decodeAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	return canonicalFromBytes(raw)
+}
+
+// Classify decodes a holder address and returns its canonical 20-byte key.
+// ok is false when the address is well-formed but not a 20-byte account (e.g. a
+// 32-byte module-derived / group / interchain account): such holders have no
+// eth-style keypair to claim with, so they are not attributed and fall through
+// to the remainder. err is returned only for genuinely malformed input.
+func Classify(addr string) (canon string, ok bool, err error) {
+	raw, err := decodeAddr(addr)
+	if err != nil {
+		return "", false, err
+	}
+	if len(raw) != addressLen {
+		return "", false, nil
+	}
+	return "0x" + hex.EncodeToString(raw), true, nil
+}
+
+// decodeAddr decodes a 0x-hex or bech32 address to its raw account bytes.
+func decodeAddr(addr string) ([]byte, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return nil, fmt.Errorf("empty address")
+	}
+	if strings.HasPrefix(addr, "0x") || strings.HasPrefix(addr, "0X") {
+		raw, err := hex.DecodeString(addr[2:])
+		if err != nil {
+			return nil, fmt.Errorf("decode hex address %q: %w", addr, err)
+		}
+		return raw, nil
+	}
+	_, raw, err := bech32.DecodeAndConvert(addr)
+	if err != nil {
+		return nil, fmt.Errorf("decode bech32 address %q: %w", addr, err)
+	}
+	return raw, nil
+}
+
+// canonicalFromBytes renders raw account-address bytes as lowercase 0x hex.
+func canonicalFromBytes(raw []byte) (string, error) {
+	if len(raw) != addressLen {
+		return "", fmt.Errorf("expected %d-byte address, got %d bytes", addressLen, len(raw))
+	}
+	return "0x" + hex.EncodeToString(raw), nil
+}

--- a/cmd/zetatool/snapshot/address_test.go
+++ b/cmd/zetatool/snapshot/address_test.go
@@ -1,0 +1,49 @@
+package snapshot
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonical(t *testing.T) {
+	// ARRANGE
+	raw := make([]byte, addressLen)
+	for i := range raw {
+		raw[i] = byte(i + 1)
+	}
+	want := "0x" + hex.EncodeToString(raw)
+
+	acc, err := bech32.ConvertAndEncode("zeta", raw)
+	require.NoError(t, err)
+	val, err := bech32.ConvertAndEncode("zetavaloper", raw)
+	require.NoError(t, err)
+	hexAddr := want
+
+	// ACT
+	gotAcc, errAcc := Canonical(acc)
+	gotVal, errVal := Canonical(val)
+	gotHex, errHex := Canonical(hexAddr)
+
+	// ASSERT
+	require.NoError(t, errAcc)
+	require.NoError(t, errVal)
+	require.NoError(t, errHex)
+	require.Equal(t, want, gotAcc)
+	require.Equal(t, want, gotVal, "validator operator and account address must collapse to the same key")
+	require.Equal(t, want, gotHex)
+}
+
+func TestCanonicalErrors(t *testing.T) {
+	// ARRANGE / ACT / ASSERT
+	_, err := Canonical("")
+	require.Error(t, err)
+
+	_, err = Canonical("0xdeadbeef") // too short
+	require.Error(t, err)
+
+	_, err = Canonical("not-a-real-address")
+	require.Error(t, err)
+}

--- a/cmd/zetatool/snapshot/compute.go
+++ b/cmd/zetatool/snapshot/compute.go
@@ -1,0 +1,195 @@
+package snapshot
+
+import (
+	"fmt"
+	"sort"
+
+	sdkmath "cosmossdk.io/math"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// SumBankDenom sums every bank balance for denom, including module accounts.
+// Used for the "parser dropped nothing" check against the recorded supply.
+func SumBankDenom(gen *Genesis, denom string) sdkmath.Int {
+	total := sdkmath.ZeroInt()
+	for i := range gen.Bank.Balances {
+		total = total.Add(gen.Bank.Balances[i].Coins.AmountOf(denom))
+	}
+	return total
+}
+
+// nonClaimableSet builds the set of canonical addresses that must not be
+// attributed: the module accounts plus the caller's pins (e.g. WZETA).
+func nonClaimableSet(pins []string) (map[string]bool, error) {
+	set := make(map[string]bool, len(moduleAccountNames)+len(pins)+1)
+	set[zeroAddress] = true
+	for _, name := range moduleAccountNames {
+		canon, err := canonicalFromBytes(authtypes.NewModuleAddress(name).Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("canonicalize module account %q: %w", name, err)
+		}
+		set[canon] = true
+	}
+	for _, pin := range pins {
+		canon, err := Canonical(pin)
+		if err != nil {
+			return nil, fmt.Errorf("canonicalize pin %q: %w", pin, err)
+		}
+		set[canon] = true
+	}
+	return set, nil
+}
+
+// Compute attributes native ZETA to each claimable address and folds everything
+// else into the remainder. It is pure and deterministic.
+//
+//   - liquid    = bank balance in denom (already includes withdrawn rewards)
+//   - staked    = sum of floor(shares * validator.tokens / validator.delegator_shares)
+//     across delegations, using the slashing-aware exchange rate for every
+//     validator status (bonded/unbonding/unbonded/jailed)
+//   - unbonding = sum of unbonding-delegation entry balances
+//
+// remainder = supply - sum(attributed). It must be >= 0: staked/unbonding azeta
+// physically sits in the (non-claimable) staking pool module accounts, so those
+// pool balances cancel against the amounts credited to delegators here.
+func Compute(gen *Genesis, cfg Config) (*Result, error) {
+	nonClaimable, err := nonClaimableSet(cfg.Pins)
+	if err != nil {
+		return nil, err
+	}
+
+	// index validators by canonical operator address for the exchange rate
+	validators := make(map[string]stakingtypes.Validator, len(gen.Staking.Validators))
+	for i := range gen.Staking.Validators {
+		v := gen.Staking.Validators[i]
+		canon, err := Canonical(v.OperatorAddress)
+		if err != nil {
+			return nil, fmt.Errorf("canonicalize validator %q: %w", v.OperatorAddress, err)
+		}
+		validators[canon] = v
+	}
+
+	accounts := make(map[string]*Account)
+	get := func(canon string) *Account {
+		acc, ok := accounts[canon]
+		if !ok {
+			class := classEOA
+			if _, isVal := validators[canon]; isVal {
+				class = classValidator
+			}
+			acc = &Account{
+				Canonical: canon,
+				Class:     class,
+				Liquid:    sdkmath.ZeroInt(),
+				Staked:    sdkmath.ZeroInt(),
+				Unbonding: sdkmath.ZeroInt(),
+			}
+			accounts[canon] = acc
+		}
+		return acc
+	}
+
+	res := &Result{NonStandardAzeta: sdkmath.ZeroInt()}
+
+	// liquid
+	for i := range gen.Bank.Balances {
+		bal := gen.Bank.Balances[i]
+		canon, ok, err := Classify(bal.Address)
+		if err != nil {
+			return nil, fmt.Errorf("classify balance holder %q: %w", bal.Address, err)
+		}
+		amt := bal.Coins.AmountOf(cfg.Denom)
+		// non-standard (non-20-byte) holders are not claimable and fall through
+		// to the remainder along with their balance.
+		if !ok {
+			if !amt.IsZero() {
+				res.NonStandard++
+				res.NonStandardAzeta = res.NonStandardAzeta.Add(amt)
+			}
+			continue
+		}
+		if nonClaimable[canon] {
+			continue
+		}
+		if amt.IsZero() {
+			continue
+		}
+		acc := get(canon)
+		acc.Liquid = acc.Liquid.Add(amt)
+	}
+
+	// staked
+	for i := range gen.Staking.Delegations {
+		del := gen.Staking.Delegations[i]
+		canon, ok, err := Classify(del.DelegatorAddress)
+		if err != nil {
+			return nil, fmt.Errorf("classify delegator %q: %w", del.DelegatorAddress, err)
+		}
+		if !ok || nonClaimable[canon] {
+			continue
+		}
+		valCanon, err := Canonical(del.ValidatorAddress)
+		if err != nil {
+			return nil, fmt.Errorf("canonicalize delegation validator %q: %w", del.ValidatorAddress, err)
+		}
+		val, ok := validators[valCanon]
+		if !ok {
+			return nil, fmt.Errorf("delegation references unknown validator %q", del.ValidatorAddress)
+		}
+		if val.DelegatorShares.IsZero() {
+			return nil, fmt.Errorf("validator %q has zero delegator shares", del.ValidatorAddress)
+		}
+		// floor(shares * tokens / delegator_shares)
+		staked := val.TokensFromShares(del.Shares).TruncateInt()
+		acc := get(canon)
+		acc.Staked = acc.Staked.Add(staked)
+	}
+
+	// unbonding
+	for i := range gen.Staking.UnbondingDelegations {
+		ubd := gen.Staking.UnbondingDelegations[i]
+		canon, ok, err := Classify(ubd.DelegatorAddress)
+		if err != nil {
+			return nil, fmt.Errorf("classify unbonding delegator %q: %w", ubd.DelegatorAddress, err)
+		}
+		if !ok || nonClaimable[canon] {
+			continue
+		}
+		acc := get(canon)
+		for _, entry := range ubd.Entries {
+			acc.Unbonding = acc.Unbonding.Add(entry.Balance)
+		}
+	}
+
+	return finalize(res, accounts, gen, cfg.Denom)
+}
+
+// finalize sorts the accounts, computes bucket totals and the remainder, and
+// verifies the remainder is non-negative.
+func finalize(res *Result, accounts map[string]*Account, gen *Genesis, denom string) (*Result, error) {
+	res.Supply = gen.Bank.Supply.AmountOf(denom)
+	res.TotalLiquid = sdkmath.ZeroInt()
+	res.TotalStaked = sdkmath.ZeroInt()
+	res.TotalUnbonding = sdkmath.ZeroInt()
+	res.Accounts = make([]Account, 0, len(accounts))
+
+	for _, acc := range accounts {
+		res.TotalLiquid = res.TotalLiquid.Add(acc.Liquid)
+		res.TotalStaked = res.TotalStaked.Add(acc.Staked)
+		res.TotalUnbonding = res.TotalUnbonding.Add(acc.Unbonding)
+		res.Accounts = append(res.Accounts, *acc)
+	}
+	sort.Slice(res.Accounts, func(i, j int) bool {
+		return res.Accounts[i].Canonical < res.Accounts[j].Canonical
+	})
+
+	res.Remainder = res.Supply.Sub(res.AttributedTotal())
+	if res.Remainder.IsNegative() {
+		return nil, fmt.Errorf(
+			"remainder is negative: supply %s < attributed %s",
+			res.Supply, res.AttributedTotal(),
+		)
+	}
+	return res, nil
+}

--- a/cmd/zetatool/snapshot/compute.go
+++ b/cmd/zetatool/snapshot/compute.go
@@ -20,25 +20,32 @@ func SumBankDenom(gen *Genesis, denom string) sdkmath.Int {
 }
 
 // nonClaimableSet builds the set of canonical addresses that must not be
-// attributed: the module accounts plus the caller's pins (e.g. WZETA).
-func nonClaimableSet(pins []string) (map[string]bool, error) {
+// attributed: the module accounts plus the caller's pins (e.g. WZETA). The pins
+// are also returned on their own, zero-seeded, so Compute can report how much
+// azeta each one kept out of attribution (two pin inputs can canonicalize to the
+// same account; the map dedupes them).
+func nonClaimableSet(pins []string) (map[string]bool, map[string]sdkmath.Int, error) {
 	set := make(map[string]bool, len(moduleAccountNames)+len(pins)+1)
+	pinned := make(map[string]sdkmath.Int, len(pins))
 	set[zeroAddress] = true
 	for _, name := range moduleAccountNames {
 		canon, err := canonicalFromBytes(authtypes.NewModuleAddress(name).Bytes())
 		if err != nil {
-			return nil, fmt.Errorf("canonicalize module account %q: %w", name, err)
+			return nil, nil, fmt.Errorf("canonicalize module account %q: %w", name, err)
 		}
 		set[canon] = true
 	}
 	for _, pin := range pins {
 		canon, err := Canonical(pin)
 		if err != nil {
-			return nil, fmt.Errorf("canonicalize pin %q: %w", pin, err)
+			return nil, nil, fmt.Errorf("canonicalize pin %q: %w", pin, err)
 		}
 		set[canon] = true
+		if _, ok := pinned[canon]; !ok {
+			pinned[canon] = sdkmath.ZeroInt()
+		}
 	}
-	return set, nil
+	return set, pinned, nil
 }
 
 // Compute attributes native ZETA to each claimable address and folds everything
@@ -54,9 +61,17 @@ func nonClaimableSet(pins []string) (map[string]bool, error) {
 // physically sits in the (non-claimable) staking pool module accounts, so those
 // pool balances cancel against the amounts credited to delegators here.
 func Compute(gen *Genesis, cfg Config) (*Result, error) {
-	nonClaimable, err := nonClaimableSet(cfg.Pins)
+	nonClaimable, pinned, err := nonClaimableSet(cfg.Pins)
 	if err != nil {
 		return nil, err
+	}
+
+	// addPinned accumulates what a pin kept out of attribution. The other
+	// non-claimable addresses (module accounts, the zero address) are not tracked.
+	addPinned := func(canon string, amt sdkmath.Int) {
+		if cur, isPin := pinned[canon]; isPin {
+			pinned[canon] = cur.Add(amt)
+		}
 	}
 
 	// index validators by canonical operator address for the exchange rate
@@ -110,6 +125,7 @@ func Compute(gen *Genesis, cfg Config) (*Result, error) {
 			continue
 		}
 		if nonClaimable[canon] {
+			addPinned(canon, amt)
 			continue
 		}
 		if amt.IsZero() {
@@ -126,7 +142,10 @@ func Compute(gen *Genesis, cfg Config) (*Result, error) {
 		if err != nil {
 			return nil, fmt.Errorf("classify delegator %q: %w", del.DelegatorAddress, err)
 		}
-		if !ok || nonClaimable[canon] {
+		// a pinned delegator skips attribution too, but only after the exchange
+		// rate math below, so its stake is reported against the pin
+		_, isPin := pinned[canon]
+		if !ok || (nonClaimable[canon] && !isPin) {
 			continue
 		}
 		valCanon, err := Canonical(del.ValidatorAddress)
@@ -142,6 +161,10 @@ func Compute(gen *Genesis, cfg Config) (*Result, error) {
 		}
 		// floor(shares * tokens / delegator_shares)
 		staked := val.TokensFromShares(del.Shares).TruncateInt()
+		if isPin {
+			addPinned(canon, staked)
+			continue
+		}
 		acc := get(canon)
 		acc.Staked = acc.Staked.Add(staked)
 	}
@@ -153,21 +176,33 @@ func Compute(gen *Genesis, cfg Config) (*Result, error) {
 		if err != nil {
 			return nil, fmt.Errorf("classify unbonding delegator %q: %w", ubd.DelegatorAddress, err)
 		}
-		if !ok || nonClaimable[canon] {
+		if !ok {
+			continue
+		}
+		sum := sdkmath.ZeroInt()
+		for _, entry := range ubd.Entries {
+			sum = sum.Add(entry.Balance)
+		}
+		if nonClaimable[canon] {
+			addPinned(canon, sum)
 			continue
 		}
 		acc := get(canon)
-		for _, entry := range ubd.Entries {
-			acc.Unbonding = acc.Unbonding.Add(entry.Balance)
-		}
+		acc.Unbonding = acc.Unbonding.Add(sum)
 	}
 
-	return finalize(res, accounts, gen, cfg.Denom)
+	return finalize(res, accounts, pinned, gen, cfg.Denom)
 }
 
-// finalize sorts the accounts, computes bucket totals and the remainder, and
-// verifies the remainder is non-negative.
-func finalize(res *Result, accounts map[string]*Account, gen *Genesis, denom string) (*Result, error) {
+// finalize sorts the accounts and pins, computes bucket totals and the
+// remainder, and verifies the remainder is non-negative.
+func finalize(
+	res *Result,
+	accounts map[string]*Account,
+	pinned map[string]sdkmath.Int,
+	gen *Genesis,
+	denom string,
+) (*Result, error) {
 	res.Supply = gen.Bank.Supply.AmountOf(denom)
 	res.TotalLiquid = sdkmath.ZeroInt()
 	res.TotalStaked = sdkmath.ZeroInt()
@@ -182,6 +217,17 @@ func finalize(res *Result, accounts map[string]*Account, gen *Genesis, denom str
 	}
 	sort.Slice(res.Accounts, func(i, j int) bool {
 		return res.Accounts[i].Canonical < res.Accounts[j].Canonical
+	})
+
+	res.Pinned = make([]PinnedAddr, 0, len(pinned))
+	for canon, amt := range pinned {
+		res.Pinned = append(res.Pinned, PinnedAddr{Canonical: canon, Azeta: amt})
+	}
+	sort.Slice(res.Pinned, func(i, j int) bool {
+		if !res.Pinned[i].Azeta.Equal(res.Pinned[j].Azeta) {
+			return res.Pinned[i].Azeta.GT(res.Pinned[j].Azeta)
+		}
+		return res.Pinned[i].Canonical < res.Pinned[j].Canonical
 	})
 
 	res.Remainder = res.Supply.Sub(res.AttributedTotal())

--- a/cmd/zetatool/snapshot/compute_test.go
+++ b/cmd/zetatool/snapshot/compute_test.go
@@ -176,6 +176,140 @@ func TestComputeZeroAddressNotAttributed(t *testing.T) {
 	require.Equal(t, "400", res.Remainder.String(), "zero-address balance folds into remainder")
 }
 
+// TestComputePinnedAccounting checks that a pin holding liquid, staked and
+// unbonding azeta is kept out of attribution while its full contribution to the
+// remainder is reported. The pin is passed twice (hex + bech32) to prove the two
+// forms collapse to one entry.
+func TestComputePinnedAccounting(t *testing.T) {
+	// ARRANGE
+	valBytes := addr20(0x02)
+	eoaBytes := addr20(0x01)
+	pinBytes := addr20(0x05)
+
+	// slashed validator: 90 tokens backing 100 shares -> exchange rate 0.9
+	validator := stakingtypes.Validator{
+		OperatorAddress: valBech32(t, valBytes),
+		Tokens:          sdkmath.NewInt(90),
+		DelegatorShares: sdkmath.LegacyNewDec(100),
+		Status:          stakingtypes.Bonded,
+	}
+	coin := func(n int64) sdk.Coins { return sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, n)) }
+
+	gen := &Genesis{
+		Bank: banktypes.GenesisState{
+			Supply: coin(1000),
+			Balances: []banktypes.Balance{
+				{Address: accBech32(t, eoaBytes), Coins: coin(600)},
+				{Address: accBech32(t, pinBytes), Coins: coin(300)},
+			},
+		},
+		Staking: stakingtypes.GenesisState{
+			Validators: []stakingtypes.Validator{validator},
+			Delegations: []stakingtypes.Delegation{
+				// pinned delegator: floor(20 * 90/100) = 18
+				{
+					DelegatorAddress: accBech32(t, pinBytes),
+					ValidatorAddress: valBech32(t, valBytes),
+					Shares:           sdkmath.LegacyNewDec(20),
+				},
+			},
+			UnbondingDelegations: []stakingtypes.UnbondingDelegation{
+				{
+					DelegatorAddress: accBech32(t, pinBytes),
+					ValidatorAddress: valBech32(t, valBytes),
+					Entries: []stakingtypes.UnbondingDelegationEntry{
+						{Balance: sdkmath.NewInt(6)},
+						{Balance: sdkmath.NewInt(4)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := Config{Denom: BaseDenom, Pins: []string{canonHex(pinBytes), accBech32(t, pinBytes)}}
+
+	// ACT
+	res, err := Compute(gen, cfg)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, res.Accounts, 1, "only the EOA is attributed")
+	require.Equal(t, canonHex(eoaBytes), res.Accounts[0].Canonical)
+
+	require.Len(t, res.Pinned, 1, "hex and bech32 forms of the same pin collapse")
+	require.Equal(t, canonHex(pinBytes), res.Pinned[0].Canonical)
+	require.Equal(t, "328", res.Pinned[0].Azeta.String(), "liquid 300 + staked 18 + unbonding 10")
+
+	require.Equal(t, "600", res.AttributedTotal().String())
+	require.Equal(t, "400", res.Remainder.String())
+	require.Equal(t, res.Supply.String(), res.AttributedTotal().Add(res.Remainder).String())
+}
+
+// TestComputePinNoHolder covers the typo case: a pin that matches nothing in the
+// export is still reported, with zero azeta, so the caller can fail the run.
+func TestComputePinNoHolder(t *testing.T) {
+	// ARRANGE
+	eoaBytes := addr20(0x01)
+	missingBytes := addr20(0x07)
+	coin := func(n int64) sdk.Coins { return sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, n)) }
+
+	gen := &Genesis{
+		Bank: banktypes.GenesisState{
+			Supply:   coin(1000),
+			Balances: []banktypes.Balance{{Address: accBech32(t, eoaBytes), Coins: coin(600)}},
+		},
+	}
+
+	// ACT
+	res, err := Compute(gen, Config{Denom: BaseDenom, Pins: []string{canonHex(missingBytes)}})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, res.Pinned, 1)
+	require.Equal(t, canonHex(missingBytes), res.Pinned[0].Canonical)
+	require.True(t, res.Pinned[0].Azeta.IsZero(), "unmatched pin reports zero azeta")
+
+	require.Len(t, res.Accounts, 1)
+	require.Equal(t, "600", res.AttributedTotal().String())
+	require.Equal(t, "400", res.Remainder.String())
+}
+
+// TestComputePinnedOrder pins three addresses and checks the reported order is
+// amount descending with the canonical address breaking ties.
+func TestComputePinnedOrder(t *testing.T) {
+	// ARRANGE
+	bigBytes := addr20(0x0c)
+	tieLowBytes := addr20(0x0a)
+	tieHighBytes := addr20(0x0b)
+	coin := func(n int64) sdk.Coins { return sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, n)) }
+
+	gen := &Genesis{
+		Bank: banktypes.GenesisState{
+			Supply: coin(1000),
+			Balances: []banktypes.Balance{
+				{Address: accBech32(t, tieHighBytes), Coins: coin(5)},
+				{Address: accBech32(t, bigBytes), Coins: coin(100)},
+				{Address: accBech32(t, tieLowBytes), Coins: coin(5)},
+			},
+		},
+	}
+	cfg := Config{Denom: BaseDenom, Pins: []string{
+		canonHex(tieHighBytes), canonHex(bigBytes), canonHex(tieLowBytes),
+	}}
+
+	// ACT
+	res, err := Compute(gen, cfg)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Empty(t, res.Accounts)
+	require.Equal(t, []PinnedAddr{
+		{Canonical: canonHex(bigBytes), Azeta: sdkmath.NewInt(100)},
+		{Canonical: canonHex(tieLowBytes), Azeta: sdkmath.NewInt(5)},
+		{Canonical: canonHex(tieHighBytes), Azeta: sdkmath.NewInt(5)},
+	}, res.Pinned)
+}
+
 func TestComputeUnknownValidator(t *testing.T) {
 	// ARRANGE: a delegation pointing at a validator not present in the set
 	gen := &Genesis{

--- a/cmd/zetatool/snapshot/compute_test.go
+++ b/cmd/zetatool/snapshot/compute_test.go
@@ -1,0 +1,199 @@
+package snapshot
+
+import (
+	"encoding/hex"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func addr20(seed byte) []byte {
+	b := make([]byte, addressLen)
+	for i := range b {
+		b[i] = seed
+	}
+	return b
+}
+
+func accBech32(t *testing.T, b []byte) string {
+	t.Helper()
+	s, err := bech32.ConvertAndEncode("zeta", b)
+	require.NoError(t, err)
+	return s
+}
+
+func valBech32(t *testing.T, b []byte) string {
+	t.Helper()
+	s, err := bech32.ConvertAndEncode("zetavaloper", b)
+	require.NoError(t, err)
+	return s
+}
+
+func canonHex(b []byte) string { return "0x" + hex.EncodeToString(b) }
+
+// TestCompute exercises the attribution rules with a hand-built fixture:
+//   - an EOA with only liquid
+//   - a slashed validator (tokens != delegator_shares) with a self-delegation
+//     and one external delegation, whose commission liquid + self-stake fold
+//     into the operator account
+//   - an external unbonding delegation
+//   - a module account (bonded pool) that must NOT be attributed
+//   - a pinned WZETA contract that must NOT be attributed
+func TestCompute(t *testing.T) {
+	// ARRANGE
+	valBytes := addr20(0x02)
+	delBytes := addr20(0x03)
+	eoaBytes := addr20(0x01)
+	unbBytes := addr20(0x04)
+	wzetaBytes := addr20(0x05)
+	poolBytes := authtypes.NewModuleAddress(stakingtypes.BondedPoolName).Bytes()
+
+	// slashed validator: 90 tokens backing 100 shares -> exchange rate 0.9
+	validator := stakingtypes.Validator{
+		OperatorAddress: valBech32(t, valBytes),
+		Tokens:          sdkmath.NewInt(90),
+		DelegatorShares: sdkmath.LegacyNewDec(100),
+		Status:          stakingtypes.Unbonded,
+		Jailed:          true, // still counted regardless of status
+	}
+
+	coin := func(n int64) sdk.Coins { return sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, n)) }
+
+	gen := &Genesis{
+		Bank: banktypes.GenesisState{
+			Supply: coin(2100),
+			Balances: []banktypes.Balance{
+				{Address: accBech32(t, eoaBytes), Coins: coin(1000)},
+				{Address: accBech32(t, valBytes), Coins: coin(500)}, // withdrawn commission
+				{Address: accBech32(t, delBytes), Coins: coin(200)},
+				{Address: accBech32(t, unbBytes), Coins: coin(10)},
+				{Address: accBech32(t, poolBytes), Coins: coin(90)}, // module: not attributed
+				{Address: accBech32(t, wzetaBytes), Coins: coin(300)}, // pinned: not attributed
+			},
+		},
+		Staking: stakingtypes.GenesisState{
+			Validators: []stakingtypes.Validator{validator},
+			Delegations: []stakingtypes.Delegation{
+				// self-delegation: floor(40 * 90/100) = 36
+				{DelegatorAddress: accBech32(t, valBytes), ValidatorAddress: valBech32(t, valBytes), Shares: sdkmath.LegacyNewDec(40)},
+				// external: floor(33 * 90/100) = floor(29.7) = 29
+				{DelegatorAddress: accBech32(t, delBytes), ValidatorAddress: valBech32(t, valBytes), Shares: sdkmath.LegacyNewDec(33)},
+			},
+			UnbondingDelegations: []stakingtypes.UnbondingDelegation{
+				{
+					DelegatorAddress: accBech32(t, unbBytes),
+					ValidatorAddress: valBech32(t, valBytes),
+					Entries: []stakingtypes.UnbondingDelegationEntry{
+						{Balance: sdkmath.NewInt(50)},
+						{Balance: sdkmath.NewInt(25)},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := Config{Denom: BaseDenom, Pins: []string{canonHex(wzetaBytes)}}
+
+	// ACT
+	res, err := Compute(gen, cfg)
+
+	// ASSERT
+	require.NoError(t, err)
+
+	byAddr := map[string]Account{}
+	for _, a := range res.Accounts {
+		byAddr[a.Canonical] = a
+	}
+
+	require.Len(t, res.Accounts, 4, "only the 4 claimable addresses are attributed")
+	require.NotContains(t, byAddr, canonHex(poolBytes), "module account must not be attributed")
+	require.NotContains(t, byAddr, canonHex(wzetaBytes), "pinned WZETA must not be attributed")
+
+	eoa := byAddr[canonHex(eoaBytes)]
+	require.Equal(t, classEOA, eoa.Class)
+	require.Equal(t, "1000", eoa.Total().String())
+
+	val := byAddr[canonHex(valBytes)]
+	require.Equal(t, classValidator, val.Class)
+	require.Equal(t, "500", val.Liquid.String())
+	require.Equal(t, "36", val.Staked.String(), "self-delegation folds into operator account")
+	require.Equal(t, "536", val.Total().String())
+
+	del := byAddr[canonHex(delBytes)]
+	require.Equal(t, "200", del.Liquid.String())
+	require.Equal(t, "29", del.Staked.String(), "slashing-aware exchange rate is floored")
+
+	unb := byAddr[canonHex(unbBytes)]
+	require.Equal(t, "75", unb.Unbonding.String())
+	require.Equal(t, "85", unb.Total().String())
+
+	// bucket totals
+	require.Equal(t, "1710", res.TotalLiquid.String()) // 1000+500+200+10
+	require.Equal(t, "65", res.TotalStaked.String())    // 36+29
+	require.Equal(t, "75", res.TotalUnbonding.String())
+
+	// invariants
+	require.Equal(t, "2100", res.Supply.String())
+	require.Equal(t, "1850", res.AttributedTotal().String())
+	require.Equal(t, "250", res.Remainder.String())
+	require.False(t, res.Remainder.IsNegative())
+	require.Equal(t, res.Supply.String(), res.AttributedTotal().Add(res.Remainder).String())
+}
+
+func TestComputeZeroAddressNotAttributed(t *testing.T) {
+	// ARRANGE: an EOA plus a balance held by the null 20-byte address
+	eoaBytes := addr20(0x01)
+	zeroBytes := make([]byte, addressLen)
+	coin := func(n int64) sdk.Coins { return sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, n)) }
+
+	gen := &Genesis{
+		Bank: banktypes.GenesisState{
+			Supply: coin(1000),
+			Balances: []banktypes.Balance{
+				{Address: accBech32(t, eoaBytes), Coins: coin(600)},
+				{Address: accBech32(t, zeroBytes), Coins: coin(400)}, // zero address: not claimable
+			},
+		},
+	}
+
+	// ACT
+	res, err := Compute(gen, Config{Denom: BaseDenom})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, res.Accounts, 1, "only the EOA is attributed")
+	require.Equal(t, canonHex(eoaBytes), res.Accounts[0].Canonical)
+	for _, a := range res.Accounts {
+		require.NotEqual(t, zeroAddress, a.Canonical, "zero address must not be attributed")
+	}
+	require.Equal(t, "600", res.AttributedTotal().String())
+	require.Equal(t, "400", res.Remainder.String(), "zero-address balance folds into remainder")
+}
+
+func TestComputeUnknownValidator(t *testing.T) {
+	// ARRANGE: a delegation pointing at a validator not present in the set
+	gen := &Genesis{
+		Bank: banktypes.GenesisState{Supply: sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, 100))},
+		Staking: stakingtypes.GenesisState{
+			Delegations: []stakingtypes.Delegation{
+				{
+					DelegatorAddress: accBech32(t, addr20(0x03)),
+					ValidatorAddress: valBech32(t, addr20(0x09)),
+					Shares:           sdkmath.LegacyNewDec(10),
+				},
+			},
+		},
+	}
+
+	// ACT
+	_, err := Compute(gen, Config{Denom: BaseDenom})
+
+	// ASSERT
+	require.ErrorContains(t, err, "unknown validator")
+}

--- a/cmd/zetatool/snapshot/output.go
+++ b/cmd/zetatool/snapshot/output.go
@@ -1,0 +1,99 @@
+package snapshot
+
+import (
+	sdkmath "cosmossdk.io/math"
+)
+
+// zetaExp is the azeta -> ZETA exponent (18 decimals) for the human audit copy.
+const zetaExp = 18
+
+// DBHeader is the column order of snapshot_db.csv (Postgres COPY-ready).
+var DBHeader = []string{
+	"canonical_address", "class", "liquid", "staked", "unbonding",
+	"total_azeta", "total_9dec", "claim_status",
+}
+
+// HumanHeader is the column order of the readable audit copy (ZETA units).
+var HumanHeader = []string{
+	"canonical_address", "class", "liquid_zeta", "staked_zeta", "unbonding_zeta",
+	"total_zeta", "claim_status",
+}
+
+// SchemaSQL is the Postgres DDL matching snapshot_db.csv. azeta amounts are
+// NUMERIC because raw azeta (up to ~1.7e27) overflows bigint; total_9dec is the
+// folded 9-decimal amount and fits in bigint.
+const SchemaSQL = `CREATE TABLE snapshot_balances (
+    canonical_address TEXT PRIMARY KEY,
+    class             TEXT    NOT NULL,
+    liquid            NUMERIC NOT NULL,
+    staked            NUMERIC NOT NULL,
+    unbonding         NUMERIC NOT NULL,
+    total_azeta       NUMERIC NOT NULL,
+    total_9dec        BIGINT  NOT NULL,
+    claim_status      TEXT    NOT NULL
+);
+
+CREATE INDEX idx_snapshot_balances_address ON snapshot_balances (canonical_address);
+`
+
+// DBRecords returns the header plus one row per claimable account and a final
+// remainder row (class=remainder, routed to the multisig).
+func (r *Result) DBRecords() [][]string {
+	records := make([][]string, 0, len(r.Accounts)+2)
+	records = append(records, DBHeader)
+	for _, a := range r.Accounts {
+		records = append(records, []string{
+			a.Canonical,
+			a.Class,
+			a.Liquid.String(),
+			a.Staked.String(),
+			a.Unbonding.String(),
+			a.Total().String(),
+			a.Total9Dec().String(),
+			claimStatusClaimable,
+		})
+	}
+	records = append(records, []string{
+		classRemainder,
+		classRemainder,
+		"0",
+		"0",
+		"0",
+		r.Remainder.String(),
+		r.Remainder.Quo(oneGZeta).String(),
+		claimStatusMultisig,
+	})
+	return records
+}
+
+// HumanRecords mirrors DBRecords in ZETA units for auditing (not published).
+func (r *Result) HumanRecords() [][]string {
+	records := make([][]string, 0, len(r.Accounts)+2)
+	records = append(records, HumanHeader)
+	for _, a := range r.Accounts {
+		records = append(records, []string{
+			a.Canonical,
+			a.Class,
+			toZeta(a.Liquid),
+			toZeta(a.Staked),
+			toZeta(a.Unbonding),
+			toZeta(a.Total()),
+			claimStatusClaimable,
+		})
+	}
+	records = append(records, []string{
+		classRemainder,
+		classRemainder,
+		"0",
+		"0",
+		"0",
+		toZeta(r.Remainder),
+		claimStatusMultisig,
+	})
+	return records
+}
+
+// toZeta renders an azeta amount as a decimal ZETA string.
+func toZeta(azeta sdkmath.Int) string {
+	return sdkmath.LegacyNewDecFromIntWithPrec(azeta, zetaExp).String()
+}

--- a/cmd/zetatool/snapshot/output_test.go
+++ b/cmd/zetatool/snapshot/output_test.go
@@ -1,0 +1,52 @@
+package snapshot
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBRecords(t *testing.T) {
+	// ARRANGE: one claimable account (2.5 ZETA) + remainder (1.5 ZETA)
+	res := &Result{
+		Supply:    sdkmath.NewIntWithDecimal(4, 18),                 // 4 ZETA
+		Remainder: sdkmath.NewIntWithDecimal(15, 17),                // 1.5 ZETA
+		Accounts: []Account{{
+			Canonical: "0x" + "01",
+			Class:     classEOA,
+			Liquid:    sdkmath.NewIntWithDecimal(25, 17), // 2.5 ZETA
+			Staked:    sdkmath.ZeroInt(),
+			Unbonding: sdkmath.ZeroInt(),
+		}},
+	}
+
+	// ACT
+	records := res.DBRecords()
+
+	// ASSERT: header + one claimable + one remainder row
+	require.Equal(t, DBHeader, records[0])
+	require.Len(t, records, 3)
+
+	claimable := records[1]
+	require.Equal(t, "2500000000000000000", claimable[5], "total_azeta")
+	require.Equal(t, "2500000000", claimable[6], "total_9dec floors 18->9 decimals")
+	require.Equal(t, claimStatusClaimable, claimable[7])
+
+	remainder := records[2]
+	require.Equal(t, classRemainder, remainder[1])
+	require.Equal(t, "1500000000000000000", remainder[5])
+	require.Equal(t, claimStatusMultisig, remainder[7])
+
+	// re-summing total_azeta across all rows equals supply
+	sum := sdkmath.ZeroInt()
+	for _, row := range records[1:] {
+		v, ok := sdkmath.NewIntFromString(row[5])
+		require.True(t, ok)
+		sum = sum.Add(v)
+	}
+	require.Equal(t, res.Supply.String(), sum.String())
+
+	// SPL cap = floored per-row totals
+	require.Equal(t, "4000000000", res.SPLCap().String())
+}

--- a/cmd/zetatool/snapshot/parse.go
+++ b/cmd/zetatool/snapshot/parse.go
@@ -1,0 +1,41 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// Genesis holds the module genesis states needed for the snapshot. Only bank
+// and staking are consumed: distribution is exported (rewards are already
+// folded into bank via --for-zero-height) but not read here.
+type Genesis struct {
+	Bank    banktypes.GenesisState
+	Staking stakingtypes.GenesisState
+}
+
+// ParseAppState pulls the bank and staking genesis states out of a decoded
+// `app_state` map. It is deterministic and does no file or RPC I/O; the caller
+// reads the export file and hands over the raw module JSON.
+func ParseAppState(cdc codec.JSONCodec, appState map[string]json.RawMessage) (*Genesis, error) {
+	bankRaw, ok := appState[banktypes.ModuleName]
+	if !ok {
+		return nil, fmt.Errorf("app_state is missing the %q module", banktypes.ModuleName)
+	}
+	stakingRaw, ok := appState[stakingtypes.ModuleName]
+	if !ok {
+		return nil, fmt.Errorf("app_state is missing the %q module", stakingtypes.ModuleName)
+	}
+
+	var gen Genesis
+	if err := cdc.UnmarshalJSON(bankRaw, &gen.Bank); err != nil {
+		return nil, fmt.Errorf("unmarshal bank genesis: %w", err)
+	}
+	if err := cdc.UnmarshalJSON(stakingRaw, &gen.Staking); err != nil {
+		return nil, fmt.Errorf("unmarshal staking genesis: %w", err)
+	}
+	return &gen, nil
+}

--- a/cmd/zetatool/snapshot/parse_test.go
+++ b/cmd/zetatool/snapshot/parse_test.go
@@ -1,0 +1,63 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/app"
+)
+
+func TestParseAppState(t *testing.T) {
+	// ARRANGE
+	cdc := app.MakeEncodingConfig(7001).Codec
+
+	bank := banktypes.GenesisState{
+		Params: banktypes.DefaultParams(),
+		Supply: sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, 1500)),
+		Balances: []banktypes.Balance{
+			{Address: accBech32(t, addr20(0x01)), Coins: sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, 1000))},
+			{Address: accBech32(t, addr20(0x02)), Coins: sdk.NewCoins(sdk.NewInt64Coin(BaseDenom, 500))},
+		},
+	}
+	staking := stakingtypes.GenesisState{
+		Params: stakingtypes.DefaultParams(),
+		Validators: []stakingtypes.Validator{{
+			OperatorAddress: valBech32(t, addr20(0x02)),
+			Tokens:          sdkmath.NewInt(500),
+			DelegatorShares: sdkmath.LegacyNewDec(500),
+			Status:          stakingtypes.Bonded,
+		}},
+	}
+
+	bankRaw, err := cdc.MarshalJSON(&bank)
+	require.NoError(t, err)
+	stakingRaw, err := cdc.MarshalJSON(&staking)
+	require.NoError(t, err)
+	appState := map[string]json.RawMessage{
+		banktypes.ModuleName:    bankRaw,
+		stakingtypes.ModuleName: stakingRaw,
+	}
+
+	// ACT
+	gen, err := ParseAppState(cdc, appState)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, gen.Bank.Balances, 2)
+	require.Len(t, gen.Staking.Validators, 1)
+	require.Equal(t, "1500", gen.Bank.Supply.AmountOf(BaseDenom).String())
+	require.Equal(t, "1500", SumBankDenom(gen, BaseDenom).String())
+}
+
+func TestParseAppStateMissingModule(t *testing.T) {
+	// ARRANGE / ACT / ASSERT
+	cdc := app.MakeEncodingConfig(7001).Codec
+	_, err := ParseAppState(cdc, map[string]json.RawMessage{})
+	require.ErrorContains(t, err, "bank")
+}

--- a/cmd/zetatool/snapshot/snapshot.go
+++ b/cmd/zetatool/snapshot/snapshot.go
@@ -1,0 +1,125 @@
+// Package snapshot holds the pure, deterministic compute for the ZETA->Solana
+// migration snapshot (Stage 2). It turns parsed bank/staking genesis state into
+// a per-address native-ZETA balance list for the Solana migration mint.
+//
+// Everything here is free of file, RPC and cobra dependencies so it can be
+// unit-tested with hand-built fixtures. Reward math is intentionally absent:
+// the Stage 1 export runs with --for-zero-height, so withdrawn staking rewards
+// and validator commission are already folded into liquid bank balances.
+package snapshot
+
+import (
+	sdkmath "cosmossdk.io/math"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
+	emissionstypes "github.com/zeta-chain/node/x/emissions/types"
+	fungibletypes "github.com/zeta-chain/node/x/fungible/types"
+)
+
+const (
+	// BaseDenom is the native ZETA denom (18 decimals). Only this denom is summed.
+	BaseDenom = "azeta"
+
+	// classEOA / classValidator / classRemainder label each output row.
+	classEOA       = "eoa"
+	classValidator = "validator"
+	classRemainder = "remainder"
+
+	// claimStatusClaimable is the initial status for an attributed address; the
+	// remainder is routed to the migration multisig instead of being claimable.
+	claimStatusClaimable = "claimable"
+	claimStatusMultisig  = "multisig"
+
+	// zeroAddress is the null 20-byte account. It has no keypair to claim with,
+	// so it is non-claimable and its balance folds into the remainder.
+	zeroAddress = "0x0000000000000000000000000000000000000000"
+)
+
+// moduleAccountNames are the module accounts that hold azeta but must never be
+// attributed to a claimant. Their balances (including the staking pools that
+// physically hold delegated azeta) fall through to the remainder, which cancels
+// against the staked/unbonding amounts credited to delegators.
+var moduleAccountNames = []string{
+	authtypes.FeeCollectorName,
+	distrtypes.ModuleName,
+	stakingtypes.BondedPoolName,
+	stakingtypes.NotBondedPoolName,
+	govtypes.ModuleName,
+	crosschaintypes.ModuleName,
+	evmtypes.ModuleName,
+	fungibletypes.ModuleName,
+	emissionstypes.ModuleName,
+	emissionstypes.UndistributedObserverRewardsPool,
+	emissionstypes.UndistributedTSSRewardsPool,
+	feemarkettypes.ModuleName,
+}
+
+// oneGZeta is 1e9 azeta, the divisor to fold 18-decimal azeta down to the
+// 9-decimal SPL representation used by the Solana mint.
+var oneGZeta = sdkmath.NewInt(1_000_000_000)
+
+// Config parameterizes a snapshot compute run.
+type Config struct {
+	// Denom is the native denom to snapshot. Callers pass BaseDenom.
+	Denom string
+	// Pins are extra non-claimable addresses (e.g. WZETA) that route to the
+	// remainder instead of being attributed. Accepts zeta1.../zetavaloper1.../0x forms.
+	Pins []string
+}
+
+// Account is a single attributed (claimable) address.
+type Account struct {
+	Canonical string
+	Class     string
+	Liquid    sdkmath.Int
+	Staked    sdkmath.Int
+	Unbonding sdkmath.Int
+}
+
+// Total returns liquid + staked + unbonding in azeta.
+func (a Account) Total() sdkmath.Int {
+	return a.Liquid.Add(a.Staked).Add(a.Unbonding)
+}
+
+// Total9Dec folds the account total from 18-decimal azeta down to 9 decimals.
+func (a Account) Total9Dec() sdkmath.Int {
+	return a.Total().Quo(oneGZeta)
+}
+
+// Result is the full snapshot output: attributed accounts plus the remainder.
+type Result struct {
+	Accounts  []Account
+	Remainder sdkmath.Int
+	Supply    sdkmath.Int
+
+	TotalLiquid    sdkmath.Int
+	TotalStaked    sdkmath.Int
+	TotalUnbonding sdkmath.Int
+
+	// NonStandard counts well-formed but non-20-byte holders (e.g. module-derived
+	// / group / interchain accounts) that have no eth-style keypair to claim with.
+	// Their azeta is not attributed and is swept into the remainder.
+	NonStandard      int
+	NonStandardAzeta sdkmath.Int
+}
+
+// AttributedTotal is the sum over attributed accounts (liquid+staked+unbonding).
+func (r *Result) AttributedTotal() sdkmath.Int {
+	return r.TotalLiquid.Add(r.TotalStaked).Add(r.TotalUnbonding)
+}
+
+// SPLCap is the total 9-decimal supply cap: the sum of floored per-row totals
+// across every claimable account plus the remainder row.
+func (r *Result) SPLCap() sdkmath.Int {
+	total := r.Remainder.Quo(oneGZeta)
+	for _, a := range r.Accounts {
+		total = total.Add(a.Total9Dec())
+	}
+	return total
+}

--- a/cmd/zetatool/snapshot/snapshot.go
+++ b/cmd/zetatool/snapshot/snapshot.go
@@ -92,11 +92,23 @@ func (a Account) Total9Dec() sdkmath.Int {
 	return a.Total().Quo(oneGZeta)
 }
 
+// PinnedAddr is a pinned non-claimable address and the azeta it contributed to
+// the remainder. Reported so an operator can confirm each pin actually matched
+// a holder in the export; a zero Azeta means the pin matched nothing.
+type PinnedAddr struct {
+	Canonical string
+	Azeta     sdkmath.Int
+}
+
 // Result is the full snapshot output: attributed accounts plus the remainder.
 type Result struct {
 	Accounts  []Account
 	Remainder sdkmath.Int
 	Supply    sdkmath.Int
+
+	// Pinned is one entry per pinned address, amount descending, holding the
+	// azeta that pin kept out of attribution.
+	Pinned []PinnedAddr
 
 	TotalLiquid    sdkmath.Int
 	TotalStaked    sdkmath.Int

--- a/contrib/snapshot/README.md
+++ b/contrib/snapshot/README.md
@@ -104,7 +104,17 @@ Flags:
 - `--chain-id`      codec chain id: testnet `7001`, mainnet `7000`.
 - `--pin` / `--wzeta`  non-claimable contract addresses routed to the remainder
                     (repeatable or comma-separated). WZETA and known pools go here.
-- `--supply-check`  fail on any supply mismatch (default true).
+- `--pin-file`      same thing from a file, one address per line (`#` comments;
+                    only the first field per line is read, so a TSV works).
+                    Mainnet list is committed: `contrib/snapshot/pins_mainnet.txt`.
+- `--supply-check`  fail on any output check (default true).
+
+Mainnet with the committed pin list:
+
+```
+go run ./cmd/zetatool snapshot --input /tmp/mainnet-export.json --chain-id 7000 \
+  --output /tmp/mainnet-snap --pin-file contrib/snapshot/pins_mainnet.txt
+```
 
 Outputs in `--output`:
 
@@ -116,9 +126,15 @@ Outputs in `--output`:
 - `schema.sql`        matching Postgres DDL.
 - `snapshot_human.csv`  readable ZETA-unit copy for eyeballing.
 
-The command prints bucket totals and runs three checks (sum export == supply;
-sum attributed + remainder == total; re-sum CSV == total), non-zero exit on any
-mismatch.
+The command prints bucket totals and runs four checks (sum export == supply; sum
+attributed + remainder == total; re-sum CSV == total; every pin matched a holder),
+non-zero exit on any failure.
+
+Pin accounting: the summary prints one line per pin with the azeta it kept out of
+attribution, plus a subtotal. A pin that matched no holder in the export reports
+zero and fails the run, which is what catches a typo'd address or a pin file
+pointed at the wrong network. `--supply-check=false` downgrades every check,
+including this one, to a stderr warning.
 
 ## Look at the output
 
@@ -148,6 +164,10 @@ by WZETA `0x5f0b1a82749cb4e2278ec87f8bf6b618dc71a8bf` (6.6M) and the Accumulated
 Finance liquid-staking / lending stack. WZETA is 1:1 backed native, so the native
 backing for all DEX/LP WZETA positions sits under that one contract.
 
+Those 16 addresses are committed as `contrib/snapshot/pins_mainnet.txt` and wired
+in with `--pin-file` (see Stage 2). The file is mainnet only; a testnet run needs
+no pins.
+
 ## Try new ideas here
 
 - Change the non-claimable set: `--pin <addr>,<addr>` to route more contracts to
@@ -156,11 +176,22 @@ backing for all DEX/LP WZETA positions sits under that one contract.
   pure package `cmd/zetatool/snapshot/` and re-run against the same `export.json`.
 - Point Stage 2 at a devnet export to test on a small state.
 
+## Verification status
+
+- Covered by unit tests: pin-file parsing (comments, blanks, TSV columns),
+  per-pin azeta accounting across liquid + staked + unbonding, and the
+  unmatched-pin failure.
+- NOT run yet: the end-to-end mainnet run with `pins_mainnet.txt`. Expected when
+  it happens — claimable accounts down by 16, remainder 41.59M -> ~50.94M ZETA,
+  total supply unchanged at 1,707,671,363.36 ZETA. Deferred, so treat those
+  numbers as a prediction, not a result.
+
 ## Open questions / parked
 
-- Full contract detection: the top-500 scan captures ~all contract value, but a
-  full all-accounts `eth_getCode` sweep (on a local node) is the exhaustive
-  pre-migration step. Not wired into the tool yet.
+- Full contract detection: the top-500 contract list is committed and wired via
+  `--pin-file`, which captures ~all contract value. What is still parked is the
+  exhaustive all-accounts `eth_getCode` sweep against a local node, the
+  pre-migration step that proves nothing was missed.
 - Squads multisig address for the remainder recipient (pending tokenomics/legal).
 - Snapshot height selection for the real migration (freeze inbound, drain
   outbounds, zero emissions, halt, export). Separate workstream.

--- a/contrib/snapshot/README.md
+++ b/contrib/snapshot/README.md
@@ -1,0 +1,168 @@
+# ZETA balance snapshot
+
+Tooling to produce a per-address list of native ZETA balances from a ZetaChain
+state export. It is the input to the ZETA to Solana migration mint, but the
+compute stage is a plain, offline balance aggregator that anyone can run and
+audit against testnet or mainnet.
+
+This doc is the quick start. Grab the PR, run the two stages, poke at the output.
+
+## What it produces
+
+One CSV row per account with its native ZETA, split into `liquid / staked /
+unbonding`, plus a single `remainder` row for everything not individually
+attributed. Books balance to the wei against total supply.
+
+## Design (two stages)
+
+```
+Stage 1  EXPORT     zetacored export        -> export.json      (contrib/snapshot, Python)
+Stage 2  SNAPSHOT   zetatool snapshot       -> snapshot_db.csv  (Go, pure/offline)
+```
+
+- Stage 1 reads committed chain state and writes a genesis-format JSON. Chain
+  specific, side-effecty, needs the matching binary.
+- Stage 2 takes only `export.json` and computes balances. No network, fully
+  deterministic, so the same code runs identically on testnet, devnet, mainnet.
+  That is the boundary to build on: new attribution ideas go here without
+  touching a node.
+
+Key facts the design leans on:
+
+- Native EVM balance IS the bank `azeta` balance (EVM StateDB is a view over
+  bank), and `azeta` is 18 decimals == EVM wei 1:1. A bank export captures every
+  EOA and every contract's native holdings.
+- ERC-20 / WZETA per-holder balances live in EVM contract storage, not bank. A
+  bank export shows only the aggregate native lump under a contract address.
+- `--for-zero-height` folds staking rewards + validator commission into bank
+  balances during export, so Stage 2 does not reimplement reward math. Trade-off:
+  exported balances are higher than a live `balanceOf` by the withdrawn rewards.
+
+Attribution model: attribute `liquid + staked + unbonding` to every account not
+in the non-claimable set (module accounts, the zero address, and any pinned
+contract). `remainder = total_supply - sum(attributed)` goes to a single row.
+Nothing is dropped; the cap equals full supply.
+
+## Prerequisites
+
+- `python3`, `lz4`, `make`, Go toolchain.
+- Disk: mainnet snapshot is ~35 GB compressed, ~39 GB extracted, and Stage 1
+  copies the data dir once (~39 GB more). Budget ~120 GB free for mainnet.
+- The binary must match the state version. Mainnet is currently on v36; a newer
+  binary can fail to open un-upgraded state. Check the current version in the
+  snapshot metadata:
+  `curl -s https://snapshots.rpc.zetachain.com/mainnet/fullnode/latest.json`
+  (`networkVersion` field). Then build the matching release:
+  `git checkout v36.1.5 && make install-zetacore` (use a worktree so you keep your
+  branch). Testnet was validated on v37.0.2.
+
+## Stage 1: export
+
+Testnet (downloads + exports latest):
+
+```
+make snapshot-export NETWORK=testnet SNAPSHOT_EXPORT_ARGS="--for-zero-height --output /tmp/testnet-export.json"
+```
+
+Mainnet:
+
+```
+make snapshot-export NETWORK=mainnet SNAPSHOT_EXPORT_ARGS="--for-zero-height --output /tmp/mainnet-export.json"
+```
+
+Or call the script directly for more control:
+
+```
+python3 contrib/snapshot/export_snapshot.py --network mainnet --for-zero-height \
+  --output /tmp/mainnet-export.json [--skip-download] [--dry-run]
+```
+
+Useful flags:
+
+- `--for-zero-height`  fold rewards + commission into bank (recommended for the migration).
+- `--modules`          default `bank,staking,distribution`.
+- `--height`           default `-1` (latest).
+- `--skip-download`    reuse the cached snapshot in `~/zetacored_snapshot_<network>`.
+- `--dry-run`          print every command, execute nothing.
+- `--node-version`     only stamps a version string; it does NOT check out or build
+                       that release. Build the matching binary yourself first (see
+                       Prerequisites).
+
+Gotcha handled by the script: `zetacored export` writes an early WARN line to
+stdout ahead of the JSON, so the raw output is stripped to the first `{`.
+
+## Stage 2: snapshot compute
+
+```
+go run ./cmd/zetatool snapshot --input /tmp/mainnet-export.json --chain-id 7000 --output /tmp/mainnet-snap
+```
+
+Flags:
+
+- `--input`         path to `export.json` (required).
+- `--output`        output directory (default `.`).
+- `--chain-id`      codec chain id: testnet `7001`, mainnet `7000`.
+- `--pin` / `--wzeta`  non-claimable contract addresses routed to the remainder
+                    (repeatable or comma-separated). WZETA and known pools go here.
+- `--supply-check`  fail on any supply mismatch (default true).
+
+Outputs in `--output`:
+
+- `snapshot_db.csv`   one row per attributed address + one `remainder` row.
+  Columns: `canonical_address, class, liquid, staked, unbonding, total_azeta,
+  total_9dec, claim_status`. Postgres COPY-ready (`schema.sql`), `azeta` as
+  `NUMERIC` (raw azeta exceeds bigint). `total_9dec` = floored 18->9; SPL cap =
+  sum of `total_9dec`.
+- `schema.sql`        matching Postgres DDL.
+- `snapshot_human.csv`  readable ZETA-unit copy for eyeballing.
+
+The command prints bucket totals and runs three checks (sum export == supply;
+sum attributed + remainder == total; re-sum CSV == total), non-zero exit on any
+mismatch.
+
+## Look at the output
+
+DuckDB queries the CSV in place (handles the big NUMERICs; `brew install duckdb`):
+
+```
+duckdb -box -c "SELECT class, count(*) n, round(sum(total_azeta)/1e18,2) zeta \
+  FROM read_csv_auto('/tmp/mainnet-snap/snapshot_db.csv', types={'total_azeta':'DECIMAL(38,0)'}) \
+  GROUP BY class ORDER BY zeta DESC"
+```
+
+Browser UI: `duckdb -ui` then `CREATE TABLE s AS SELECT * FROM read_csv_auto(...)`.
+
+Or load `schema.sql` + `\copy` the CSV into Postgres and use any GUI.
+
+## Contract vs EOA (the WZETA / pool question)
+
+Accounts export as cosmos `BaseAccount` with no code hash, so you CANNOT tell a
+contract from an EOA in the export. Detect contracts out-of-band with
+`eth_getCode` against an EVM RPC (contracts return bytecode, EOAs return `0x`),
+then feed the contract addresses to Stage 2 via `--pin`. Contracts hold native
+that no one can claim on Solana, so pinning routes it to the remainder.
+
+Measured on mainnet (top 500 holders, H17619782): the 8 largest holders are EOAs
+(~1.0B ZETA, claimable); 16 are contracts holding 9.35M ZETA (~0.55%), dominated
+by WZETA `0x5f0b1a82749cb4e2278ec87f8bf6b618dc71a8bf` (6.6M) and the Accumulated
+Finance liquid-staking / lending stack. WZETA is 1:1 backed native, so the native
+backing for all DEX/LP WZETA positions sits under that one contract.
+
+## Try new ideas here
+
+- Change the non-claimable set: `--pin <addr>,<addr>` to route more contracts to
+  the remainder.
+- Swap the attribution rule (e.g. exclude unbonding, or split rewards out) in the
+  pure package `cmd/zetatool/snapshot/` and re-run against the same `export.json`.
+- Point Stage 2 at a devnet export to test on a small state.
+
+## Open questions / parked
+
+- Full contract detection: the top-500 scan captures ~all contract value, but a
+  full all-accounts `eth_getCode` sweep (on a local node) is the exhaustive
+  pre-migration step. Not wired into the tool yet.
+- Squads multisig address for the remainder recipient (pending tokenomics/legal).
+- Snapshot height selection for the real migration (freeze inbound, drain
+  outbounds, zero emissions, halt, export). Separate workstream.
+- Per-holder WZETA / DEX / LP attribution and the claim service / Solana program
+  are out of scope for the snapshot.

--- a/contrib/snapshot/export_snapshot.py
+++ b/contrib/snapshot/export_snapshot.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Snapshot Export Script
+======================
+Produces a `zetacored export` genesis JSON for testnet or mainnet, exporting the
+modules needed for a downstream snapshot (e.g. a ZETA -> Solana migration snapshot).
+
+Unlike the devnet fork flow, this does NOT sync or start the node: `zetacored export`
+reads committed state directly from the data dir, so we only init a home, drop in the
+network config, load a snapshot's `data/` into it, and run the export.
+
+Run from the root zeta-node directory:
+    python3 contrib/snapshot/export_snapshot.py --network testnet
+    python3 contrib/snapshot/export_snapshot.py --network mainnet
+Or:
+    make snapshot-export NETWORK=mainnet
+    make snapshot-export NETWORK=testnet SNAPSHOT_EXPORT_ARGS="--height 1000000 --modules bank,staking"
+
+Examples:
+    # Testnet, latest height, default modules (bank,staking,distribution)
+    python3 contrib/snapshot/export_snapshot.py --network testnet
+
+    # Mainnet, stamping a version label on the locally-built binary
+    python3 contrib/snapshot/export_snapshot.py --network mainnet --node-version v36.0.1
+
+    # Reuse an already-downloaded snapshot cache
+    python3 contrib/snapshot/export_snapshot.py --network mainnet --skip-download
+
+    # Dry run: print every resolved command, execute nothing
+    python3 contrib/snapshot/export_snapshot.py --network mainnet --dry-run
+
+Caveats:
+    1. Binary-version compatibility: the `zetacored` binary must be able to open the
+       snapshot's store, so build it from source checked out at the release the snapshot
+       was produced with (e.g. `git checkout v36.0.1`) BEFORE running. `--node-version`
+       only stamps the version string into the binary via `make install`'s linker flags;
+       it does NOT fetch or check out that release. Opening a snapshot with an
+       incompatible binary can fail or read incorrectly.
+    2. Pruned height: `--height <H>` for a specific old height only works if that height
+       is still un-pruned in the snapshot store. The default (-1 / latest) always works.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import requests
+
+# ============================================================================
+# Configuration Constants
+# ============================================================================
+
+HOME_DIR = Path.home()
+
+# Default export home — deliberately NOT the user's ~/.zetacored.
+DEFAULT_EXPORT_HOME = HOME_DIR / ".zetacored-snapshot-export"
+
+# network-config raw base + the files we pull into <HOME>/config/.
+NETWORK_CONFIG_BASE = "https://raw.githubusercontent.com/zeta-chain/network-config/main"
+CONFIG_FILES = ["genesis.json", "app.toml", "config.toml", "client.toml"]
+
+# Snapshot downloader is reused via subprocess rather than reimplemented.
+DOWNLOAD_SNAPSHOT_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "localnet"
+    / "scripts_python"
+    / "download_snapshot.py"
+)
+
+NETWORKS = {
+    "testnet": {
+        "chain_id": "athens_7001-1",
+        "config_dir": "athens3",
+        "cache_dir": HOME_DIR / "zetacored_snapshot_testnet",
+        "name": "Testnet",
+    },
+    "mainnet": {
+        "chain_id": "zetachain_7000-1",
+        "config_dir": "mainnet",
+        "cache_dir": HOME_DIR / "zetacored_snapshot_mainnet",
+        "name": "Mainnet",
+    },
+}
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def run_command(cmd, dry_run=False, shell=True, check=True):
+    """Run a shell command, or just print it in dry-run mode."""
+    print(f"Running: {cmd}")
+    if dry_run:
+        return
+    try:
+        subprocess.run(cmd, shell=shell, check=check, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Error running command: {cmd}")
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+def download_file(url, dest_path, dry_run=False):
+    """Download a file from URL to destination path, or print it in dry-run mode."""
+    print(f"Downloading {url} to {dest_path}")
+    if dry_run:
+        return
+    try:
+        response = requests.get(url, timeout=300)
+        response.raise_for_status()
+        with open(dest_path, 'wb') as f:
+            f.write(response.content)
+        print(f"Successfully downloaded {dest_path}")
+    except Exception as e:
+        print(f"Error downloading {url}: {e}")
+        sys.exit(1)
+
+def strip_preamble(raw_path, out_path):
+    """Copy raw_path to out_path, dropping any lines before the JSON object.
+
+    `zetacored export` prints the genesis JSON to stdout but the node logger can
+    emit warnings there first, so keep only from the first line starting with '{'.
+    """
+    with open(raw_path) as src, open(out_path, 'w') as dst:
+        started = False
+        for line in src:
+            if not started and not line.lstrip().startswith('{'):
+                continue
+            started = True
+            dst.write(line)
+    if not started:
+        print(f"Error: no JSON object found in export output {raw_path}")
+        sys.exit(1)
+
+# ============================================================================
+# Main Script
+# ============================================================================
+
+def main(args):
+    network = NETWORKS[args.network]
+    chain_id = network["chain_id"]
+    cache_dir = network["cache_dir"]
+    home = Path(args.home).expanduser() if args.home else DEFAULT_EXPORT_HOME
+    config_dir = home / "config"
+
+    height_label = "latest" if args.height == -1 else str(args.height)
+    output = Path(args.output).expanduser() if args.output else (
+        HOME_DIR / f"zeta-snapshot-{args.network}-{height_label}.json"
+    )
+    log_path = output.with_suffix(".log")
+
+    print("=" * 80)
+    print(f"ZetaChain Snapshot Export — {network['name']}")
+    print("=" * 80)
+    print(f"Chain ID:  {chain_id}")
+    print(f"Home:      {home}")
+    print(f"Modules:   {args.modules}")
+    print(f"Height:    {height_label}")
+    print(f"Output:    {output}")
+    if args.dry_run:
+        print("Mode:      DRY RUN (nothing will be executed)")
+    print("=" * 80)
+
+    # Step 1: Optionally build the binary at a specific version.
+    print("\n[1/5] Building zetacored...")
+    if args.node_version:
+        run_command(f"NODE_VERSION={args.node_version} make install", dry_run=args.dry_run)
+    else:
+        print("No --node-version given; using zetacored already on PATH.")
+
+    # Step 2: Initialize the export home.
+    print("\n[2/5] Initializing export home...")
+    run_command(
+        f"zetacored init export-node --chain-id {chain_id} --home {home} -o",
+        dry_run=args.dry_run,
+    )
+
+    # Step 3: Download network-config files into <HOME>/config/.
+    print("\n[3/5] Downloading network configuration...")
+    base = f"{NETWORK_CONFIG_BASE}/{network['config_dir']}"
+    for filename in CONFIG_FILES:
+        download_file(f"{base}/{filename}", config_dir / filename, dry_run=args.dry_run)
+
+    # Step 4: Load the snapshot's data dir into the export home.
+    print("\n[4/5] Loading snapshot data...")
+    if args.skip_download:
+        print("--skip-download set; reusing existing snapshot cache.")
+    else:
+        run_command(
+            f"python3 {DOWNLOAD_SNAPSHOT_SCRIPT} --chain-id {chain_id}",
+            dry_run=args.dry_run,
+        )
+
+    data_dir = home / "data"
+    run_command(f'rm -rf "{data_dir}"', dry_run=args.dry_run)
+    run_command(f'cp -r "{cache_dir / "data"}" "{data_dir}"', dry_run=args.dry_run)
+
+    # Step 5: Run the export.
+    print("\n[5/5] Exporting genesis...")
+    raw_output = output.with_name(output.name + ".raw")
+    export_cmd = f"zetacored export --home {home} --modules-to-export {args.modules}"
+    if args.height != -1:
+        export_cmd += f" --height {args.height}"
+    if args.for_zero_height:
+        export_cmd += " --for-zero-height"
+    export_cmd += f' > "{raw_output}" 2> "{log_path}"'
+    run_command(export_cmd, dry_run=args.dry_run)
+
+    # The node logger emits an early warning to stdout ahead of the JSON, which
+    # would make the output invalid JSON. Keep only from the first line that
+    # opens the genesis object.
+    if not args.dry_run:
+        strip_preamble(raw_output, output)
+        raw_output.unlink()
+
+    print("\n" + "=" * 80)
+    print(f"Export written to: {output}")
+    print(f"Export log:        {log_path}")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Export a zetacored genesis snapshot for testnet or mainnet",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--network",
+        required=True,
+        choices=["testnet", "mainnet"],
+        help="Which network to export",
+    )
+    parser.add_argument(
+        "--node-version",
+        default=None,
+        help="Build this node version before exporting (e.g. v36.0.1). "
+             "If omitted, uses the zetacored already on PATH.",
+    )
+    parser.add_argument(
+        "--modules",
+        default="bank,staking,distribution",
+        help="Comma-separated modules to export (default: bank,staking,distribution)",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=-1,
+        help="Height to export (default: -1 = latest)",
+    )
+    parser.add_argument(
+        "--for-zero-height",
+        action="store_true",
+        help="Prepare the export for a fresh zero-height genesis",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output path for the exported JSON "
+             "(default: ~/zeta-snapshot-<network>-<height>.json)",
+    )
+    parser.add_argument(
+        "--home",
+        default=None,
+        help=f"Export home directory (default: {DEFAULT_EXPORT_HOME})",
+    )
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Reuse the existing snapshot cache instead of downloading",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print every resolved command but execute nothing",
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/contrib/snapshot/pins_mainnet.txt
+++ b/contrib/snapshot/pins_mainnet.txt
@@ -1,0 +1,35 @@
+# Non-claimable native-ZETA holders on ZetaChain mainnet (chain 7000).
+#
+# These are contracts, not EOAs: they hold native ZETA that no keypair can claim
+# on Solana, so `zetatool snapshot --pin-file` routes their balances to the
+# remainder (migration multisig) instead of attributing them to a claimant.
+#
+# Source: eth_getCode over the 500 largest native-ZETA holders in the mainnet
+# export at height 17619782. Total 9,351,261 ZETA (~0.55% of supply).
+#
+# Only the address is parsed. Everything after `#` is a comment, and the ZETA
+# amounts below are a snapshot-time reference, not input.
+#
+# Caveats:
+#   - MAINNET ONLY. A testnet run needs no pins and will fail the pin-match
+#     check with this file (none of these addresses exist there).
+#   - Top-500 bounded. Smaller contract holders are still attributed and get
+#     resolved at claim time; the exhaustive all-accounts eth_getCode sweep is
+#     still open.
+
+0x5f0b1a82749cb4e2278ec87f8bf6b618dc71a8bf  # WETH9, 6,599,031 ZETA: canonical wrapped ZETA (WZETA); native backing for all WZETA/DEX/LP
+0x1840aabe58042e4080e248c7384381cb37178215  # stZETAMinterV203, 1,186,842 ZETA: Accumulated Finance unstZETA minter (unstake escrow)
+0x0fc8f47c5bd1c89b0e2f08bfe72df4ea9dff61aa  # proxy -> TTUV2Native, 680,661 ZETA: TTU v2 native staking/vault
+0x6197c0e4ce29338b8d40b7cc21a31344140ec58d  # FxEscrowProxy -> ZetaStaking, 299,405 ZETA: staking escrow
+0xa094488127a6c2282cb5289314ad1e511f2453ab  # stZETAMinterV205, 179,529 ZETA: AF unstZETA minter (v205)
+0x2463acdcea20513e6718d30fc43cf99d3b779039  # proxy -> CustomFeesNativeMerkleDistributor, 127,288 ZETA: airdrop/fee merkle distributor
+0x540095363a3642bc6dde623825261851b71d1b71  # wstZETALendingV102, 65,357 ZETA: AF wstZETA lending market
+0x866c2c90499071a7bdf57aa65cb23a12cb17eef1  # TransparentUpgradeableProxy, 30,584 ZETA: -> impl 0xA93f21B1 (unverified); 1 of 4 identical instances
+0x5bf8285e5452b4624f309eef659d8fd43a5639f0  # TransparentUpgradeableProxy, 30,472 ZETA: -> 0xA93f21B1; identical instance
+0x46f0f9cabae6d2691fe21322e1cabb3df5581db0  # TransparentUpgradeableProxy, 30,472 ZETA: -> 0xA93f21B1; identical instance
+0xb05ca1b178c042bdd0e6739047a13ba73142ce03  # TransparentUpgradeableProxy, 30,472 ZETA: -> 0xA93f21B1; identical instance
+0xcf83b0fc9cb8e15f0ce749ca9a0a5701490af20b  # proxy -> CustomFeesNativeMerkleDistributor, 28,338 ZETA: airdrop/fee merkle distributor
+0xf17e1f5b79c9d73db9904e4e9f9c8dc027dbebc0  # GnosisSafeProxy -> GnosisSafeL2, 22,531 ZETA: multisig wallet
+0x9b694d0ed151374989a4ec71d8a14764ae47f89d  # wstZETALendingV100, 15,195 ZETA: AF wstZETA lending market (v100)
+0x458e40fcd600b6e7d37a0dbd6c7cebe046f2122b  # SugarsV1, 15,128 ZETA: standalone contract
+0x987104c0ad5fb90bb685de45f1db4abadc975a21  # SafeProxy -> GnosisSafeL2, 9,955 ZETA: multisig wallet


### PR DESCRIPTION
## Summary
- **Stage 1, export** (`contrib/snapshot/export_snapshot.py` + `make snapshot-export`): produces a `zetacored export` genesis JSON for testnet or mainnet. Reuses `download_snapshot.py` for the fetch and skips the node sync a devnet fork needs, since `export` reads committed state straight from the data dir. Strips the logger preamble so the output is valid JSON.
- **Stage 2, compute** (`zetatool snapshot`): a pure, deterministic function over that export. Attributes `liquid + staked + unbonding` per address (slashing-aware via `TokensFromShares`), routes module accounts, the zero address and pinned contracts to a single remainder, and emits Postgres-ready CSV + `schema.sql`. `remainder = supply - attributed`, so nothing is dropped and the books balance by construction.
- **Contract pinning**: contracts hold native ZETA no keypair can claim, so they are pinned out of attribution. `--pin-file` reads them from a file, and `contrib/snapshot/pins_mainnet.txt` carries the 16 mainnet contracts found by an `eth_getCode` scan of the top-500 holders (9,351,261 ZETA). A pin that matches no holder now fails the run, which is what catches a typo or a wrong-network pin file.
- Verified against a real testnet export at height 22052574: sum of 2,411,443 balances equals recorded bank supply equals live supply, to the wei. Mainnet export at height 17619782 also produced and reconciled.
- Offline tooling only. No changes to consensus, modules, or runtime behavior.

`contrib/snapshot/README.md` has the exact commands for both stages, the flags, and a Verification status section listing what is and is not proven yet.

Generated with [Claude Code](https://claude.com/claude-code)
