### PR TITLE
fix(ci): build drain artifacts inside goreleaser-cross, not bare ubuntu-latest

### DIFF
--- a/.github/workflows/build-drain-artifacts.yml
+++ b/.github/workflows/build-drain-artifacts.yml
@@ -58,37 +58,47 @@ jobs:
           ref: ${{ env.SERVER_REF }}
           path: server
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: client/go.mod
-
-      - name: Install cross toolchain
+      # Cross-compile inside the SAME pinned goreleaser-cross image the real
+      # zetaclientd releases use (Makefile GORELEASER / .goreleaser-zetaclient.yaml),
+      # instead of bare `apt-get install gcc-aarch64-linux-gnu` on whatever glibc
+      # ubuntu-latest happens to ship that week. The prior version of this workflow
+      # built on plain ubuntu-latest and produced a binary requiring GLIBC_2.38,
+      # which the signer hosts don't have -- zetaclientd failed at the dynamic
+      # linker before main() ever ran, so it silently never armed the drain poller.
+      # This is exactly the toolchain that already produces the binaries running
+      # successfully on those same hosts today.
+      - name: Write build script
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-                                  gcc-x86-64-linux-gnu g++-x86-64-linux-gnu
-
-      - name: Build
-        env:
-          ARCH: ${{ matrix.arch }}
-          CGO_ENABLED: '1'
-        run: |
+          cat > build.sh <<'SCRIPT'
           set -euo pipefail
-          if [ "$ARCH" = "arm64" ]; then export CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++; else export CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++; fi
-          export GOOS=linux GOARCH="$ARCH"
+          ARCH="$1"
+          if [ "$ARCH" = "arm64" ]; then CC=aarch64-linux-gnu-gcc; CXX=aarch64-linux-gnu-g++; else CC=x86_64-linux-gnu-gcc; CXX=x86_64-linux-gnu-g++; fi
+          export CGO_ENABLED=1 GOOS=linux GOARCH="$ARCH" CC CXX
           # Only the DBBackend ldflag is functional; the rest is version cosmetics.
           LDBASE="-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -s -w"
           mkdir -p dist
 
-          echo "--> zetaclientd (drain) linux/${ARCH} from ${CLIENT_REF}"
+          echo "--> zetaclientd (drain) linux/${ARCH}"
           ( cd client && go build -tags pebbledb,ledger,drain \
               -ldflags "$LDBASE -X github.com/zeta-chain/node/pkg/constant.CommitHash=$(git rev-parse --short HEAD)" \
               -o "../dist/zetaclientd-drain-linux-${ARCH}" ./cmd/zetaclientd )
 
-          echo "--> zetatool linux/${ARCH} from ${SERVER_REF}"
+          echo "--> zetatool linux/${ARCH}"
           ( cd server && go build -tags pebbledb,ledger \
               -ldflags "$LDBASE -X github.com/zeta-chain/node/pkg/constant.CommitHash=$(git rev-parse --short HEAD)" \
               -o "../dist/zetatool-linux-${ARCH}" ./cmd/zetatool )
+          SCRIPT
+
+      - name: Build (goreleaser-cross v1.22.7, same image release-template.yml uses)
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          mkdir -p dist
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            ghcr.io/goreleaser/goreleaser-cross:v1.22.7@sha256:24b2d75007f0ec8e35d01f3a8efa40c197235b200a1a91422d78b851f67ecce4 \
+            bash build.sh "${ARCH}"
 
           ( cd dist && sha256sum * > "SHA256SUMS-${ARCH}.txt" && cat "SHA256SUMS-${ARCH}.txt" )
 


### PR DESCRIPTION
## Summary

The `Build Drain Artifacts` workflow cross-compiled `zetaclientd-drain` with `apt-get install gcc-aarch64-linux-gnu` directly on `ubuntu-latest`, linking against whatever glibc that runner ships. Deployed to a live testnet signer and confirmed broken:

```
zetaclientd: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by zetaclientd)
```

Process dies at the dynamic linker before `main()` runs, so the drain poller never logs anything — not even `drain not armed`. From the outside this is indistinguishable from an env-var/config problem, which is exactly what it looked like during the rehearsal until `systemctl status` surfaced the real error.

## Fix

Real `zetaclientd` releases avoid this by cross-compiling inside a pinned `ghcr.io/goreleaser/goreleaser-cross:v1.22.7` image (`Makefile` `GORELEASER` target / `.goreleaser-zetaclient.yaml`) — same `CC`/`CXX` names (`aarch64-linux-gnu-gcc` etc.), different (older, matched-to-production) glibc baseline. This workflow now builds inside that same image instead of bare `ubuntu-latest`, so it produces binaries with the same glibc floor as what's already running successfully on these hosts.

No change to build tags, ldflags, or output filenames — only where the compilation happens.

## Verification

- Extracted the exact bash heredoc YAML produces and ran it locally (`bash -n`) — syntax clean, `build.sh` generated correctly, terminator lines up (YAML block-scalar indentation stripped uniformly).
- Not yet re-run in CI — merging this and re-dispatching is the next step, needed to unblock the in-progress testnet drain rehearsal.

## Scope

CI-only change, this workflow file only. No production code, no deploy step — matches the existing "Low Risk" classification from the workflow's original review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no application or deploy logic; risk is limited to whether the Docker build step succeeds in Actions.
> 
> **Overview**
> The **Build Drain Artifacts** workflow no longer cross-compiles on plain `ubuntu-latest` with `setup-go` and `apt-get` cross GCC packages. It now writes a `build.sh` and runs the same `go build` steps inside the **pinned** `ghcr.io/goreleaser/goreleaser-cross:v1.22.7` image used for real `zetaclientd` releases (`Makefile` / release workflows).
> 
> That aligns drain binaries with the **older glibc baseline** production signers already run, instead of linking against newer runner glibc (e.g. `GLIBC_2.38`), which caused `zetaclientd-drain` to fail at the dynamic linker before `main()`. **Build tags, ldflags, output names, and checksum/upload steps are unchanged**—only where compilation runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a188665453484cee381d9df9b87e54096ec3bd53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves drain-artifact cross-compilation from the hosted runner into the digest-pinned goreleaser-cross image to target the production glibc baseline.
- Generates a shared build script for the amd64 and arm64 matrix jobs.
- Bind-mounts the checked-out client and server repositories into the cross-compilation container.
- Preserves the existing artifact names, build tags, linker flags, checksums, and uploads.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until the container invocation explicitly runs the build script rather than passing it to Goreleaser.

The new Build step never executes build.sh because the image entrypoint interprets the supplied shell command as Goreleaser arguments, leaving both matrix jobs without artifacts.

**Files Needing Attention:** .github/workflows/build-drain-artifacts.yml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-drain-artifacts.yml | Moves compilation into goreleaser-cross, but invokes the intended shell script without overriding the image’s Goreleaser entrypoint, preventing artifact generation. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant GHA as GitHub Actions
  participant Docker as Docker
  participant Entry as goreleaser-cross entrypoint
  participant GR as Goreleaser
  participant Script as build.sh
  GHA->>Docker: run image bash build.sh ARCH
  Docker->>Entry: /entrypoint.sh bash build.sh ARCH
  Entry->>GR: goreleaser bash build.sh ARCH
  GR-->>GHA: invalid command / failure
  Note over Script: Never executed
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/build-drain-artifacts.yml:97-101
**Goreleaser entrypoint swallows build script**

When either matrix job reaches this step, the image entrypoint runs `goreleaser bash build.sh <arch>` instead of executing `build.sh`, causing the build to fail without producing or uploading drain artifacts.

```suggestion
          docker run --rm \
            -v "${{ github.workspace }}:/workspace" \
            -w /workspace \
            --entrypoint bash \
            ghcr.io/goreleaser/goreleaser-cross:v1.22.7@sha256:24b2d75007f0ec8e35d01f3a8efa40c197235b200a1a91422d78b851f67ecce4 \
            build.sh "${ARCH}"
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): build drain artifacts inside go..."](https://github.com/zeta-chain/node/commit/a188665453484cee381d9df9b87e54096ec3bd53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56425111)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->