### PR TITLE
ci: on-demand build workflow for emergency-drain binaries

### DIFF
--- a/.github/workflows/build-drain-artifacts.yml
+++ b/.github/workflows/build-drain-artifacts.yml
@@ -1,0 +1,91 @@
+name: Build Drain Artifacts
+
+# On-demand build of the emergency-drain binaries. Deliberately NOT tied to any
+# release: the drain client is a dedicated, temporary build operators run only for
+# the drain window (RFC 002), so it is produced here by manual dispatch, never
+# shipped in a normal release.
+#
+# Produces, cross-compiled for the signer hosts (linux amd64 + arm64):
+#   - zetaclientd  built with `-tags pebbledb,ledger,drain`  → the drain CLIENT.
+#       Run this workflow from a release/zetaclient/v38 (or v37) ref, matching what
+#       the target signers run, so the go-tss ceremony/state is compatible.
+#   - zetatool     built normally                            → the drain SERVER
+#       (`zetatool drain-payload --serve`). Run from `main`, where that subcommand
+#       and the receiver anchors live.
+#
+# Nothing here deploys, arms, or moves funds. It only emits binaries as artifacts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to build from (v38 release branch for the client; main for zetatool)'
+        required: true
+        type: string
+        default: 'release/zetaclient/v38'
+      build_client:
+        description: 'Build zetaclientd with the drain tag (the client)'
+        required: false
+        type: boolean
+        default: true
+      build_zetatool:
+        description: 'Build zetatool (the serve-cron server) — use ref=main'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+                                  gcc-x86-64-linux-gnu g++-x86-64-linux-gnu
+
+      - name: Build
+        env:
+          ARCH: ${{ matrix.arch }}
+          CGO_ENABLED: '1'
+        run: |
+          set -euo pipefail
+          if [ "$ARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++; else export CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++; fi
+          export GOOS=linux GOARCH="$ARCH"
+          COMMIT=$(git rev-parse --short HEAD)
+          # Only the DBBackend ldflag is functional; the rest is version cosmetics.
+          LDFLAGS="-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -X github.com/zeta-chain/node/pkg/constant.CommitHash=${COMMIT} -s -w"
+          mkdir -p dist
+          if [ "${{ inputs.build_client }}" = "true" ]; then
+            echo "--> building zetaclientd (drain) linux/${ARCH}"
+            go build -tags pebbledb,ledger,drain -ldflags "$LDFLAGS" \
+              -o "dist/zetaclientd-drain-linux-${ARCH}" ./cmd/zetaclientd
+          fi
+          if [ "${{ inputs.build_zetatool }}" = "true" ]; then
+            echo "--> building zetatool linux/${ARCH}"
+            go build -tags pebbledb,ledger -ldflags "$LDFLAGS" \
+              -o "dist/zetatool-linux-${ARCH}" ./cmd/zetatool
+          fi
+          ( cd dist && sha256sum * > "SHA256SUMS-${ARCH}.txt" && cat "SHA256SUMS-${ARCH}.txt" )
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: drain-binaries-${{ matrix.arch }}
+          path: dist/*


### PR DESCRIPTION
Adds a `workflow_dispatch` job (`Build Drain Artifacts`) that cross-compiles the emergency-drain binaries as downloadable artifacts, so cutting the drain build is a button instead of a manual local cross-compile.

Builds (linux amd64 + arm64, matching the signer hosts):
- **zetaclientd** with `-tags pebbledb,ledger,drain` — the drain **client**. Run from `release/zetaclient/v38` (matches what testnet signers run).
- **zetatool** — the drain **server** (`zetatool drain-payload --serve`). Run from `main` (where the subcommand + anchors live), via the `build_zetatool` input.

Deliberately NOT wired into any release: RFC 002 wants the drain client as a dedicated, temporary build for the drain window only, never shipped in a normal release. This job **builds nothing until manually triggered**, and deploys/arms/moves nothing — it only emits binaries + SHA256SUMS as artifacts.

Part of staging the testnet drain so activation is just: run this → download → point ansible at the binaries. Companion to the receiver-anchor PRs (#4616 merged, #4617 pending).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only, read-only permissions, and manual trigger; it only produces binaries and checksums with no deploy or runtime behavior changes.
> 
> **Overview**
> Adds a **manual** GitHub Actions workflow (`Build Drain Artifacts`) so operators can cross-compile RFC 002 emergency-drain binaries for linux **amd64** and **arm64** and download them as artifacts (with per-arch `SHA256SUMS`), instead of doing local cross-builds.
> 
> The job is **`workflow_dispatch` only** with inputs for **git ref**, **`build_client`** (default on), and **`build_zetatool`** (default off). It can emit **`zetaclientd-drain-linux-*`** via `go build` with `-tags pebbledb,ledger,drain` (aligned with `install-zetaclient-drain` in the Makefile) and optionally **`zetatool-linux-*`** for the drain server. Comments document building the client from a zetaclient release branch and zetatool from `main`; the workflow does not deploy or wire into normal releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f347093f2b025367af1023f16616428462225406. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a manually dispatched workflow that cross-compiles emergency-drain client and server binaries for Linux AMD64 and ARM64.

- Selects client and zetatool builds through workflow inputs.
- Builds with the required database, ledger, and drain tags.
- Generates architecture-specific checksums and uploads the results as workflow artifacts.

<h3>Confidence Score: 4/5</h3>

The workflow should not be merged until it prevents the client and server from being built together from one source ref; input validation and immutable action pins are also advisable.

Both build toggles can currently select binaries that require different branches while the workflow performs only one checkout, so an apparently successful dispatch can distribute an artifact from the wrong source line.

**Files Needing Attention:** .github/workflows/build-drain-artifacts.yml

<details open><summary><h3>Security Review</h3></summary>

The workflow uses mutable major-version references for every action in the emergency-binary build and upload chain, without signing or provenance attestation.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-drain-artifacts.yml | Adds the complete on-demand cross-compilation workflow, but one checkout can incorrectly serve two branch-specific builds and invalid empty selections fail during checksum generation. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  D[Manual workflow dispatch] --> C[Checkout selected ref]
  C --> M{Architecture matrix}
  M -->|amd64| B1[Configure x86_64 cross-compiler]
  M -->|arm64| B2[Configure aarch64 cross-compiler]
  B1 --> S{Selected binaries}
  B2 --> S
  S -->|build_client| ZC[Build zetaclientd with drain tag]
  S -->|build_zetatool| ZT[Build zetatool]
  ZC --> H[Generate SHA256SUMS]
  ZT --> H
  H --> U[Upload architecture artifact]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/build-drain-artifacts.yml:21-24
**Shared ref builds wrong artifact**

When both build options are enabled, the workflow compiles both binaries from the single `inputs.ref` checkout, even though the client requires `release/zetaclient/v38` and zetatool requires `main`. Consequently, at least one downloaded artifact comes from the wrong source line and can lack the required drain behavior or be incompatible with the signer release.

### Issue 2
.github/workflows/build-drain-artifacts.yml:85
**Empty selection breaks checksumming**

When both build options are false, `dist` remains empty and the unmatched `*` is passed to `sha256sum`. The command exits nonzero under `set -e`, leaving a permitted dispatch combination as a failed workflow with an unrelated file-not-found error.

### Issue 3
.github/workflows/build-drain-artifacts.yml:49
**Mutable emergency build actions**

The checkout, Go setup, and artifact upload steps use mutable major-version tags, so moving one of those tags changes the code participating in this security-sensitive binary pipeline without a repository change. Pinning all three actions to immutable commit SHAs would make the source, toolchain setup, and artifact upload implementations reproducible. **How this was verified:** The workflow directly builds and uploads unsigned emergency binaries through `actions/checkout@v4`, `actions/setup-go@v5`, and `actions/upload-artifact@v4`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: on-demand build workflow for emergen..."](https://github.com/zeta-chain/node/commit/f347093f2b025367af1023f16616428462225406) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52790813)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->