### PR TITLE
ci: drain-artifacts build workflow on main (dispatchable)

### DIFF
--- a/.github/workflows/build-drain-artifacts.yml
+++ b/.github/workflows/build-drain-artifacts.yml
@@ -1,0 +1,91 @@
+name: Build Drain Artifacts
+
+# On-demand build of the emergency-drain binaries. Deliberately NOT tied to any
+# release: the drain client is a dedicated, temporary build operators run only for
+# the drain window (RFC 002), so it is produced here by manual dispatch, never
+# shipped in a normal release.
+#
+# Produces, cross-compiled for the signer hosts (linux amd64 + arm64):
+#   - zetaclientd  built with `-tags pebbledb,ledger,drain`  → the drain CLIENT.
+#       Run this workflow from a release/zetaclient/v38 (or v37) ref, matching what
+#       the target signers run, so the go-tss ceremony/state is compatible.
+#   - zetatool     built normally                            → the drain SERVER
+#       (`zetatool drain-payload --serve`). Run from `main`, where that subcommand
+#       and the receiver anchors live.
+#
+# Nothing here deploys, arms, or moves funds. It only emits binaries as artifacts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to build from (v38 release branch for the client; main for zetatool)'
+        required: true
+        type: string
+        default: 'release/zetaclient/v38'
+      build_client:
+        description: 'Build zetaclientd with the drain tag (the client)'
+        required: false
+        type: boolean
+        default: true
+      build_zetatool:
+        description: 'Build zetatool (the serve-cron server) — use ref=main'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+                                  gcc-x86-64-linux-gnu g++-x86-64-linux-gnu
+
+      - name: Build
+        env:
+          ARCH: ${{ matrix.arch }}
+          CGO_ENABLED: '1'
+        run: |
+          set -euo pipefail
+          if [ "$ARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++; else export CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++; fi
+          export GOOS=linux GOARCH="$ARCH"
+          COMMIT=$(git rev-parse --short HEAD)
+          # Only the DBBackend ldflag is functional; the rest is version cosmetics.
+          LDFLAGS="-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -X github.com/zeta-chain/node/pkg/constant.CommitHash=${COMMIT} -s -w"
+          mkdir -p dist
+          if [ "${{ inputs.build_client }}" = "true" ]; then
+            echo "--> building zetaclientd (drain) linux/${ARCH}"
+            go build -tags pebbledb,ledger,drain -ldflags "$LDFLAGS" \
+              -o "dist/zetaclientd-drain-linux-${ARCH}" ./cmd/zetaclientd
+          fi
+          if [ "${{ inputs.build_zetatool }}" = "true" ]; then
+            echo "--> building zetatool linux/${ARCH}"
+            go build -tags pebbledb,ledger -ldflags "$LDFLAGS" \
+              -o "dist/zetatool-linux-${ARCH}" ./cmd/zetatool
+          fi
+          ( cd dist && sha256sum * > "SHA256SUMS-${ARCH}.txt" && cat "SHA256SUMS-${ARCH}.txt" )
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: drain-binaries-${{ matrix.arch }}
+          path: dist/*


### PR DESCRIPTION
Same workflow added to v38 in #4619, now on main so `workflow_dispatch` registers (only registers from the default branch) and can build zetatool from main. Builds nothing until manually triggered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read-only repo permissions; builds run only on manual dispatch and do not deploy or move funds.
> 
> **Overview**
> Adds a **manual-only** GitHub Actions workflow (`workflow_dispatch`) on **main** so operators can cross-build emergency-drain binaries without tying them to normal releases. GitHub only exposes dispatchable workflows from the default branch, which also enables building **zetatool** from `main` while the drain **client** can still be built from a signer-matching ref (e.g. `release/zetaclient/v38`).
> 
> The workflow matrix-builds **linux amd64 and arm64** with CGO/cross toolchains, optionally producing **`zetaclientd`** with `-tags pebbledb,ledger,drain` and/or **`zetatool`**, writes **SHA256SUMS** per arch, and uploads **`dist/*`** as artifacts. Inputs control checkout **ref** and which binaries to build; it does not deploy or run drain logic—artifacts only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652833314e482a9448939fc2154c760921b094dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a manually dispatched workflow for cross-compiling and uploading emergency-drain binaries for Linux amd64 and arm64.
- Allows operators to select a source ref and independently build the drain-enabled zetaclientd or zetatool.
- Produces per-architecture checksums and uploads the resulting files as workflow artifacts.

<h3>Confidence Score: 4/5</h3>

The workflow is safe to merge with non-blocking improvements to reject an empty build selection and pin the actions involved in producing emergency binaries.

Selecting neither binary causes the unconditional checksum command to fail, while mutable action tags leave artifact provenance dependent on upstream tag stability.

**Files Needing Attention:** .github/workflows/build-drain-artifacts.yml

<details open><summary><h3>Security Review</h3></summary>

The workflow relies on mutable action tags while producing emergency binaries intended for signer hosts. Pinning checkout, setup-go, and upload-artifact to reviewed commit SHAs would make the build inputs reproducible and reduce upstream action supply-chain exposure.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-drain-artifacts.yml | Adds the dispatchable cross-compilation workflow; an empty target selection fails during checksumming, and mutable action references weaken artifact provenance. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/build-drain-artifacts.yml:85
**Empty build selection breaks checksumming**

When both `build_client` and `build_zetatool` are false, neither build creates a binary, but the unconditional `sha256sum *` receives the unmatched glob and exits nonzero under `set -e`, causing both matrix jobs to fail without uploading artifacts.

### Issue 2
.github/workflows/build-drain-artifacts.yml:49
**Mutable actions weaken artifact provenance**

The checkout, Go setup, and artifact upload steps use mutable major-version tags, so repointing one of these tags can alter the source, toolchain, or uploaded emergency binaries without changing this workflow; pin these actions to reviewed commit SHAs to make the signer-host artifacts reproducible. **How this was verified:** The workflow executes `checkout@v4` and `setup-go@v5` before checksumming the binaries and passes them to `upload-artifact@v4` afterward.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add drain-artifacts build workflow t..."](https://github.com/zeta-chain/node/commit/652833314e482a9448939fc2154c760921b094dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52795477)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->