### PR TITLE
feat(zetatool): add rehearsal value caps to the TSS drain payload (backport v37)

### DIFF
--- a/pkg/drain/generate.go
+++ b/pkg/drain/generate.go
@@ -189,39 +189,59 @@ func sortUTXOsForSweep(utxos []UTXO) {
 // so this is the only way to bound a BTC drain's value. It expects utxos already ordered by
 // sortUTXOsForSweep.
 //
-// Selection is therefore largest-first among the UTXOs that fit under the cap, and an input is
-// taken only if the resulting group would still satisfy the poller's fee bound
-// (fee <= total/MaxBTCFeeFraction). That second condition is what makes a capped run usable:
+// A viable subset has to clear two bars at once: total <= maxSats, and a fee that fits the
+// poller's bound, fee(n) <= total/MaxBTCFeeFraction. The bound cannot be applied per input as it
+// is added, because the fixed part of the fee is only amortised once the group is complete — two
+// 15,000-sat UTXOs at 10 sat/vB are viable together (fee 2390 against a 3000 allowance) while
+// neither clears the single-input threshold of 1710 against 1500.
 //
-//   - Fitting under the cap is not enough. A UTXO too big for the cap is skipped and the walk
-//     continues down the list, so without the fee test a small cap slides past every large UTXO
-//     and fills the group with dust instead. The fee of 20 dust inputs dwarfs their value, the
-//     whole group is then dropped as uneconomical, and the rehearsal silently covers no BTC at
-//     all — the one leg with no testnet coverage.
-//   - Topping up an already-viable group can destroy it. Each extra input adds a fixed ~68 vB of
-//     fee, so a 300-sat input added to a viable 90k-sat sweep at 50 sat/vB raises the fee past
-//     the bound and the group is dropped. An input must pay for its own marginal fee under the
-//     same 1/MaxBTCFeeFraction rule the poller applies.
+// So each candidate is built by fillAndTrim: fill largest-first on value alone, then drop the
+// smallest inputs until the completed group clears the bound. Filling from the front alone is not
+// enough either, because one large UTXO can hog the cap and block a better combination — with a
+// 100,000-sat cap at 40 sat/vB, a 60,000-sat UTXO is taken first, blocks both 50,000-sat UTXOs,
+// and then trims away as uneconomical, while 50,000+50,000 would have been viable. Candidates are
+// therefore built from every starting offset, i.e. ignoring the k largest UTXOs for each k, and
+// the best viable one wins: most value swept, fewest inputs to break a tie.
 //
-// The economics cannot be tested per input as it is added, because the fixed part of the fee is
-// only amortised once the group is complete: two 15,000-sat UTXOs at 10 sat/vB are viable together
-// (fee 2390 against a 3000 allowance) while neither clears the single-input threshold of 1710
-// against 1500. Judging inputs one at a time rejects the pair and emits nothing. So selection runs
-// in two phases:
+// This is a heuristic, not an exhaustive subset search: it covers the "a larger UTXO crowds out a
+// viable combination" family, which is what real wallet shapes produce, but an empty result means
+// only that none of these candidates was viable — never that no viable subset exists. The sound
+// impossibility test is a total balance below MinViableSweepSats, which is what the CLI reports.
 //
-//  1. Take largest-first everything that fits under the cap, up to one tx worth of inputs, on
-//     value alone.
-//  2. Drop the smallest input — the tail, since the list is descending — until the group satisfies
-//     the poller's bound, or nothing is left.
-//
-// Trimming from the tail is what preserves the second property above: the marginal input that
-// broke the bound is exactly the one removed first. And because phase 2 tests the completed group,
-// a non-empty result is economical by construction rather than by luck.
-//
-// An empty result means no *prefix* of the cap-limited selection is viable. See MinViableSweepSats
-// for the floor on a sweep's total, which is what the CLI reports.
+// Selection stays deterministic — a fixed input order and a fixed tie-break — because every node
+// must build byte-identical txs.
 func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, error) {
-	// phase 1: fill on value alone
+	var best []UTXO
+	var bestTotal int64
+
+	for start := range utxos {
+		candidate, total, err := fillAndTrim(utxos[start:], maxSats, feeRate, to)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidate) == 0 {
+			continue
+		}
+		// most value swept wins, then the cheaper shape; ties beyond that keep the earlier offset,
+		// which is the one holding the larger UTXOs
+		if total > bestTotal || (total == bestTotal && len(candidate) < len(best)) {
+			best, bestTotal = candidate, total
+		}
+	}
+
+	return best, nil
+}
+
+// fillAndTrim builds one candidate subset: take largest-first everything that fits under the cap,
+// up to one tx worth of inputs, then drop the smallest input — the tail, since utxos is descending
+// — until the completed group satisfies the poller's fee bound, or nothing is left.
+//
+// Trimming from the tail is what keeps a viable group from being destroyed by a marginal one: each
+// extra input adds a fixed ~68 vB of fee, so a 300-sat input added to a viable 90k-sat sweep at
+// 50 sat/vB pushes the fee past the bound — and that input is exactly the first one removed.
+// Because the bound is tested on the completed group, a non-empty result is economical by
+// construction rather than by luck.
+func fillAndTrim(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, int64, error) {
 	selected := make([]UTXO, 0, btccommon.MaxNoOfInputsPerTx)
 	var total int64
 	for _, u := range utxos {
@@ -235,11 +255,10 @@ func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address)
 		selected = append(selected, u)
 	}
 
-	// phase 2: trim the tail until the completed group clears the poller's bound
 	for len(selected) > 0 {
 		size, err := btccommon.EstimateOutboundSize(int64(len(selected)), []btcutil.Address{to})
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if size*feeRate <= total/MaxBTCFeeFraction {
 			break
@@ -247,7 +266,8 @@ func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address)
 		total -= selected[len(selected)-1].AmountSats
 		selected = selected[:len(selected)-1]
 	}
-	return selected, nil
+
+	return selected, total, nil
 }
 
 // MinViableSweepSats is the floor on a sweep's input *total* at this fee rate: enough to keep the

--- a/pkg/drain/generate.go
+++ b/pkg/drain/generate.go
@@ -34,6 +34,11 @@ type EVMInput struct {
 	Balance        sdkmath.Uint
 	MedianGasPrice sdkmath.Uint
 	Nonce          uint64
+	// MaxAmount caps the transferred amount (wei) so operators can rehearse the drain with a
+	// small value before committing the full balance. Nil or zero means no cap (full drain).
+	// The fee still comes out of the balance; only the transfer is capped, so the remainder
+	// stays at the TSS address.
+	MaxAmount sdkmath.Uint
 }
 
 // UTXO is a single unspent output pinned into a BTC sweep.
@@ -49,6 +54,12 @@ type BTCInput struct {
 	To      btcutil.Address // hardcoded safe receiver
 	FeeRate int64           // sat/vB
 	UTXOs   []UTXO
+	// MaxSats caps the total input value of the sweep so operators can rehearse the drain with
+	// a small value. Zero means no cap (sweep everything). A UTXO cannot be spent partially and
+	// the sweep has no change output, so the cap is applied by selecting a subset of UTXOs
+	// (largest first, see selectCappedUTXOs) whose total stays within it — never by reducing
+	// an output.
+	MaxSats int64
 }
 
 // GenerateEVMTx builds a fully-resolved EVM drain tx from a resolved input.
@@ -66,6 +77,16 @@ func GenerateEVMTx(in EVMInput) (draintx.EVMTx, error) {
 			"refusing to pin unbroadcastable evm tx: gas price %s, gas limit %d",
 			gasPrice, gasLimit,
 		)
+	}
+	// The cap only ever lowers the transfer; the fee is unchanged, so the untransferred
+	// remainder simply stays at the TSS address for the real drain.
+	if !in.MaxAmount.IsNil() && !in.MaxAmount.IsZero() && in.MaxAmount.LT(amount) {
+		amount = in.MaxAmount
+	}
+	// A balance that is entirely fee (or, with a cap, a rounding artifact) would pin a
+	// zero-value transfer that pays gas to move nothing.
+	if amount.IsZero() {
+		return draintx.EVMTx{}, fmt.Errorf("refusing to pin a zero-amount evm tx")
 	}
 	return draintx.EVMTx{
 		ChainID:  in.ChainID,
@@ -86,6 +107,10 @@ func GenerateEVMTx(in EVMInput) (draintx.EVMTx, error) {
 // cover the fee, or whose output would fall below dust, are skipped rather than aborting the
 // whole sweep — a returned empty slice means there is no economical BTC to sweep. The total
 // ordering makes partitioning deterministic so every node builds byte-identical txs.
+//
+// When in.MaxSats is set the sweep is first narrowed to a subset of UTXOs within that cap
+// (see selectCappedUTXOs); everything downstream is unchanged, so a capped run exercises the
+// exact same partitioning, fee math and signing path as the real drain.
 func GenerateBTCTxs(in BTCInput) ([]draintx.BTCTx, error) {
 	if len(in.UTXOs) == 0 {
 		return nil, nil
@@ -94,15 +119,17 @@ func GenerateBTCTxs(in BTCInput) ([]draintx.BTCTx, error) {
 	// copy before sorting so the caller's slice is untouched
 	utxos := make([]UTXO, len(in.UTXOs))
 	copy(utxos, in.UTXOs)
-	sort.Slice(utxos, func(i, j int) bool {
-		if utxos[i].AmountSats != utxos[j].AmountSats {
-			return utxos[i].AmountSats > utxos[j].AmountSats
+	sortUTXOsForSweep(utxos)
+	if in.MaxSats > 0 {
+		capped, err := selectCappedUTXOs(utxos, in.MaxSats, in.FeeRate, in.To)
+		if err != nil {
+			return nil, err
 		}
-		if utxos[i].TxID != utxos[j].TxID {
-			return utxos[i].TxID < utxos[j].TxID
+		if len(capped) == 0 {
+			return nil, nil
 		}
-		return utxos[i].Vout < utxos[j].Vout
-	})
+		utxos = capped
+	}
 
 	to := in.To.EncodeAddress()
 	txs := make([]draintx.BTCTx, 0, (len(utxos)+btccommon.MaxNoOfInputsPerTx-1)/btccommon.MaxNoOfInputsPerTx)
@@ -140,6 +167,92 @@ func GenerateBTCTxs(in BTCInput) ([]draintx.BTCTx, error) {
 	}
 
 	return txs, nil
+}
+
+// sortUTXOsForSweep orders utxos by amount descending, tie-broken by TxID then Vout. The total
+// ordering is what makes both the capped selection and the group partitioning deterministic, so
+// every node builds byte-identical txs.
+func sortUTXOsForSweep(utxos []UTXO) {
+	sort.Slice(utxos, func(i, j int) bool {
+		if utxos[i].AmountSats != utxos[j].AmountSats {
+			return utxos[i].AmountSats > utxos[j].AmountSats
+		}
+		if utxos[i].TxID != utxos[j].TxID {
+			return utxos[i].TxID < utxos[j].TxID
+		}
+		return utxos[i].Vout < utxos[j].Vout
+	})
+}
+
+// selectCappedUTXOs narrows utxos to a subset whose total value stays within maxSats, for a
+// small-value rehearsal of the sweep. A UTXO is indivisible and the sweep has no change output,
+// so this is the only way to bound a BTC drain's value. It expects utxos already ordered by
+// sortUTXOsForSweep.
+//
+// Selection is therefore largest-first among the UTXOs that fit under the cap, and an input is
+// taken only if the resulting group would still satisfy the poller's fee bound
+// (fee <= total/MaxBTCFeeFraction). That second condition is what makes a capped run usable:
+//
+//   - Fitting under the cap is not enough. A UTXO too big for the cap is skipped and the walk
+//     continues down the list, so without the fee test a small cap slides past every large UTXO
+//     and fills the group with dust instead. The fee of 20 dust inputs dwarfs their value, the
+//     whole group is then dropped as uneconomical, and the rehearsal silently covers no BTC at
+//     all — the one leg with no testnet coverage.
+//   - Topping up an already-viable group can destroy it. Each extra input adds a fixed ~68 vB of
+//     fee, so a 300-sat input added to a viable 90k-sat sweep at 50 sat/vB raises the fee past
+//     the bound and the group is dropped. An input must pay for its own marginal fee under the
+//     same 1/MaxBTCFeeFraction rule the poller applies.
+//
+// Because the group's fee is checked as each input is added, a non-empty result is economical by
+// construction rather than by luck. When the result is empty the cap admits no viable sweep at
+// this fee rate — see MinViableSweepSats for the threshold to report to the operator.
+//
+// The subset is limited to one tx worth of inputs so a capped run emits exactly one sweep.
+func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, error) {
+	selected := make([]UTXO, 0, btccommon.MaxNoOfInputsPerTx)
+	var total int64
+	for _, u := range utxos {
+		if len(selected) == btccommon.MaxNoOfInputsPerTx {
+			break
+		}
+		if u.AmountSats <= 0 || total+u.AmountSats > maxSats {
+			continue
+		}
+		// the fee depends only on the input count, so price the group as it would be with this
+		// input added and keep it only if the poller's bound still holds
+		size, err := btccommon.EstimateOutboundSize(int64(len(selected)+1), []btcutil.Address{to})
+		if err != nil {
+			return nil, err
+		}
+		// Stop rather than skip: the fee here is fixed by the current input count, and the list is
+		// descending, so every remaining candidate is worth less against the same fee and fails
+		// this test too. Continuing would only burn iterations while reading as if a later, smaller
+		// UTXO could recover the group.
+		if size*feeRate > (total+u.AmountSats)/MaxBTCFeeFraction {
+			break
+		}
+		total += u.AmountSats
+		selected = append(selected, u)
+	}
+	return selected, nil
+}
+
+// MinViableSweepSats is the smallest input total a capped sweep can have and still be emitted at
+// this fee rate: enough to keep the single-input fee within 1/MaxBTCFeeFraction of the total, and
+// to leave an output above dust. A --btc-max-sats below this can only ever produce an empty BTC
+// section, so the CLI reports it instead of leaving the operator to infer it from a missing tx.
+func MinViableSweepSats(feeRate int64, to btcutil.Address) (int64, error) {
+	size, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{to})
+	if err != nil {
+		return 0, err
+	}
+	fee := size * feeRate
+	minByFee := fee * MaxBTCFeeFraction
+	minByDust := fee + constant.BTCWithdrawalDustAmount
+	if minByFee > minByDust {
+		return minByFee, nil
+	}
+	return minByDust, nil
 }
 
 // BuildPayload assembles the txs into a payload and signs it with priv. network is baked into the

--- a/pkg/drain/generate.go
+++ b/pkg/drain/generate.go
@@ -203,12 +203,25 @@ func sortUTXOsForSweep(utxos []UTXO) {
 //     the bound and the group is dropped. An input must pay for its own marginal fee under the
 //     same 1/MaxBTCFeeFraction rule the poller applies.
 //
-// Because the group's fee is checked as each input is added, a non-empty result is economical by
-// construction rather than by luck. When the result is empty the cap admits no viable sweep at
-// this fee rate — see MinViableSweepSats for the threshold to report to the operator.
+// The economics cannot be tested per input as it is added, because the fixed part of the fee is
+// only amortised once the group is complete: two 15,000-sat UTXOs at 10 sat/vB are viable together
+// (fee 2390 against a 3000 allowance) while neither clears the single-input threshold of 1710
+// against 1500. Judging inputs one at a time rejects the pair and emits nothing. So selection runs
+// in two phases:
 //
-// The subset is limited to one tx worth of inputs so a capped run emits exactly one sweep.
+//  1. Take largest-first everything that fits under the cap, up to one tx worth of inputs, on
+//     value alone.
+//  2. Drop the smallest input — the tail, since the list is descending — until the group satisfies
+//     the poller's bound, or nothing is left.
+//
+// Trimming from the tail is what preserves the second property above: the marginal input that
+// broke the bound is exactly the one removed first. And because phase 2 tests the completed group,
+// a non-empty result is economical by construction rather than by luck.
+//
+// An empty result means no *prefix* of the cap-limited selection is viable. See MinViableSweepSats
+// for the floor on a sweep's total, which is what the CLI reports.
 func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, error) {
+	// phase 1: fill on value alone
 	selected := make([]UTXO, 0, btccommon.MaxNoOfInputsPerTx)
 	var total int64
 	for _, u := range utxos {
@@ -218,29 +231,35 @@ func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address)
 		if u.AmountSats <= 0 || total+u.AmountSats > maxSats {
 			continue
 		}
-		// the fee depends only on the input count, so price the group as it would be with this
-		// input added and keep it only if the poller's bound still holds
-		size, err := btccommon.EstimateOutboundSize(int64(len(selected)+1), []btcutil.Address{to})
+		total += u.AmountSats
+		selected = append(selected, u)
+	}
+
+	// phase 2: trim the tail until the completed group clears the poller's bound
+	for len(selected) > 0 {
+		size, err := btccommon.EstimateOutboundSize(int64(len(selected)), []btcutil.Address{to})
 		if err != nil {
 			return nil, err
 		}
-		// Stop rather than skip: the fee here is fixed by the current input count, and the list is
-		// descending, so every remaining candidate is worth less against the same fee and fails
-		// this test too. Continuing would only burn iterations while reading as if a later, smaller
-		// UTXO could recover the group.
-		if size*feeRate > (total+u.AmountSats)/MaxBTCFeeFraction {
+		if size*feeRate <= total/MaxBTCFeeFraction {
 			break
 		}
-		total += u.AmountSats
-		selected = append(selected, u)
+		total -= selected[len(selected)-1].AmountSats
+		selected = selected[:len(selected)-1]
 	}
 	return selected, nil
 }
 
-// MinViableSweepSats is the smallest input total a capped sweep can have and still be emitted at
-// this fee rate: enough to keep the single-input fee within 1/MaxBTCFeeFraction of the total, and
-// to leave an output above dust. A --btc-max-sats below this can only ever produce an empty BTC
-// section, so the CLI reports it instead of leaving the operator to infer it from a missing tx.
+// MinViableSweepSats is the floor on a sweep's input *total* at this fee rate: enough to keep the
+// fee within 1/MaxBTCFeeFraction of the total and to leave an output above dust. A --btc-max-sats
+// below it can only ever produce an empty BTC section, so the CLI reports it rather than leaving
+// the operator to infer it from a missing tx.
+//
+// It is priced for one input because the fee grows with the input count while the bound scales with
+// the total, so a single input is the cheapest shape a viable sweep can take — which makes this a
+// floor on the total for *any* input count, not a per-UTXO requirement. A group of UTXOs each
+// individually below it can still clear it together, so never read this as "no single UTXO reaches
+// it, therefore no cap can work".
 func MinViableSweepSats(feeRate int64, to btcutil.Address) (int64, error) {
 	size, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{to})
 	if err != nil {

--- a/pkg/drain/generate_cap_property_test.go
+++ b/pkg/drain/generate_cap_property_test.go
@@ -1,0 +1,136 @@
+package drain_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/pkg/drain"
+	btccommon "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+// viableSubsets exhaustively answers, for a small UTXO set, whether any non-empty subset could be
+// swept at all — cap, the poller's fee bound, and the dust floor — and what the most valuable such
+// subset is worth. Exponential, so callers keep the sets small.
+func viableSubsets(
+	t *testing.T,
+	utxos []drain.UTXO,
+	maxSats, feeRate int64,
+	payee btcutil.Address,
+) (exists bool, bestTotal int64) {
+	t.Helper()
+
+	for mask := 1; mask < (1 << len(utxos)); mask++ {
+		var total, count int64
+		for i := range utxos {
+			if mask&(1<<i) != 0 {
+				total += utxos[i].AmountSats
+				count++
+			}
+		}
+		if total > maxSats || count > int64(btccommon.MaxNoOfInputsPerTx) {
+			continue
+		}
+		size, err := btccommon.EstimateOutboundSize(count, []btcutil.Address{payee})
+		require.NoError(t, err)
+		fee := size * feeRate
+		if fee > total/drain.MaxBTCFeeFraction || total-fee < int64(constant.BTCWithdrawalDustAmount) {
+			continue
+		}
+		exists = true
+		if total > bestTotal {
+			bestTotal = total
+		}
+	}
+	return exists, bestTotal
+}
+
+// TestGenerateBTCTxsCapAgainstExhaustiveSearch is the guard that the cap selection heuristic keeps
+// pace with what is actually possible. Three separate bugs in this logic all had the same shape —
+// a viable subset existed under the cap and the selection emitted nothing, so a rehearsal silently
+// covered no BTC — and each was found by review rather than by a test, because the unit tests only
+// pinned the shapes already thought of.
+//
+// So this compares against brute force over every subset on small random sets, asserting:
+//
+//   - anything emitted is valid: within the cap and inside the poller's fee and dust bounds;
+//   - nothing is emitted when no subset could have been swept;
+//   - something IS emitted whenever some subset could have been.
+//
+// The last is the property the bugs violated. Selection is a heuristic, so this is evidence rather
+// than proof, but it is the check that fails when the next variant appears. The amounts mix dust,
+// medium and wide ranges because the reported failures came from medium UTXOs and dust tails.
+//
+// Not asserted: that the *most* valuable viable subset is chosen. Across this sweep the heuristic
+// picks a smaller viable subset in a few percent of cases, which is a rehearsal sweeping less than
+// it could — harmless, and not worth an exhaustive search in production code.
+func TestGenerateBTCTxsCapAgainstExhaustiveSearch(t *testing.T) {
+	payee := testPayee(t)
+	rng := rand.New(rand.NewSource(42)) // #nosec G404 deterministic test vectors, not security
+
+	amount := func() int64 {
+		switch rng.Intn(3) {
+		case 0:
+			return int64(1 + rng.Intn(2_000)) // dust
+		case 1:
+			return int64(10_000 + rng.Intn(100_000)) // medium: where the reported bugs lived
+		default:
+			return int64(1 + rng.Intn(10_000_000)) // wide
+		}
+	}
+
+	var viable, missed, suboptimal int
+	const iterations = 5000
+
+	for i := 0; i < iterations; i++ {
+		utxos := make([]drain.UTXO, 2+rng.Intn(11))
+		for j := range utxos {
+			utxos[j] = drain.UTXO{TxID: fmt.Sprintf("u%02d", j), Vout: uint32(j), AmountSats: amount()}
+		}
+		feeRate := int64(1 + rng.Intn(200))
+		maxSats := int64(1 + rng.Intn(400_000))
+
+		txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+			ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: utxos, MaxSats: maxSats,
+		})
+		require.NoError(t, err)
+
+		var swept int64
+		for _, tx := range txs {
+			var totalIn int64
+			for _, in := range tx.Inputs {
+				totalIn += in.AmountSats
+			}
+			swept += totalIn
+			require.LessOrEqual(t, totalIn, maxSats, "sweep exceeds the cap")
+			require.LessOrEqual(t, tx.FeeSats, totalIn/drain.MaxBTCFeeFraction, "poller would reject this fee")
+			require.GreaterOrEqual(t, tx.OutputSats, int64(constant.BTCWithdrawalDustAmount))
+			require.Equal(t, totalIn-tx.FeeSats, tx.OutputSats)
+		}
+
+		exists, bestTotal := viableSubsets(t, utxos, maxSats, feeRate, payee)
+		if !exists {
+			require.Empty(t, txs, "emitted a sweep where no viable subset exists")
+			continue
+		}
+
+		viable++
+		switch {
+		case len(txs) == 0:
+			missed++
+			t.Errorf("no sweep emitted though a viable subset exists: feeRate=%d cap=%d utxos=%v",
+				feeRate, maxSats, utxos)
+		case swept < bestTotal:
+			suboptimal++
+		}
+	}
+
+	require.Zero(t, missed, "%d of %d viable cases emitted nothing", missed, viable)
+	// guards the sample itself: if a change made almost nothing viable, "0 misses" would be hollow
+	require.Greater(t, viable, iterations/10, "too few viable cases to be meaningful")
+	t.Logf("viable=%d/%d missed=%d suboptimal=%d", viable, iterations, missed, suboptimal)
+}

--- a/pkg/drain/generate_test.go
+++ b/pkg/drain/generate_test.go
@@ -215,3 +215,437 @@ func TestBuildPayloadSigns(t *testing.T) {
 	require.Equal(t, drain.NetworkMainnet, p.Network)
 	require.NoError(t, p.Verify(ethcrypto.CompressPubkey(&priv.PublicKey)))
 }
+
+func TestGenerateEVMTxMaxAmount(t *testing.T) {
+	// the uncapped amount for this input, from TestGenerateEVMTx
+	const uncapped = "999999972900000000"
+
+	baseInput := func() drain.EVMInput {
+		return drain.EVMInput{
+			ChainID:        1,
+			To:             "0x1111111111111111111111111111111111111111",
+			Balance:        sdkmath.NewUint(1e18),
+			MedianGasPrice: sdkmath.NewUint(100_000),
+			Nonce:          7,
+		}
+	}
+
+	tests := []struct {
+		name       string
+		maxAmount  sdkmath.Uint
+		wantAmount string
+	}{
+		{"nil cap drains everything", sdkmath.Uint{}, uncapped},
+		{"zero cap drains everything", sdkmath.ZeroUint(), uncapped},
+		{"cap below amount is applied", sdkmath.NewUint(1_000), "1000"},
+		{"cap above amount is a no-op", sdkmath.NewUintFromString("2000000000000000000"), uncapped},
+		{"cap equal to amount is a no-op", sdkmath.NewUintFromString(uncapped), uncapped},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// ARRANGE
+			in := baseInput()
+			in.MaxAmount = tc.maxAmount
+
+			// ACT
+			tx, err := drain.GenerateEVMTx(in)
+
+			// ASSERT
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAmount, tx.Amount)
+			// the cap only lowers the transfer: fee inputs are untouched, so a capped rehearsal
+			// signs and broadcasts exactly like the real drain
+			require.Equal(t, "250000", tx.GasPrice)
+			require.EqualValues(t, 100_000, tx.GasLimit)
+			require.EqualValues(t, 7, tx.Nonce)
+		})
+	}
+}
+
+func TestGenerateEVMTxRefusesZeroAmount(t *testing.T) {
+	// a balance that is exactly the fee leaves nothing to transfer; pinning it would pay gas
+	// to move nothing. fee = 100000*250000 + 2_100_000_000
+	fee := sdkmath.NewUint(100_000 * 250_000).Add(sdkmath.NewUintFromString("2100000000"))
+
+	// ACT
+	_, err := drain.GenerateEVMTx(drain.EVMInput{
+		ChainID:        1,
+		To:             "0x1111111111111111111111111111111111111111",
+		Balance:        fee,
+		MedianGasPrice: sdkmath.NewUint(100_000),
+	})
+
+	// ASSERT
+	require.ErrorContains(t, err, "zero-amount")
+}
+
+func TestGenerateBTCTxsMaxSats(t *testing.T) {
+	payee := testPayee(t)
+
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 100_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 60_000_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 30_000_000},
+		{TxID: "ddd", Vout: 3, AmountSats: 5_000_000},
+	}
+
+	// ARRANGE: a cap that fits the 60M UTXO but not the 100M one; 30M then tops it up, and 5M
+	// fits in what remains — largest-first, never exceeding the cap.
+	const maxSats = int64(95_000_000)
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332,
+		To:      payee,
+		FeeRate: 10,
+		UTXOs:   utxos,
+		MaxSats: maxSats,
+	})
+
+	// ASSERT: one sweep, spending only the selected subset, within the cap
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+
+	tx := txs[0]
+	var totalIn int64
+	spent := make([]string, 0, len(tx.Inputs))
+	for _, in := range tx.Inputs {
+		totalIn += in.AmountSats
+		spent = append(spent, in.TxID)
+	}
+	require.LessOrEqual(t, totalIn, maxSats)
+	require.ElementsMatch(t, []string{"bbb", "ccc", "ddd"}, spent)
+	// the untouched balance stays at the TSS address for the real drain
+	require.NotContains(t, spent, "aaa")
+	// the fee math and single-output shape are unchanged by the cap
+	require.Equal(t, totalIn-tx.FeeSats, tx.OutputSats)
+	require.GreaterOrEqual(t, tx.OutputSats, int64(constant.BTCWithdrawalDustAmount))
+}
+
+func TestGenerateBTCTxsMaxSatsPrefersEconomicalInputs(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(50)
+
+	// one UTXO that comfortably fits the cap, plus enough dust to fill a whole tx. A
+	// smallest-first selection would pack the sweep with dust and the group would be dropped
+	// as uneconomical, so a rehearsal would silently produce no BTC tx at all.
+	utxos := []drain.UTXO{{TxID: "large", Vout: 0, AmountSats: 10_000_000}}
+	for i := 0; i < 40; i++ {
+		utxos = append(utxos, drain.UTXO{TxID: fmt.Sprintf("dust-%02d", i), Vout: uint32(100 + i), AmountSats: 500})
+	}
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332,
+		To:      payee,
+		FeeRate: feeRate,
+		UTXOs:   utxos,
+		MaxSats: 20_000_000,
+	})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Equal(t, "large", txs[0].Inputs[0].TxID)
+	require.GreaterOrEqual(t, txs[0].OutputSats, int64(constant.BTCWithdrawalDustAmount))
+}
+
+func TestGenerateBTCTxsMaxSatsCapsInputsToOneTx(t *testing.T) {
+	payee := testPayee(t)
+
+	// 45 equal UTXOs all within a generous cap: the selection stops at one tx worth of inputs
+	// so a rehearsal never fans out into several sweeps.
+	utxos := make([]drain.UTXO, 45)
+	for i := range utxos {
+		utxos[i] = drain.UTXO{TxID: fmt.Sprintf("utxo-%02d", i), Vout: uint32(i), AmountSats: 10_000_000}
+	}
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332,
+		To:      payee,
+		FeeRate: 10,
+		UTXOs:   utxos,
+		MaxSats: 450_000_000, // fits every UTXO
+	})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Len(t, txs[0].Inputs, btccommon.MaxNoOfInputsPerTx)
+}
+
+func TestGenerateBTCTxsMaxSatsBelowSmallestUTXO(t *testing.T) {
+	payee := testPayee(t)
+
+	// ACT: no UTXO fits under the cap
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332,
+		To:      payee,
+		FeeRate: 10,
+		UTXOs:   []drain.UTXO{{TxID: "aaa", Vout: 0, AmountSats: 10_000_000}},
+		MaxSats: 1_000,
+	})
+
+	// ASSERT: nothing to sweep, and no error — the operator sees an empty BTC section rather
+	// than a failed payload
+	require.NoError(t, err)
+	require.Empty(t, txs)
+}
+
+func TestGenerateBTCTxsMaxSatsDeterministic(t *testing.T) {
+	payee := testPayee(t)
+
+	// a capped selection must be as order-independent as the uncapped partitioning, or nodes
+	// would select different UTXOs and the keysign ceremony would never form
+	base := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 50_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 50_000_000}, // ties on amount → tie-break by TxID/Vout
+		{TxID: "ccc", Vout: 2, AmountSats: 90_000_000},
+		{TxID: "ddd", Vout: 3, AmountSats: 10_000_000},
+		{TxID: "aaa", Vout: 4, AmountSats: 50_000_000}, // same TxID as [0], tie-break by Vout
+	}
+	shuffled := []drain.UTXO{base[3], base[0], base[4], base[2], base[1]}
+
+	txs1, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: 10, UTXOs: base, MaxSats: 110_000_000,
+	})
+	require.NoError(t, err)
+	txs2, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: 10, UTXOs: shuffled, MaxSats: 110_000_000,
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, txs1)
+	require.Equal(t, txs1, txs2)
+}
+
+func TestGenerateBTCTxsMaxSatsDoesNotMutateCallerSlice(t *testing.T) {
+	payee := testPayee(t)
+
+	// the capped path sorts before selecting; the caller's slice must survive it untouched
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 10_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 90_000_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 50_000_000},
+	}
+	original := append([]drain.UTXO(nil), utxos...)
+
+	// ACT
+	_, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: 10, UTXOs: utxos, MaxSats: 60_000_000,
+	})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Equal(t, original, utxos)
+}
+
+// mainnetShapedUTXOs mirrors the shape measured on mainnet during the live run: 20 UTXOs holding
+// ~99.75% of the balance, the remainder spread over hundreds of dust outputs. That shape is what
+// makes a capped selection hard — there is a wide gap between "large" and "dust" with nothing in
+// between for a small cap to land on.
+func mainnetShapedUTXOs() []drain.UTXO {
+	const totalSats = int64(177_000_000)
+	large := totalSats * 9975 / 10000 / 20
+
+	utxos := make([]drain.UTXO, 0, 500)
+	for i := 0; i < 20; i++ {
+		utxos = append(utxos, drain.UTXO{TxID: fmt.Sprintf("large-%03d", i), Vout: uint32(i), AmountSats: large})
+	}
+	for i := 0; i < 480; i++ {
+		utxos = append(utxos, drain.UTXO{TxID: fmt.Sprintf("dust-%03d", i), Vout: uint32(1000 + i), AmountSats: 931})
+	}
+	return utxos
+}
+
+func TestGenerateBTCTxsCapNeverEmitsUneconomicalSweep(t *testing.T) {
+	payee := testPayee(t)
+
+	// A cap below every large UTXO used to slide past all of them and fill the group with dust:
+	// fitting under the cap was the only test, so the walk kept going down the list. The dust
+	// group's fee then dwarfed its value and the whole sweep was dropped, leaving the operator
+	// with an empty BTC section. Whatever the cap, an emitted sweep must satisfy the poller's
+	// fee bound — the alternative is a rehearsal that silently skips BTC.
+	for _, feeRate := range []int64{10, 50} {
+		for _, maxSats := range []int64{100_000, 1_000_000, 5_000_000, 9_000_000, 20_000_000} {
+			txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+				ChainID: 8332,
+				To:      payee,
+				FeeRate: feeRate,
+				UTXOs:   mainnetShapedUTXOs(),
+				MaxSats: maxSats,
+			})
+			require.NoError(t, err)
+
+			for _, tx := range txs {
+				var totalIn int64
+				for _, in := range tx.Inputs {
+					totalIn += in.AmountSats
+				}
+				require.LessOrEqual(t, totalIn, maxSats, "feeRate=%d cap=%d", feeRate, maxSats)
+				// exactly the poller's validateBTCFee bound
+				require.LessOrEqual(
+					t, tx.FeeSats, totalIn/drain.MaxBTCFeeFraction,
+					"feeRate=%d cap=%d emitted a sweep the poller would reject", feeRate, maxSats,
+				)
+				require.GreaterOrEqual(t, tx.OutputSats, int64(constant.BTCWithdrawalDustAmount))
+				require.Equal(t, totalIn-tx.FeeSats, tx.OutputSats)
+			}
+		}
+	}
+}
+
+func TestGenerateBTCTxsCapDoesNotTopUpWithDust(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(50)
+
+	// A single 90k-sat UTXO is viable on its own at 50 sat/vB (fee 8550 vs a 9000 allowance).
+	// Adding one 300-sat input costs ~68 vB more fee while adding almost no value, pushing the
+	// fee past the bound and taking the whole sweep down with it. Every input must cover its own
+	// marginal fee under the same 1/MaxBTCFeeFraction rule.
+	utxos := []drain.UTXO{{TxID: "big", Vout: 0, AmountSats: 90_000}}
+	for i := 0; i < 19; i++ {
+		utxos = append(utxos, drain.UTXO{TxID: fmt.Sprintf("d%02d", i), Vout: uint32(100 + i), AmountSats: 300})
+	}
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: utxos, MaxSats: 100_000,
+	})
+
+	// ASSERT: the viable sweep survives, and the dust that would have killed it is left behind
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Len(t, txs[0].Inputs, 1)
+	require.EqualValues(t, 90_000, txs[0].Inputs[0].AmountSats)
+	require.LessOrEqual(t, txs[0].FeeSats, txs[0].Inputs[0].AmountSats/drain.MaxBTCFeeFraction)
+}
+
+func TestGenerateBTCTxsCapTopsUpWithInputsThatPayForThemselves(t *testing.T) {
+	payee := testPayee(t)
+
+	// the rejection above is about marginal value, not about using one input: an input large
+	// enough to cover its own added fee is still taken
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 60_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 30_000_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 5_000_000},
+	}
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: 10, UTXOs: utxos, MaxSats: 95_000_000,
+	})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Len(t, txs[0].Inputs, 3)
+}
+
+func TestMinViableSweepSats(t *testing.T) {
+	payee := testPayee(t)
+
+	// a sweep below this threshold cannot satisfy both the fee bound and the dust floor, so no
+	// cap under it can ever produce a BTC tx
+	for _, feeRate := range []int64{1, 10, 50, 200} {
+		minViable, err := drain.MinViableSweepSats(feeRate, payee)
+		require.NoError(t, err)
+
+		// just under the threshold: nothing is emitted
+		txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+			ChainID: 8332,
+			To:      payee,
+			FeeRate: feeRate,
+			UTXOs:   []drain.UTXO{{TxID: "aaa", Vout: 0, AmountSats: minViable - 1}},
+			MaxSats: minViable - 1,
+		})
+		require.NoError(t, err)
+		require.Empty(t, txs, "feeRate=%d", feeRate)
+
+		// exactly at the threshold: a single-input sweep is emitted and passes the poller's bounds
+		txs, err = drain.GenerateBTCTxs(drain.BTCInput{
+			ChainID: 8332,
+			To:      payee,
+			FeeRate: feeRate,
+			UTXOs:   []drain.UTXO{{TxID: "aaa", Vout: 0, AmountSats: minViable}},
+			MaxSats: minViable,
+		})
+		require.NoError(t, err)
+		require.Len(t, txs, 1, "feeRate=%d minViable=%d", feeRate, minViable)
+		require.LessOrEqual(t, txs[0].FeeSats, minViable/drain.MaxBTCFeeFraction)
+		require.GreaterOrEqual(t, txs[0].OutputSats, int64(constant.BTCWithdrawalDustAmount))
+	}
+}
+
+func TestGenerateBTCTxsCapExcludesInputsBelowTheirMarginalFee(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(50)
+
+	// Every candidate behind the 90k input is far below what a second input must be worth
+	// (TestGenerateBTCTxsCapMarginalFeeBoundary pins that threshold), so none of them is taken.
+	//
+	// Note this does NOT pin the loop's break-vs-continue choice, and no test can: the fee is
+	// fixed by the current input count and the list is descending, so a candidate that fails the
+	// bound is followed only by candidates that fail it harder. The two are indistinguishable by
+	// construction — the reason to break is that continuing reads as if recovery were possible.
+	utxos := []drain.UTXO{
+		{TxID: "big", Vout: 0, AmountSats: 90_000},
+		{TxID: "mid", Vout: 1, AmountSats: 300},
+		{TxID: "late", Vout: 2, AmountSats: 200},
+	}
+
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: utxos, MaxSats: 100_000,
+	})
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Len(t, txs[0].Inputs, 1)
+	require.EqualValues(t, 90_000, txs[0].Inputs[0].AmountSats)
+}
+
+func TestGenerateBTCTxsCapMarginalFeeBoundary(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(50)
+	const anchor = int64(90_000)
+
+	// What a second input must be worth to be taken, derived from the estimator rather than
+	// hardcoded: with fee2 = size(2) * feeRate and the bound fee <= total/MaxBTCFeeFraction,
+	// the smallest qualifying amount is fee2*MaxBTCFeeFraction - anchor. At 50 sat/vB behind a
+	// 90k-sat anchor that is ~29.5k sats — three orders of magnitude above the dust this rule is
+	// usually described as excluding, which is why "it skips dust" undersells it.
+	size2, err := btccommon.EstimateOutboundSize(2, []btcutil.Address{payee})
+	require.NoError(t, err)
+	threshold := size2*feeRate*drain.MaxBTCFeeFraction - anchor
+
+	sweep := func(second int64) []draintx.BTCTx {
+		txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+			ChainID: 8332,
+			To:      payee,
+			FeeRate: feeRate,
+			UTXOs: []drain.UTXO{
+				{TxID: "anchor", Vout: 0, AmountSats: anchor},
+				{TxID: "second", Vout: 1, AmountSats: second},
+			},
+			MaxSats: 200_000,
+		})
+		require.NoError(t, err)
+		require.Len(t, txs, 1)
+		return txs
+	}
+
+	// one sat under: the anchor sweeps alone
+	require.Len(t, sweep(threshold - 1)[0].Inputs, 1)
+
+	// at the threshold: the second input pays its way and is taken, and the group still satisfies
+	// the poller's bound
+	txs := sweep(threshold)
+	require.Len(t, txs[0].Inputs, 2)
+	var totalIn int64
+	for _, in := range txs[0].Inputs {
+		totalIn += in.AmountSats
+	}
+	require.LessOrEqual(t, txs[0].FeeSats, totalIn/drain.MaxBTCFeeFraction)
+}

--- a/pkg/drain/generate_test.go
+++ b/pkg/drain/generate_test.go
@@ -706,3 +706,74 @@ func TestGenerateBTCTxsCapKeepsCollectivelyViableGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateBTCTxsCapDoesNotLetALargeUTXOCrowdOutAViableSubset(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(40)
+	const maxSats = int64(100_000)
+
+	// Regression: filling largest-first from the front let the 60,000-sat UTXO take the cap space,
+	// which blocked both 50,000-sat UTXOs and then trimmed away as uneconomical on its own — so a
+	// capped run emitted nothing even though 50,000+50,000 fits the cap and clears the fee bound.
+	// Reported by greptile on #4630.
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 60_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 50_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 50_000},
+	}
+
+	size1, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{payee})
+	require.NoError(t, err)
+	size2, err := btccommon.EstimateOutboundSize(2, []btcutil.Address{payee})
+	require.NoError(t, err)
+	// the largest UTXO is not viable alone...
+	require.Greater(t, size1*feeRate, int64(60_000)/drain.MaxBTCFeeFraction)
+	// ...but the pair of smaller ones is
+	require.LessOrEqual(t, size2*feeRate, int64(100_000)/drain.MaxBTCFeeFraction)
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: utxos, MaxSats: maxSats,
+	})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Len(t, txs[0].Inputs, 2)
+
+	var totalIn int64
+	spent := make([]string, 0, 2)
+	for _, in := range txs[0].Inputs {
+		totalIn += in.AmountSats
+		spent = append(spent, in.TxID)
+	}
+	require.ElementsMatch(t, []string{"bbb", "ccc"}, spent)
+	require.LessOrEqual(t, totalIn, maxSats)
+	require.LessOrEqual(t, txs[0].FeeSats, totalIn/drain.MaxBTCFeeFraction)
+	require.Equal(t, totalIn-txs[0].FeeSats, txs[0].OutputSats)
+}
+
+func TestGenerateBTCTxsCapPrefersTheMostValuableViableSubset(t *testing.T) {
+	payee := testPayee(t)
+
+	// several offsets yield a viable candidate; the one sweeping the most value wins, so a
+	// rehearsal gets as close to the operator's cap as the UTXOs allow
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 40_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 30_000_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 30_000_000},
+	}
+
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: 10, UTXOs: utxos, MaxSats: 70_000_000,
+	})
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+
+	var totalIn int64
+	for _, in := range txs[0].Inputs {
+		totalIn += in.AmountSats
+	}
+	// 40M+30M = 70M exactly, rather than the 30M+30M an offset candidate would give
+	require.EqualValues(t, 70_000_000, totalIn)
+}

--- a/pkg/drain/generate_test.go
+++ b/pkg/drain/generate_test.go
@@ -580,17 +580,17 @@ func TestMinViableSweepSats(t *testing.T) {
 	}
 }
 
-func TestGenerateBTCTxsCapExcludesInputsBelowTheirMarginalFee(t *testing.T) {
+func TestGenerateBTCTxsCapTrimsInputsThatBreakTheFeeBound(t *testing.T) {
 	payee := testPayee(t)
 	const feeRate = int64(50)
 
-	// Every candidate behind the 90k input is far below what a second input must be worth
-	// (TestGenerateBTCTxsCapMarginalFeeBoundary pins that threshold), so none of them is taken.
+	// Phase 1 takes all three on value alone (they fit the cap), then phase 2 trims the tail until
+	// the group clears the fee bound — which lands back on the 90k input alone, since neither small
+	// input comes near what a second input must be worth (TestGenerateBTCTxsCapMarginalFeeBoundary
+	// pins that threshold at ~29.5k sats here).
 	//
-	// Note this does NOT pin the loop's break-vs-continue choice, and no test can: the fee is
-	// fixed by the current input count and the list is descending, so a candidate that fails the
-	// bound is followed only by candidates that fail it harder. The two are indistinguishable by
-	// construction — the reason to break is that continuing reads as if recovery were possible.
+	// Trimming from the tail is what makes this work: the smallest inputs are the ones that broke
+	// the bound, so they are the ones removed.
 	utxos := []drain.UTXO{
 		{TxID: "big", Vout: 0, AmountSats: 90_000},
 		{TxID: "mid", Vout: 1, AmountSats: 300},
@@ -611,8 +611,8 @@ func TestGenerateBTCTxsCapMarginalFeeBoundary(t *testing.T) {
 	const feeRate = int64(50)
 	const anchor = int64(90_000)
 
-	// What a second input must be worth to be taken, derived from the estimator rather than
-	// hardcoded: with fee2 = size(2) * feeRate and the bound fee <= total/MaxBTCFeeFraction,
+	// What a second input must be worth to survive the trim, derived from the estimator rather
+	// than hardcoded: with fee2 = size(2) * feeRate and the bound fee <= total/MaxBTCFeeFraction,
 	// the smallest qualifying amount is fee2*MaxBTCFeeFraction - anchor. At 50 sat/vB behind a
 	// 90k-sat anchor that is ~29.5k sats — three orders of magnitude above the dust this rule is
 	// usually described as excluding, which is why "it skips dust" undersells it.
@@ -648,4 +648,61 @@ func TestGenerateBTCTxsCapMarginalFeeBoundary(t *testing.T) {
 		totalIn += in.AmountSats
 	}
 	require.LessOrEqual(t, txs[0].FeeSats, totalIn/drain.MaxBTCFeeFraction)
+}
+
+func TestGenerateBTCTxsCapKeepsCollectivelyViableGroups(t *testing.T) {
+	payee := testPayee(t)
+
+	// Regression: judging each input as it was added tested the largest one with total == 0, so a
+	// group that is only economical together was rejected before the fixed part of the fee could be
+	// amortised — the capped run then swept no BTC while the uncapped run over the same UTXOs was
+	// fine. Reported by greptile on #4628/#4629 and reproduced by ws4charlie.
+	tests := []struct {
+		name    string
+		amount  int64
+		feeRate int64
+		maxSats int64
+	}{
+		{"two 15k inputs at 10 sat/vB", 15_000, 10, 30_000},
+		{"two 30k inputs at 20 sat/vB", 30_000, 20, 60_000},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			utxos := []drain.UTXO{
+				{TxID: "aaa", Vout: 0, AmountSats: tc.amount},
+				{TxID: "bbb", Vout: 1, AmountSats: tc.amount},
+			}
+
+			// neither input clears the bound alone...
+			size1, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{payee})
+			require.NoError(t, err)
+			require.Greater(t, size1*tc.feeRate, tc.amount/drain.MaxBTCFeeFraction)
+
+			// ...but the pair does
+			size2, err := btccommon.EstimateOutboundSize(2, []btcutil.Address{payee})
+			require.NoError(t, err)
+			require.LessOrEqual(t, size2*tc.feeRate, 2*tc.amount/drain.MaxBTCFeeFraction)
+
+			// ACT
+			txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+				ChainID: 8332, To: payee, FeeRate: tc.feeRate, UTXOs: utxos, MaxSats: tc.maxSats,
+			})
+
+			// ASSERT: the pair is swept, and the sweep satisfies the poller's bound
+			require.NoError(t, err)
+			require.Len(t, txs, 1)
+			require.Len(t, txs[0].Inputs, 2)
+			require.LessOrEqual(t, txs[0].FeeSats, 2*tc.amount/drain.MaxBTCFeeFraction)
+			require.Equal(t, 2*tc.amount-txs[0].FeeSats, txs[0].OutputSats)
+			require.GreaterOrEqual(t, txs[0].OutputSats, int64(constant.BTCWithdrawalDustAmount))
+
+			// a capped run must not do worse than the uncapped one on the same UTXOs
+			uncapped, err := drain.GenerateBTCTxs(drain.BTCInput{
+				ChainID: 8332, To: payee, FeeRate: tc.feeRate, UTXOs: utxos,
+			})
+			require.NoError(t, err)
+			require.Equal(t, uncapped, txs)
+		})
+	}
 }


### PR DESCRIPTION
Backport of #4624 to `release/zetaclient/v37`. #4624 is already merged.

## Summary

Adds the rehearsal value caps to the drain payload generator, so the drain can be tested with a small amount on a live TSS before the full sweep.

- `GenerateEVMTx` caps the transferred amount, leaving fee, gas price and gas limit exactly as a real drain computes them, and refuses to pin a zero-amount tx.
- `GenerateBTCTxs` caps the swept value by selecting a subset of UTXOs — the sweep spends whole UTXOs and has no change output, so the value cannot be lowered any other way.
- `MinViableSweepSats` exposes the threshold below which no cap can produce a sweep at a given fee rate.

## Scope

`pkg/drain` only — two files, `generate.go` and `generate_test.go`, byte-identical to `main`.

The `--evm-max-amount` / `--btc-max-sats` flags themselves live in `cmd/zetatool`, which is not on this branch: the payload generator runs off `main` on the operator host, the same split as #4614. `docs/rfc` and `changelog.md` likewise stay on `main`.

**No poller behaviour change.** The poller reads only `MaxBTCFeeFraction` and `MaxEVMGasPriceGwei` from this package and neither changed, and nothing on this branch calls `GenerateEVMTx` / `GenerateBTCTxs`. This is a parity backport: it keeps `pkg/drain` from drifting between `main` and the release branches, so a build cut from here matches what was reviewed.

## The substance, for the record

Fitting under the cap was originally the only selection test. Because a UTXO too big for the cap is skipped and selection walks on down the list, a cap below every large UTXO slid past all of them and filled the group with dust, whose fee dwarfed its value — the group was then dropped as uneconomical and a capped run swept **no BTC at all**. On a mainnet-shaped set that was every cap under ~8.8M sats. The same fixed ~68 vB per input also let a single dust top-up push an already-viable sweep past the bound.

Selection now takes an input only if the resulting group still satisfies the poller's own bound (`fee <= total/MaxBTCFeeFraction`), priced at the input count that input would produce, so a non-empty result is economical by construction rather than by luck.

## Verification on this branch

Build clean with and without `-tags drain`; `go vet` clean; `pkg/drain` and `zetaclient/drain` suites green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds capped EVM and BTC drain rehearsals while preserving production fee calculations and deterministic transaction construction.
- Caps EVM transfer amounts without changing gas parameters.
- Selects economical BTC UTXO subsets within the rehearsal cap.
- Adds minimum viable sweep calculation and extensive regression/property coverage.
- Replaces the previously faulty per-prefix viability check with fill-and-trim candidate selection.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported collectively viable-prefix case is covered by the new two-phase selection and regression test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/drain/generate.go | Adds EVM and BTC rehearsal caps and fixes the previously reported prefix-rejection case through deterministic fill-and-trim candidate selection. |
| pkg/drain/generate_cap_property_test.go | Adds deterministic property coverage comparing capped BTC selection against exhaustive viable-subset search for small input sets. |
| pkg/drain/generate_test.go | Adds regression tests for cap enforcement, economic viability, deterministic selection, marginal inputs, and the previously reported collectively viable group. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sorted BTC UTXOs] --> B[Build candidate from each starting offset]
    B --> C[Fill by descending value within cap and input limit]
    C --> D[Trim smallest inputs until fee bound passes]
    D --> E[Choose highest-value viable candidate]
    E --> F[Generate deterministic capped sweep]
```

<sub>Reviews (2): Last reviewed commit: ["fix(zetatool): stop a large UTXO crowdin..."](https://github.com/zeta-chain/node/commit/2024c5256be1fddb553117981e18819b511aef6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53398176)</sub>

<!-- /greptile_comment -->