### PR TITLE
chore: key Bitcoin testnet4 DNS seeds

### DIFF
--- a/pkg/chains/bitcoin_testnet4.go
+++ b/pkg/chains/bitcoin_testnet4.go
@@ -113,8 +113,8 @@ var TestNet4Params = chaincfg.Params{
 	Net:         TestNet4,
 	DefaultPort: "48333",
 	DNSSeeds: []chaincfg.DNSSeed{
-		{"seed.testnet4.bitcoin.sprovoost.nl", true},
-		{"seed.testnet4.wiz.biz", true},
+		{Host: "seed.testnet4.bitcoin.sprovoost.nl", HasFiltering: true},
+		{Host: "seed.testnet4.wiz.biz", HasFiltering: true},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use keyed `chaincfg.DNSSeed` literals for the Bitcoin testnet4 seeds. This removes the unkeyed-field vet warning and makes it clear that each value sets `Host` and `HasFiltering`.

There is no behavior change.

# How Has This Been Tested?

<!--- Please describe the tests that you ran to verify your changes. Include instructions and any relevant details so others can reproduce. Link any optional github actions runs. -->

- [ ] Tested CCTX in localnet
- [ ] Tested in development environment
- [x] Go unit tests
- [x] Go integration tests
- [x] Tested via GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic struct literal change in testnet4 chain params; no logic, security, or data-path impact.
> 
> **Overview**
> Updates `TestNet4Params.DNSSeeds` in `bitcoin_testnet4.go` to use explicit `Host` and `HasFiltering` fields on each `chaincfg.DNSSeed` entry instead of positional struct literals.
> 
> This is a readability and static-analysis fix only—the same two seeds and filtering flag as before, with no runtime or networking behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0194e6c41a2344b418156c1b38f7789628680bd8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces positional Bitcoin testnet4 DNS seed literals with equivalent keyed `Host` and `HasFiltering` fields, improving clarity and eliminating the unkeyed-field vet warning without changing configured values.
- Preserves both existing testnet4 DNS seed hosts.
- Preserves DNS filtering as enabled for each seed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it preserves the existing DNS seed values and behavior.

The only changes replace positional struct initialization with explicit field names while retaining identical host strings and filtering values, and no actionable defect was identified.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pkg/chains/bitcoin_testnet4.go | Converts two `chaincfg.DNSSeed` values to keyed literals while preserving their hosts and filtering settings. |

<sub>Reviews (1): Last reviewed commit: ["chore: key Bitcoin testnet4 DNS seeds"](https://github.com/zeta-chain/node/commit/0194e6c41a2344b418156c1b38f7789628680bd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57548310)</sub>

<!-- /greptile_comment -->