### PR TITLE
feat(drain): testnet receivers on main (drain server anchors)

### DIFF
--- a/pkg/drain/receivers.go
+++ b/pkg/drain/receivers.go
@@ -10,7 +10,7 @@ import (
 // used to verify drain payloads. It is a PLACEHOLDER and MUST be replaced with the real
 // operator public key (reviewed in the PR) before a drain build is cut. The arm-time guard
 // rejects this all-zero placeholder so an unconfigured build fails closed.
-const OperatorPubKeyHex = "0x000000000000000000000000000000000000000000000000000000000000000000"
+const OperatorPubKeyHex = "0x03579d09c8a72ebf96e943c121926f3bfaf7600b9685eda7692786bf3cfca2c9fc"
 
 // unset is the sentinel for a receiver that has not been configured. It is deliberately not
 // a valid address, so an unconfigured testnet/mainnet build fails closed rather than
@@ -46,8 +46,8 @@ type Receivers struct {
 // drain build has no localnet path at all and cannot be redirected via a localnet env.
 var receiversByNetwork = map[string]Receivers{
 	NetworkTestnet: {
-		EVM: unset,
-		BTC: unset,
+		EVM: "0xb741531a1A8984d5188d1058f47EB7cBd57F4655",
+		BTC: "tb1qz7n05rg9swm97h4lyyx2uuphzm0cxd6sj529k4",
 	},
 	NetworkMainnet: {
 		EVM: unset,

--- a/pkg/drain/receivers.go
+++ b/pkg/drain/receivers.go
@@ -7,9 +7,9 @@ import (
 )
 
 // OperatorPubKeyHex is the compiled-in secp256k1 public key (33-byte compressed, 0x-hex)
-// used to verify drain payloads. It is a PLACEHOLDER and MUST be replaced with the real
-// operator public key (reviewed in the PR) before a drain build is cut. The arm-time guard
-// rejects this all-zero placeholder so an unconfigured build fails closed.
+// used to verify drain payloads. This is the TESTNET operator key (reviewed in #4616/#4617);
+// the matching private key is supplied to the drain server at runtime via --signing-key.
+// The arm-time guard rejects an all-zero value so an unconfigured build fails closed.
 const OperatorPubKeyHex = "0x03579d09c8a72ebf96e943c121926f3bfaf7600b9685eda7692786bf3cfca2c9fc"
 
 // unset is the sentinel for a receiver that has not been configured. It is deliberately not
@@ -39,11 +39,12 @@ type Receivers struct {
 
 // receiversByNetwork is the single source of truth for the production drain destinations.
 //
-// The testnet and mainnet values are UNSET sentinels and MUST be replaced with the real
-// safe-wallet addresses (reviewed in the PR) before a drain build is cut; the arm-time
-// guard rejects UNSET so an unconfigured build fails closed. Localnet is deliberately absent:
-// its anchors live behind the drain_localnet build tag (receivers_localnet.go) so a production
-// drain build has no localnet path at all and cannot be redirected via a localnet env.
+// Testnet is configured (reviewed in #4616/#4617) with the e2e safe wallets. Mainnet is still
+// the UNSET sentinel and MUST be replaced with the real refund-system safe wallets (a separate
+// reviewed PR) before a mainnet drain build is cut; the arm-time guard rejects UNSET so a
+// mainnet build fails closed until then. Localnet is deliberately absent: its anchors live
+// behind the drain_localnet build tag (receivers_localnet.go) so a production drain build has
+// no localnet path at all and cannot be redirected via a localnet env.
 var receiversByNetwork = map[string]Receivers{
 	NetworkTestnet: {
 		EVM: "0xb741531a1A8984d5188d1058f47EB7cBd57F4655",

--- a/pkg/drain/receivers_localnet_test.go
+++ b/pkg/drain/receivers_localnet_test.go
@@ -30,6 +30,6 @@ func TestResolveAnchorsTestnetIgnoresEnv(t *testing.T) {
 	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
 	require.NoError(t, err)
 	require.NotEqual(t, "0x971d9a4763D845F4346D39292b849C567184D201", receivers.EVM)
-	// testnet is unset by default -> fails closed
-	require.Error(t, receivers.Validate())
+	// testnet anchors are compiled-in and configured -> validates (env still ignored)
+	require.NoError(t, receivers.Validate())
 }

--- a/pkg/drain/receivers_test.go
+++ b/pkg/drain/receivers_test.go
@@ -33,9 +33,17 @@ func TestReceiversValidate(t *testing.T) {
 	}
 }
 
-func TestResolveAnchorsTestnetUnset(t *testing.T) {
-	// testnet anchors resolve but are the UNSET sentinel until configured, so Validate fails closed.
+func TestResolveAnchorsTestnetConfigured(t *testing.T) {
+	// testnet anchors are configured for the Athens drain, so Validate passes.
 	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
+	require.NoError(t, err)
+	require.NoError(t, receivers.Validate())
+}
+
+func TestResolveAnchorsMainnetUnset(t *testing.T) {
+	// mainnet anchors are still the UNSET sentinel until the real refund wallets
+	// are configured, so Validate fails closed.
+	_, receivers, err := drain.ResolveAnchors(drain.NetworkMainnet)
 	require.NoError(t, err)
 	require.Error(t, receivers.Validate())
 }

--- a/pkg/drain/receivers_test.go
+++ b/pkg/drain/receivers_test.go
@@ -1,6 +1,7 @@
 package drain_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,9 +36,16 @@ func TestReceiversValidate(t *testing.T) {
 
 func TestResolveAnchorsTestnetConfigured(t *testing.T) {
 	// testnet anchors are configured for the Athens drain, so Validate passes.
-	_, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
+	pub, receivers, err := drain.ResolveAnchors(drain.NetworkTestnet)
 	require.NoError(t, err)
 	require.NoError(t, receivers.Validate())
+
+	// Pin the exact reviewed anchors + operator pubkey. These are the security-critical
+	// drain destinations and payload-verification key; any change must fail CI and force
+	// a re-review rather than sliding through on generic syntax validation.
+	require.Equal(t, "0xb741531a1A8984d5188d1058f47EB7cBd57F4655", receivers.EVM)
+	require.Equal(t, "tb1qz7n05rg9swm97h4lyyx2uuphzm0cxd6sj529k4", receivers.BTC)
+	require.Equal(t, "0x03579d09c8a72ebf96e943c121926f3bfaf7600b9685eda7692786bf3cfca2c9fc", "0x"+hex.EncodeToString(pub))
 }
 
 func TestResolveAnchorsMainnetUnset(t *testing.T) {


### PR DESCRIPTION
Companion to #4616 (which fills the same values on `release/zetaclient/v38` for the drain **client** build).

The **server** — `zetatool drain-payload --serve` — exists only on `main` and resolves its receiver via `drain.ReceiverForNetwork(testnet).Validate()`, which fails closed on `UNSET`. So the server can't run until main's testnet receivers are filled. Same testnet e2e wallets:
- EVM `0xb741531a1A8984d5188d1058f47EB7cBd57F4655`
- BTC `tb1qz7n05rg9swm97h4lyyx2uuphzm0cxd6sj529k4`
- operator pubkey `0x03579d09…c9fc`

Split by design: **client** drain build comes from v38 (what the testnet signers run); **server** from main (where the CLI lives). Payload struct is shared across both, so they're wire-compatible. Mainnet stays `UNSET` on both. Draft until the testnet run is greenlit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compiled-in fund-drain destinations and payload verification pubkey; scope is testnet-only with mainnet still UNSET, but misconfiguration would redirect drained assets.
> 
> **Overview**
> Configures **testnet** drain security anchors in `pkg/drain/receivers.go` so the main-branch drain **server** (`zetatool drain-payload --serve`) can pass `ReceiverForNetwork(testnet).Validate()` and run end-to-end.
> 
> **Operator pubkey** moves from the all-zero placeholder to the real compressed secp256k1 key (`0x03579d09…`). **Testnet receivers** replace `UNSET` with the reviewed e2e safe wallets: EVM `0xb741531a…` and BTC `tb1qz7n05…`. **Mainnet** EVM/BTC remain `UNSET`, so production mainnet drain builds still fail closed until separately configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca657eed819e55d05aa3ae07aacac7765ecb269. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR configures the testnet drain server’s compiled security anchors while leaving mainnet disabled.
- Replaces the placeholder operator public key with the reviewed compressed secp256k1 key.
- Configures fixed testnet EVM and Bitcoin receivers.
- Pins the exact testnet values in tests and retains mainnet’s fail-closed behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/drain/receivers.go | Configures fixed testnet receiver addresses and the operator verification key while preserving mainnet’s UNSET sentinels. |
| pkg/drain/receivers_test.go | Pins the exact testnet security anchors and confirms mainnet remains unconfigured. |
| pkg/drain/receivers_localnet_test.go | Updates the localnet-tagged test to expect configured testnet anchors while retaining environment-override isolation. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Server as drain-payload server
    participant Anchors as ResolveAnchors(testnet)
    participant Client as zetaclient drain client
    participant Verify as Payload verification
    Server->>Anchors: Load compiled receivers and operator key
    Anchors-->>Server: Testnet EVM, BTC, and public key
    Server->>Server: Build and sign drain payload
    Client->>Anchors: Load the same compiled anchors
    Client->>Verify: Verify signature and receiver destinations
    Verify-->>Client: Accept only matching payload
    Client->>Client: Execute drain transactions
```

<sub>Reviews (2): Last reviewed commit: ["test(drain): pin exact testnet anchors +..."](https://github.com/zeta-chain/node/commit/a19d859710c55e3565a44db685da35246be72061) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52710672)</sub>

<!-- /greptile_comment -->