### PR TITLE
fix(ci): override goreleaser-cross entrypoint in drain build

### DIFF
--- a/.github/workflows/build-drain-artifacts.yml
+++ b/.github/workflows/build-drain-artifacts.yml
@@ -94,11 +94,15 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           mkdir -p dist
+          # goreleaser-cross's image ENTRYPOINT is the goreleaser binary itself, so a plain
+          # `docker run <image> bash build.sh` gets parsed as `goreleaser bash build.sh` --
+          # override it to actually get a shell.
           docker run --rm \
+            --entrypoint bash \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ghcr.io/goreleaser/goreleaser-cross:v1.22.7@sha256:24b2d75007f0ec8e35d01f3a8efa40c197235b200a1a91422d78b851f67ecce4 \
-            bash build.sh "${ARCH}"
+            build.sh "${ARCH}"
 
           ( cd dist && sha256sum * > "SHA256SUMS-${ARCH}.txt" && cat "SHA256SUMS-${ARCH}.txt" )
 


### PR DESCRIPTION
Follow-up to #4632, which fixed the glibc mismatch but the re-dispatched build (run 32781022216) failed on both arches with `error=unknown command "bash" for "goreleaser release"` — the image's ENTRYPOINT is `goreleaser` itself, so `docker run <image> bash build.sh` was parsed as a goreleaser subcommand, not a shell call. `--entrypoint bash` fixes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Docker invocation fix with no runtime or application code changes.
> 
> **Overview**
> Fixes the **Build Drain Artifacts** workflow so cross-compilation inside `goreleaser-cross` actually runs `build.sh` instead of treating `bash` as a `goreleaser` subcommand.
> 
> The `docker run` step now passes **`--entrypoint bash`** and invokes **`build.sh "${ARCH}"`** directly (with a short comment explaining the image’s default ENTRYPOINT). No change to the build script, image pin, or artifact upload—only how the container is started after the glibc/toolchain follow-up in #4632.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c704afd0dcd4613e0e26a6b5bbae786ebe7dc12c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the drain-artifact container invocation by overriding the goreleaser-cross image entrypoint with Bash.
- Adds `--entrypoint bash` to prevent the image from interpreting `bash` as a goreleaser subcommand.
- Passes `build.sh` and the target architecture directly as Bash arguments.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete actionable defects established in the entrypoint correction.

The updated Docker command consistently selects Bash as the container entrypoint and supplies the existing build script and architecture argument in the expected command position.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-drain-artifacts.yml | Correctly overrides the container entrypoint so the existing cross-compilation script is invoked through Bash. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): override goreleaser-cross&#39;s ent..."](https://github.com/zeta-chain/node/commit/c704afd0dcd4613e0e26a6b5bbae786ebe7dc12c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56426969)</sub>

<!-- /greptile_comment -->