### PR TITLE
feat(drain): testnet receivers + operator pubkey (Athens drain phase)

### DIFF
--- a/pkg/drain/receivers.go
+++ b/pkg/drain/receivers.go
@@ -10,7 +10,7 @@ import (
 // used to verify drain payloads. It is a PLACEHOLDER and MUST be replaced with the real
 // operator public key (reviewed in the PR) before a drain build is cut. The arm-time guard
 // rejects this all-zero placeholder so an unconfigured build fails closed.
-const OperatorPubKeyHex = "0x000000000000000000000000000000000000000000000000000000000000000000"
+const OperatorPubKeyHex = "0x03579d09c8a72ebf96e943c121926f3bfaf7600b9685eda7692786bf3cfca2c9fc"
 
 // unset is the sentinel for a receiver that has not been configured. It is deliberately not
 // a valid address, so an unconfigured testnet/mainnet build fails closed rather than
@@ -46,8 +46,8 @@ type Receivers struct {
 // drain build has no localnet path at all and cannot be redirected via a localnet env.
 var receiversByNetwork = map[string]Receivers{
 	NetworkTestnet: {
-		EVM: unset,
-		BTC: unset,
+		EVM: "0xb741531a1A8984d5188d1058f47EB7cBd57F4655",
+		BTC: "tb1qz7n05rg9swm97h4lyyx2uuphzm0cxd6sj529k4",
 	},
 	NetworkMainnet: {
 		EVM: unset,

--- a/pkg/drain/receivers_localnet_test.go
+++ b/pkg/drain/receivers_localnet_test.go
@@ -30,6 +30,6 @@ func TestResolveAnchorsTestnetIgnoresEnv(t *testing.T) {
 	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
 	require.NoError(t, err)
 	require.NotEqual(t, "0x971d9a4763D845F4346D39292b849C567184D201", receivers.EVM)
-	// testnet is unset by default -> fails closed
-	require.Error(t, receivers.Validate())
+	// testnet anchors are compiled-in and configured -> validates (env still ignored)
+	require.NoError(t, receivers.Validate())
 }

--- a/pkg/drain/receivers_test.go
+++ b/pkg/drain/receivers_test.go
@@ -33,9 +33,17 @@ func TestReceiversValidate(t *testing.T) {
 	}
 }
 
-func TestResolveAnchorsTestnetUnset(t *testing.T) {
-	// testnet anchors resolve but are the UNSET sentinel until configured, so Validate fails closed.
+func TestResolveAnchorsTestnetConfigured(t *testing.T) {
+	// testnet anchors are configured for the Athens drain, so Validate passes.
 	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
+	require.NoError(t, err)
+	require.NoError(t, receivers.Validate())
+}
+
+func TestResolveAnchorsMainnetUnset(t *testing.T) {
+	// mainnet anchors are still the UNSET sentinel until the real refund wallets
+	// are configured, so Validate fails closed.
+	_, receivers, err := drain.ResolveAnchors(drain.NetworkMainnet)
 	require.NoError(t, err)
 	require.Error(t, receivers.Validate())
 }

--- a/pkg/drain/receivers_test.go
+++ b/pkg/drain/receivers_test.go
@@ -1,6 +1,7 @@
 package drain_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,9 +36,16 @@ func TestReceiversValidate(t *testing.T) {
 
 func TestResolveAnchorsTestnetConfigured(t *testing.T) {
 	// testnet anchors are configured for the Athens drain, so Validate passes.
-	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
+	pub, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
 	require.NoError(t, err)
 	require.NoError(t, receivers.Validate())
+
+	// Pin the exact reviewed anchors + operator pubkey. These are the security-critical
+	// drain destinations and payload-verification key; any change must fail CI and force
+	// a re-review rather than sliding through on generic syntax validation.
+	require.Equal(t, "0xb741531a1A8984d5188d1058f47EB7cBd57F4655", receivers.EVM)
+	require.Equal(t, "tb1qz7n05rg9swm97h4lyyx2uuphzm0cxd6sj529k4", receivers.BTC)
+	require.Equal(t, "0x03579d09c8a72ebf96e943c121926f3bfaf7600b9685eda7692786bf3cfca2c9fc", "0x"+hex.EncodeToString(pub))
 }
 
 func TestResolveAnchorsMainnetUnset(t *testing.T) {


### PR DESCRIPTION
Fills the compile-time drain anchors for the **testnet Athens** phase of RFC 002 (TSS emergency drain). Cut the testnet drain build from this branch (v38 = what the testnet signers run).

**Values** (existing e2e accounts, keys held by the team):
- EVM receiver: `0xb741531a1A8984d5188d1058f47EB7cBd57F4655`
- BTC receiver: `tb1qz7n05rg9swm97h4lyyx2uuphzm0cxd6sj529k4` (testnet p2wpkh)
- Operator pubkey: `0x03579d09c8a72ebf96e943c121926f3bfaf7600b9685eda7692786bf3cfca2c9fc` (secp256k1 compressed)

Both receiver keys and the operator private key are held by the team; the private key is passed to `zetatool drain-payload --serve` at runtime (`--signing-key`), never committed. BTC address + EVM address independently re-derived from their keys and verified before filling.

**Mainnet stays `UNSET`** — the arm-time guard fails closed on it, so this build cannot drain mainnet. Mainnet anchors (Gnosis Safe on EVM + a BTC multisig) land in a separate reviewed PR once treasury provides them.

Draft until the testnet run is greenlit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes hardcoded emergency-drain destinations and payload verification key; incorrect values would misdirect testnet TSS funds during a drain.
> 
> **Overview**
> Configures **testnet** compile-time emergency-drain anchors in `receivers.go` for the Athens drain phase, replacing placeholders so a drain build can arm on testnet only.
> 
> **Operator pubkey:** `OperatorPubKeyHex` moves from the all-zero placeholder to a real compressed secp256k1 key used to verify operator-signed drain payloads.
> 
> **Testnet receivers:** `receiversByNetwork[testnet]` EVM and BTC entries move from `UNSET` to fixed safe-wallet destinations (`0xb741…F4655` and `tb1qz7n05…529k4`). **Mainnet** EVM/BTC remain `UNSET`, so arm-time validation still fails closed for mainnet.
> 
> No logic changes—only the anchored constants that `ResolveAnchors` / `Validate` already enforce.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47a4ae350f32c8acbcdaa0e53462a64f788479c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
**Note (per review):** the testnet EVM receiver, BTC receiver, and operator pubkey are all derived from the same e2e key we hold — deliberate for the testnet drill, so the hardcoded-receiver anchor is not a real separation here. For mainnet, the receivers will be wallets the operator does NOT hold the signing key to (refund-system Gnosis Safe + BTC multisig); mainnet stays UNSET in this build.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Configures the Athens-phase emergency-drain anchors for testnet while keeping mainnet disabled.
- Sets the testnet EVM and BTC receiver addresses and operator verification public key.
- Pins all three reviewed values in tests so subsequent anchor changes fail CI.
- Retains the mainnet fail-closed validation coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/drain/receivers.go | Replaces the testnet drain placeholders with the reviewed Athens receiver addresses and operator public key while leaving mainnet unset. |
| pkg/drain/receivers_test.go | Pins the exact testnet anchors and operator public key and preserves explicit mainnet fail-closed coverage. |
| pkg/drain/receivers_localnet_test.go | Updates localnet-environment isolation coverage to expect the newly configured testnet receivers to validate. |

<sub>Reviews (2): Last reviewed commit: ["test(drain): pin exact testnet anchors +..."](https://github.com/zeta-chain/node/commit/522fb5d52181bc3343743f4c428219ad9d602e65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52710642)</sub>

<!-- /greptile_comment -->