### PR TITLE
fix(ci): disable go build VCS auto-stamping in drain build

### DIFF
--- a/.github/workflows/build-drain-artifacts.yml
+++ b/.github/workflows/build-drain-artifacts.yml
@@ -79,12 +79,12 @@ jobs:
           mkdir -p dist
 
           echo "--> zetaclientd (drain) linux/${ARCH}"
-          ( cd client && go build -tags pebbledb,ledger,drain \
+          ( cd client && go build -buildvcs=false -tags pebbledb,ledger,drain \
               -ldflags "$LDBASE -X github.com/zeta-chain/node/pkg/constant.CommitHash=$(git rev-parse --short HEAD)" \
               -o "../dist/zetaclientd-drain-linux-${ARCH}" ./cmd/zetaclientd )
 
           echo "--> zetatool linux/${ARCH}"
-          ( cd server && go build -tags pebbledb,ledger \
+          ( cd server && go build -buildvcs=false -tags pebbledb,ledger \
               -ldflags "$LDBASE -X github.com/zeta-chain/node/pkg/constant.CommitHash=$(git rev-parse --short HEAD)" \
               -o "../dist/zetatool-linux-${ARCH}" ./cmd/zetatool )
           SCRIPT


### PR DESCRIPTION
Third fix in this chain (#4632 glibc, #4633 entrypoint). Build got past both and then hit `error obtaining VCS status: exit status 128` on both arches — go build's own git status probing fails in the container due to bind-mount UID mismatch ("dubious ownership"). `-buildvcs=false` per Go's own suggested remedy in the error output; the explicit `-ldflags CommitHash=$(git rev-parse --short HEAD)` stamp is untouched and already works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; binary versioning via explicit ldflags is preserved and runtime drain logic is untouched.
> 
> **Overview**
> Fixes drain-artifact CI builds that were failing with `error obtaining VCS status` when `go build` probes git inside the goreleaser-cross container (bind-mount ownership / “dubious ownership”).
> 
> Both **`zetaclientd-drain`** and **`zetatool`** `go build` invocations in `build-drain-artifacts.yml` now pass **`-buildvcs=false`**, so Go skips automatic VCS metadata embedding. The existing **`-ldflags … CommitHash=$(git rev-parse --short HEAD)`** stamping is unchanged and still supplies the commit hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b84705bcec54d478ee82b8d4df0ee755226bb1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables Go’s automatic VCS stamping for both binaries in the drain-artifact workflow, avoiding Git ownership failures inside the cross-compilation container while preserving the explicit commit-hash linker stamp.
- Adds `-buildvcs=false` to the `zetaclientd` drain build.
- Adds the same flag to the `zetatool` build.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the configured toolchain supports the new flag and repository version reporting does not rely on the disabled automatic VCS metadata.

Both drain-artifact builds retain their explicit CommitHash linker value, and no concrete build, runtime, metadata, or security regression remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-drain-artifacts.yml | Disables redundant automatic VCS metadata collection on both Go builds without altering the workflow’s explicit commit-hash stamping. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): disable go build&#39;s VCS auto-sta..."](https://github.com/zeta-chain/node/commit/22b84705bcec54d478ee82b8d4df0ee755226bb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56429216)</sub>

<!-- /greptile_comment -->