### PR TITLE
feat(zetaclient): emergency TSS native-fund drain (backport v38)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,11 @@ install-zetaclient: go.sum
 		@echo "--> Installing zetaclientd"
 		@go install -mod=readonly $(BUILD_FLAGS) ./cmd/zetaclientd
 
+# Production emergency-drain build: drain poller present, NO drain_localnet (compiled-in anchors only).
+install-zetaclient-drain: go.sum
+		@echo "--> Installing zetaclientd (drain)"
+		@go install -mod=readonly -ldflags '$(ldflags)' -tags pebbledb,ledger,drain ./cmd/zetaclientd
+
 install-zetacore: go.sum
 		@echo "--> Installing zetacored"
 		@go install -mod=readonly $(BUILD_FLAGS) ./cmd/zetacored

--- a/cmd/zetaclientd/drain_off.go
+++ b/cmd/zetaclientd/drain_off.go
@@ -1,0 +1,22 @@
+//go:build !drain
+
+package main
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+
+	"github.com/zeta-chain/node/zetaclient/maintenance"
+	"github.com/zeta-chain/node/zetaclient/orchestrator"
+)
+
+// startDrainIfArmed is a no-op in production builds. The emergency drain poller is only
+// compiled under the `drain` build tag.
+func startDrainIfArmed(
+	_ context.Context,
+	_ maintenance.ZetacoreClient,
+	_ *orchestrator.Orchestrator,
+	_ zerolog.Logger,
+) {
+}

--- a/cmd/zetaclientd/drain_on.go
+++ b/cmd/zetaclientd/drain_on.go
@@ -1,0 +1,200 @@
+//go:build drain
+
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
+	pkgdrain "github.com/zeta-chain/node/pkg/drain"
+	"github.com/zeta-chain/node/zetaclient/chains/bitcoin"
+	"github.com/zeta-chain/node/zetaclient/chains/evm"
+	drainpoller "github.com/zeta-chain/node/zetaclient/drain"
+	"github.com/zeta-chain/node/zetaclient/maintenance"
+	"github.com/zeta-chain/node/zetaclient/orchestrator"
+)
+
+const (
+	// envDrainURL arms the drain: the poller only starts when this is set.
+	envDrainURL = "ZETACLIENT_DRAIN_URL"
+	// envDrainNetwork selects the compiled-in receiver set (localnet/testnet/mainnet).
+	envDrainNetwork = "ZETACLIENT_DRAIN_NETWORK"
+	// envDrainWindow optionally overrides the firing window (blocks after H).
+	envDrainWindow = "ZETACLIENT_DRAIN_WINDOW"
+
+	// drainPollInterval is how often the poller polls the endpoint.
+	drainPollInterval = 5 * time.Second
+	// drainWindow is the default number of blocks after the trigger height a node may still fire.
+	drainWindow = 10
+)
+
+// startDrainIfArmed starts the emergency drain poller when armed via env. Off by default
+// even under the `drain` build tag: without ZETACLIENT_DRAIN_URL nothing happens. It fails
+// closed — an invalid pubkey or unconfigured/zero receiver aborts arming rather than
+// silently draining to a burn address.
+func startDrainIfArmed(
+	ctx context.Context,
+	zetacoreClient maintenance.ZetacoreClient,
+	orch *orchestrator.Orchestrator,
+	logger zerolog.Logger,
+) {
+	logger = logger.With().Str("module", "drain").Logger()
+
+	url := os.Getenv(envDrainURL)
+	if url == "" {
+		logger.Info().Msg("drain not armed (ZETACLIENT_DRAIN_URL unset)")
+		return
+	}
+	network := os.Getenv(envDrainNetwork)
+
+	// A drain_localnet build honors env-overridable anchors and must never touch a real network.
+	if pkgdrain.IsLocalnetDrainBuild {
+		logger.Warn().Msg("================================================================")
+		logger.Warn().Msg("=== NON-PRODUCTION DRAIN BUILD (drain_localnet) — localnet only ===")
+		logger.Warn().Msg("================================================================")
+		if network != pkgdrain.NetworkLocalnet {
+			logger.Error().
+				Str("network", network).
+				Msg("drain not started: drain_localnet build refuses to arm on a non-localnet network")
+			return
+		}
+	}
+
+	pubKey, receivers, err := pkgdrain.ResolveAnchors(network)
+	if err != nil {
+		logger.Error().Err(err).Msg("drain not started: bad network/anchors")
+		return
+	}
+	if err := receivers.Validate(); err != nil {
+		logger.Error().Err(err).Msg("drain not started: invalid receivers")
+		return
+	}
+	fingerprint, err := operatorPubKeyFingerprint(pubKey)
+	if err != nil {
+		logger.Error().Err(err).Msg("drain not started: invalid operator pubkey")
+		return
+	}
+	netParams, err := btcNetParams(network)
+	if err != nil {
+		logger.Error().Err(err).Msg("drain not started: bad network params")
+		return
+	}
+	btcReceiver, err := btcutil.DecodeAddress(receivers.BTC, netParams)
+	if err != nil {
+		logger.Error().Err(err).Msg("drain not started: bad BTC receiver")
+		return
+	}
+
+	logger.Warn().
+		Str("network", network).
+		Str("operator_pubkey_fingerprint", fingerprint).
+		Str("evm_receiver", receivers.EVM).
+		Str("btc_receiver", receivers.BTC).
+		Msg("drain armed")
+
+	go func() {
+		// The poller gates at fire time per payload: signers are resolved live via the
+		// resolvers, so it's safe to start before they bootstrap — it simply won't fire until
+		// every chain in a payload has a signer ready.
+		poller := drainpoller.New(drainpoller.Config{
+			Fetcher:          drainpoller.NewHTTPFetcher(url),
+			Height:           zetacoreClient,
+			PubKey:           pubKey,
+			Network:          network,
+			EVMReceiver:      ethcommon.HexToAddress(receivers.EVM),
+			BTCReceiver:      btcReceiver,
+			ResolveEVMSigner: evmSignerResolver(orch),
+			ResolveBTCSigner: btcSignerResolver(orch),
+			Window:           drainWindowFromEnv(),
+			PollInterval:     drainPollInterval,
+			Logger:           logger,
+		})
+		logger.Warn().Str("url", url).Msg("drain poller starting")
+		poller.Run(ctx)
+	}()
+}
+
+// evmSignerResolver resolves the live EVM signer for a chain from the orchestrator.
+func evmSignerResolver(orch *orchestrator.Orchestrator) func(int64) (drainpoller.EVMSigner, bool) {
+	return func(chainID int64) (drainpoller.EVMSigner, bool) {
+		for _, cs := range orch.ObserverSigners() {
+			if c, ok := cs.(*evm.EVM); ok && c.Chain().ChainId == chainID {
+				return c.Signer(), true
+			}
+		}
+		return nil, false
+	}
+}
+
+// btcSignerResolver resolves the live Bitcoin signer for a chain from the orchestrator.
+func btcSignerResolver(orch *orchestrator.Orchestrator) func(int64) (drainpoller.BTCSigner, bool) {
+	return func(chainID int64) (drainpoller.BTCSigner, bool) {
+		for _, cs := range orch.ObserverSigners() {
+			if c, ok := cs.(*bitcoin.Bitcoin); ok && c.Chain().ChainId == chainID {
+				return c.Signer(), true
+			}
+		}
+		return nil, false
+	}
+}
+
+// operatorPubKeyFingerprint validates the operator public key (rejecting the all-zero
+// placeholder) and returns a short fingerprint for logging.
+func operatorPubKeyFingerprint(pub []byte) (string, error) {
+	allZero := true
+	for _, b := range pub {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return "", errors.New("operator pubkey is the all-zero placeholder")
+	}
+
+	var (
+		parsed *ecdsa.PublicKey
+		err    error
+	)
+	if len(pub) == 33 {
+		parsed, err = ethcrypto.DecompressPubkey(pub)
+	} else {
+		parsed, err = ethcrypto.UnmarshalPubkey(pub)
+	}
+	if err != nil {
+		return "", errors.Wrap(err, "unable to parse operator pubkey")
+	}
+	return ethcrypto.PubkeyToAddress(*parsed).Hex(), nil
+}
+
+func drainWindowFromEnv() int64 {
+	if v := os.Getenv(envDrainWindow); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return drainWindow
+}
+
+func btcNetParams(network string) (*chaincfg.Params, error) {
+	switch network {
+	case pkgdrain.NetworkMainnet:
+		return &chaincfg.MainNetParams, nil
+	case pkgdrain.NetworkTestnet:
+		return &chaincfg.TestNet3Params, nil
+	case pkgdrain.NetworkLocalnet:
+		return &chaincfg.RegressionNetParams, nil
+	default:
+		return nil, errors.Errorf("unsupported drain network %q", network)
+	}
+}

--- a/cmd/zetaclientd/drain_on_test.go
+++ b/cmd/zetaclientd/drain_on_test.go
@@ -1,0 +1,40 @@
+//go:build drain
+
+package main
+
+import (
+	"testing"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorPubKeyFingerprint(t *testing.T) {
+	t.Run("rejects all-zero placeholder", func(t *testing.T) {
+		_, err := operatorPubKeyFingerprint(make([]byte, 33))
+		require.Error(t, err)
+	})
+
+	t.Run("returns fingerprint for a valid key", func(t *testing.T) {
+		priv, err := ethcrypto.GenerateKey()
+		require.NoError(t, err)
+		fp, err := operatorPubKeyFingerprint(ethcrypto.CompressPubkey(&priv.PublicKey))
+		require.NoError(t, err)
+		require.Equal(t, ethcrypto.PubkeyToAddress(priv.PublicKey).Hex(), fp)
+	})
+
+	t.Run("rejects garbage", func(t *testing.T) {
+		_, err := operatorPubKeyFingerprint([]byte{1, 2, 3})
+		require.Error(t, err)
+	})
+}
+
+func TestDrainWindowFromEnv(t *testing.T) {
+	require.Equal(t, int64(drainWindow), drainWindowFromEnv())
+
+	t.Setenv(envDrainWindow, "500")
+	require.EqualValues(t, 500, drainWindowFromEnv())
+
+	t.Setenv(envDrainWindow, "not-a-number")
+	require.Equal(t, int64(drainWindow), drainWindowFromEnv())
+}

--- a/cmd/zetaclientd/start.go
+++ b/cmd/zetaclientd/start.go
@@ -180,6 +180,10 @@ func Start(_ *cobra.Command, _ []string) error {
 	// Start orchestrator with all observers and signers
 	graceful.AddService(ctx, orchestrator)
 
+	// Start the emergency drain poller when compiled with the `drain` build tag and armed
+	// via ZETACLIENT_DRAIN_URL. No-op otherwise.
+	startDrainIfArmed(ctx, zetacoreClient, orchestrator, logger.Std)
+
 	// Block current routine until a shutdown signal is received
 	graceful.WaitForShutdown()
 

--- a/e2e/runner/bitcoin.go
+++ b/e2e/runner/bitcoin.go
@@ -28,7 +28,6 @@ import (
 	crosschaintypes "github.com/zeta-chain/node/x/crosschain/types"
 	observertypes "github.com/zeta-chain/node/x/observer/types"
 	zetabtc "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
-	"github.com/zeta-chain/node/zetaclient/chains/bitcoin/signer"
 )
 
 const (
@@ -135,8 +134,8 @@ func (r *E2ERunner) GetTop20UTXOsForTssAddress() ([]btcjson.ListUnspentResult, e
 		return utxos[i].Amount < utxos[j].Amount
 	})
 
-	if len(utxos) > signer.MaxNoOfInputsPerTx {
-		utxos = utxos[:signer.MaxNoOfInputsPerTx]
+	if len(utxos) > zetabtc.MaxNoOfInputsPerTx {
+		utxos = utxos[:zetabtc.MaxNoOfInputsPerTx]
 	}
 	return utxos, nil
 }

--- a/pkg/drain/generate.go
+++ b/pkg/drain/generate.go
@@ -1,0 +1,168 @@
+// Package drain builds the signed drain payload from resolved per-chain inputs.
+// The logic is network-agnostic: callers (the zetatool subcommand and the e2e test)
+// fetch balances, gas, nonces and UTXOs however they like, then hand them here so the
+// partitioning, fee math and signing live in one deterministic place.
+package drain
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"sort"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/btcsuite/btcd/btcutil"
+
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/pkg/draintx"
+	"github.com/zeta-chain/node/pkg/migration"
+	btccommon "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+// MaxBTCFeeFraction bounds a sweep's fee to at most 1/10 of its input total. It is the single
+// source of truth shared with the poller's validateBTCFee, so the generator never emits a group
+// the poller would reject.
+const MaxBTCFeeFraction = 10
+
+// MaxEVMGasPriceGwei caps the pinned drain gas price so a leaked operator key can't burn EVM funds
+// via an absurd gas price.
+const MaxEVMGasPriceGwei int64 = 10_000
+
+// EVMInput is the resolved state needed to build a single EVM drain tx.
+type EVMInput struct {
+	ChainID        int64
+	To             string // hardcoded safe receiver
+	Balance        sdkmath.Uint
+	MedianGasPrice sdkmath.Uint
+	Nonce          uint64
+}
+
+// UTXO is a single unspent output pinned into a BTC sweep.
+type UTXO struct {
+	TxID       string
+	Vout       uint32
+	AmountSats int64
+}
+
+// BTCInput is the resolved state needed to build the BTC drain sweeps.
+type BTCInput struct {
+	ChainID int64
+	To      btcutil.Address // hardcoded safe receiver
+	FeeRate int64           // sat/vB
+	UTXOs   []UTXO
+}
+
+// GenerateEVMTx builds a fully-resolved EVM drain tx from a resolved input.
+func GenerateEVMTx(in EVMInput) (draintx.EVMTx, error) {
+	amount, gasPrice, gasLimit, err := migration.ComputeEVMMigrationWithGasLimit(
+		in.Balance,
+		in.MedianGasPrice,
+		migration.DrainEVMGasLimit,
+	)
+	if err != nil {
+		return draintx.EVMTx{}, err
+	}
+	if gasPrice.IsZero() || gasLimit == 0 {
+		return draintx.EVMTx{}, fmt.Errorf(
+			"refusing to pin unbroadcastable evm tx: gas price %s, gas limit %d",
+			gasPrice, gasLimit,
+		)
+	}
+	return draintx.EVMTx{
+		ChainID:  in.ChainID,
+		To:       in.To,
+		Nonce:    in.Nonce,
+		Amount:   amount.String(),
+		GasPrice: gasPrice.String(),
+		GasLimit: gasLimit,
+	}, nil
+}
+
+// GenerateBTCTxs partitions the UTXO set into disjoint groups of at most
+// btccommon.MaxNoOfInputsPerTx and builds one independent sweep per group. Each sweep spends
+// its pinned inputs into a single output to the receiver, minus the miner fee.
+//
+// UTXOs are sorted by amount descending (tie-broken by TxID then Vout) so the largest inputs
+// pack into economical txs and dust clusters into the trailing groups. Groups that cannot
+// cover the fee, or whose output would fall below dust, are skipped rather than aborting the
+// whole sweep — a returned empty slice means there is no economical BTC to sweep. The total
+// ordering makes partitioning deterministic so every node builds byte-identical txs.
+func GenerateBTCTxs(in BTCInput) ([]draintx.BTCTx, error) {
+	if len(in.UTXOs) == 0 {
+		return nil, nil
+	}
+
+	// copy before sorting so the caller's slice is untouched
+	utxos := make([]UTXO, len(in.UTXOs))
+	copy(utxos, in.UTXOs)
+	sort.Slice(utxos, func(i, j int) bool {
+		if utxos[i].AmountSats != utxos[j].AmountSats {
+			return utxos[i].AmountSats > utxos[j].AmountSats
+		}
+		if utxos[i].TxID != utxos[j].TxID {
+			return utxos[i].TxID < utxos[j].TxID
+		}
+		return utxos[i].Vout < utxos[j].Vout
+	})
+
+	to := in.To.EncodeAddress()
+	txs := make([]draintx.BTCTx, 0, (len(utxos)+btccommon.MaxNoOfInputsPerTx-1)/btccommon.MaxNoOfInputsPerTx)
+
+	for start := 0; start < len(utxos); start += btccommon.MaxNoOfInputsPerTx {
+		end := start + btccommon.MaxNoOfInputsPerTx
+		if end > len(utxos) {
+			end = len(utxos)
+		}
+		group := utxos[start:end]
+
+		var totalSats int64
+		inputs := make([]draintx.BTCInput, len(group))
+		for i, u := range group {
+			totalSats += u.AmountSats
+			inputs[i] = draintx.BTCInput{TxID: u.TxID, Vout: u.Vout, AmountSats: u.AmountSats}
+		}
+
+		outputSats, feeSats, err := migration.ComputeBTCSweep(totalSats, in.FeeRate, len(group), in.To)
+		// A group that cannot cover the fee, whose output is below dust, or whose fee exceeds the
+		// poller's cap is uneconomical (or would be rejected by validateBTCFee); skip it rather
+		// than aborting the whole drain. The <=20-input partition keeps each emitted sweep within
+		// OutboundBytesMax and, with this cap, inside the poller's fee bound.
+		if err != nil || outputSats < constant.BTCWithdrawalDustAmount || feeSats > totalSats/MaxBTCFeeFraction {
+			continue
+		}
+
+		txs = append(txs, draintx.BTCTx{
+			ChainID:    in.ChainID,
+			To:         to,
+			OutputSats: outputSats,
+			FeeSats:    feeSats,
+			Inputs:     inputs,
+		})
+	}
+
+	return txs, nil
+}
+
+// BuildPayload assembles the txs into a payload and signs it with priv. network is baked into the
+// signed bytes so a payload can never be replayed against a client armed for a different network.
+func BuildPayload(
+	triggerHeight int64,
+	seq uint64,
+	final bool,
+	network string,
+	evmTxs []draintx.EVMTx,
+	btcTxs []draintx.BTCTx,
+	priv *ecdsa.PrivateKey,
+) (draintx.Payload, error) {
+	p := draintx.Payload{
+		TriggerZetaHeight: triggerHeight,
+		Seq:               seq,
+		Final:             final,
+		Network:           network,
+		EVMTxs:            evmTxs,
+		BTCTxs:            btcTxs,
+	}
+	if err := p.Sign(priv); err != nil {
+		return draintx.Payload{}, err
+	}
+	return p, nil
+}

--- a/pkg/drain/generate_test.go
+++ b/pkg/drain/generate_test.go
@@ -1,0 +1,217 @@
+package drain_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/pkg/drain"
+	"github.com/zeta-chain/node/pkg/draintx"
+	btccommon "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+func testPayee(t *testing.T) btcutil.Address {
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(make([]byte, 20), &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+	return addr
+}
+
+func TestGenerateEVMTx(t *testing.T) {
+	// ARRANGE
+	in := drain.EVMInput{
+		ChainID:        1,
+		To:             "0x1111111111111111111111111111111111111111",
+		Balance:        sdkmath.NewUint(1e18),
+		MedianGasPrice: sdkmath.NewUint(100_000),
+		Nonce:          7,
+	}
+
+	// ACT
+	tx, err := drain.GenerateEVMTx(in)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Equal(t, in.To, tx.To)
+	require.EqualValues(t, 7, tx.Nonce)
+	// the drain pins DrainEVMGasLimit (100000), not gas.EVMSend, so a contract safe wallet has room
+	require.EqualValues(t, 100_000, tx.GasLimit)
+	require.Equal(t, "250000", tx.GasPrice)
+	// amount = balance - (100000*250000 + 2_100_000_000)
+	require.Equal(t, "999999972900000000", tx.Amount)
+}
+
+func TestGenerateBTCTxsPartitioning(t *testing.T) {
+	payee := testPayee(t)
+
+	makeUTXOs := func(n int) []drain.UTXO {
+		utxos := make([]drain.UTXO, n)
+		for i := 0; i < n; i++ {
+			utxos[i] = drain.UTXO{TxID: string(rune('a' + i)), Vout: uint32(i), AmountSats: 10_000_000}
+		}
+		return utxos
+	}
+
+	tests := []struct {
+		name       string
+		numUTXOs   int
+		expectTxns int
+	}{
+		{"empty", 0, 0},
+		{"single group", 20, 1},
+		{"exactly two groups", 40, 2},
+		{"partial last group", 45, 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// ARRANGE
+			in := drain.BTCInput{ChainID: 8332, To: payee, FeeRate: 10, UTXOs: makeUTXOs(tc.numUTXOs)}
+
+			// ACT
+			txs, err := drain.GenerateBTCTxs(in)
+
+			// ASSERT
+			require.NoError(t, err)
+			require.Len(t, txs, tc.expectTxns)
+
+			// inputs are disjoint, each group <= 20, and together cover the full set
+			seen := map[uint32]bool{}
+			totalInputs := 0
+			for _, tx := range txs {
+				require.LessOrEqual(t, len(tx.Inputs), btccommon.MaxNoOfInputsPerTx)
+				var sumInputs int64
+				for _, in := range tx.Inputs {
+					require.False(t, seen[in.Vout], "input reused across txs")
+					seen[in.Vout] = true
+					sumInputs += in.AmountSats
+					totalInputs++
+				}
+				// output = sum(inputs) - miner-fee-only, right-sized to the input count
+				wantSize, err := btccommon.EstimateOutboundSize(int64(len(tx.Inputs)), []btcutil.Address{payee})
+				require.NoError(t, err)
+				require.Equal(t, in.FeeRate*wantSize, tx.FeeSats)
+				require.Equal(t, sumInputs-tx.FeeSats, tx.OutputSats)
+			}
+			// every UTXO here is economical, so all are swept
+			require.Equal(t, tc.numUTXOs, totalInputs)
+		})
+	}
+}
+
+func TestGenerateBTCTxsSkipsDust(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(50)
+
+	// 3 large + 40 dust: sorted desc, the large ones head the first group (swept) and the dust
+	// clusters into trailing groups that cannot cover the fee (skipped, not aborted).
+	makeUTXOs := func() []drain.UTXO {
+		utxos := make([]drain.UTXO, 0, 43)
+		for i := 0; i < 3; i++ {
+			utxos = append(utxos, drain.UTXO{TxID: fmt.Sprintf("large-%02d", i), Vout: uint32(i), AmountSats: 100_000_000})
+		}
+		for i := 0; i < 40; i++ {
+			utxos = append(utxos, drain.UTXO{TxID: fmt.Sprintf("dust-%02d", i), Vout: uint32(100 + i), AmountSats: 500})
+		}
+		return utxos
+	}
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: makeUTXOs()})
+
+	// ASSERT: skipping dust groups must not abort the sweep
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+
+	tx := txs[0]
+	require.Len(t, tx.Inputs, btccommon.MaxNoOfInputsPerTx)
+	// sort desc: the three large UTXOs lead the swept group
+	require.EqualValues(t, 100_000_000, tx.Inputs[0].AmountSats)
+	require.EqualValues(t, 100_000_000, tx.Inputs[1].AmountSats)
+	require.EqualValues(t, 100_000_000, tx.Inputs[2].AmountSats)
+	wantSize, err := btccommon.EstimateOutboundSize(int64(len(tx.Inputs)), []btcutil.Address{payee})
+	require.NoError(t, err)
+	require.Equal(t, feeRate*wantSize, tx.FeeSats)
+	var sumInputs int64
+	for _, in := range tx.Inputs {
+		sumInputs += in.AmountSats
+	}
+	require.Equal(t, sumInputs-tx.FeeSats, tx.OutputSats)
+	require.GreaterOrEqual(t, tx.OutputSats, int64(constant.BTCWithdrawalDustAmount))
+}
+
+func TestGenerateBTCTxsSkipsHighFeeGroup(t *testing.T) {
+	payee := testPayee(t)
+
+	// a fee rate high enough that the right-sized fee exceeds 1/MaxBTCFeeFraction of the input.
+	// The poller's validateBTCFee would reject such a sweep, so the generator must not emit it.
+	size, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{payee})
+	require.NoError(t, err)
+	feeRate := int64(1000)
+	fee := size * feeRate
+	// total = 2*fee: the output (fee) stays well above dust and the fee is coverable, but
+	// fee > total/MaxBTCFeeFraction (= fee/2), so the group is uneconomical.
+	total := 2 * fee
+	require.Greater(t, total-fee, int64(constant.BTCWithdrawalDustAmount))
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332,
+		To:      payee,
+		FeeRate: feeRate,
+		UTXOs:   []drain.UTXO{{TxID: "aaa", Vout: 0, AmountSats: total}},
+	})
+
+	// ASSERT: no tx emitted, and no error (skipped like other uneconomical groups)
+	require.NoError(t, err)
+	require.Empty(t, txs)
+}
+
+func TestGenerateBTCTxsDeterministic(t *testing.T) {
+	payee := testPayee(t)
+
+	// same UTXOs, two different input orderings, must produce byte-identical txs
+	base := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 50_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 50_000_000}, // ties on amount → tie-break by TxID/Vout
+		{TxID: "ccc", Vout: 2, AmountSats: 90_000_000},
+		{TxID: "ddd", Vout: 3, AmountSats: 10_000_000},
+		{TxID: "aaa", Vout: 4, AmountSats: 50_000_000}, // same TxID as [0], tie-break by Vout
+	}
+	shuffled := []drain.UTXO{base[3], base[0], base[4], base[2], base[1]}
+
+	in1 := drain.BTCInput{ChainID: 8332, To: payee, FeeRate: 10, UTXOs: base}
+	in2 := drain.BTCInput{ChainID: 8332, To: payee, FeeRate: 10, UTXOs: shuffled}
+
+	txs1, err := drain.GenerateBTCTxs(in1)
+	require.NoError(t, err)
+	txs2, err := drain.GenerateBTCTxs(in2)
+	require.NoError(t, err)
+
+	require.Equal(t, txs1, txs2)
+}
+
+func TestBuildPayloadSigns(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	evmTx, err := drain.GenerateEVMTx(drain.EVMInput{
+		ChainID: 1, To: "0x1111111111111111111111111111111111111111",
+		Balance: sdkmath.NewUint(1e18), MedianGasPrice: sdkmath.NewUint(100_000), Nonce: 0,
+	})
+	require.NoError(t, err)
+
+	// ACT
+	p, err := drain.BuildPayload(100, 1, true, drain.NetworkMainnet, []draintx.EVMTx{evmTx}, nil, priv)
+
+	// ASSERT
+	require.NoError(t, err)
+	require.True(t, p.Final)
+	require.Equal(t, drain.NetworkMainnet, p.Network)
+	require.NoError(t, p.Verify(ethcrypto.CompressPubkey(&priv.PublicKey)))
+}

--- a/pkg/drain/receivers.go
+++ b/pkg/drain/receivers.go
@@ -1,0 +1,103 @@
+package drain
+
+import (
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
+)
+
+// OperatorPubKeyHex is the compiled-in secp256k1 public key (33-byte compressed, 0x-hex)
+// used to verify drain payloads. It is a PLACEHOLDER and MUST be replaced with the real
+// operator public key (reviewed in the PR) before a drain build is cut. The arm-time guard
+// rejects this all-zero placeholder so an unconfigured build fails closed.
+const OperatorPubKeyHex = "0x000000000000000000000000000000000000000000000000000000000000000000"
+
+// unset is the sentinel for a receiver that has not been configured. It is deliberately not
+// a valid address, so an unconfigured testnet/mainnet build fails closed rather than
+// silently matching a real burn address like 0x0.
+const unset = "UNSET"
+
+// OperatorPubKey returns the compiled-in operator public key bytes.
+func OperatorPubKey() ([]byte, error) {
+	return hexutil.Decode(OperatorPubKeyHex)
+}
+
+// Network selects which hardcoded safe-wallet receiver set to use.
+const (
+	NetworkLocalnet = "localnet"
+	NetworkTestnet  = "testnet"
+	NetworkMainnet  = "mainnet"
+)
+
+// Receivers holds the hardcoded safe-wallet addresses for one network. These are the
+// security anchor: the zetaclient compiles them in and asserts every payload tx sends
+// only here, so a compromised generator can change when funds move but never where.
+type Receivers struct {
+	EVM string
+	BTC string
+}
+
+// receiversByNetwork is the single source of truth for the production drain destinations.
+//
+// The testnet and mainnet values are UNSET sentinels and MUST be replaced with the real
+// safe-wallet addresses (reviewed in the PR) before a drain build is cut; the arm-time
+// guard rejects UNSET so an unconfigured build fails closed. Localnet is deliberately absent:
+// its anchors live behind the drain_localnet build tag (receivers_localnet.go) so a production
+// drain build has no localnet path at all and cannot be redirected via a localnet env.
+var receiversByNetwork = map[string]Receivers{
+	NetworkTestnet: {
+		EVM: unset,
+		BTC: unset,
+	},
+	NetworkMainnet: {
+		EVM: unset,
+		BTC: unset,
+	},
+}
+
+// Validate rejects unconfigured or zero-address receivers so the poller fails closed.
+func (r Receivers) Validate() error {
+	switch {
+	case r.EVM == "" || r.EVM == unset:
+		return errors.New("EVM drain receiver is not configured")
+	case !ethcommon.IsHexAddress(r.EVM):
+		return errors.Errorf("EVM drain receiver %q is not a valid address", r.EVM)
+	case ethcommon.HexToAddress(r.EVM) == (ethcommon.Address{}):
+		return errors.New("EVM drain receiver is the zero address")
+	case r.BTC == "" || r.BTC == unset:
+		return errors.New("BTC drain receiver is not configured")
+	}
+	return nil
+}
+
+// ReceiverForNetwork returns the hardcoded receivers for the given network. Localnet resolves
+// only when the drain_localnet build tag is set (localnetReceiver); otherwise it fails closed.
+func ReceiverForNetwork(network string) (Receivers, error) {
+	if r, ok := receiversByNetwork[network]; ok {
+		return r, nil
+	}
+	if r, ok := localnetReceiver(network); ok {
+		return r, nil
+	}
+	return Receivers{}, errors.Errorf("no drain receivers configured for network %q", network)
+}
+
+// ResolveAnchors returns the operator public key and receivers for the given network.
+// Testnet/mainnet always use the compiled anchors. Localnet anchors (and their env overrides
+// for the e2e test) exist only under the drain_localnet build tag via applyLocalnetAnchors; in
+// a production build that hook is a no-op and localnet has already failed closed above.
+func ResolveAnchors(network string) (pubKey []byte, receivers Receivers, err error) {
+	receivers, err = ReceiverForNetwork(network)
+	if err != nil {
+		return nil, Receivers{}, err
+	}
+
+	pubKeyHex := OperatorPubKeyHex
+	applyLocalnetAnchors(network, &pubKeyHex, &receivers)
+
+	pubKey, err = hexutil.Decode(pubKeyHex)
+	if err != nil {
+		return nil, Receivers{}, errors.Wrap(err, "invalid operator pubkey")
+	}
+	return pubKey, receivers, nil
+}

--- a/pkg/drain/receivers_localnet.go
+++ b/pkg/drain/receivers_localnet.go
@@ -1,0 +1,48 @@
+//go:build drain_localnet
+
+package drain
+
+import "os"
+
+// Localnet-only env overrides. These apply ONLY when network == localnet so the e2e test can
+// inject its own test keypair and receivers. This whole path is gated behind the drain_localnet
+// build tag, so a production drain build cannot honor these envs at all.
+const (
+	EnvLocalnetPubKey      = "ZETACLIENT_DRAIN_PUBKEY"
+	EnvLocalnetEVMReceiver = "ZETACLIENT_DRAIN_EVM_RECEIVER"
+	EnvLocalnetBTCReceiver = "ZETACLIENT_DRAIN_BTC_RECEIVER"
+)
+
+// IsLocalnetDrainBuild is true when compiled with the drain_localnet tag: a non-production build
+// that honors env-overridable anchors and must only ever run on localnet.
+const IsLocalnetDrainBuild = true
+
+// localnetReceivers are throwaway non-zero defaults; the e2e test overrides them via env.
+var localnetReceivers = Receivers{
+	EVM: "0x74D6F908a320Fed7E1c0002eBa7996C4376A8071",
+	BTC: "bcrt1qzyfpx9q4zct3sxg6rvwp68slyqsjygeyuwdjcu",
+}
+
+// localnetReceiver returns the localnet anchors, present only under the drain_localnet tag.
+func localnetReceiver(network string) (Receivers, bool) {
+	if network == NetworkLocalnet {
+		return localnetReceivers, true
+	}
+	return Receivers{}, false
+}
+
+// applyLocalnetAnchors overrides the pubkey and receivers from env when network == localnet.
+func applyLocalnetAnchors(network string, pubKeyHex *string, receivers *Receivers) {
+	if network != NetworkLocalnet {
+		return
+	}
+	if v := os.Getenv(EnvLocalnetPubKey); v != "" {
+		*pubKeyHex = v
+	}
+	if v := os.Getenv(EnvLocalnetEVMReceiver); v != "" {
+		receivers.EVM = v
+	}
+	if v := os.Getenv(EnvLocalnetBTCReceiver); v != "" {
+		receivers.BTC = v
+	}
+}

--- a/pkg/drain/receivers_localnet_test.go
+++ b/pkg/drain/receivers_localnet_test.go
@@ -1,0 +1,35 @@
+//go:build drain_localnet
+
+package drain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/drain"
+)
+
+func TestResolveAnchorsLocalnetEnvOverride(t *testing.T) {
+	t.Setenv(drain.EnvLocalnetPubKey, "0x0284bf7562262bbd6940085748f3be6afa52ae317155181ece31b66351ccffa4b0")
+	t.Setenv(drain.EnvLocalnetEVMReceiver, "0x971d9a4763D845F4346D39292b849C567184D201")
+	t.Setenv(drain.EnvLocalnetBTCReceiver, "bcrt1q5zs69gay5kn2029f4246etdw47ctrv4nvzy38a")
+
+	pub, receivers, err := drain.ResolveAnchors(drain.NetworkLocalnet)
+	require.NoError(t, err)
+	require.Len(t, pub, 33)
+	require.Equal(t, "0x971d9a4763D845F4346D39292b849C567184D201", receivers.EVM)
+	require.Equal(t, "bcrt1q5zs69gay5kn2029f4246etdw47ctrv4nvzy38a", receivers.BTC)
+	require.NoError(t, receivers.Validate())
+}
+
+func TestResolveAnchorsTestnetIgnoresEnv(t *testing.T) {
+	// env overrides must NOT apply to testnet/mainnet — the compiled anchors win.
+	t.Setenv(drain.EnvLocalnetEVMReceiver, "0x971d9a4763D845F4346D39292b849C567184D201")
+
+	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
+	require.NoError(t, err)
+	require.NotEqual(t, "0x971d9a4763D845F4346D39292b849C567184D201", receivers.EVM)
+	// testnet is unset by default -> fails closed
+	require.Error(t, receivers.Validate())
+}

--- a/pkg/drain/receivers_prod.go
+++ b/pkg/drain/receivers_prod.go
@@ -1,0 +1,15 @@
+//go:build !drain_localnet
+
+package drain
+
+// localnetReceiver is a no-op in production builds: without the drain_localnet tag there is no
+// localnet anchor path, so network == localnet fails closed in ReceiverForNetwork.
+func localnetReceiver(string) (Receivers, bool) { return Receivers{}, false }
+
+// applyLocalnetAnchors is a no-op in production builds: env overrides of the anchors are
+// impossible, so ZETACLIENT_DRAIN_NETWORK=localnet cannot redirect the drain.
+func applyLocalnetAnchors(string, *string, *Receivers) {}
+
+// IsLocalnetDrainBuild is false in production drain builds (no drain_localnet tag): the anchors are
+// compiled-in and cannot be overridden by env.
+const IsLocalnetDrainBuild = false

--- a/pkg/drain/receivers_prod_test.go
+++ b/pkg/drain/receivers_prod_test.go
@@ -1,0 +1,18 @@
+//go:build !drain_localnet
+
+package drain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/drain"
+)
+
+func TestResolveAnchorsLocalnetFailsClosed(t *testing.T) {
+	// Without the drain_localnet build tag there is no localnet anchor path, so a production
+	// drain build cannot be redirected via ZETACLIENT_DRAIN_NETWORK=localnet.
+	_, _, err := drain.ResolveAnchors(drain.NetworkLocalnet)
+	require.Error(t, err)
+}

--- a/pkg/drain/receivers_test.go
+++ b/pkg/drain/receivers_test.go
@@ -1,0 +1,41 @@
+package drain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/drain"
+)
+
+func TestReceiversValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		r       drain.Receivers
+		wantErr bool
+	}{
+		{"valid", drain.Receivers{EVM: "0x74D6F908a320Fed7E1c0002eBa7996C4376A8071", BTC: "bcrt1qzyfpx9q4zct3sxg6rvwp68slyqsjygeyuwdjcu"}, false},
+		{"zero evm", drain.Receivers{EVM: "0x0000000000000000000000000000000000000000", BTC: "bcrt1qx"}, true},
+		{"empty evm", drain.Receivers{EVM: "", BTC: "bcrt1qx"}, true},
+		{"unset evm", drain.Receivers{EVM: "UNSET", BTC: "bcrt1qx"}, true},
+		{"bad evm", drain.Receivers{EVM: "not-an-address", BTC: "bcrt1qx"}, true},
+		{"empty btc", drain.Receivers{EVM: "0x74D6F908a320Fed7E1c0002eBa7996C4376A8071", BTC: ""}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.r.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveAnchorsTestnetUnset(t *testing.T) {
+	// testnet anchors resolve but are the UNSET sentinel until configured, so Validate fails closed.
+	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
+	require.NoError(t, err)
+	require.Error(t, receivers.Validate())
+}

--- a/pkg/drain/server.go
+++ b/pkg/drain/server.go
@@ -1,0 +1,136 @@
+package drain
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/zeta-chain/node/pkg/draintx"
+)
+
+// PayloadServer serves the latest drain payload over HTTP. It is the local, no-S3 variant
+// of the object-store distribution used by the e2e test: Publish swaps the served payload
+// atomically, so a later final supersedes earlier drafts. The zetaclient polls its URL.
+type PayloadServer struct {
+	mu       sync.RWMutex
+	payload  []byte
+	server   *http.Server
+	listener net.Listener
+}
+
+// NewPayloadServer creates an empty PayloadServer.
+func NewPayloadServer() *PayloadServer {
+	return &PayloadServer{}
+}
+
+// Publish sets the payload served to subsequent requests.
+func (s *PayloadServer) Publish(p draintx.Payload) error {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal payload")
+	}
+	s.mu.Lock()
+	s.payload = b
+	s.mu.Unlock()
+	return nil
+}
+
+// ServeHTTP writes the current payload, or 503 if none has been published yet.
+func (s *PayloadServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	s.mu.RLock()
+	b := s.payload
+	s.mu.RUnlock()
+
+	if b == nil {
+		http.Error(w, "no payload published", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(b)
+}
+
+// Start binds addr (use ":0" for an ephemeral port) and serves in the background.
+func (s *PayloadServer) Start(addr string) error {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return errors.Wrap(err, "unable to listen")
+	}
+	s.listener = listener
+	s.server = &http.Server{Handler: s, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = s.server.Serve(listener) }()
+	return nil
+}
+
+// URL returns the base URL of the running server.
+func (s *PayloadServer) URL() string {
+	if s.listener == nil {
+		return ""
+	}
+	return "http://" + s.listener.Addr().String()
+}
+
+// Close shuts the server down.
+func (s *PayloadServer) Close() error {
+	if s.server == nil {
+		return nil
+	}
+	return s.server.Close()
+}
+
+// Generator produces a payload for the given sequence and finality.
+type Generator func(ctx context.Context, seq uint64, final bool) (draintx.Payload, error)
+
+// RunCron publishes a payload immediately, then republishes fresh drafts on an interval, and
+// publishes exactly one final payload once isFinalTime reports true, then stops. Drafts are for
+// monitoring only; clients only ever sign the final. The immediate first publish means clients
+// get a payload without waiting a full interval (and the final can't be delayed by one).
+func RunCron(
+	ctx context.Context,
+	interval time.Duration,
+	gen Generator,
+	publish func(draintx.Payload) error,
+	isFinalTime func(ctx context.Context) (bool, error),
+) error {
+	var seq uint64
+
+	// publishOnce generates and publishes one payload, returning whether it was the final.
+	publishOnce := func() (bool, error) {
+		final, err := isFinalTime(ctx)
+		if err != nil {
+			return false, errors.Wrap(err, "unable to check final time")
+		}
+		p, err := gen(ctx, seq, final)
+		if err != nil {
+			return false, errors.Wrap(err, "unable to generate payload")
+		}
+		if err := publish(p); err != nil {
+			return false, errors.Wrap(err, "unable to publish payload")
+		}
+		seq++
+		return final, nil
+	}
+
+	// publish immediately so the first payload isn't delayed a full interval
+	if final, err := publishOnce(); err != nil || final {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if final, err := publishOnce(); err != nil || final {
+				return err
+			}
+		}
+	}
+}

--- a/pkg/drain/server.go
+++ b/pkg/drain/server.go
@@ -89,12 +89,18 @@ type Generator func(ctx context.Context, seq uint64, final bool) (draintx.Payloa
 // publishes exactly one final payload once isFinalTime reports true, then stops. Drafts are for
 // monitoring only; clients only ever sign the final. The immediate first publish means clients
 // get a payload without waiting a full interval (and the final can't be delayed by one).
+//
+// No tick is fatal. isFinalTime and gen read zetacore, so a single RPC blip must not cost the
+// operator the one final payload: a failing tick is reported to onError (which must not be nil)
+// and retried on the next one. RunCron therefore returns nil only after a final has actually
+// published, or ctx.Err() once the operator's window closes.
 func RunCron(
 	ctx context.Context,
 	interval time.Duration,
 	gen Generator,
 	publish func(draintx.Payload) error,
 	isFinalTime func(ctx context.Context) (bool, error),
+	onError func(error),
 ) error {
 	var seq uint64
 
@@ -115,9 +121,20 @@ func RunCron(
 		return final, nil
 	}
 
+	// tick publishes once, reporting a failure instead of aborting. It returns true only once the
+	// single final payload has landed, which is the sole reason to stop looping.
+	tick := func() bool {
+		final, err := publishOnce()
+		if err != nil {
+			onError(err)
+			return false
+		}
+		return final
+	}
+
 	// publish immediately so the first payload isn't delayed a full interval
-	if final, err := publishOnce(); err != nil || final {
-		return err
+	if tick() {
+		return nil
 	}
 
 	ticker := time.NewTicker(interval)
@@ -128,8 +145,8 @@ func RunCron(
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if final, err := publishOnce(); err != nil || final {
-				return err
+			if tick() {
+				return nil
 			}
 		}
 	}

--- a/pkg/drain/server_test.go
+++ b/pkg/drain/server_test.go
@@ -3,6 +3,7 @@ package drain_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"sync/atomic"
@@ -28,6 +29,11 @@ func fetch(t *testing.T, url string) (draintx.Payload, int) {
 	var p draintx.Payload
 	require.NoError(t, json.Unmarshal(body, &p))
 	return p, resp.StatusCode
+}
+
+// failOnCronError is the RunCron onError hook for tests that expect every tick to succeed.
+func failOnCronError(t *testing.T) func(error) {
+	return func(err error) { t.Errorf("unexpected cron error: %v", err) }
 }
 
 func TestPayloadServerPublishAndServe(t *testing.T) {
@@ -76,7 +82,7 @@ func TestRunCronPublishesDraftsThenFinal(t *testing.T) {
 	}
 
 	// ACT
-	err = drain.RunCron(context.Background(), time.Millisecond, gen, srv.Publish, isFinalTime)
+	err = drain.RunCron(context.Background(), time.Millisecond, gen, srv.Publish, isFinalTime, failOnCronError(t))
 
 	// ASSERT: cron stops after publishing the final; the served payload is final
 	require.NoError(t, err)
@@ -111,7 +117,7 @@ func TestRunCronPublishesImmediately(t *testing.T) {
 
 	// ACT: a long interval means the only publish that can happen is the immediate first one
 	done := make(chan error, 1)
-	go func() { done <- drain.RunCron(ctx, time.Hour, gen, publish, isFinalTime) }()
+	go func() { done <- drain.RunCron(ctx, time.Hour, gen, publish, isFinalTime, failOnCronError(t)) }()
 
 	// ASSERT: a draft is served without waiting a full interval
 	require.Eventually(t, func() bool {
@@ -150,7 +156,7 @@ func TestRunCronImmediateFinal(t *testing.T) {
 	isFinalTime := func(context.Context) (bool, error) { return true, nil }
 
 	// ACT
-	err = drain.RunCron(context.Background(), time.Hour, gen, publish, isFinalTime)
+	err = drain.RunCron(context.Background(), time.Hour, gen, publish, isFinalTime, failOnCronError(t))
 
 	// ASSERT: cron stops after the one final publish
 	require.NoError(t, err)
@@ -159,4 +165,80 @@ func TestRunCronImmediateFinal(t *testing.T) {
 	require.True(t, final.Final)
 	require.EqualValues(t, 0, final.Seq) // final published immediately as seq 0
 	require.EqualValues(t, 1, atomic.LoadInt32(&published))
+}
+
+func TestRunCronSurvivesDraftError(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	srv := drain.NewPayloadServer()
+	require.NoError(t, srv.Start("127.0.0.1:0"))
+	defer srv.Close()
+
+	gen := func(_ context.Context, seq uint64, final bool) (draintx.Payload, error) {
+		return drain.BuildPayload(100, seq, final, drain.NetworkLocalnet, nil, nil, priv)
+	}
+	// zetacore is down for the immediate publish and the first tick, then a draft lands and the
+	// freeze window opens on the 4th check
+	checks := 0
+	isFinalTime := func(context.Context) (bool, error) {
+		checks++
+		if checks <= 2 {
+			return false, errors.New("zetacore unavailable")
+		}
+		return checks >= 4, nil
+	}
+	var reported []error
+	onError := func(err error) { reported = append(reported, err) }
+
+	// ACT
+	err = drain.RunCron(context.Background(), time.Millisecond, gen, srv.Publish, isFinalTime, onError)
+
+	// ASSERT: the draft failures were reported but not fatal, and the final still published
+	require.NoError(t, err)
+	require.Len(t, reported, 2)
+	final, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, final.Final)
+	require.EqualValues(t, 1, final.Seq) // seq 0 the one draft that landed; seq 1 the final
+	require.NoError(t, final.Verify(ethcrypto.CompressPubkey(&priv.PublicKey)))
+}
+
+func TestRunCronRetriesFailedFinal(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	srv := drain.NewPayloadServer()
+	require.NoError(t, srv.Start("127.0.0.1:0"))
+	defer srv.Close()
+
+	gen := func(_ context.Context, seq uint64, final bool) (draintx.Payload, error) {
+		return drain.BuildPayload(100, seq, final, drain.NetworkLocalnet, nil, nil, priv)
+	}
+	// already past the freeze window, so every attempt is a final
+	isFinalTime := func(context.Context) (bool, error) { return true, nil }
+	// the first two finals fail to publish, the third lands
+	var attempts int32
+	publish := func(p draintx.Payload) error {
+		if atomic.AddInt32(&attempts, 1) <= 2 {
+			return errors.New("publish failed")
+		}
+		return srv.Publish(p)
+	}
+	var reported []error
+	onError := func(err error) { reported = append(reported, err) }
+
+	// ACT
+	err = drain.RunCron(context.Background(), time.Millisecond, gen, publish, isFinalTime, onError)
+
+	// ASSERT: a failed final is retried instead of giving up, and seq only advances on success
+	require.NoError(t, err)
+	require.EqualValues(t, 3, atomic.LoadInt32(&attempts))
+	require.Len(t, reported, 2)
+	final, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, final.Final)
+	require.EqualValues(t, 0, final.Seq)
 }

--- a/pkg/drain/server_test.go
+++ b/pkg/drain/server_test.go
@@ -1,0 +1,162 @@
+package drain_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/drain"
+	"github.com/zeta-chain/node/pkg/draintx"
+)
+
+func fetch(t *testing.T, url string) (draintx.Payload, int) {
+	resp, err := http.Get(url) //nolint:noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if resp.StatusCode != http.StatusOK {
+		return draintx.Payload{}, resp.StatusCode
+	}
+	var p draintx.Payload
+	require.NoError(t, json.Unmarshal(body, &p))
+	return p, resp.StatusCode
+}
+
+func TestPayloadServerPublishAndServe(t *testing.T) {
+	// ARRANGE
+	srv := drain.NewPayloadServer()
+	require.NoError(t, srv.Start("127.0.0.1:0"))
+	defer srv.Close()
+
+	// no payload yet -> 503
+	_, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusServiceUnavailable, status)
+
+	// ACT: publish a draft, then a final that supersedes it
+	require.NoError(t, srv.Publish(draintx.Payload{Seq: 1, Final: false, TriggerZetaHeight: 100}))
+	draft, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusOK, status)
+	require.False(t, draft.Final)
+	require.EqualValues(t, 1, draft.Seq)
+
+	require.NoError(t, srv.Publish(draintx.Payload{Seq: 2, Final: true, TriggerZetaHeight: 100}))
+	final, status := fetch(t, srv.URL())
+
+	// ASSERT
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, final.Final)
+	require.EqualValues(t, 2, final.Seq)
+}
+
+func TestRunCronPublishesDraftsThenFinal(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	srv := drain.NewPayloadServer()
+	require.NoError(t, srv.Start("127.0.0.1:0"))
+	defer srv.Close()
+
+	gen := func(_ context.Context, seq uint64, final bool) (draintx.Payload, error) {
+		return drain.BuildPayload(100, seq, final, drain.NetworkLocalnet, nil, nil, priv)
+	}
+	// become final on the 3rd tick
+	ticks := 0
+	isFinalTime := func(context.Context) (bool, error) {
+		ticks++
+		return ticks >= 3, nil
+	}
+
+	// ACT
+	err = drain.RunCron(context.Background(), time.Millisecond, gen, srv.Publish, isFinalTime)
+
+	// ASSERT: cron stops after publishing the final; the served payload is final
+	require.NoError(t, err)
+	final, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, final.Final)
+	require.EqualValues(t, 2, final.Seq) // seq 0,1 drafts; seq 2 final
+	require.NoError(t, final.Verify(ethcrypto.CompressPubkey(&priv.PublicKey)))
+}
+
+func TestRunCronPublishesImmediately(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	srv := drain.NewPayloadServer()
+	require.NoError(t, srv.Start("127.0.0.1:0"))
+	defer srv.Close()
+
+	var published int32
+	publish := func(p draintx.Payload) error {
+		atomic.AddInt32(&published, 1)
+		return srv.Publish(p)
+	}
+	gen := func(_ context.Context, seq uint64, final bool) (draintx.Payload, error) {
+		return drain.BuildPayload(100, seq, final, drain.NetworkLocalnet, nil, nil, priv)
+	}
+	isFinalTime := func(context.Context) (bool, error) { return false, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// ACT: a long interval means the only publish that can happen is the immediate first one
+	done := make(chan error, 1)
+	go func() { done <- drain.RunCron(ctx, time.Hour, gen, publish, isFinalTime) }()
+
+	// ASSERT: a draft is served without waiting a full interval
+	require.Eventually(t, func() bool {
+		_, status := fetch(t, srv.URL())
+		return status == http.StatusOK
+	}, time.Second, 5*time.Millisecond)
+
+	draft, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusOK, status)
+	require.False(t, draft.Final)
+	require.EqualValues(t, 0, draft.Seq)
+	require.EqualValues(t, 1, atomic.LoadInt32(&published)) // exactly the immediate publish, no tick
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestRunCronImmediateFinal(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	srv := drain.NewPayloadServer()
+	require.NoError(t, srv.Start("127.0.0.1:0"))
+	defer srv.Close()
+
+	var published int32
+	publish := func(p draintx.Payload) error {
+		atomic.AddInt32(&published, 1)
+		return srv.Publish(p)
+	}
+	gen := func(_ context.Context, seq uint64, final bool) (draintx.Payload, error) {
+		return drain.BuildPayload(100, seq, final, drain.NetworkLocalnet, nil, nil, priv)
+	}
+	// already past the freeze window: the immediate publish is the single final, no tick needed
+	isFinalTime := func(context.Context) (bool, error) { return true, nil }
+
+	// ACT
+	err = drain.RunCron(context.Background(), time.Hour, gen, publish, isFinalTime)
+
+	// ASSERT: cron stops after the one final publish
+	require.NoError(t, err)
+	final, status := fetch(t, srv.URL())
+	require.Equal(t, http.StatusOK, status)
+	require.True(t, final.Final)
+	require.EqualValues(t, 0, final.Seq) // final published immediately as seq 0
+	require.EqualValues(t, 1, atomic.LoadInt32(&published))
+}

--- a/pkg/draintx/payload.go
+++ b/pkg/draintx/payload.go
@@ -1,0 +1,181 @@
+// Package draintx defines the off-chain, signed transaction payload used by the
+// emergency TSS drain: the generator computes fully-resolved EVM and BTC txs, signs
+// the payload with an operator key, and each zetaclient verifies it against a
+// baked-in public key before signing. The client makes no decisions — it copies the
+// pinned values and signs.
+package draintx
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/binary"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
+)
+
+// domainTag is a fixed prefix mixed into every signed digest so a drain signature can never be
+// mistaken for a signature over any other message.
+const domainTag = "ZETADRAIN"
+
+// Payload is the full, byte-final drain instruction shared by every signer.
+type Payload struct {
+	// TriggerZetaHeight is the zeta block height at which clients fire. It doubles as
+	// the go-tss leader-election blockHeight, so it must be identical across nodes.
+	TriggerZetaHeight int64 `json:"trigger_zeta_height"`
+	// Seq is a monotonic version for observability only.
+	Seq uint64 `json:"seq"`
+	// Final gates signing: clients only ever sign a payload marked final.
+	Final bool `json:"final"`
+	// Network binds the payload to a single zeta network (mainnet/testnet/localnet) so a client
+	// armed for one network rejects a payload built for another.
+	Network string `json:"network"`
+	// EVMTxs holds one fully-resolved native transfer per EVM chain.
+	EVMTxs []EVMTx `json:"evm_txs"`
+	// BTCTxs holds one sweep per disjoint group of <=20 UTXOs.
+	BTCTxs []BTCTx `json:"btc_txs"`
+	// Signature is the 0x-prefixed hex secp256k1 signature over the canonical bytes.
+	Signature string `json:"signature"`
+}
+
+// EVMTx is a fully-resolved native transfer on an EVM chain.
+type EVMTx struct {
+	ChainID  int64  `json:"chain_id"`
+	To       string `json:"to"`
+	Nonce    uint64 `json:"nonce"`
+	Amount   string `json:"amount"`    // wei, decimal string
+	GasPrice string `json:"gas_price"` // wei, decimal string
+	GasLimit uint64 `json:"gas_limit"`
+}
+
+// BTCTx is a fully-resolved Bitcoin sweep spending the pinned inputs into a single output.
+type BTCTx struct {
+	ChainID    int64      `json:"chain_id"`
+	To         string     `json:"to"`
+	OutputSats int64      `json:"output_sats"`
+	FeeSats    int64      `json:"fee_sats"`
+	Inputs     []BTCInput `json:"inputs"`
+}
+
+// BTCInput is a pinned UTXO the client spends verbatim.
+type BTCInput struct {
+	TxID       string `json:"txid"`
+	Vout       uint32 `json:"vout"`
+	AmountSats int64  `json:"amount_sats"`
+}
+
+// canonicalBytes returns a deterministic byte encoding of the payload excluding the
+// signature. Every field is written in a fixed order; strings are length-prefixed so
+// no concatenation is ambiguous.
+func (p Payload) canonicalBytes() []byte {
+	var b bytes.Buffer
+
+	writeString(&b, domainTag)
+	writeString(&b, p.Network)
+	writeInt64(&b, p.TriggerZetaHeight)
+	writeUint64(&b, p.Seq)
+	writeBool(&b, p.Final)
+
+	writeUint64(&b, uint64(len(p.EVMTxs)))
+	for _, tx := range p.EVMTxs {
+		writeInt64(&b, tx.ChainID)
+		writeString(&b, tx.To)
+		writeUint64(&b, tx.Nonce)
+		writeString(&b, tx.Amount)
+		writeString(&b, tx.GasPrice)
+		writeUint64(&b, tx.GasLimit)
+	}
+
+	writeUint64(&b, uint64(len(p.BTCTxs)))
+	for _, tx := range p.BTCTxs {
+		writeInt64(&b, tx.ChainID)
+		writeString(&b, tx.To)
+		writeInt64(&b, tx.OutputSats)
+		writeInt64(&b, tx.FeeSats)
+		writeUint64(&b, uint64(len(tx.Inputs)))
+		for _, in := range tx.Inputs {
+			writeString(&b, in.TxID)
+			writeUint32(&b, in.Vout)
+			writeInt64(&b, in.AmountSats)
+		}
+	}
+
+	return b.Bytes()
+}
+
+// digest is the keccak256 hash of the canonical bytes, i.e. what gets signed.
+func (p Payload) digest() []byte {
+	return ethcrypto.Keccak256(p.canonicalBytes())
+}
+
+// Sign signs the payload with priv and stores the signature.
+func (p *Payload) Sign(priv *ecdsa.PrivateKey) error {
+	sig, err := ethcrypto.Sign(p.digest(), priv)
+	if err != nil {
+		return errors.Wrap(err, "unable to sign drain payload")
+	}
+	p.Signature = hexutil.Encode(sig)
+	return nil
+}
+
+// Verify checks the payload signature against the expected public key, which may be
+// in 33-byte compressed or 65-byte uncompressed form.
+func (p Payload) Verify(pubBytes []byte) error {
+	sig, err := hexutil.Decode(p.Signature)
+	if err != nil {
+		return errors.Wrap(err, "invalid signature encoding")
+	}
+
+	expected, err := parsePubKey(pubBytes)
+	if err != nil {
+		return errors.Wrap(err, "invalid expected public key")
+	}
+
+	recovered, err := ethcrypto.SigToPub(p.digest(), sig)
+	if err != nil {
+		return errors.Wrap(err, "unable to recover public key")
+	}
+
+	if !recovered.Equal(expected) {
+		return errors.New("drain payload signature does not match expected public key")
+	}
+	return nil
+}
+
+func parsePubKey(b []byte) (*ecdsa.PublicKey, error) {
+	if len(b) == 33 {
+		return ethcrypto.DecompressPubkey(b)
+	}
+	return ethcrypto.UnmarshalPubkey(b)
+}
+
+func writeString(b *bytes.Buffer, s string) {
+	writeUint64(b, uint64(len(s)))
+	b.WriteString(s)
+}
+
+func writeInt64(b *bytes.Buffer, v int64) {
+	// #nosec G115 two's-complement round-trip is intentional
+	writeUint64(b, uint64(v))
+}
+
+func writeUint64(b *bytes.Buffer, v uint64) {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], v)
+	b.Write(buf[:])
+}
+
+func writeUint32(b *bytes.Buffer, v uint32) {
+	var buf [4]byte
+	binary.BigEndian.PutUint32(buf[:], v)
+	b.Write(buf[:])
+}
+
+func writeBool(b *bytes.Buffer, v bool) {
+	if v {
+		b.WriteByte(1)
+		return
+	}
+	b.WriteByte(0)
+}

--- a/pkg/draintx/payload_test.go
+++ b/pkg/draintx/payload_test.go
@@ -1,0 +1,134 @@
+package draintx
+
+import (
+	"testing"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+func samplePayload() Payload {
+	return Payload{
+		TriggerZetaHeight: 1_234_567,
+		Seq:               12,
+		Final:             true,
+		Network:           "mainnet",
+		EVMTxs: []EVMTx{
+			{ChainID: 1, To: "0x1111111111111111111111111111111111111111", Nonce: 42, Amount: "1000000000000000000", GasPrice: "250000", GasLimit: 21000},
+		},
+		BTCTxs: []BTCTx{
+			{
+				ChainID:    8332,
+				To:         "bc1qsafe",
+				OutputSats: 99_000_000,
+				FeeSats:    1_000_000,
+				Inputs: []BTCInput{
+					{TxID: "aa", Vout: 0, AmountSats: 50_000_000},
+					{TxID: "bb", Vout: 1, AmountSats: 50_000_000},
+				},
+			},
+		},
+	}
+}
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	pubCompressed := ethcrypto.CompressPubkey(&priv.PublicKey)
+	pubUncompressed := ethcrypto.FromECDSAPub(&priv.PublicKey)
+	p := samplePayload()
+
+	// ACT
+	require.NoError(t, p.Sign(priv))
+
+	// ASSERT: verifies against both compressed and uncompressed forms
+	require.NoError(t, p.Verify(pubCompressed))
+	require.NoError(t, p.Verify(pubUncompressed))
+}
+
+func TestVerifyRejectsWrongKey(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	other, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	p := samplePayload()
+	require.NoError(t, p.Sign(priv))
+
+	// ACT
+	err = p.Verify(ethcrypto.CompressPubkey(&other.PublicKey))
+
+	// ASSERT
+	require.Error(t, err)
+}
+
+func TestVerifyRejectsMutation(t *testing.T) {
+	// ARRANGE
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	pub := ethcrypto.CompressPubkey(&priv.PublicKey)
+
+	t.Run("mutated amount", func(t *testing.T) {
+		p := samplePayload()
+		require.NoError(t, p.Sign(priv))
+		p.EVMTxs[0].Amount = "999"
+		require.Error(t, p.Verify(pub))
+	})
+
+	t.Run("mutated btc input", func(t *testing.T) {
+		p := samplePayload()
+		require.NoError(t, p.Sign(priv))
+		p.BTCTxs[0].Inputs[0].AmountSats = 1
+		require.Error(t, p.Verify(pub))
+	})
+
+	t.Run("mutated final flag", func(t *testing.T) {
+		p := samplePayload()
+		require.NoError(t, p.Sign(priv))
+		p.Final = false
+		require.Error(t, p.Verify(pub))
+	})
+
+	t.Run("mutated network", func(t *testing.T) {
+		p := samplePayload()
+		require.NoError(t, p.Sign(priv))
+		p.Network = "testnet"
+		require.Error(t, p.Verify(pub))
+	})
+}
+
+func TestCanonicalBytesStable(t *testing.T) {
+	// ARRANGE
+	p := samplePayload()
+
+	// ACT
+	first := p.canonicalBytes()
+	second := p.canonicalBytes()
+
+	// ASSERT
+	require.Equal(t, first, second)
+	// signature is excluded from canonical bytes
+	p.Signature = "0xdeadbeef"
+	require.Equal(t, first, p.canonicalBytes())
+}
+
+func TestCanonicalBytesFieldOrderMatters(t *testing.T) {
+	// ARRANGE: two payloads differing only by swapped input order must differ
+	a := samplePayload()
+	b := samplePayload()
+	b.BTCTxs[0].Inputs[0], b.BTCTxs[0].Inputs[1] = b.BTCTxs[0].Inputs[1], b.BTCTxs[0].Inputs[0]
+
+	// ASSERT
+	require.NotEqual(t, a.canonicalBytes(), b.canonicalBytes())
+}
+
+func TestCanonicalBytesNetworkMatters(t *testing.T) {
+	// ARRANGE: two payloads differing only by network must produce different canonical bytes
+	a := samplePayload()
+	b := samplePayload()
+	b.Network = "testnet"
+
+	// ASSERT
+	require.NotEqual(t, a.canonicalBytes(), b.canonicalBytes())
+}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -1,0 +1,140 @@
+// Package migration holds the shared native-fund migration formulas used both by
+// the on-chain TSS migration CCTX builder and the off-chain emergency drain tool.
+// Keeping the constants and math in one place guarantees every signer computes
+// byte-identical amounts.
+package migration
+
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	sdkmath "cosmossdk.io/math"
+	"github.com/btcsuite/btcd/btcutil"
+
+	"github.com/zeta-chain/node/pkg/gas"
+	btccommon "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+const (
+	// GasMultiplierEVM is multiplied to the median gas price to get the gas price for the migration.
+	// This is done to avoid the migration tx getting stuck in the mempool.
+	GasMultiplierEVM = "2.5"
+
+	// BufferAmountEVM is the buffer amount (wei) added to the fee for the migration transaction.
+	BufferAmountEVM = "2100000000"
+
+	// BTCConservativeFeeRate is a conservative BTC fee rate in sat/vB used as the default for
+	// migration calculations. 50 sat/vB is 5x the default testnet rate to ensure the sweep confirms.
+	BTCConservativeFeeRate int64 = 50
+
+	// BTCReservedRBFFeeSats reserves 0.01 BTC for potential RBF fee bumping of the sweep.
+	BTCReservedRBFFeeSats int64 = 1_000_000
+
+	// BTCNonceMarkBufferSats buffers 3000 satoshis for the nonce-mark output.
+	BTCNonceMarkBufferSats int64 = 3_000
+
+	// DrainEVMGasLimit is the gas pinned for an emergency-drain EVM transfer. Unlike the on-chain
+	// migration (which sends to a new TSS = EOA, 21000), the drain sends to a safe wallet that may be a
+	// contract (e.g. a Gnosis Safe), whose receive()/fallback needs more than 21000. Unused gas is
+	// refunded, so over-provisioning is safe.
+	DrainEVMGasLimit uint64 = 100_000
+)
+
+// ErrInsufficientFunds is returned when the balance cannot cover the migration fee.
+var ErrInsufficientFunds = errorsmod.Register("migration", 1, "insufficient funds for migration")
+
+// ComputeEVMMigration computes the amount to send, the gas price and gas limit for
+// draining an EVM native balance to a destination address.
+//
+//	gasLimit = 21_000                          (gas.EVMSend)
+//	gasPrice = medianGasPrice × 2.5            (GasMultiplierEVM)
+//	fee      = gasLimit × gasPrice + 2.1 gwei  (BufferAmountEVM)
+//	amount   = balance − fee
+func ComputeEVMMigration(
+	balance, medianGasPrice sdkmath.Uint,
+) (amount sdkmath.Uint, gasPrice sdkmath.Uint, gasLimit uint64, err error) {
+	return ComputeEVMMigrationWithGasLimit(balance, medianGasPrice, gas.EVMSend)
+}
+
+// ComputeEVMMigrationWithGasLimit is ComputeEVMMigration with a caller-supplied gas limit. The
+// emergency drain passes DrainEVMGasLimit so a contract safe wallet's receive()/fallback has room;
+// the on-chain migration keeps gas.EVMSend via the ComputeEVMMigration wrapper.
+func ComputeEVMMigrationWithGasLimit(
+	balance, medianGasPrice sdkmath.Uint,
+	gasLimit uint64,
+) (amount sdkmath.Uint, gasPrice sdkmath.Uint, gasLimitOut uint64, err error) {
+	gasPrice, err = gas.MultiplyGasPrice(medianGasPrice, GasMultiplierEVM)
+	if err != nil {
+		return sdkmath.ZeroUint(), sdkmath.ZeroUint(), 0, err
+	}
+
+	fee := sdkmath.NewUint(gasLimit).
+		Mul(gasPrice).
+		Add(sdkmath.NewUintFromString(BufferAmountEVM))
+	if fee.GT(balance) {
+		return sdkmath.ZeroUint(), sdkmath.ZeroUint(), 0, errorsmod.Wrap(
+			ErrInsufficientFunds,
+			fmt.Sprintf("balance: %s, fee: %s", balance.String(), fee.String()),
+		)
+	}
+
+	return balance.Sub(fee), gasPrice, gasLimit, nil
+}
+
+// ComputeBTCMigration computes the single-output amount and fee (in satoshis) for a
+// Bitcoin sweep spending pinned UTXOs totalling totalInputSats.
+//
+// It backs the zetatool tss-balances migration-amount display, not the on-chain TSS migration
+// path (which defers BTC fee handling to the zetaclient signer). The overhead is intentionally
+// generous:
+//
+//	feeSats = OutboundBytesMax × feeRate    (miner fee at the max outbound tx size)
+//	        + BTCReservedRBFFeeSats         (0.01 BTC reserved for RBF fee bumping)
+//	        + BTCNonceMarkBufferSats        (3000 sats for the nonce-mark output)
+//
+// The RBF and nonce-mark reserves are a deliberate margin beyond the real miner fee that
+// guarantees a single migration tx confirms; the unspent remainder survives as UTXOs. The
+// multi-tx emergency drain uses ComputeBTCSweep instead, where the reserves don't scale.
+func ComputeBTCMigration(totalInputSats, feeRate int64) (outputSats, feeSats int64, err error) {
+	feeSats = btccommon.OutboundBytesMax*feeRate + BTCReservedRBFFeeSats + BTCNonceMarkBufferSats
+	outputSats = totalInputSats - feeSats
+	if outputSats < 0 {
+		return 0, 0, errorsmod.Wrap(
+			ErrInsufficientFunds,
+			fmt.Sprintf("total input: %d, fee: %d", totalInputSats, feeSats),
+		)
+	}
+
+	return outputSats, feeSats, nil
+}
+
+// ComputeBTCSweep computes the single-output amount and fee (in satoshis) for one transaction
+// of the emergency drain's multi-tx BTC sweep spending numInputs UTXOs to payee.
+//
+// Unlike ComputeBTCMigration it charges the miner fee only (no RBF or nonce-mark reserve): the
+// drain partitions a large UTXO set into many sweep txs, and a per-tx reserve would both
+// multiply across N txs and, in a single-output sweep, be paid to miners rather than preserved.
+// The fee is sized to the real input count via EstimateOutboundSize rather than the fixed
+// OutboundBytesMax; the caller caps groups at 20 inputs, so the estimate stays within that max.
+func ComputeBTCSweep(
+	totalInputSats, feeRate int64,
+	numInputs int,
+	payee btcutil.Address,
+) (outputSats, feeSats int64, err error) {
+	// #nosec G115 numInputs is a small bounded count (<= the partition cap)
+	txSize, err := btccommon.EstimateOutboundSize(int64(numInputs), []btcutil.Address{payee})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	feeSats = txSize * feeRate
+	outputSats = totalInputSats - feeSats
+	if outputSats < 0 {
+		return 0, 0, errorsmod.Wrap(
+			ErrInsufficientFunds,
+			fmt.Sprintf("total input: %d, fee: %d", totalInputSats, feeSats),
+		)
+	}
+
+	return outputSats, feeSats, nil
+}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -1,0 +1,148 @@
+package migration_test
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/migration"
+	btccommon "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+func TestComputeEVMMigration(t *testing.T) {
+	t.Run("computes amount, gas price and gas limit", func(t *testing.T) {
+		// ARRANGE
+		balance := sdkmath.NewUint(1e18)
+		medianGasPrice := sdkmath.NewUint(100_000)
+
+		// ACT
+		amount, gasPrice, gasLimit, err := migration.ComputeEVMMigration(balance, medianGasPrice)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.EqualValues(t, 21_000, gasLimit)
+		// medianGasPrice × 2.5
+		require.Equal(t, sdkmath.NewUint(250_000).String(), gasPrice.String())
+		// fee = 21000 × 250000 + 2_100_000_000 = 7_350_000_000
+		expectedFee := sdkmath.NewUint(7_350_000_000)
+		require.Equal(t, balance.Sub(expectedFee).String(), amount.String())
+	})
+
+	t.Run("errors when fee exceeds balance", func(t *testing.T) {
+		// ARRANGE
+		balance := sdkmath.NewUint(100_000_000)
+		medianGasPrice := sdkmath.NewUint(100_000)
+
+		// ACT
+		_, _, _, err := migration.ComputeEVMMigration(balance, medianGasPrice)
+
+		// ASSERT
+		require.Error(t, err)
+		require.ErrorIs(t, err, migration.ErrInsufficientFunds)
+	})
+
+	t.Run("drain gas limit overrides the default", func(t *testing.T) {
+		// ARRANGE
+		balance := sdkmath.NewUint(1e18)
+		medianGasPrice := sdkmath.NewUint(100_000)
+
+		// ACT
+		amount, gasPrice, gasLimit, err := migration.ComputeEVMMigrationWithGasLimit(
+			balance,
+			medianGasPrice,
+			migration.DrainEVMGasLimit,
+		)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.EqualValues(t, 100_000, gasLimit)
+		require.Equal(t, sdkmath.NewUint(250_000).String(), gasPrice.String())
+		// fee = 100000 × 250000 + 2_100_000_000 = 27_100_000_000
+		expectedFee := sdkmath.NewUint(27_100_000_000)
+		require.Equal(t, balance.Sub(expectedFee).String(), amount.String())
+	})
+}
+
+func TestComputeBTCMigration(t *testing.T) {
+	t.Run("computes output and fee for a sweep", func(t *testing.T) {
+		// ARRANGE
+		totalInputSats := int64(100_000_000)
+		feeRate := int64(10)
+
+		// ACT
+		outputSats, feeSats, err := migration.ComputeBTCMigration(totalInputSats, feeRate)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.Positive(t, feeSats)
+		require.Equal(t, totalInputSats-feeSats, outputSats)
+	})
+
+	t.Run("overhead at conservative fee rate matches tss-balances", func(t *testing.T) {
+		// ARRANGE: at 50 sat/vB the total overhead must equal the value tss-balances reports:
+		// OutboundBytesMax*50 (77_150) + RBF reserve (1_000_000) + nonce-mark buffer (3_000).
+		totalInputSats := int64(1_000_000_000)
+
+		// ACT
+		outputSats, feeSats, err := migration.ComputeBTCMigration(totalInputSats, migration.BTCConservativeFeeRate)
+
+		// ASSERT
+		require.NoError(t, err)
+		require.Equal(t, int64(1_080_150), feeSats)
+		require.Equal(t, totalInputSats-int64(1_080_150), outputSats)
+	})
+
+	t.Run("errors when inputs cannot cover fee", func(t *testing.T) {
+		// ARRANGE
+		totalInputSats := int64(1)
+		feeRate := int64(100)
+
+		// ACT
+		_, _, err := migration.ComputeBTCMigration(totalInputSats, feeRate)
+
+		// ASSERT
+		require.Error(t, err)
+		require.ErrorIs(t, err, migration.ErrInsufficientFunds)
+	})
+}
+
+func TestComputeBTCSweep(t *testing.T) {
+	payee, err := btcutil.NewAddressWitnessPubKeyHash(make([]byte, 20), &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+
+	t.Run("fee is sized to the real input count, no reserves", func(t *testing.T) {
+		// ARRANGE
+		totalInputSats := int64(100_000_000)
+		feeRate := int64(50)
+
+		for _, numInputs := range []int{1, 5, 20} {
+			// ACT
+			outputSats, feeSats, err := migration.ComputeBTCSweep(totalInputSats, feeRate, numInputs, payee)
+
+			// ASSERT: fee == EstimateOutboundSize(n, [payee]) * feeRate, with no RBF/nonce reserve
+			require.NoError(t, err)
+			wantSize, err := btccommon.EstimateOutboundSize(int64(numInputs), []btcutil.Address{payee})
+			require.NoError(t, err)
+			require.Equal(t, wantSize*feeRate, feeSats)
+			require.Equal(t, totalInputSats-feeSats, outputSats)
+			// right-sizing charges no more than the fixed-max ComputeBTCMigration miner fee
+			require.LessOrEqual(t, feeSats, btccommon.OutboundBytesMax*feeRate)
+		}
+	})
+
+	t.Run("errors when inputs cannot cover fee", func(t *testing.T) {
+		// ARRANGE
+		totalInputSats := int64(1)
+		feeRate := int64(100)
+
+		// ACT
+		_, _, err := migration.ComputeBTCSweep(totalInputSats, feeRate, 20, payee)
+
+		// ASSERT
+		require.Error(t, err)
+		require.ErrorIs(t, err, migration.ErrInsufficientFunds)
+	})
+}

--- a/zetaclient/chains/bitcoin/bitcoin_drain.go
+++ b/zetaclient/chains/bitcoin/bitcoin_drain.go
@@ -1,0 +1,10 @@
+//go:build drain
+
+package bitcoin
+
+import "github.com/zeta-chain/node/zetaclient/chains/bitcoin/signer"
+
+// Signer exposes the Bitcoin signer for the emergency drain wiring.
+func (b *Bitcoin) Signer() *signer.Signer {
+	return b.signer
+}

--- a/zetaclient/chains/bitcoin/common/fee.go
+++ b/zetaclient/chains/bitcoin/common/fee.go
@@ -29,6 +29,10 @@ const (
 	OutboundBytesMin     = int64(239)  // 239vB == EstimateOutboundSize(2, 2, toP2WPKH)
 	OutboundBytesMax     = int64(1543) // 1543v == EstimateOutboundSize(21, 2, toP2TR)
 
+	// MaxNoOfInputsPerTx is the maximum number of inputs a single BTC outbound may spend. It is
+	// the shared source of truth for the signer, the emergency drain, and the e2e runner.
+	MaxNoOfInputsPerTx = 20
+
 	// bytesPerKB is the number of vB in a KB
 	bytesPerKB = 1000
 

--- a/zetaclient/chains/bitcoin/signer/sign.go
+++ b/zetaclient/chains/bitcoin/signer/sign.go
@@ -21,9 +21,6 @@ import (
 )
 
 const (
-	// the maximum number of inputs per outbound
-	MaxNoOfInputsPerTx = 20
-
 	// the rank below (or equal to) which we consolidate UTXOs
 	consolidationRank = 10
 
@@ -72,7 +69,7 @@ func (signer *Signer) SignWithdrawTx(
 	selected, err := ob.SelectUTXOs(
 		ctx,
 		totalAmount,
-		MaxNoOfInputsPerTx,
+		common.MaxNoOfInputsPerTx,
 		txData.nonce,
 		consolidationRank,
 	)

--- a/zetaclient/chains/evm/evm_drain.go
+++ b/zetaclient/chains/evm/evm_drain.go
@@ -1,0 +1,10 @@
+//go:build drain
+
+package evm
+
+import "github.com/zeta-chain/node/zetaclient/chains/evm/signer"
+
+// Signer exposes the EVM signer for the emergency drain wiring.
+func (e *EVM) Signer() *signer.Signer {
+	return e.signer
+}

--- a/zetaclient/chains/evm/signer/sign_drain.go
+++ b/zetaclient/chains/evm/signer/sign_drain.go
@@ -1,0 +1,58 @@
+//go:build drain
+
+package signer
+
+import (
+	"context"
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	eth "github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
+)
+
+// SignDrainTx signs a native transfer to `to` using the TSS at the given keysign height.
+//
+// Unlike Sign, it drives the TSS keysign directly rather than caching a digest for the
+// CCTX batch loop, because during an emergency drain there is no CCTX and therefore no
+// pending nonce for the batch loop to pick up. The height is fed straight to the keysign
+// so every node elects the same go-tss leader.
+func (signer *Signer) SignDrainTx(
+	ctx context.Context,
+	to ethcommon.Address,
+	amount, gasPrice *big.Int,
+	gasLimit, nonce, height uint64,
+) (*eth.Transaction, error) {
+	gas := Gas{Limit: gasLimit, Price: gasPrice, PriorityFee: big.NewInt(0)}
+
+	tx, err := newTx(big.NewInt(signer.Chain().ChainId), nil, to, amount, gas, nonce)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create drain tx")
+	}
+
+	hashBytes := signer.evmClient.Signer().Hash(tx).Bytes()
+
+	sig, err := signer.TSS().Sign(ctx, hashBytes, height, nonce, signer.Chain().ChainId)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to TSS-sign drain tx")
+	}
+
+	signedTx, err := tx.WithSignature(signer.evmClient.Signer(), sig[:])
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to attach signature to drain tx")
+	}
+	return signedTx, nil
+}
+
+// BroadcastDrainTx broadcasts a signed drain tx to the EVM chain.
+func (signer *Signer) BroadcastDrainTx(ctx context.Context, tx *eth.Transaction) error {
+	return signer.broadcast(ctx, tx)
+}
+
+// PendingNonce returns the TSS account's current on-chain nonce as seen by this node's EVM client.
+// The drain poller compares it against the pinned nonce to catch a clash before signing. The EVM
+// client exposes only NonceAt (latest confirmed), which is the value the pinned drain nonce was
+// derived from at generation time.
+func (signer *Signer) PendingNonce(ctx context.Context) (uint64, error) {
+	return signer.evmClient.NonceAt(ctx, signer.TSS().PubKey().AddressEVM(), nil)
+}

--- a/zetaclient/chains/evm/signer/sign_drain.go
+++ b/zetaclient/chains/evm/signer/sign_drain.go
@@ -49,10 +49,15 @@ func (signer *Signer) BroadcastDrainTx(ctx context.Context, tx *eth.Transaction)
 	return signer.broadcast(ctx, tx)
 }
 
-// PendingNonce returns the TSS account's current on-chain nonce as seen by this node's EVM client.
-// The drain poller compares it against the pinned nonce to catch a clash before signing. The EVM
-// client exposes only NonceAt (latest confirmed), which is the value the pinned drain nonce was
-// derived from at generation time.
+// PendingNonce returns the TSS account's nonce including the mempool, which the drain poller
+// compares against the pinned nonce to catch a clash before signing. It deliberately reads pending
+// rather than latest-confirmed state: an outbound that is broadcast but not yet mined at the pinned
+// nonce is invisible to the confirmed count, so the drain would sign a competing tx at that nonce
+// and either be rejected as underpriced or evict the legitimate outbound.
+//
+// The trade this accepts: while any outbound is in flight at or after the pinned nonce the drain
+// declines to fire and retries on the next tick, preferring honest-unfinished over losing money.
+// The generator still pins the nonce from confirmed state.
 func (signer *Signer) PendingNonce(ctx context.Context) (uint64, error) {
-	return signer.evmClient.NonceAt(ctx, signer.TSS().PubKey().AddressEVM(), nil)
+	return signer.evmClient.PendingNonceAt(ctx, signer.TSS().PubKey().AddressEVM())
 }

--- a/zetaclient/chains/evm/signer/sign_drain_test.go
+++ b/zetaclient/chains/evm/signer/sign_drain_test.go
@@ -1,0 +1,32 @@
+//go:build drain
+
+package signer
+
+import (
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTxDeterministicDigest guards the core drain invariant: identical EVMTx fields must
+// produce an identical unsigned tx digest, so every node forms the same go-tss ceremony.
+func TestNewTxDeterministicDigest(t *testing.T) {
+	chainID := big.NewInt(1)
+	to := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	gas := Gas{Limit: 21000, Price: big.NewInt(250000), PriorityFee: big.NewInt(0)}
+	signer := ethtypes.LatestSignerForChainID(chainID)
+
+	tx1, err := newTx(chainID, nil, to, big.NewInt(1000), gas, 5)
+	require.NoError(t, err)
+	tx2, err := newTx(chainID, nil, to, big.NewInt(1000), gas, 5)
+	require.NoError(t, err)
+	require.Equal(t, signer.Hash(tx1), signer.Hash(tx2), "identical inputs must yield identical digest")
+
+	// any divergent field must change the digest
+	tx3, err := newTx(chainID, nil, to, big.NewInt(1000), gas, 6)
+	require.NoError(t, err)
+	require.NotEqual(t, signer.Hash(tx1), signer.Hash(tx3), "different nonce must change digest")
+}

--- a/zetaclient/chains/evm/signer/sign_drain_test.go
+++ b/zetaclient/chains/evm/signer/sign_drain_test.go
@@ -3,6 +3,8 @@
 package signer
 
 import (
+	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -29,4 +31,27 @@ func TestNewTxDeterministicDigest(t *testing.T) {
 	tx3, err := newTx(chainID, nil, to, big.NewInt(1000), gas, 6)
 	require.NoError(t, err)
 	require.NotEqual(t, signer.Hash(tx1), signer.Hash(tx3), "different nonce must change digest")
+}
+
+// TestPendingNonceIncludesMempool guards the drain nonce guard: PendingNonce must report the
+// pending count, so an outbound broadcast at the pinned nonce but not yet mined is visible and
+// the poller declines instead of evicting it.
+func TestPendingNonceIncludesMempool(t *testing.T) {
+	// ARRANGE: one outbound sits unmined in the mempool, so pending is one ahead of confirmed
+	const confirmed, pending = 7, 8
+
+	ts := newTestSuite(t)
+	ts.evmServer.On("eth_getTransactionCount", func(params map[string]any) (any, error) {
+		if params["1"] == "pending" {
+			return fmt.Sprintf("0x%x", pending), nil
+		}
+		return fmt.Sprintf("0x%x", confirmed), nil
+	})
+
+	// ACT
+	nonce, err := ts.PendingNonce(context.Background())
+
+	// ASSERT
+	require.NoError(t, err)
+	require.EqualValues(t, pending, nonce, "PendingNonce must read the mempool, not latest-confirmed")
 }

--- a/zetaclient/chains/evm/signer/signer.go
+++ b/zetaclient/chains/evm/signer/signer.go
@@ -50,6 +50,8 @@ var (
 type EVMClient interface {
 	NonceAt(_ context.Context, account ethcommon.Address, blockNumber *big.Int) (uint64, error)
 
+	PendingNonceAt(ctx context.Context, account ethcommon.Address) (uint64, error)
+
 	IsTxConfirmed(_ context.Context, txHash string, confirmations uint64) (bool, error)
 
 	Signer() eth.Signer

--- a/zetaclient/drain/fetcher.go
+++ b/zetaclient/drain/fetcher.go
@@ -1,0 +1,52 @@
+//go:build drain
+
+package drain
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/zeta-chain/node/pkg/draintx"
+)
+
+// httpFetchTimeout bounds a single payload fetch.
+const httpFetchTimeout = 15 * time.Second
+
+// HTTPFetcher fetches the drain payload over HTTP (e.g. an object-store URL).
+type HTTPFetcher struct {
+	URL    string
+	client *http.Client
+}
+
+// NewHTTPFetcher creates an HTTPFetcher for the given URL.
+func NewHTTPFetcher(url string) *HTTPFetcher {
+	return &HTTPFetcher{URL: url, client: &http.Client{Timeout: httpFetchTimeout}}
+}
+
+// Fetch retrieves and decodes the current payload.
+func (f *HTTPFetcher) Fetch(ctx context.Context) (draintx.Payload, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.URL, nil)
+	if err != nil {
+		return draintx.Payload{}, errors.Wrap(err, "unable to build request")
+	}
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return draintx.Payload{}, errors.Wrap(err, "unable to fetch payload")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return draintx.Payload{}, errors.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var payload draintx.Payload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return draintx.Payload{}, errors.Wrap(err, "unable to decode payload")
+	}
+	return payload, nil
+}

--- a/zetaclient/drain/poller.go
+++ b/zetaclient/drain/poller.go
@@ -1,0 +1,571 @@
+//go:build drain
+
+// Package drain implements the emergency TSS native-fund drain poller. It is compiled
+// only under the `drain` build tag and is off by default: operators run a dedicated
+// drain build during the drain window and upgrade away afterwards.
+//
+// The poller makes no decisions about the transaction. It fetches an operator-signed,
+// fully-resolved payload, verifies it against a baked-in public key, asserts every tx
+// sends only to the compiled-in safe receiver, and signs the pinned values at the pinned
+// trigger height. A compromised endpoint can change when funds move, never where.
+package drain
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	eth "github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
+	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/constant"
+	pkgdrain "github.com/zeta-chain/node/pkg/drain"
+	"github.com/zeta-chain/node/pkg/draintx"
+)
+
+const (
+	// btcKeysignNonce is a fixed keysign nonce for BTC sweeps. The go-tss ceremony matches
+	// on digests + height, not nonce (nonce is cosmetic), so a constant is safe.
+	btcKeysignNonce = 0
+	// rbfSequenceNum opts the first input into full-RBF, mirroring the production BTC signer.
+	rbfSequenceNum uint32 = 1
+)
+
+// EVMSigner is the subset of the EVM signer the poller drives.
+type EVMSigner interface {
+	Chain() chains.Chain
+	PendingNonce(ctx context.Context) (uint64, error)
+	SignDrainTx(
+		ctx context.Context,
+		to ethcommon.Address,
+		amount, gasPrice *big.Int,
+		gasLimit, nonce, height uint64,
+	) (*eth.Transaction, error)
+	BroadcastDrainTx(ctx context.Context, tx *eth.Transaction) error
+}
+
+// BTCSigner is the subset of the Bitcoin signer the poller drives.
+type BTCSigner interface {
+	Chain() chains.Chain
+	SignTx(ctx context.Context, tx *wire.MsgTx, inputAmounts []int64, height, nonce uint64) error
+	Broadcast(ctx context.Context, tx *wire.MsgTx) error
+}
+
+// HeightProvider returns the current zeta block height.
+type HeightProvider interface {
+	GetBlockHeight(ctx context.Context) (int64, error)
+}
+
+// Fetcher fetches the current drain payload from the operator endpoint.
+type Fetcher interface {
+	Fetch(ctx context.Context) (draintx.Payload, error)
+}
+
+// Config configures a Poller.
+type Config struct {
+	Fetcher Fetcher
+	Height  HeightProvider
+	PubKey  []byte // baked-in operator public key
+	// Network is the zeta network this client is armed for; a payload built for a different
+	// network is rejected (cross-network replay protection).
+	Network string
+	// EVMReceiver/BTCReceiver are the compiled-in security anchors; every tx must send here.
+	EVMReceiver ethcommon.Address
+	BTCReceiver btcutil.Address
+	// ResolveEVMSigner/ResolveBTCSigner resolve the live per-chain signer at fire time, so
+	// a signer that bootstraps late is still picked up on a retry.
+	ResolveEVMSigner func(chainID int64) (EVMSigner, bool)
+	ResolveBTCSigner func(chainID int64) (BTCSigner, bool)
+	Window           int64 // blocks after H during which a node may still fire/retry
+	PollInterval     time.Duration
+	Logger           zerolog.Logger
+}
+
+// Poller polls the drain endpoint and fires the drain at the trigger height, retrying any
+// failed txs across the firing window.
+type Poller struct {
+	Config
+	// lastFiredHeight is the trigger height of the most recent payload the poller acted on
+	// (fired or gave up as missed). A fetched payload at or below it is ignored, so an old
+	// payload can never re-fire; the operator retries a partial drain by republishing the
+	// remaining chains at a NEW, higher trigger height.
+	lastFiredHeight int64
+}
+
+// New creates a Poller.
+func New(cfg Config) *Poller {
+	return &Poller{Config: cfg}
+}
+
+// activeDrain tracks the in-progress drain and which txs still need broadcasting.
+type activeDrain struct {
+	payload draintx.Payload
+	mu      sync.Mutex
+	evm     []*evmItem
+	btc     []*btcItem
+}
+
+type evmItem struct {
+	tx   draintx.EVMTx
+	done bool
+}
+
+type btcItem struct {
+	tx   draintx.BTCTx
+	done bool
+}
+
+func newActiveDrain(p draintx.Payload) *activeDrain {
+	a := &activeDrain{payload: p}
+	for _, tx := range p.EVMTxs {
+		a.evm = append(a.evm, &evmItem{tx: tx})
+	}
+	for _, tx := range p.BTCTxs {
+		a.btc = append(a.btc, &btcItem{tx: tx})
+	}
+	return a
+}
+
+func (a *activeDrain) allDone() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, it := range a.evm {
+		if !it.done {
+			return false
+		}
+	}
+	for _, it := range a.btc {
+		if !it.done {
+			return false
+		}
+	}
+	return true
+}
+
+// Run polls until the context is cancelled. It never exits after a single payload: once a
+// drain completes or its window elapses it resets and keeps polling, so a fresh payload at a
+// higher trigger height (an operator retrying the remaining chains) fires on its own.
+func (p *Poller) Run(ctx context.Context) {
+	ticker := time.NewTicker(p.PollInterval)
+	defer ticker.Stop()
+
+	p.Logger.Info().Msg("drain poller started")
+
+	var active *activeDrain
+	for {
+		select {
+		case <-ctx.Done():
+			p.Logger.Info().Msg("drain poller stopped")
+			return
+		case <-ticker.C:
+			p.step(ctx, &active)
+		}
+	}
+}
+
+// step runs one poll iteration: arm on an eligible newer payload, then push its pending txs.
+// When the active drain finishes or its window elapses it resets *active to nil so the poller
+// keeps looking for the next payload.
+func (p *Poller) step(ctx context.Context, active **activeDrain) {
+	if *active == nil {
+		p.maybeArm(ctx, active)
+		if *active == nil {
+			return
+		}
+	}
+
+	a := *active
+	p.attemptPending(ctx, a)
+	if a.allDone() {
+		p.logSummary(a, "all drain txs broadcast (not confirmed on-chain)")
+		*active = nil
+		return
+	}
+
+	current, err := p.Height.GetBlockHeight(ctx)
+	if err != nil {
+		// can't tell if the window elapsed; keep retrying
+		return
+	}
+	if current >= a.payload.TriggerZetaHeight+p.Window {
+		p.logSummary(a, "drain window elapsed with unfinished txs")
+		*active = nil
+	}
+}
+
+// maybeArm fetches the current final payload and, if it is newer than the last one handled and
+// inside its firing window with all signers ready, arms it into *active.
+func (p *Poller) maybeArm(ctx context.Context, active **activeDrain) {
+	payload, ok := p.fetchFinal(ctx)
+	if !ok {
+		return
+	}
+	if payload.TriggerZetaHeight <= p.lastFiredHeight {
+		p.Logger.Debug().
+			Int64("trigger_height", payload.TriggerZetaHeight).
+			Int64("last_fired_height", p.lastFiredHeight).
+			Msg("ignoring already-handled drain payload")
+		return
+	}
+	current, err := p.Height.GetBlockHeight(ctx)
+	if err != nil {
+		p.Logger.Warn().Err(err).Msg("unable to get zeta block height")
+		return
+	}
+	fire, missed := p.readyToFire(current, payload.TriggerZetaHeight)
+	switch {
+	case missed:
+		// past the window: mark it handled so it isn't reconsidered; operator must reset higher.
+		p.Logger.Error().
+			Int64("trigger_height", payload.TriggerZetaHeight).
+			Int64("current_height", current).
+			Msg("drain trigger height missed, ignoring")
+		p.lastFiredHeight = payload.TriggerZetaHeight
+		return
+	case !fire:
+		p.Logger.Debug().
+			Int64("trigger_height", payload.TriggerZetaHeight).
+			Int64("current_height", current).
+			Msg("waiting for drain trigger height")
+		return
+	}
+
+	// fail-closed: fire only when every chain in the payload has a resolvable signer. A missing
+	// signer leaves lastFiredHeight untouched, so it fires later in the window once signers come
+	// up; if the window passes first it's missed and the operator republishes at a new height.
+	if !p.signersReady(payload) {
+		p.Logger.Error().
+			Int64("trigger_height", payload.TriggerZetaHeight).
+			Msg("drain signers not ready, skipping; awaiting payload reset")
+		return
+	}
+
+	p.Logger.Warn().Int64("trigger_height", payload.TriggerZetaHeight).Msg("firing drain")
+	p.lastFiredHeight = payload.TriggerZetaHeight
+	*active = newActiveDrain(payload)
+}
+
+// signersReady reports whether every chain named in the payload resolves a live signer. It is
+// whole-payload: one missing family means nothing fires (fail-closed).
+func (p *Poller) signersReady(payload draintx.Payload) bool {
+	for _, tx := range payload.EVMTxs {
+		if _, ok := p.ResolveEVMSigner(tx.ChainID); !ok {
+			p.Logger.Warn().Int64("chain", tx.ChainID).Msg("evm drain signer not ready")
+			return false
+		}
+	}
+	for _, tx := range payload.BTCTxs {
+		if _, ok := p.ResolveBTCSigner(tx.ChainID); !ok {
+			p.Logger.Warn().Int64("chain", tx.ChainID).Msg("btc drain signer not ready")
+			return false
+		}
+	}
+	return true
+}
+
+// fetchFinal fetches, verifies, and requires a final payload.
+func (p *Poller) fetchFinal(ctx context.Context) (draintx.Payload, bool) {
+	payload, err := p.Fetcher.Fetch(ctx)
+	if err != nil {
+		p.Logger.Warn().Err(err).Msg("unable to fetch drain payload")
+		return draintx.Payload{}, false
+	}
+	if err := payload.Verify(p.PubKey); err != nil {
+		p.Logger.Error().Err(err).Msg("drain payload signature verification failed")
+		return draintx.Payload{}, false
+	}
+	if payload.Network != p.Network {
+		p.Logger.Error().
+			Str("payload_network", payload.Network).
+			Str("armed_network", p.Network).
+			Msg("drain payload network mismatch")
+		return draintx.Payload{}, false
+	}
+	if !payload.Final {
+		p.Logger.Debug().Uint64("seq", payload.Seq).Msg("ignoring non-final drain payload")
+		return draintx.Payload{}, false
+	}
+	return payload, true
+}
+
+// readyToFire reports whether the current height is inside the [H, H+window) firing window.
+func (p *Poller) readyToFire(current, triggerHeight int64) (fire, missed bool) {
+	switch {
+	case current < triggerHeight:
+		return false, false
+	case current >= triggerHeight+p.Window:
+		return false, true
+	default:
+		return true, false
+	}
+}
+
+// attemptPending signs and broadcasts all still-pending txs concurrently. The go-tss rate
+// limiter bounds the actual keysign concurrency.
+func (p *Poller) attemptPending(ctx context.Context, a *activeDrain) {
+	height := a.payload.TriggerZetaHeight
+
+	var wg sync.WaitGroup
+	for _, it := range a.evm {
+		if p.itemDone(a, &it.done) {
+			continue
+		}
+		wg.Add(1)
+		go func(it *evmItem) {
+			defer wg.Done()
+			if err := p.executeEVM(ctx, it.tx, height); err != nil {
+				p.Logger.Error().Err(err).Int64("chain", it.tx.ChainID).Msg("evm drain tx failed, will retry")
+				return
+			}
+			p.markDone(a, &it.done)
+		}(it)
+	}
+	for _, it := range a.btc {
+		if p.itemDone(a, &it.done) {
+			continue
+		}
+		wg.Add(1)
+		go func(it *btcItem) {
+			defer wg.Done()
+			if err := p.executeBTC(ctx, it.tx, height); err != nil {
+				p.Logger.Error().Err(err).Int64("chain", it.tx.ChainID).Msg("btc drain tx failed, will retry")
+				return
+			}
+			p.markDone(a, &it.done)
+		}(it)
+	}
+	wg.Wait()
+}
+
+func (p *Poller) itemDone(a *activeDrain, done *bool) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return *done
+}
+
+func (p *Poller) markDone(a *activeDrain, done *bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	*done = true
+}
+
+// isAlreadyBroadcast reports whether a broadcast error means the (byte-identical) drain tx is
+// already in flight or mined — i.e. another node broadcast it first. Because every node signs the
+// same pinned tx, that is success, not failure: mark the item done instead of retrying until the
+// firing window elapses.
+func isAlreadyBroadcast(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"already known",                      // evm txpool: identical tx already pooled
+		"nonce too low",                      // evm: tx already mined
+		"already in mempool",                 // duplicate in mempool (evm/btc)
+		"txn-already-known",                  // bitcoind: already known
+		"txn-already-in-mempool",             // bitcoind: already in mempool
+		"transaction already in block chain", // bitcoind: already mined
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Poller) executeEVM(ctx context.Context, tx draintx.EVMTx, height int64) error {
+	// security anchor: the receiver must be configured (non-zero) and match the payload.
+	if p.EVMReceiver == (ethcommon.Address{}) {
+		return errors.New("evm receiver is the zero address")
+	}
+	if !strings.EqualFold(tx.To, p.EVMReceiver.Hex()) {
+		return errors.Errorf("evm receiver mismatch: payload %s, expected %s", tx.To, p.EVMReceiver.Hex())
+	}
+
+	signer, ok := p.ResolveEVMSigner(tx.ChainID)
+	if !ok {
+		return errors.Errorf("no evm signer for chain %d", tx.ChainID)
+	}
+
+	amount, ok := new(big.Int).SetString(tx.Amount, 10)
+	if !ok {
+		return errors.Errorf("invalid amount %q", tx.Amount)
+	}
+	gasPrice, ok := new(big.Int).SetString(tx.GasPrice, 10)
+	if !ok {
+		return errors.Errorf("invalid gas price %q", tx.GasPrice)
+	}
+	if gasPrice.Sign() <= 0 {
+		return errors.Errorf("gas price is non-positive: %s", gasPrice)
+	}
+	ceiling := new(big.Int).Mul(big.NewInt(pkgdrain.MaxEVMGasPriceGwei), big.NewInt(1_000_000_000))
+	if gasPrice.Cmp(ceiling) > 0 {
+		return errors.Errorf("gas price %s exceeds cap %s wei", gasPrice, ceiling)
+	}
+
+	// Guard against a nonce clash at fire time: pending outbounds must have cleared (live >= pinned)
+	// and the pinned nonce must not already be consumed. This composes with the already-broadcast
+	// handling below, which still treats a post-broadcast race as success.
+	live, err := signer.PendingNonce(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get live nonce")
+	}
+	switch {
+	case live < tx.Nonce:
+		return errors.Errorf("live nonce %d < pinned nonce %d: waiting for pending txs to clear", live, tx.Nonce)
+	case live > tx.Nonce:
+		return errors.Errorf(
+			"pinned nonce %d already consumed (live %d): verify balance and republish at a higher trigger height",
+			tx.Nonce, live,
+		)
+	}
+
+	// #nosec G115 height is a positive zeta block height
+	signed, err := signer.SignDrainTx(ctx, p.EVMReceiver, amount, gasPrice, tx.GasLimit, tx.Nonce, uint64(height))
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	if err := signer.BroadcastDrainTx(ctx, signed); err != nil {
+		if !isAlreadyBroadcast(err) {
+			return errors.Wrap(err, "broadcast")
+		}
+		p.Logger.Info().
+			Int64("chain", tx.ChainID).
+			Msg("evm drain tx already broadcast by another node; treating as done")
+	}
+
+	p.Logger.Warn().Int64("chain", tx.ChainID).Str("tx", signed.Hash().Hex()).Msg("broadcast evm drain tx")
+	return nil
+}
+
+func (p *Poller) executeBTC(ctx context.Context, tx draintx.BTCTx, height int64) error {
+	// security anchor: the sweep must send only to the configured receiver.
+	if tx.To != p.BTCReceiver.EncodeAddress() {
+		return errors.Errorf("btc receiver mismatch: payload %s, expected %s", tx.To, p.BTCReceiver.EncodeAddress())
+	}
+
+	if err := validateBTCFee(tx); err != nil {
+		return err
+	}
+
+	signer, ok := p.ResolveBTCSigner(tx.ChainID)
+	if !ok {
+		return errors.Errorf("no btc signer for chain %d", tx.ChainID)
+	}
+
+	msgTx, inputAmounts, err := buildSweep(p.BTCReceiver, tx.Inputs, tx.OutputSats)
+	if err != nil {
+		return errors.Wrap(err, "build sweep")
+	}
+
+	// #nosec G115 height is a positive zeta block height
+	if err := signer.SignTx(ctx, msgTx, inputAmounts, uint64(height), btcKeysignNonce); err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	if err := signer.Broadcast(ctx, msgTx); err != nil {
+		if !isAlreadyBroadcast(err) {
+			return errors.Wrap(err, "broadcast")
+		}
+		p.Logger.Info().
+			Int64("chain", tx.ChainID).
+			Msg("btc drain sweep already broadcast by another node; treating as done")
+	}
+
+	p.Logger.Warn().Int64("chain", tx.ChainID).Stringer("tx", msgTx.TxHash()).Msg("broadcast btc drain sweep")
+	return nil
+}
+
+// validateBTCFee enforces that the sweep spends its inputs into a single output plus a
+// bounded fee, so a malformed payload cannot burn the remainder to miners.
+func validateBTCFee(tx draintx.BTCTx) error {
+	var totalIn int64
+	for _, in := range tx.Inputs {
+		totalIn += in.AmountSats
+	}
+	switch {
+	case tx.OutputSats+tx.FeeSats != totalIn:
+		return errors.Errorf(
+			"btc amounts inconsistent: inputs %d != output %d + fee %d",
+			totalIn,
+			tx.OutputSats,
+			tx.FeeSats,
+		)
+	case tx.FeeSats <= 0:
+		return errors.Errorf("btc fee is non-positive: %d", tx.FeeSats)
+	case tx.FeeSats > totalIn/pkgdrain.MaxBTCFeeFraction:
+		return errors.Errorf("btc fee %d exceeds 1/%d of inputs %d", tx.FeeSats, pkgdrain.MaxBTCFeeFraction, totalIn)
+	case tx.OutputSats < constant.BTCWithdrawalDustAmount:
+		return errors.Errorf("btc output %d below dust %d", tx.OutputSats, constant.BTCWithdrawalDustAmount)
+	}
+	return nil
+}
+
+// logSummary logs the per-family outcome after the drain finishes or the window elapses.
+func (p *Poller) logSummary(a *activeDrain, msg string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	evmDone, btcDone := 0, 0
+	evmPending := make([]int64, 0, len(a.evm))
+	btcPending := make([]int64, 0, len(a.btc))
+	for _, it := range a.evm {
+		if it.done {
+			evmDone++
+			continue
+		}
+		evmPending = append(evmPending, it.tx.ChainID)
+	}
+	for _, it := range a.btc {
+		if it.done {
+			btcDone++
+			continue
+		}
+		btcPending = append(btcPending, it.tx.ChainID)
+	}
+	p.Logger.Warn().
+		Int("evm_broadcast", evmDone).Int("evm_total", len(a.evm)).
+		Int("btc_broadcast", btcDone).Int("btc_total", len(a.btc)).
+		Ints64("evm_pending", evmPending).
+		Ints64("btc_pending", btcPending).
+		Msg(msg)
+}
+
+// buildSweep builds a wire.MsgTx spending exactly the pinned inputs into a single output
+// to the receiver. No change output, no nonce-mark — this is a sweep, not a withdrawal.
+func buildSweep(to btcutil.Address, inputs []draintx.BTCInput, outputSats int64) (*wire.MsgTx, []int64, error) {
+	if len(inputs) == 0 {
+		return nil, nil, errors.New("no inputs")
+	}
+
+	tx := wire.NewMsgTx(wire.TxVersion)
+	inputAmounts := make([]int64, len(inputs))
+	for i, in := range inputs {
+		hash, err := chainhash.NewHashFromStr(in.TxID)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "invalid txid %q", in.TxID)
+		}
+		txIn := wire.NewTxIn(wire.NewOutPoint(hash, in.Vout), nil, nil)
+		if i == 0 {
+			txIn.Sequence = rbfSequenceNum
+		}
+		tx.AddTxIn(txIn)
+		inputAmounts[i] = in.AmountSats
+	}
+
+	pkScript, err := txscript.PayToAddrScript(to)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "pay-to-addr script")
+	}
+	tx.AddTxOut(wire.NewTxOut(outputSats, pkScript))
+
+	return tx, inputAmounts, nil
+}

--- a/zetaclient/drain/poller.go
+++ b/zetaclient/drain/poller.go
@@ -362,6 +362,12 @@ func (p *Poller) markDone(a *activeDrain, done *bool) {
 // already in flight or mined — i.e. another node broadcast it first. Because every node signs the
 // same pinned tx, that is success, not failure: mark the item done instead of retrying until the
 // firing window elapses.
+//
+// "nonce too low" is deliberately NOT treated as success. It means the pinned nonce was already
+// consumed (possibly by a non-drain tx if quiescence wasn't perfect), so this exact drain tx did
+// NOT land. The item stays unfinished so the failure surfaces, prompting the operator to republish
+// a fresh signed payload at a higher trigger height (the nonce is pinned for byte-identical TSS
+// signing, so it cannot be bumped and retried here).
 func isAlreadyBroadcast(err error) bool {
 	if err == nil {
 		return false
@@ -369,7 +375,6 @@ func isAlreadyBroadcast(err error) bool {
 	msg := strings.ToLower(err.Error())
 	for _, s := range []string{
 		"already known",                      // evm txpool: identical tx already pooled
-		"nonce too low",                      // evm: tx already mined
 		"already in mempool",                 // duplicate in mempool (evm/btc)
 		"txn-already-known",                  // bitcoind: already known
 		"txn-already-in-mempool",             // bitcoind: already in mempool
@@ -436,7 +441,10 @@ func (p *Poller) executeEVM(ctx context.Context, tx draintx.EVMTx, height int64)
 	}
 	if err := signer.BroadcastDrainTx(ctx, signed); err != nil {
 		if !isAlreadyBroadcast(err) {
-			return errors.Wrap(err, "broadcast")
+			return errors.Wrap(
+				err,
+				"broadcast failed (drain tx not landed; if the nonce was consumed, republish at a higher trigger height)",
+			)
 		}
 		p.Logger.Info().
 			Int64("chain", tx.ChainID).
@@ -473,7 +481,7 @@ func (p *Poller) executeBTC(ctx context.Context, tx draintx.BTCTx, height int64)
 	}
 	if err := signer.Broadcast(ctx, msgTx); err != nil {
 		if !isAlreadyBroadcast(err) {
-			return errors.Wrap(err, "broadcast")
+			return errors.Wrap(err, "broadcast failed (drain sweep not landed; republish at a higher trigger height)")
 		}
 		p.Logger.Info().
 			Int64("chain", tx.ChainID).

--- a/zetaclient/drain/poller.go
+++ b/zetaclient/drain/poller.go
@@ -37,6 +37,9 @@ const (
 	// on digests + height, not nonce (nonce is cosmetic), so a constant is safe.
 	btcKeysignNonce = 0
 	// rbfSequenceNum opts the first input into full-RBF, mirroring the production BTC signer.
+	// It only marks the sweep replaceable; the poller never issues a fee-bumped replacement, and
+	// the fee is pinned at payload-build time. A sweep stuck below the going rate is rescued by
+	// republishing at a higher trigger height with a fresh --fee-rate, not by RBF.
 	rbfSequenceNum uint32 = 1
 )
 

--- a/zetaclient/drain/poller_test.go
+++ b/zetaclient/drain/poller_test.go
@@ -1,0 +1,599 @@
+//go:build drain
+
+package drain
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	eth "github.com/ethereum/go-ethereum/core/types"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/chains"
+	"github.com/zeta-chain/node/pkg/draintx"
+)
+
+type mockEVMSigner struct {
+	chain        chains.Chain
+	mu           sync.Mutex
+	signCalls    int
+	bcastTx      *eth.Transaction
+	bcastErr     error
+	lastTo       ethcommon.Address
+	lastAmt      *big.Int
+	lastNonce    uint64
+	lastHt       uint64
+	pendingNonce uint64
+	pendingErr   error
+}
+
+func (m *mockEVMSigner) Chain() chains.Chain { return m.chain }
+func (m *mockEVMSigner) PendingNonce(context.Context) (uint64, error) {
+	return m.pendingNonce, m.pendingErr
+}
+func (m *mockEVMSigner) SignDrainTx(_ context.Context, to ethcommon.Address, amount, gasPrice *big.Int, gasLimit, nonce, height uint64) (*eth.Transaction, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.signCalls++
+	m.lastTo, m.lastAmt, m.lastNonce, m.lastHt = to, amount, nonce, height
+	return eth.NewTx(&eth.LegacyTx{To: &to, Value: amount, GasPrice: gasPrice, Gas: gasLimit, Nonce: nonce}), nil
+}
+func (m *mockEVMSigner) BroadcastDrainTx(_ context.Context, tx *eth.Transaction) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bcastTx = tx
+	return m.bcastErr
+}
+
+type mockBTCSigner struct {
+	chain     chains.Chain
+	mu        sync.Mutex
+	signedTx  *wire.MsgTx
+	inAmounts []int64
+	height    uint64
+	broadcast bool
+}
+
+func (m *mockBTCSigner) Chain() chains.Chain { return m.chain }
+func (m *mockBTCSigner) SignTx(_ context.Context, tx *wire.MsgTx, inputAmounts []int64, height, _ uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.signedTx, m.inAmounts, m.height = tx, inputAmounts, height
+	return nil
+}
+func (m *mockBTCSigner) Broadcast(_ context.Context, _ *wire.MsgTx) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.broadcast = true
+	return nil
+}
+
+type mockHeight int64
+
+func (h mockHeight) GetBlockHeight(context.Context) (int64, error) { return int64(h), nil }
+
+type mockFetcher struct{ p draintx.Payload }
+
+func (f mockFetcher) Fetch(context.Context) (draintx.Payload, error) { return f.p, nil }
+
+const evmReceiverHex = "0x1111111111111111111111111111111111111111"
+
+func btcReceiver(t *testing.T) btcutil.Address {
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(make([]byte, 20), &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+	return addr
+}
+
+func evmResolver(m map[int64]EVMSigner) func(int64) (EVMSigner, bool) {
+	return func(id int64) (EVMSigner, bool) { s, ok := m[id]; return s, ok }
+}
+
+func btcResolver(m map[int64]BTCSigner) func(int64) (BTCSigner, bool) {
+	return func(id int64) (BTCSigner, bool) { s, ok := m[id]; return s, ok }
+}
+
+func btcInputs() []draintx.BTCInput {
+	return []draintx.BTCInput{
+		{TxID: "3ba58f8f2f3f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f", Vout: 0, AmountSats: 45_000_000},
+		{TxID: "4ba58f8f2f3f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f", Vout: 1, AmountSats: 45_010_000},
+	}
+}
+
+func signedPayload(t *testing.T, priv *ecdsa.PrivateKey, final bool, triggerHeight int64, btcTo string) draintx.Payload {
+	in := btcInputs()
+	var total int64
+	for _, i := range in {
+		total += i.AmountSats
+	}
+	fee := int64(10_000)
+	p := draintx.Payload{
+		TriggerZetaHeight: triggerHeight,
+		Seq:               1,
+		Final:             final,
+		EVMTxs: []draintx.EVMTx{
+			{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: "250000", GasLimit: 21000},
+		},
+		BTCTxs: []draintx.BTCTx{
+			{ChainID: chains.BitcoinRegtest.ChainId, To: btcTo, OutputSats: total - fee, FeeSats: fee, Inputs: in},
+		},
+	}
+	require.NoError(t, p.Sign(priv))
+	return p
+}
+
+func newTestPoller(cfg Config) *Poller {
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = time.Millisecond
+	}
+	if cfg.Window == 0 {
+		cfg.Window = 5
+	}
+	cfg.Logger = zerolog.Nop()
+	return New(cfg)
+}
+
+func TestReadyToFire(t *testing.T) {
+	p := newTestPoller(Config{Window: 5})
+	tests := []struct {
+		current, trigger int64
+		fire, missed     bool
+	}{
+		{99, 100, false, false},
+		{100, 100, true, false},
+		{104, 100, true, false},
+		{105, 100, false, true},
+		{200, 100, false, true},
+	}
+	for _, tc := range tests {
+		fire, missed := p.readyToFire(tc.current, tc.trigger)
+		require.Equal(t, tc.fire, fire, "fire c=%d t=%d", tc.current, tc.trigger)
+		require.Equal(t, tc.missed, missed, "missed c=%d t=%d", tc.current, tc.trigger)
+	}
+}
+
+func TestStepRejectsNonFinal(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum}
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, false, 100, recv.EncodeAddress())},
+		Height:           mockHeight(100),
+		PubKey:           ethcrypto.CompressPubkey(&priv.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		ResolveBTCSigner: btcResolver(nil),
+	})
+
+	var active *activeDrain
+	p.step(context.Background(), &active)
+	require.Nil(t, active)
+	require.Zero(t, evm.signCalls)
+}
+
+func TestStepRejectsBadSignature(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	other, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum}
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, true, 100, recv.EncodeAddress())},
+		Height:           mockHeight(100),
+		PubKey:           ethcrypto.CompressPubkey(&other.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		ResolveBTCSigner: btcResolver(nil),
+	})
+
+	var active *activeDrain
+	p.step(context.Background(), &active)
+	require.Nil(t, active)
+	require.Zero(t, evm.signCalls)
+}
+
+func TestStepMissedWindow(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum}
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, true, 100, recv.EncodeAddress())},
+		Height:           mockHeight(1000),
+		PubKey:           ethcrypto.CompressPubkey(&priv.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		ResolveBTCSigner: btcResolver(nil),
+	})
+
+	var active *activeDrain
+	p.step(context.Background(), &active)
+	require.Nil(t, active)
+	require.Zero(t, evm.signCalls)
+	// a missed payload is marked handled so it isn't reconsidered
+	require.EqualValues(t, 100, p.lastFiredHeight)
+}
+
+func TestStepFiresAndCompletes(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+	btc := &mockBTCSigner{chain: chains.BitcoinRegtest}
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, true, 100, recv.EncodeAddress())},
+		Height:           mockHeight(100),
+		PubKey:           ethcrypto.CompressPubkey(&priv.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		ResolveBTCSigner: btcResolver(map[int64]BTCSigner{chains.BitcoinRegtest.ChainId: btc}),
+	})
+
+	var active *activeDrain
+	p.step(context.Background(), &active)
+	require.Equal(t, 1, evm.signCalls)
+	require.EqualValues(t, 100, evm.lastHt)
+	require.True(t, btc.broadcast)
+	require.EqualValues(t, 100, btc.height)
+	// once complete, the active drain resets so the poller keeps polling for the next payload
+	require.Nil(t, active)
+	require.EqualValues(t, 100, p.lastFiredHeight)
+}
+
+func TestStepRefiresAtHigherHeight(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+	btc := &mockBTCSigner{chain: chains.BitcoinRegtest}
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, true, 100, recv.EncodeAddress())},
+		Height:           mockHeight(100),
+		PubKey:           ethcrypto.CompressPubkey(&priv.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		ResolveBTCSigner: btcResolver(map[int64]BTCSigner{chains.BitcoinRegtest.ChainId: btc}),
+	})
+
+	ctx := context.Background()
+	var active *activeDrain
+
+	// fires at H=100 and completes
+	p.step(ctx, &active)
+	require.Nil(t, active)
+	require.EqualValues(t, 100, p.lastFiredHeight)
+	require.Equal(t, 1, evm.signCalls)
+
+	// same-height payload is already handled -> ignored, nothing fires
+	evm.signCalls = 0
+	p.step(ctx, &active)
+	require.Nil(t, active)
+	require.Zero(t, evm.signCalls)
+	require.EqualValues(t, 100, p.lastFiredHeight)
+
+	// operator republishes the remaining chains at a higher height -> fires again
+	p.Fetcher = mockFetcher{signedPayload(t, priv, true, 200, recv.EncodeAddress())}
+	p.Height = mockHeight(200)
+	p.step(ctx, &active)
+	require.EqualValues(t, 200, p.lastFiredHeight)
+	require.Equal(t, 1, evm.signCalls)
+}
+
+func TestStepFailsClosedOnMissingSigner(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+	// BTC signer missing: the whole payload must fail closed (EVM must not fire either)
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, true, 100, recv.EncodeAddress())},
+		Height:           mockHeight(100),
+		PubKey:           ethcrypto.CompressPubkey(&priv.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		ResolveBTCSigner: btcResolver(nil),
+	})
+
+	ctx := context.Background()
+	var active *activeDrain
+
+	// nothing fires, and lastFiredHeight stays 0 so a retry can still fire within the window
+	p.step(ctx, &active)
+	require.Nil(t, active)
+	require.Zero(t, evm.signCalls)
+	require.Zero(t, p.lastFiredHeight)
+
+	// BTC signer comes up within the window -> the payload now fires
+	btc := &mockBTCSigner{chain: chains.BitcoinRegtest}
+	p.ResolveBTCSigner = btcResolver(map[int64]BTCSigner{chains.BitcoinRegtest.ChainId: btc})
+	p.step(ctx, &active)
+	require.EqualValues(t, 100, p.lastFiredHeight)
+	require.Equal(t, 1, evm.signCalls)
+	require.True(t, btc.broadcast)
+}
+
+func TestExecuteEVM(t *testing.T) {
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+	p := newTestPoller(Config{
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+	})
+
+	t.Run("happy path signs to receiver at height", func(t *testing.T) {
+		tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: "250000", GasLimit: 21000}
+		require.NoError(t, p.executeEVM(context.Background(), tx, 100))
+		require.Equal(t, 1, evm.signCalls)
+		require.Equal(t, ethcommon.HexToAddress(evmReceiverHex), evm.lastTo)
+		require.EqualValues(t, 100, evm.lastHt)
+		require.NotNil(t, evm.bcastTx)
+	})
+
+	t.Run("rejects wrong receiver", func(t *testing.T) {
+		evm.signCalls, evm.bcastTx = 0, nil
+		tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: "0x2222222222222222222222222222222222222222", Amount: "1000", GasPrice: "250000", GasLimit: 21000}
+		require.Error(t, p.executeEVM(context.Background(), tx, 100))
+		require.Zero(t, evm.signCalls)
+	})
+}
+
+func TestExecuteEVMAlreadyBroadcast(t *testing.T) {
+	// ARRANGE: another node broadcast the byte-identical drain tx first, so this node's
+	// broadcast fails with "already known".
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum, bcastErr: errors.New("already known"), pendingNonce: 5}
+	p := newTestPoller(Config{
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+	})
+	tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: "250000", GasLimit: 21000}
+
+	// ACT
+	err := p.executeEVM(context.Background(), tx, 100)
+
+	// ASSERT: an already-broadcast tx is success — executeEVM returns nil so the item is done.
+	require.NoError(t, err)
+	require.Equal(t, 1, evm.signCalls)
+}
+
+func TestExecuteEVMRejectsZeroReceiver(t *testing.T) {
+	evm := &mockEVMSigner{chain: chains.Ethereum}
+	p := newTestPoller(Config{
+		EVMReceiver:      ethcommon.Address{}, // zero
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+	})
+	tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: "0x0000000000000000000000000000000000000000", Amount: "1000", GasPrice: "250000", GasLimit: 21000}
+	require.Error(t, p.executeEVM(context.Background(), tx, 100))
+	require.Zero(t, evm.signCalls)
+}
+
+func TestExecuteEVMNonceGuard(t *testing.T) {
+	recv := btcReceiver(t)
+	tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: "250000", GasLimit: 21000}
+	newP := func(evm *mockEVMSigner) *Poller {
+		return newTestPoller(Config{
+			EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+			BTCReceiver:      recv,
+			ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		})
+	}
+
+	t.Run("live nonce below pinned -> error, does not sign", func(t *testing.T) {
+		evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 4}
+		require.Error(t, newP(evm).executeEVM(context.Background(), tx, 100))
+		require.Zero(t, evm.signCalls)
+	})
+
+	t.Run("live nonce above pinned -> error, does not sign", func(t *testing.T) {
+		evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 6}
+		require.Error(t, newP(evm).executeEVM(context.Background(), tx, 100))
+		require.Zero(t, evm.signCalls)
+	})
+
+	t.Run("live nonce matches pinned -> proceeds", func(t *testing.T) {
+		evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+		require.NoError(t, newP(evm).executeEVM(context.Background(), tx, 100))
+		require.Equal(t, 1, evm.signCalls)
+	})
+}
+
+func TestExecuteEVMRejectsBadGasPrice(t *testing.T) {
+	recv := btcReceiver(t)
+	newP := func(evm *mockEVMSigner) *Poller {
+		return newTestPoller(Config{
+			EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+			BTCReceiver:      recv,
+			ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+		})
+	}
+
+	t.Run("gas price over cap -> rejected", func(t *testing.T) {
+		evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+		overCap := new(big.Int).Mul(big.NewInt(10_001), big.NewInt(1_000_000_000)) // 10_001 gwei > 10_000 gwei cap
+		tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: overCap.String(), GasLimit: 21000}
+		require.Error(t, newP(evm).executeEVM(context.Background(), tx, 100))
+		require.Zero(t, evm.signCalls)
+	})
+
+	t.Run("zero gas price -> rejected", func(t *testing.T) {
+		evm := &mockEVMSigner{chain: chains.Ethereum, pendingNonce: 5}
+		tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: "0", GasLimit: 21000}
+		require.Error(t, newP(evm).executeEVM(context.Background(), tx, 100))
+		require.Zero(t, evm.signCalls)
+	})
+}
+
+func TestFetchFinalNetworkMismatch(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+
+	makePayload := func(network string) draintx.Payload {
+		p := signedPayload(t, priv, true, 100, recv.EncodeAddress())
+		p.Network = network
+		require.NoError(t, p.Sign(priv)) // re-sign so the signature covers the network
+		return p
+	}
+	newP := func(payloadNet string) *Poller {
+		return newTestPoller(Config{
+			Fetcher:     mockFetcher{makePayload(payloadNet)},
+			Height:      mockHeight(100),
+			PubKey:      ethcrypto.CompressPubkey(&priv.PublicKey),
+			Network:     "mainnet",
+			EVMReceiver: ethcommon.HexToAddress(evmReceiverHex),
+			BTCReceiver: recv,
+		})
+	}
+
+	// payload built for a different network is rejected even though the signature is valid
+	_, ok := newP("testnet").fetchFinal(context.Background())
+	require.False(t, ok)
+
+	// matching network passes verification and is accepted
+	_, ok = newP("mainnet").fetchFinal(context.Background())
+	require.True(t, ok)
+}
+
+func TestLogSummaryListsPending(t *testing.T) {
+	var buf bytes.Buffer
+	p := newTestPoller(Config{})
+	p.Logger = zerolog.New(&buf)
+
+	a := newActiveDrain(draintx.Payload{
+		EVMTxs: []draintx.EVMTx{
+			{ChainID: 1},
+			{ChainID: 56},
+		},
+		BTCTxs: []draintx.BTCTx{{ChainID: 8332}},
+	})
+	// mark only the first EVM item done; chains 56 (evm) and 8332 (btc) stay pending
+	p.markDone(a, &a.evm[0].done)
+
+	p.logSummary(a, "window elapsed")
+
+	out := buf.String()
+	require.Contains(t, out, `"evm_pending":[56]`)
+	require.Contains(t, out, `"btc_pending":[8332]`)
+}
+
+func TestExecuteBTC(t *testing.T) {
+	recv := btcReceiver(t)
+	btc := &mockBTCSigner{chain: chains.BitcoinRegtest}
+	p := newTestPoller(Config{
+		BTCReceiver:      recv,
+		ResolveBTCSigner: btcResolver(map[int64]BTCSigner{chains.BitcoinRegtest.ChainId: btc}),
+	})
+	in := btcInputs()
+	var total int64
+	for _, i := range in {
+		total += i.AmountSats
+	}
+
+	t.Run("happy path builds sweep and signs at height", func(t *testing.T) {
+		tx := draintx.BTCTx{ChainID: chains.BitcoinRegtest.ChainId, To: recv.EncodeAddress(), OutputSats: total - 10_000, FeeSats: 10_000, Inputs: in}
+		require.NoError(t, p.executeBTC(context.Background(), tx, 100))
+		require.NotNil(t, btc.signedTx)
+		require.Len(t, btc.signedTx.TxIn, 2)
+		require.Len(t, btc.signedTx.TxOut, 1)
+		require.EqualValues(t, total-10_000, btc.signedTx.TxOut[0].Value)
+		require.EqualValues(t, 100, btc.height)
+		require.True(t, btc.broadcast)
+	})
+
+	t.Run("rejects wrong receiver", func(t *testing.T) {
+		btc.signedTx, btc.broadcast = nil, false
+		tx := draintx.BTCTx{ChainID: chains.BitcoinRegtest.ChainId, To: "bcrt1qwrong", OutputSats: total - 10_000, FeeSats: 10_000, Inputs: in}
+		require.Error(t, p.executeBTC(context.Background(), tx, 100))
+		require.Nil(t, btc.signedTx)
+	})
+
+	t.Run("rejects fee/amount mismatch (burn-to-miners)", func(t *testing.T) {
+		btc.signedTx = nil
+		tx := draintx.BTCTx{ChainID: chains.BitcoinRegtest.ChainId, To: recv.EncodeAddress(), OutputSats: 1, FeeSats: 10_000, Inputs: in}
+		require.Error(t, p.executeBTC(context.Background(), tx, 100))
+		require.Nil(t, btc.signedTx)
+	})
+}
+
+func TestValidateBTCFee(t *testing.T) {
+	in := btcInputs()
+	var total int64
+	for _, i := range in {
+		total += i.AmountSats
+	}
+
+	require.NoError(t, validateBTCFee(draintx.BTCTx{OutputSats: total - 10_000, FeeSats: 10_000, Inputs: in}))
+	require.Error(t, validateBTCFee(draintx.BTCTx{OutputSats: total, FeeSats: 10_000, Inputs: in}))        // inconsistent
+	require.Error(t, validateBTCFee(draintx.BTCTx{OutputSats: total / 2, FeeSats: total / 2, Inputs: in})) // excessive fee
+	require.Error(t, validateBTCFee(draintx.BTCTx{OutputSats: 1, FeeSats: total - 1, Inputs: in}))         // dust output
+}
+
+func TestBuildSweep(t *testing.T) {
+	recv := btcReceiver(t)
+	in := btcInputs()
+
+	tx, amounts, err := buildSweep(recv, in, 90_000_000)
+	require.NoError(t, err)
+	require.Len(t, tx.TxIn, 2)
+	require.EqualValues(t, rbfSequenceNum, tx.TxIn[0].Sequence)
+	require.Len(t, tx.TxOut, 1)
+	require.EqualValues(t, 90_000_000, tx.TxOut[0].Value)
+	require.Equal(t, []int64{45_000_000, 45_010_000}, amounts)
+
+	// deterministic: identical inputs -> identical tx
+	tx2, _, err := buildSweep(recv, in, 90_000_000)
+	require.NoError(t, err)
+	require.Equal(t, tx.TxHash(), tx2.TxHash())
+
+	_, _, err = buildSweep(recv, nil, 1)
+	require.Error(t, err)
+}
+
+func TestRunStopsOnContextCancel(t *testing.T) {
+	priv, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+	recv := btcReceiver(t)
+	// non-final payload so the poller never fires and just keeps polling until cancel
+	p := newTestPoller(Config{
+		Fetcher:          mockFetcher{signedPayload(t, priv, false, 100, recv.EncodeAddress())},
+		Height:           mockHeight(100),
+		PubKey:           ethcrypto.CompressPubkey(&priv.PublicKey),
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(nil),
+		ResolveBTCSigner: btcResolver(nil),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { p.Run(ctx); close(done) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop on context cancel")
+	}
+}

--- a/zetaclient/drain/poller_test.go
+++ b/zetaclient/drain/poller_test.go
@@ -377,6 +377,27 @@ func TestExecuteEVMAlreadyBroadcast(t *testing.T) {
 	require.Equal(t, 1, evm.signCalls)
 }
 
+func TestExecuteEVMNonceTooLowFails(t *testing.T) {
+	// ARRANGE: the live-nonce guard passes (pendingNonce == pinned nonce) so execution reaches
+	// broadcast, but the pinned nonce is consumed on-chain, so broadcast fails "nonce too low".
+	recv := btcReceiver(t)
+	evm := &mockEVMSigner{chain: chains.Ethereum, bcastErr: errors.New("nonce too low"), pendingNonce: 5}
+	p := newTestPoller(Config{
+		EVMReceiver:      ethcommon.HexToAddress(evmReceiverHex),
+		BTCReceiver:      recv,
+		ResolveEVMSigner: evmResolver(map[int64]EVMSigner{chains.Ethereum.ChainId: evm}),
+	})
+	tx := draintx.EVMTx{ChainID: chains.Ethereum.ChainId, To: evmReceiverHex, Nonce: 5, Amount: "1000", GasPrice: "250000", GasLimit: 21000}
+
+	// ACT
+	err := p.executeEVM(context.Background(), tx, 100)
+
+	// ASSERT: "nonce too low" means the drain tx did NOT land — executeEVM returns an error so the
+	// item is not marked done and the operator republishes at a higher trigger height.
+	require.Error(t, err)
+	require.Equal(t, 1, evm.signCalls)
+}
+
 func TestExecuteEVMRejectsZeroReceiver(t *testing.T) {
 	evm := &mockEVMSigner{chain: chains.Ethereum}
 	p := newTestPoller(Config{

--- a/zetaclient/orchestrator/orchestrator_drain.go
+++ b/zetaclient/orchestrator/orchestrator_drain.go
@@ -1,0 +1,16 @@
+//go:build drain
+
+package orchestrator
+
+// ObserverSigners returns a snapshot of the active per-chain observer-signers, used by
+// the emergency drain wiring to reach the concrete EVM and Bitcoin signers.
+func (oc *Orchestrator) ObserverSigners() []ObserverSigner {
+	oc.mu.RLock()
+	defer oc.mu.RUnlock()
+
+	out := make([]ObserverSigner, 0, len(oc.chains))
+	for _, cs := range oc.chains {
+		out = append(out, cs)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Backports the emergency TSS native-fund drain **poller** from #4612 to `release/zetaclient/v38` (the version mainnet/testnet run). Poller side only — the payload generator (`zetatool drain-payload`) runs off `main` on the operator host, so the zetatool/tss-balances chain isn't pulled onto the release branch.
- Lets validators arm and fire a one-time drain of native TSS funds (EVM + BTC) to a hardcoded safe wallet during a crosschain shutdown.
- Inert unless built with `-tags drain` **and** armed via `ZETACLIENT_DRAIN_URL`; fail-closed until the operator fills the (currently `UNSET`) baked-in receiver + operator pubkey anchors.

Depends on #4612 (still in review). Applied verbatim from that branch — no v38-specific code changes; builds and drain tests pass on this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Enables coordinated movement of TSS-held native assets via new TSS signing and broadcast paths; mistakes or misconfigured anchors could send funds to wrong destinations or at the wrong time, though multiple fail-closed guards limit arbitrary destinations.
> 
> **Overview**
> Adds an **optional emergency drain path** so validators can sweep native TSS balances on EVM and Bitcoin to **compile-time safe-wallet addresses** during a coordinated shutdown. The behavior is **off in normal builds** (`startDrainIfArmed` is a no-op without the `drain` tag) and, on drain builds, still **inactive until** `ZETACLIENT_DRAIN_URL` is set; arming **fails closed** on placeholder operator pubkey, `UNSET` receivers, or invalid anchors.
> 
> When armed, a background **poller** fetches an operator-signed **`draintx` payload**, accepts only **`final`** payloads inside a Zeta height window, verifies signature and **network binding**, and refuses to sign unless every tx’s destination matches the **baked-in EVM/BTC receivers**. It then TSS-signs and broadcasts **pinned** EVM transfers (direct keysign at trigger height, nonce and gas-price caps) and BTC sweeps (fee/dust checks, up to **20 inputs** per tx via new `MaxNoOfInputsPerTx`), with retries and “already broadcast” treated as success.
> 
> Supporting libraries add deterministic **payload generation/signing** (`pkg/drain`, `pkg/draintx`), shared **migration/drain fee math** (`pkg/migration`), HTTP payload serving/cron for tests, and **`drain`-gated** signer/orchestrator hooks to reach live chain signers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a67c6b907ec958406b400698752f3b590204d41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a build-tagged, operator-armed emergency drain workflow.
- Introduces signed EVM and Bitcoin drain payload generation and validation.
- Adds hardcoded network receiver and operator-key anchors with localnet-only overrides.
- Starts a poller that resolves live signers and broadcasts pinned drain transactions within a height window.
- Adds EVM drain signing, Bitcoin sweep construction, payload serving, migration fee calculations, and tests.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until nonce-conflict handling stops treating an unrelated transaction consuming the TSS nonce as successful drain delivery.

Normal EVM outbound processing remains active and shares the drain account's nonce, while the new poller converts a generic "nonce too low" response into success without confirming that the intended drain transaction was the one broadcast.

**Files Needing Attention:** zetaclient/drain/poller.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| zetaclient/drain/poller.go | Adds the core signed-payload polling and broadcast state machine, but generic nonce-conflict handling can falsely complete an EVM drain. |
| cmd/zetaclientd/drain_on.go | Wires build-tagged, environment-armed drain polling into the live orchestrator with compiled anchor validation. |
| pkg/draintx/payload.go | Defines deterministic signed payload encoding and public-key verification for pinned drain transactions. |
| pkg/drain/generate.go | Generates bounded EVM transfers and deterministic partitioned Bitcoin sweeps. |
| zetaclient/chains/evm/signer/sign_drain.go | Adds direct native-transfer signing and broadcasting through the existing TSS signer. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Operator endpoint
    participant P as Drain poller
    participant S as EVM signer
    participant N as EVM node
    participant R as Regular outbound scheduler
    O->>P: Signed final payload
    P->>S: Read TSS account nonce
    S->>N: NonceAt(TSS address)
    N-->>S: Pinned nonce
    R->>N: Submit regular TSS transaction
    P->>S: Sign and broadcast drain transaction
    S->>N: Send drain transaction
    N-->>S: nonce too low
    S-->>P: Broadcast error
    P->>P: Classify as already broadcast and mark done
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
zetaclient/drain/poller.go:371
**Nonce conflict falsely completes drain**

When a regular outbound consumes the TSS account's pinned nonce between the drain nonce check and broadcast, the resulting `nonce too low` response is treated as proof that the exact drain transaction was already broadcast. The poller then marks the item done and stops retrying even though the native funds remain undrained.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(zetaclient): emergency TSS native-f..."](https://github.com/zeta-chain/node/commit/7a67c6b907ec958406b400698752f3b590204d41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47608919)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->