### PR TITLE
fix(zetatool): keep collectively-viable UTXOs in a capped BTC sweep

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * [4612](https://github.com/zeta-chain/node/pull/4612) - add an emergency TSS native-fund drain tool to move all native funds (EVM + BTC) to a safe wallet during crosschain shutdown.
 * [4624](https://github.com/zeta-chain/node/pull/4624) - add `--evm-max-amount` and `--btc-max-sats` rehearsal caps to `zetatool drain-payload` so the drain can be tested with a small value before the full sweep.
+* [4630](https://github.com/zeta-chain/node/pull/4630) - fix `zetatool drain-payload` rejecting BTC UTXOs that are only economical as a group, which made a capped rehearsal sweep no BTC.
 
 ### Refactor
 

--- a/cmd/zetatool/cli/drain.go
+++ b/cmd/zetatool/cli/drain.go
@@ -768,11 +768,12 @@ func reportNonceState(w io.Writer, chainID int64, pinnedNonce, pending uint64) {
 
 // reportUnviableBTCCap explains why a capped run produced no BTC sweep, and what cap would.
 //
-// A UTXO wallet cannot always honour a small cap: the sweep spends whole UTXOs, so a viable
-// rehearsal needs a single UTXO that is at once large enough to out-earn its own fee and small
-// enough to fit the cap. If the wallet's UTXOs are all far above the cap and the rest is dust,
-// no cap in between exists — the operator needs to know that now, not after concluding BTC was
-// covered.
+// The sweep spends whole UTXOs, so a viable rehearsal needs the selected inputs to total at least
+// MinViableSweepSats while staying under the cap — and a cap can fall in a gap the wallet's UTXOs
+// simply cannot land on. The operator needs to know that now, not after concluding BTC was covered.
+//
+// The only sound impossibility test is against the whole balance: individual UTXOs below the floor
+// say nothing, since a group of them can clear it together.
 func reportUnviableBTCCap(
 	w io.Writer,
 	utxos []drain.UTXO,
@@ -786,43 +787,42 @@ func reportUnviableBTCCap(
 		return
 	}
 
-	// the smallest UTXO that would make a viable one-input sweep on its own; the operator can
-	// raise the cap to it, and if none exists the wallet's shape rules out a small BTC rehearsal
-	var smallestViable int64
+	var walletTotal int64
 	for _, u := range utxos {
-		if u.AmountSats >= minViable && (smallestViable == 0 || u.AmountSats < smallestViable) {
-			smallestViable = u.AmountSats
+		if u.AmountSats > 0 {
+			walletTotal += u.AmountSats
 		}
 	}
 
 	fmt.Fprintf(
 		w,
 		"ERROR chain %d: REHEARSAL SWEPT NO BTC. --%s %d admits no economical sweep at %d sat/vB "+
-			"(a sweep needs at least %d sats to out-earn its own fee)\n",
+			"(a sweep's inputs must total at least %d sats to out-earn the fee)\n",
 		chainID,
 		FlagBTCMaxSats,
 		maxSats,
 		feeRate,
 		minViable,
 	)
-	if smallestViable > 0 {
+	if walletTotal < minViable {
 		fmt.Fprintf(
 			w,
-			"ERROR chain %d: raise --%s to at least %d (the smallest UTXO that can be swept alone) "+
-				"or lower --%s, otherwise this run does NOT rehearse BTC\n",
+			"ERROR chain %d: the entire TSS balance is %d sats, below that floor, so no cap can "+
+				"rehearse BTC at this fee rate — lower --%s or drain BTC uncapped\n",
 			chainID,
-			FlagBTCMaxSats,
-			smallestViable,
+			walletTotal,
 			FlagFeeRate,
 		)
 		return
 	}
 	fmt.Fprintf(
 		w,
-		"ERROR chain %d: no single UTXO reaches %d sats at this fee rate, so no cap can rehearse BTC "+
-			"on these holdings — BTC can only be drained uncapped\n",
+		"ERROR chain %d: raise --%s to at least %d, or lower --%s. UTXOs are spent whole, so the "+
+			"cap must also be reachable by summing them; otherwise this run does NOT rehearse BTC\n",
 		chainID,
+		FlagBTCMaxSats,
 		minViable,
+		FlagFeeRate,
 	)
 }
 

--- a/cmd/zetatool/cli/drain.go
+++ b/cmd/zetatool/cli/drain.go
@@ -111,7 +111,7 @@ tss-balances.`,
 		FlagBTCMaxSats,
 		0,
 		"rehearsal only: cap the total BTC swept at this many sats, by selecting a subset of UTXOs. "+
-			"Whole UTXOs only, so a cap below the smallest sweepable UTXO sweeps nothing (reported) (default: all)",
+			"Whole UTXOs only, so a cap the UTXOs cannot sum to sweeps nothing (reported) (default: all)",
 	)
 
 	return cmd
@@ -196,9 +196,12 @@ func setupGenerator(cmd *cobra.Command, chainArg string) (*payloadGenerator, dra
 	if err != nil {
 		return nil, opts, err
 	}
-	btcMaxSats := must(cmd.Flags().GetInt64(FlagBTCMaxSats))
-	if btcMaxSats < 0 {
-		return nil, opts, fmt.Errorf("--%s must not be negative, got %d", FlagBTCMaxSats, btcMaxSats)
+	btcMaxSats, err := parseBTCMaxSats(
+		must(cmd.Flags().GetInt64(FlagBTCMaxSats)),
+		cmd.Flags().Changed(FlagBTCMaxSats),
+	)
+	if err != nil {
+		return nil, opts, err
 	}
 
 	priv, err := ethcrypto.HexToECDSA(strings.TrimPrefix(must(cmd.Flags().GetString(FlagSigningKey)), "0x"))
@@ -275,6 +278,23 @@ func parseEVMMaxAmount(s string) (sdkmath.Uint, error) {
 		)
 	}
 	return sdkmath.NewUintFromBigInt(v), nil
+}
+
+// parseBTCMaxSats validates the --btc-max-sats flag. Zero doubles as the uncapped sentinel, so
+// "typed 0" and "not passed" have to be told apart: an operator who types 0 meaning "no BTC" would
+// otherwise get the full BTC drain. changed carries that distinction from cobra.
+func parseBTCMaxSats(v int64, changed bool) (int64, error) {
+	switch {
+	case v < 0:
+		return 0, fmt.Errorf("--%s must not be negative, got %d", FlagBTCMaxSats, v)
+	case v == 0 && changed:
+		return 0, fmt.Errorf(
+			"--%s must be positive; omit the flag to sweep all BTC, or use --%s to skip the BTC chain",
+			FlagBTCMaxSats,
+			FlagExcludeChains,
+		)
+	}
+	return v, nil
 }
 
 // warnIfCapped makes a rehearsal payload impossible to mistake for the real drain: the caps only

--- a/cmd/zetatool/cli/drain_cap_test.go
+++ b/cmd/zetatool/cli/drain_cap_test.go
@@ -192,3 +192,31 @@ func TestReportNonceState(t *testing.T) {
 		require.Contains(t, out, "load-balanced")
 	})
 }
+
+func TestParseBTCMaxSats(t *testing.T) {
+	t.Run("omitted flag means uncapped", func(t *testing.T) {
+		v, err := parseBTCMaxSats(0, false)
+		require.NoError(t, err)
+		require.Zero(t, v)
+	})
+
+	t.Run("an explicit zero is rejected", func(t *testing.T) {
+		// zero is the uncapped sentinel, so typing it meaning "no BTC" would sweep everything;
+		// --evm-max-amount already rejects an explicit 0 and these should not disagree
+		_, err := parseBTCMaxSats(0, true)
+		require.ErrorContains(t, err, "must be positive")
+		require.ErrorContains(t, err, "omit the flag to sweep all BTC")
+		require.ErrorContains(t, err, FlagExcludeChains)
+	})
+
+	t.Run("negative is rejected", func(t *testing.T) {
+		_, err := parseBTCMaxSats(-1, true)
+		require.ErrorContains(t, err, "must not be negative")
+	})
+
+	t.Run("a positive cap passes through", func(t *testing.T) {
+		v, err := parseBTCMaxSats(100_000, true)
+		require.NoError(t, err)
+		require.EqualValues(t, 100_000, v)
+	})
+}

--- a/cmd/zetatool/cli/drain_cap_test.go
+++ b/cmd/zetatool/cli/drain_cap_test.go
@@ -107,8 +107,8 @@ func TestReportUnviableBTCCap(t *testing.T) {
 	minViable, err := drain.MinViableSweepSats(feeRate, payee)
 	require.NoError(t, err)
 
-	t.Run("points at the smallest cap that would work", func(t *testing.T) {
-		// mainnet-shaped: large UTXOs far above the cap, the rest dust far below the threshold
+	t.Run("reports the floor on the sweep total", func(t *testing.T) {
+		// mainnet-shaped: large UTXOs far above the cap, the rest dust
 		utxos := []drain.UTXO{
 			{TxID: "large", Vout: 0, AmountSats: 8_828_175},
 			{TxID: "dust", Vout: 1, AmountSats: 931},
@@ -119,13 +119,15 @@ func TestReportUnviableBTCCap(t *testing.T) {
 
 		out := buf.String()
 		require.Contains(t, out, "REHEARSAL SWEPT NO BTC")
-		require.Contains(t, out, fmt.Sprintf("at least %d sats", minViable))
-		// the actionable number: the smallest UTXO that can be swept on its own
-		require.Contains(t, out, "8828175")
+		require.Contains(t, out, fmt.Sprintf("must total at least %d sats", minViable))
+		require.Contains(t, out, fmt.Sprintf("raise --btc-max-sats to at least %d", minViable))
+		// the floor is on the total, not on any one UTXO: pointing at the smallest sweepable UTXO
+		// would overstate the cap needed, since smaller UTXOs can clear the floor as a group
+		require.NotContains(t, out, "8828175")
 	})
 
-	t.Run("says so when no cap can rehearse BTC", func(t *testing.T) {
-		// every UTXO is below the viability threshold, so raising the cap cannot help
+	t.Run("only claims impossibility against the whole balance", func(t *testing.T) {
+		// the entire balance is below the floor, which is the one sound impossibility test
 		utxos := []drain.UTXO{
 			{TxID: "dust-0", Vout: 0, AmountSats: 931},
 			{TxID: "dust-1", Vout: 1, AmountSats: 500},
@@ -136,8 +138,26 @@ func TestReportUnviableBTCCap(t *testing.T) {
 
 		out := buf.String()
 		require.Contains(t, out, "REHEARSAL SWEPT NO BTC")
+		require.Contains(t, out, "the entire TSS balance is 1431 sats")
 		require.Contains(t, out, "no cap can rehearse BTC")
-		require.Contains(t, out, "can only be drained uncapped")
+	})
+
+	t.Run("does not claim impossibility when a group could clear the floor", func(t *testing.T) {
+		// no single UTXO reaches the floor, but together they exceed it — the old per-UTXO test
+		// declared this wallet un-rehearsable, which was wrong
+		utxos := []drain.UTXO{
+			{TxID: "a", Vout: 0, AmountSats: 15_000},
+			{TxID: "b", Vout: 1, AmountSats: 15_000},
+		}
+		require.Less(t, utxos[0].AmountSats, minViable)
+		require.Greater(t, utxos[0].AmountSats+utxos[1].AmountSats, minViable)
+
+		var buf bytes.Buffer
+		reportUnviableBTCCap(&buf, utxos, 10_000, feeRate, payee, 8332)
+
+		out := buf.String()
+		require.NotContains(t, out, "no cap can rehearse BTC")
+		require.Contains(t, out, fmt.Sprintf("raise --btc-max-sats to at least %d", minViable))
 	})
 }
 

--- a/pkg/drain/generate.go
+++ b/pkg/drain/generate.go
@@ -189,39 +189,59 @@ func sortUTXOsForSweep(utxos []UTXO) {
 // so this is the only way to bound a BTC drain's value. It expects utxos already ordered by
 // sortUTXOsForSweep.
 //
-// Selection is therefore largest-first among the UTXOs that fit under the cap, and an input is
-// taken only if the resulting group would still satisfy the poller's fee bound
-// (fee <= total/MaxBTCFeeFraction). That second condition is what makes a capped run usable:
+// A viable subset has to clear two bars at once: total <= maxSats, and a fee that fits the
+// poller's bound, fee(n) <= total/MaxBTCFeeFraction. The bound cannot be applied per input as it
+// is added, because the fixed part of the fee is only amortised once the group is complete — two
+// 15,000-sat UTXOs at 10 sat/vB are viable together (fee 2390 against a 3000 allowance) while
+// neither clears the single-input threshold of 1710 against 1500.
 //
-//   - Fitting under the cap is not enough. A UTXO too big for the cap is skipped and the walk
-//     continues down the list, so without the fee test a small cap slides past every large UTXO
-//     and fills the group with dust instead. The fee of 20 dust inputs dwarfs their value, the
-//     whole group is then dropped as uneconomical, and the rehearsal silently covers no BTC at
-//     all — the one leg with no testnet coverage.
-//   - Topping up an already-viable group can destroy it. Each extra input adds a fixed ~68 vB of
-//     fee, so a 300-sat input added to a viable 90k-sat sweep at 50 sat/vB raises the fee past
-//     the bound and the group is dropped. An input must pay for its own marginal fee under the
-//     same 1/MaxBTCFeeFraction rule the poller applies.
+// So each candidate is built by fillAndTrim: fill largest-first on value alone, then drop the
+// smallest inputs until the completed group clears the bound. Filling from the front alone is not
+// enough either, because one large UTXO can hog the cap and block a better combination — with a
+// 100,000-sat cap at 40 sat/vB, a 60,000-sat UTXO is taken first, blocks both 50,000-sat UTXOs,
+// and then trims away as uneconomical, while 50,000+50,000 would have been viable. Candidates are
+// therefore built from every starting offset, i.e. ignoring the k largest UTXOs for each k, and
+// the best viable one wins: most value swept, fewest inputs to break a tie.
 //
-// The economics cannot be tested per input as it is added, because the fixed part of the fee is
-// only amortised once the group is complete: two 15,000-sat UTXOs at 10 sat/vB are viable together
-// (fee 2390 against a 3000 allowance) while neither clears the single-input threshold of 1710
-// against 1500. Judging inputs one at a time rejects the pair and emits nothing. So selection runs
-// in two phases:
+// This is a heuristic, not an exhaustive subset search: it covers the "a larger UTXO crowds out a
+// viable combination" family, which is what real wallet shapes produce, but an empty result means
+// only that none of these candidates was viable — never that no viable subset exists. The sound
+// impossibility test is a total balance below MinViableSweepSats, which is what the CLI reports.
 //
-//  1. Take largest-first everything that fits under the cap, up to one tx worth of inputs, on
-//     value alone.
-//  2. Drop the smallest input — the tail, since the list is descending — until the group satisfies
-//     the poller's bound, or nothing is left.
-//
-// Trimming from the tail is what preserves the second property above: the marginal input that
-// broke the bound is exactly the one removed first. And because phase 2 tests the completed group,
-// a non-empty result is economical by construction rather than by luck.
-//
-// An empty result means no *prefix* of the cap-limited selection is viable. See MinViableSweepSats
-// for the floor on a sweep's total, which is what the CLI reports.
+// Selection stays deterministic — a fixed input order and a fixed tie-break — because every node
+// must build byte-identical txs.
 func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, error) {
-	// phase 1: fill on value alone
+	var best []UTXO
+	var bestTotal int64
+
+	for start := range utxos {
+		candidate, total, err := fillAndTrim(utxos[start:], maxSats, feeRate, to)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidate) == 0 {
+			continue
+		}
+		// most value swept wins, then the cheaper shape; ties beyond that keep the earlier offset,
+		// which is the one holding the larger UTXOs
+		if total > bestTotal || (total == bestTotal && len(candidate) < len(best)) {
+			best, bestTotal = candidate, total
+		}
+	}
+
+	return best, nil
+}
+
+// fillAndTrim builds one candidate subset: take largest-first everything that fits under the cap,
+// up to one tx worth of inputs, then drop the smallest input — the tail, since utxos is descending
+// — until the completed group satisfies the poller's fee bound, or nothing is left.
+//
+// Trimming from the tail is what keeps a viable group from being destroyed by a marginal one: each
+// extra input adds a fixed ~68 vB of fee, so a 300-sat input added to a viable 90k-sat sweep at
+// 50 sat/vB pushes the fee past the bound — and that input is exactly the first one removed.
+// Because the bound is tested on the completed group, a non-empty result is economical by
+// construction rather than by luck.
+func fillAndTrim(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, int64, error) {
 	selected := make([]UTXO, 0, btccommon.MaxNoOfInputsPerTx)
 	var total int64
 	for _, u := range utxos {
@@ -235,11 +255,10 @@ func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address)
 		selected = append(selected, u)
 	}
 
-	// phase 2: trim the tail until the completed group clears the poller's bound
 	for len(selected) > 0 {
 		size, err := btccommon.EstimateOutboundSize(int64(len(selected)), []btcutil.Address{to})
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if size*feeRate <= total/MaxBTCFeeFraction {
 			break
@@ -247,7 +266,8 @@ func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address)
 		total -= selected[len(selected)-1].AmountSats
 		selected = selected[:len(selected)-1]
 	}
-	return selected, nil
+
+	return selected, total, nil
 }
 
 // MinViableSweepSats is the floor on a sweep's input *total* at this fee rate: enough to keep the

--- a/pkg/drain/generate.go
+++ b/pkg/drain/generate.go
@@ -203,12 +203,25 @@ func sortUTXOsForSweep(utxos []UTXO) {
 //     the bound and the group is dropped. An input must pay for its own marginal fee under the
 //     same 1/MaxBTCFeeFraction rule the poller applies.
 //
-// Because the group's fee is checked as each input is added, a non-empty result is economical by
-// construction rather than by luck. When the result is empty the cap admits no viable sweep at
-// this fee rate — see MinViableSweepSats for the threshold to report to the operator.
+// The economics cannot be tested per input as it is added, because the fixed part of the fee is
+// only amortised once the group is complete: two 15,000-sat UTXOs at 10 sat/vB are viable together
+// (fee 2390 against a 3000 allowance) while neither clears the single-input threshold of 1710
+// against 1500. Judging inputs one at a time rejects the pair and emits nothing. So selection runs
+// in two phases:
 //
-// The subset is limited to one tx worth of inputs so a capped run emits exactly one sweep.
+//  1. Take largest-first everything that fits under the cap, up to one tx worth of inputs, on
+//     value alone.
+//  2. Drop the smallest input — the tail, since the list is descending — until the group satisfies
+//     the poller's bound, or nothing is left.
+//
+// Trimming from the tail is what preserves the second property above: the marginal input that
+// broke the bound is exactly the one removed first. And because phase 2 tests the completed group,
+// a non-empty result is economical by construction rather than by luck.
+//
+// An empty result means no *prefix* of the cap-limited selection is viable. See MinViableSweepSats
+// for the floor on a sweep's total, which is what the CLI reports.
 func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address) ([]UTXO, error) {
+	// phase 1: fill on value alone
 	selected := make([]UTXO, 0, btccommon.MaxNoOfInputsPerTx)
 	var total int64
 	for _, u := range utxos {
@@ -218,29 +231,35 @@ func selectCappedUTXOs(utxos []UTXO, maxSats, feeRate int64, to btcutil.Address)
 		if u.AmountSats <= 0 || total+u.AmountSats > maxSats {
 			continue
 		}
-		// the fee depends only on the input count, so price the group as it would be with this
-		// input added and keep it only if the poller's bound still holds
-		size, err := btccommon.EstimateOutboundSize(int64(len(selected)+1), []btcutil.Address{to})
+		total += u.AmountSats
+		selected = append(selected, u)
+	}
+
+	// phase 2: trim the tail until the completed group clears the poller's bound
+	for len(selected) > 0 {
+		size, err := btccommon.EstimateOutboundSize(int64(len(selected)), []btcutil.Address{to})
 		if err != nil {
 			return nil, err
 		}
-		// Stop rather than skip: the fee here is fixed by the current input count, and the list is
-		// descending, so every remaining candidate is worth less against the same fee and fails
-		// this test too. Continuing would only burn iterations while reading as if a later, smaller
-		// UTXO could recover the group.
-		if size*feeRate > (total+u.AmountSats)/MaxBTCFeeFraction {
+		if size*feeRate <= total/MaxBTCFeeFraction {
 			break
 		}
-		total += u.AmountSats
-		selected = append(selected, u)
+		total -= selected[len(selected)-1].AmountSats
+		selected = selected[:len(selected)-1]
 	}
 	return selected, nil
 }
 
-// MinViableSweepSats is the smallest input total a capped sweep can have and still be emitted at
-// this fee rate: enough to keep the single-input fee within 1/MaxBTCFeeFraction of the total, and
-// to leave an output above dust. A --btc-max-sats below this can only ever produce an empty BTC
-// section, so the CLI reports it instead of leaving the operator to infer it from a missing tx.
+// MinViableSweepSats is the floor on a sweep's input *total* at this fee rate: enough to keep the
+// fee within 1/MaxBTCFeeFraction of the total and to leave an output above dust. A --btc-max-sats
+// below it can only ever produce an empty BTC section, so the CLI reports it rather than leaving
+// the operator to infer it from a missing tx.
+//
+// It is priced for one input because the fee grows with the input count while the bound scales with
+// the total, so a single input is the cheapest shape a viable sweep can take — which makes this a
+// floor on the total for *any* input count, not a per-UTXO requirement. A group of UTXOs each
+// individually below it can still clear it together, so never read this as "no single UTXO reaches
+// it, therefore no cap can work".
 func MinViableSweepSats(feeRate int64, to btcutil.Address) (int64, error) {
 	size, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{to})
 	if err != nil {

--- a/pkg/drain/generate_cap_property_test.go
+++ b/pkg/drain/generate_cap_property_test.go
@@ -1,0 +1,136 @@
+package drain_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zeta-chain/node/pkg/constant"
+	"github.com/zeta-chain/node/pkg/drain"
+	btccommon "github.com/zeta-chain/node/zetaclient/chains/bitcoin/common"
+)
+
+// viableSubsets exhaustively answers, for a small UTXO set, whether any non-empty subset could be
+// swept at all — cap, the poller's fee bound, and the dust floor — and what the most valuable such
+// subset is worth. Exponential, so callers keep the sets small.
+func viableSubsets(
+	t *testing.T,
+	utxos []drain.UTXO,
+	maxSats, feeRate int64,
+	payee btcutil.Address,
+) (exists bool, bestTotal int64) {
+	t.Helper()
+
+	for mask := 1; mask < (1 << len(utxos)); mask++ {
+		var total, count int64
+		for i := range utxos {
+			if mask&(1<<i) != 0 {
+				total += utxos[i].AmountSats
+				count++
+			}
+		}
+		if total > maxSats || count > int64(btccommon.MaxNoOfInputsPerTx) {
+			continue
+		}
+		size, err := btccommon.EstimateOutboundSize(count, []btcutil.Address{payee})
+		require.NoError(t, err)
+		fee := size * feeRate
+		if fee > total/drain.MaxBTCFeeFraction || total-fee < int64(constant.BTCWithdrawalDustAmount) {
+			continue
+		}
+		exists = true
+		if total > bestTotal {
+			bestTotal = total
+		}
+	}
+	return exists, bestTotal
+}
+
+// TestGenerateBTCTxsCapAgainstExhaustiveSearch is the guard that the cap selection heuristic keeps
+// pace with what is actually possible. Three separate bugs in this logic all had the same shape —
+// a viable subset existed under the cap and the selection emitted nothing, so a rehearsal silently
+// covered no BTC — and each was found by review rather than by a test, because the unit tests only
+// pinned the shapes already thought of.
+//
+// So this compares against brute force over every subset on small random sets, asserting:
+//
+//   - anything emitted is valid: within the cap and inside the poller's fee and dust bounds;
+//   - nothing is emitted when no subset could have been swept;
+//   - something IS emitted whenever some subset could have been.
+//
+// The last is the property the bugs violated. Selection is a heuristic, so this is evidence rather
+// than proof, but it is the check that fails when the next variant appears. The amounts mix dust,
+// medium and wide ranges because the reported failures came from medium UTXOs and dust tails.
+//
+// Not asserted: that the *most* valuable viable subset is chosen. Across this sweep the heuristic
+// picks a smaller viable subset in a few percent of cases, which is a rehearsal sweeping less than
+// it could — harmless, and not worth an exhaustive search in production code.
+func TestGenerateBTCTxsCapAgainstExhaustiveSearch(t *testing.T) {
+	payee := testPayee(t)
+	rng := rand.New(rand.NewSource(42)) // #nosec G404 deterministic test vectors, not security
+
+	amount := func() int64 {
+		switch rng.Intn(3) {
+		case 0:
+			return int64(1 + rng.Intn(2_000)) // dust
+		case 1:
+			return int64(10_000 + rng.Intn(100_000)) // medium: where the reported bugs lived
+		default:
+			return int64(1 + rng.Intn(10_000_000)) // wide
+		}
+	}
+
+	var viable, missed, suboptimal int
+	const iterations = 5000
+
+	for i := 0; i < iterations; i++ {
+		utxos := make([]drain.UTXO, 2+rng.Intn(11))
+		for j := range utxos {
+			utxos[j] = drain.UTXO{TxID: fmt.Sprintf("u%02d", j), Vout: uint32(j), AmountSats: amount()}
+		}
+		feeRate := int64(1 + rng.Intn(200))
+		maxSats := int64(1 + rng.Intn(400_000))
+
+		txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+			ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: utxos, MaxSats: maxSats,
+		})
+		require.NoError(t, err)
+
+		var swept int64
+		for _, tx := range txs {
+			var totalIn int64
+			for _, in := range tx.Inputs {
+				totalIn += in.AmountSats
+			}
+			swept += totalIn
+			require.LessOrEqual(t, totalIn, maxSats, "sweep exceeds the cap")
+			require.LessOrEqual(t, tx.FeeSats, totalIn/drain.MaxBTCFeeFraction, "poller would reject this fee")
+			require.GreaterOrEqual(t, tx.OutputSats, int64(constant.BTCWithdrawalDustAmount))
+			require.Equal(t, totalIn-tx.FeeSats, tx.OutputSats)
+		}
+
+		exists, bestTotal := viableSubsets(t, utxos, maxSats, feeRate, payee)
+		if !exists {
+			require.Empty(t, txs, "emitted a sweep where no viable subset exists")
+			continue
+		}
+
+		viable++
+		switch {
+		case len(txs) == 0:
+			missed++
+			t.Errorf("no sweep emitted though a viable subset exists: feeRate=%d cap=%d utxos=%v",
+				feeRate, maxSats, utxos)
+		case swept < bestTotal:
+			suboptimal++
+		}
+	}
+
+	require.Zero(t, missed, "%d of %d viable cases emitted nothing", missed, viable)
+	// guards the sample itself: if a change made almost nothing viable, "0 misses" would be hollow
+	require.Greater(t, viable, iterations/10, "too few viable cases to be meaningful")
+	t.Logf("viable=%d/%d missed=%d suboptimal=%d", viable, iterations, missed, suboptimal)
+}

--- a/pkg/drain/generate_test.go
+++ b/pkg/drain/generate_test.go
@@ -706,3 +706,74 @@ func TestGenerateBTCTxsCapKeepsCollectivelyViableGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateBTCTxsCapDoesNotLetALargeUTXOCrowdOutAViableSubset(t *testing.T) {
+	payee := testPayee(t)
+	const feeRate = int64(40)
+	const maxSats = int64(100_000)
+
+	// Regression: filling largest-first from the front let the 60,000-sat UTXO take the cap space,
+	// which blocked both 50,000-sat UTXOs and then trimmed away as uneconomical on its own — so a
+	// capped run emitted nothing even though 50,000+50,000 fits the cap and clears the fee bound.
+	// Reported by greptile on #4630.
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 60_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 50_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 50_000},
+	}
+
+	size1, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{payee})
+	require.NoError(t, err)
+	size2, err := btccommon.EstimateOutboundSize(2, []btcutil.Address{payee})
+	require.NoError(t, err)
+	// the largest UTXO is not viable alone...
+	require.Greater(t, size1*feeRate, int64(60_000)/drain.MaxBTCFeeFraction)
+	// ...but the pair of smaller ones is
+	require.LessOrEqual(t, size2*feeRate, int64(100_000)/drain.MaxBTCFeeFraction)
+
+	// ACT
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: feeRate, UTXOs: utxos, MaxSats: maxSats,
+	})
+
+	// ASSERT
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+	require.Len(t, txs[0].Inputs, 2)
+
+	var totalIn int64
+	spent := make([]string, 0, 2)
+	for _, in := range txs[0].Inputs {
+		totalIn += in.AmountSats
+		spent = append(spent, in.TxID)
+	}
+	require.ElementsMatch(t, []string{"bbb", "ccc"}, spent)
+	require.LessOrEqual(t, totalIn, maxSats)
+	require.LessOrEqual(t, txs[0].FeeSats, totalIn/drain.MaxBTCFeeFraction)
+	require.Equal(t, totalIn-txs[0].FeeSats, txs[0].OutputSats)
+}
+
+func TestGenerateBTCTxsCapPrefersTheMostValuableViableSubset(t *testing.T) {
+	payee := testPayee(t)
+
+	// several offsets yield a viable candidate; the one sweeping the most value wins, so a
+	// rehearsal gets as close to the operator's cap as the UTXOs allow
+	utxos := []drain.UTXO{
+		{TxID: "aaa", Vout: 0, AmountSats: 40_000_000},
+		{TxID: "bbb", Vout: 1, AmountSats: 30_000_000},
+		{TxID: "ccc", Vout: 2, AmountSats: 30_000_000},
+	}
+
+	txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+		ChainID: 8332, To: payee, FeeRate: 10, UTXOs: utxos, MaxSats: 70_000_000,
+	})
+	require.NoError(t, err)
+	require.Len(t, txs, 1)
+
+	var totalIn int64
+	for _, in := range txs[0].Inputs {
+		totalIn += in.AmountSats
+	}
+	// 40M+30M = 70M exactly, rather than the 30M+30M an offset candidate would give
+	require.EqualValues(t, 70_000_000, totalIn)
+}

--- a/pkg/drain/generate_test.go
+++ b/pkg/drain/generate_test.go
@@ -580,17 +580,17 @@ func TestMinViableSweepSats(t *testing.T) {
 	}
 }
 
-func TestGenerateBTCTxsCapExcludesInputsBelowTheirMarginalFee(t *testing.T) {
+func TestGenerateBTCTxsCapTrimsInputsThatBreakTheFeeBound(t *testing.T) {
 	payee := testPayee(t)
 	const feeRate = int64(50)
 
-	// Every candidate behind the 90k input is far below what a second input must be worth
-	// (TestGenerateBTCTxsCapMarginalFeeBoundary pins that threshold), so none of them is taken.
+	// Phase 1 takes all three on value alone (they fit the cap), then phase 2 trims the tail until
+	// the group clears the fee bound — which lands back on the 90k input alone, since neither small
+	// input comes near what a second input must be worth (TestGenerateBTCTxsCapMarginalFeeBoundary
+	// pins that threshold at ~29.5k sats here).
 	//
-	// Note this does NOT pin the loop's break-vs-continue choice, and no test can: the fee is
-	// fixed by the current input count and the list is descending, so a candidate that fails the
-	// bound is followed only by candidates that fail it harder. The two are indistinguishable by
-	// construction — the reason to break is that continuing reads as if recovery were possible.
+	// Trimming from the tail is what makes this work: the smallest inputs are the ones that broke
+	// the bound, so they are the ones removed.
 	utxos := []drain.UTXO{
 		{TxID: "big", Vout: 0, AmountSats: 90_000},
 		{TxID: "mid", Vout: 1, AmountSats: 300},
@@ -611,8 +611,8 @@ func TestGenerateBTCTxsCapMarginalFeeBoundary(t *testing.T) {
 	const feeRate = int64(50)
 	const anchor = int64(90_000)
 
-	// What a second input must be worth to be taken, derived from the estimator rather than
-	// hardcoded: with fee2 = size(2) * feeRate and the bound fee <= total/MaxBTCFeeFraction,
+	// What a second input must be worth to survive the trim, derived from the estimator rather
+	// than hardcoded: with fee2 = size(2) * feeRate and the bound fee <= total/MaxBTCFeeFraction,
 	// the smallest qualifying amount is fee2*MaxBTCFeeFraction - anchor. At 50 sat/vB behind a
 	// 90k-sat anchor that is ~29.5k sats — three orders of magnitude above the dust this rule is
 	// usually described as excluding, which is why "it skips dust" undersells it.
@@ -648,4 +648,61 @@ func TestGenerateBTCTxsCapMarginalFeeBoundary(t *testing.T) {
 		totalIn += in.AmountSats
 	}
 	require.LessOrEqual(t, txs[0].FeeSats, totalIn/drain.MaxBTCFeeFraction)
+}
+
+func TestGenerateBTCTxsCapKeepsCollectivelyViableGroups(t *testing.T) {
+	payee := testPayee(t)
+
+	// Regression: judging each input as it was added tested the largest one with total == 0, so a
+	// group that is only economical together was rejected before the fixed part of the fee could be
+	// amortised — the capped run then swept no BTC while the uncapped run over the same UTXOs was
+	// fine. Reported by greptile on #4628/#4629 and reproduced by ws4charlie.
+	tests := []struct {
+		name    string
+		amount  int64
+		feeRate int64
+		maxSats int64
+	}{
+		{"two 15k inputs at 10 sat/vB", 15_000, 10, 30_000},
+		{"two 30k inputs at 20 sat/vB", 30_000, 20, 60_000},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			utxos := []drain.UTXO{
+				{TxID: "aaa", Vout: 0, AmountSats: tc.amount},
+				{TxID: "bbb", Vout: 1, AmountSats: tc.amount},
+			}
+
+			// neither input clears the bound alone...
+			size1, err := btccommon.EstimateOutboundSize(1, []btcutil.Address{payee})
+			require.NoError(t, err)
+			require.Greater(t, size1*tc.feeRate, tc.amount/drain.MaxBTCFeeFraction)
+
+			// ...but the pair does
+			size2, err := btccommon.EstimateOutboundSize(2, []btcutil.Address{payee})
+			require.NoError(t, err)
+			require.LessOrEqual(t, size2*tc.feeRate, 2*tc.amount/drain.MaxBTCFeeFraction)
+
+			// ACT
+			txs, err := drain.GenerateBTCTxs(drain.BTCInput{
+				ChainID: 8332, To: payee, FeeRate: tc.feeRate, UTXOs: utxos, MaxSats: tc.maxSats,
+			})
+
+			// ASSERT: the pair is swept, and the sweep satisfies the poller's bound
+			require.NoError(t, err)
+			require.Len(t, txs, 1)
+			require.Len(t, txs[0].Inputs, 2)
+			require.LessOrEqual(t, txs[0].FeeSats, 2*tc.amount/drain.MaxBTCFeeFraction)
+			require.Equal(t, 2*tc.amount-txs[0].FeeSats, txs[0].OutputSats)
+			require.GreaterOrEqual(t, txs[0].OutputSats, int64(constant.BTCWithdrawalDustAmount))
+
+			// a capped run must not do worse than the uncapped one on the same UTXOs
+			uncapped, err := drain.GenerateBTCTxs(drain.BTCInput{
+				ChainID: 8332, To: payee, FeeRate: tc.feeRate, UTXOs: utxos,
+			})
+			require.NoError(t, err)
+			require.Equal(t, uncapped, txs)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes a real bug in #4624: a capped BTC rehearsal could sweep nothing even though a viable subset existed under the cap.

`selectCappedUTXOs` judged each input as it was added, which tests the largest one with `total == 0`. A group that is only economical *together* was rejected before the fixed part of the fee could be amortised:

```
2x15,000 sats at 10 sat/vB, cap 30,000
  single input: fee 1710 vs allowance 1500 -> rejected
  as a pair:    fee 2390 vs allowance 3000 -> viable
  CAPPED -> 0 txs / UNCAPPED -> 1 tx
```

That is the same failure mode #4624 set out to remove — a capped run silently covering no BTC — just reached from the other direction.

## Fix

Selection is now two-phase:

1. **Fill** largest-first on value alone, up to the cap and one tx worth of inputs.
2. **Trim** the tail until the completed group clears `fee <= total/MaxBTCFeeFraction`.

Trimming from the tail preserves what the per-input check was there for — the marginal input that broke the bound is the first one removed, so the "a 300-sat top-up destroys a viable 90k sweep" case still resolves to the 90k input alone — while letting groups form that are unviable in isolation. A non-empty result is still economical by construction, since phase 2 tests the completed group against the poller's own bound.

## Same root cause in the operator message

`reportUnviableBTCCap` looked for the smallest single UTXO above `MinViableSweepSats` and, finding none, told the operator **no cap could ever rehearse BTC** — wrong for exactly the wallets above.

`MinViableSweepSats` is a floor on the sweep's *total*, not a per-UTXO requirement: the fee grows with input count while the bound scales with the total, so one input is the cheapest shape a viable sweep can take, which makes it a floor for any input count. The only sound impossibility test is against the **whole balance**. Reworded, and it now points at the floor instead of at a specific UTXO.

## Credit

Found by greptile on the v37/v38 backports (#4628 / #4629) and reproduced independently by @ws4charlie, who also confirmed the uncapped path was unaffected.

## Tests

- `TestGenerateBTCTxsCapKeepsCollectivelyViableGroups` covers both reported shapes and asserts a capped run never does worse than the uncapped one over the same UTXOs.
- `TestReportUnviableBTCCap` now pins that impossibility is only claimed against the whole balance, and that a wallet whose UTXOs clear the floor only as a group is not declared un-rehearsable.
- Existing guards still hold: the mainnet-shaped sweep over `{10,50} sat/vB × {100k … 20M}` asserting nothing emitted can violate `validateBTCFee`, the dust top-up case, the marginal-fee boundary, and determinism under shuffled input.

`go build` with and without `-tags drain`, `go vet`, `pkg/drain`, `cmd/zetatool` and `zetaclient/drain` suites all green.

## Backports

#4628 / #4629 will carry this commit so `pkg/drain` stays byte-identical across `main`, `release/zetaclient/v37` and `v38`.

---

## Update: further review findings

**Greedy fill could still miss a viable subset** (greptile). Filling largest-first from the front let one UTXO hog the cap — at 40 sat/vB with a 100,000-sat cap the 60,000-sat UTXO is taken, blocks both 50,000-sat UTXOs, then trims away as uneconomical, while 50,000+50,000 was viable. Candidates are now built from every starting offset and the best viable one wins (most value swept, fewest inputs to break a tie).

This was the **third** bug of the same shape, and all three were found by review rather than by tests, because the unit tests only pinned shapes already thought of. So `TestGenerateBTCTxsCapAgainstExhaustiveSearch` now brute-forces every subset on small random sets and asserts a sweep is emitted whenever anything was sweepable, nothing is emitted when nothing was, and nothing emitted would be rejected by the poller. 5000 cases, 1008 viable, **no miss**; a smaller-than-optimal viable subset in ~3%, documented as accepted rather than asserted. Selection is still a heuristic, so this is evidence rather than proof — the docs no longer imply an empty result proves impossibility.

**`--btc-max-sats 0` was silently "uncapped"** (@julianrubino) while `--evm-max-amount 0` errors, so typing `0` meaning "no BTC" gave the full BTC drain. Now rejected via `cmd.Flags().Changed()`, pointing at `--exclude-chains`, extracted as `parseBTCMaxSats` and unit-tested.

Julian's other two notes needed no change: the skip-not-abort path is unreachable for the uncapped real drain (`GenerateBTCTxs` can only error when `MaxSats > 0`), and the extra `ethclient.Dial` matches the file's existing convention — both answered inline.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes capped BTC rehearsals that previously emitted no transaction despite an economical subset existing, and improves related operator guidance and cap validation.
- Builds and trims deterministic candidates from every UTXO starting offset, selecting the viable candidate that sweeps the most value.
- Corrects the no-sweep diagnostic to reason about total wallet balance rather than individual UTXOs.
- Rejects an explicitly supplied zero BTC cap instead of interpreting it as an uncapped drain.
- Adds exhaustive-subset comparison tests and focused regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/drain/generate.go | Reworks capped UTXO selection to evaluate fill-and-trim candidates from every sorted offset, resolving the previously reported crowd-out case while preserving deterministic output. |
| pkg/drain/generate_cap_property_test.go | Compares capped selection against exhaustive subset viability over deterministic randomized cases and validates emitted fee, dust, and cap constraints. |
| pkg/drain/generate_test.go | Adds regression coverage for collectively viable groups and the previously reported large-UTXO crowd-out scenario. |
| cmd/zetatool/cli/drain.go | Corrects no-sweep operator guidance and distinguishes an omitted BTC cap from an explicitly supplied zero. |
| cmd/zetatool/cli/drain_cap_test.go | Covers total-balance viability messaging and explicit-zero BTC cap validation. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Sort UTXOs deterministically] --> B[Build candidate from each starting offset]
  B --> C[Fill largest-first under cap and input limit]
  C --> D[Trim smallest inputs until fee bound passes]
  D --> E{Candidate viable?}
  E -- No --> B
  E -- Yes --> F[Compare total value and input-count tie-break]
  F --> B
  B --> G[Emit best viable capped sweep or no BTC transaction]
```

<sub>Reviews (2): Last reviewed commit: ["fix(zetatool): stop a large UTXO crowdin..."](https://github.com/zeta-chain/node/commit/18c37e01024d946357583510df1b20efe502a850) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53406370)</sub>

<!-- /greptile_comment -->