### PR TITLE
ci(drain): one-run build (client@v38 + zetatool@main) + push trigger

### DIFF
--- a/.github/workflows/build-drain-artifacts.yml
+++ b/.github/workflows/build-drain-artifacts.yml
@@ -2,37 +2,35 @@ name: Build Drain Artifacts
 
 # On-demand build of the emergency-drain binaries. Deliberately NOT tied to any
 # release: the drain client is a dedicated, temporary build operators run only for
-# the drain window (RFC 002), so it is produced here by manual dispatch, never
-# shipped in a normal release.
+# the drain window (RFC 002), so it is produced here, never shipped in a release.
 #
-# Produces, cross-compiled for the signer hosts (linux amd64 + arm64):
-#   - zetaclientd  built with `-tags pebbledb,ledger,drain`  → the drain CLIENT.
-#       Run this workflow from a release/zetaclient/v38 (or v37) ref, matching what
-#       the target signers run, so the go-tss ceremony/state is compatible.
-#   - zetatool     built normally                            → the drain SERVER
-#       (`zetatool drain-payload --serve`). Run from `main`, where that subcommand
-#       and the receiver anchors live.
+# One run produces, cross-compiled for the signer hosts (linux amd64 + arm64):
+#   - zetaclientd-drain  from CLIENT_REF (default release/zetaclient/v38),
+#       built with `-tags pebbledb,ledger,drain` → the drain CLIENT (matches the
+#       version the signers run so the go-tss ceremony/state is compatible).
+#   - zetatool           from SERVER_REF (default main), built normally → the
+#       drain SERVER (`zetatool drain-payload --serve`), where the subcommand +
+#       receiver anchors live.
 #
-# Nothing here deploys, arms, or moves funds. It only emits binaries as artifacts.
+# Triggerable by manual dispatch, or by pushing a `drain-build/**` branch (so it
+# can be produced from the v38 branch without the main-branch dispatch registration).
+# Nothing here deploys, arms, or moves funds — it only emits binaries as artifacts.
 
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Ref to build from (v38 release branch for the client; main for zetatool)'
-        required: true
+      client_ref:
+        description: 'Ref for the drain client (zetaclientd)'
+        required: false
         type: string
         default: 'release/zetaclient/v38'
-      build_client:
-        description: 'Build zetaclientd with the drain tag (the client)'
+      server_ref:
+        description: 'Ref for the server (zetatool)'
         required: false
-        type: boolean
-        default: true
-      build_zetatool:
-        description: 'Build zetatool (the serve-cron server) — use ref=main'
-        required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'main'
+  push:
+    branches: ['drain-build/**']
 
 permissions:
   contents: read
@@ -44,15 +42,25 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
+    env:
+      CLIENT_REF: ${{ inputs.client_ref || 'release/zetaclient/v38' }}
+      SERVER_REF: ${{ inputs.server_ref || 'main' }}
     steps:
-      - name: Checkout ${{ inputs.ref }}
+      - name: Checkout client ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ env.CLIENT_REF }}
+          path: client
+
+      - name: Checkout server ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SERVER_REF }}
+          path: server
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: client/go.mod
 
       - name: Install cross toolchain
         run: |
@@ -68,20 +76,20 @@ jobs:
           set -euo pipefail
           if [ "$ARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++; else export CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++; fi
           export GOOS=linux GOARCH="$ARCH"
-          COMMIT=$(git rev-parse --short HEAD)
           # Only the DBBackend ldflag is functional; the rest is version cosmetics.
-          LDFLAGS="-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -X github.com/zeta-chain/node/pkg/constant.CommitHash=${COMMIT} -s -w"
+          LDBASE="-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -s -w"
           mkdir -p dist
-          if [ "${{ inputs.build_client }}" = "true" ]; then
-            echo "--> building zetaclientd (drain) linux/${ARCH}"
-            go build -tags pebbledb,ledger,drain -ldflags "$LDFLAGS" \
-              -o "dist/zetaclientd-drain-linux-${ARCH}" ./cmd/zetaclientd
-          fi
-          if [ "${{ inputs.build_zetatool }}" = "true" ]; then
-            echo "--> building zetatool linux/${ARCH}"
-            go build -tags pebbledb,ledger -ldflags "$LDFLAGS" \
-              -o "dist/zetatool-linux-${ARCH}" ./cmd/zetatool
-          fi
+
+          echo "--> zetaclientd (drain) linux/${ARCH} from ${CLIENT_REF}"
+          ( cd client && go build -tags pebbledb,ledger,drain \
+              -ldflags "$LDBASE -X github.com/zeta-chain/node/pkg/constant.CommitHash=$(git rev-parse --short HEAD)" \
+              -o "../dist/zetaclientd-drain-linux-${ARCH}" ./cmd/zetaclientd )
+
+          echo "--> zetatool linux/${ARCH} from ${SERVER_REF}"
+          ( cd server && go build -tags pebbledb,ledger \
+              -ldflags "$LDBASE -X github.com/zeta-chain/node/pkg/constant.CommitHash=$(git rev-parse --short HEAD)" \
+              -o "../dist/zetatool-linux-${ARCH}" ./cmd/zetatool )
+
           ( cd dist && sha256sum * > "SHA256SUMS-${ARCH}.txt" && cat "SHA256SUMS-${ARCH}.txt" )
 
       - name: Upload artifacts


### PR DESCRIPTION
Updates the drain build workflow on v38 to build BOTH binaries in one run (zetaclientd-drain from v38, zetatool from main via two checkouts) and adds a `drain-build/**` push trigger so it runs from v38 without needing the main-branch dispatch registration (#4620). Build-only; nothing deploys/arms/moves funds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no runtime, auth, or fund-movement logic.
> 
> **Overview**
> **Build Drain Artifacts** now cross-compiles **both** emergency-drain binaries in a single workflow run instead of optional one-at-a-time builds.
> 
> Dispatch inputs change from a single `ref` plus `build_client` / `build_zetatool` booleans to **`client_ref`** (default `release/zetaclient/v38`) and **`server_ref`** (default `main`). The job checks out each ref into `client/` and `server/`, builds `zetaclientd-drain` from the client tree and `zetatool` from the server tree, and stamps each binary with that checkout’s commit hash. Go is pinned via **`client/go.mod`**.
> 
> A **`push` on `drain-build/**`** was added so the workflow can run from the v38 line without relying on main-only `workflow_dispatch` registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7564a7f1bd5671a4754b4d5f023c860350535764. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the emergency-drain artifact workflow to build the v38 drain client and main-branch zetatool together in one matrix run.
- Adds separate configurable client and server checkouts.
- Builds and packages both binaries for Linux amd64 and arm64.
- Adds a `drain-build/**` push trigger while retaining manual dispatch.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the dual-checkout build, shared toolchain selection, artifact paths, and trigger behavior are internally consistent.

Both selected refs use compatible module toolchain requirements, each build writes to the workspace artifact directory, and the upload step packages the resulting binaries and checksums as intended.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-drain-artifacts.yml | Splits source checkouts by role, builds both drain binaries into a shared artifact directory, and adds the branch push trigger without an identified correctness or security defect. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Manual dispatch or drain-build/** push] --> B[Resolve client and server refs]
  B --> C[Checkout client into client/]
  B --> D[Checkout server into server/]
  C --> E[Set up shared Go and cross-compilation toolchain]
  D --> E
  E --> F[Build zetaclientd-drain]
  E --> G[Build zetatool]
  F --> H[Generate architecture checksums]
  G --> H
  H --> I[Upload per-architecture artifact]
```

<sub>Reviews (1): Last reviewed commit: ["ci(drain): build both binaries in one ru..."](https://github.com/zeta-chain/node/commit/7564a7f1bd5671a4754b4d5f023c860350535764) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52808808)</sub>

<!-- /greptile_comment -->