### PR TITLE
fix(security): bump evm to GHSA Aug-2026 patched commit (mainnet/v36)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -415,7 +415,7 @@ replace (
 	// which is a fork of https://github.com/threshold-network/tss-lib
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 
-	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20250821154530-f0addce1e5ac
+	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
 )

--- a/go.sum
+++ b/go.sum
@@ -1961,6 +1961,8 @@ github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtC
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zeta-chain/evm v0.0.0-20250821154530-f0addce1e5ac h1:OQYitaQxJqWzyGvXq5EGJksQSXK+0XEdjgCc91BsYTM=
 github.com/zeta-chain/evm v0.0.0-20250821154530-f0addce1e5ac/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
+github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34 h1:rBuDVBifvIJn0CDHkBpre1+/4pc6P8KuVrTjo1I0tE4=
+github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
 github.com/zeta-chain/go-tss v0.6.3 h1:c/zSEvI0h7MJ+xxu42M58uBdEWrlzfD3NI1kP/FlWBE=


### PR DESCRIPTION
Mainnet (node `release/v36`) node-side of the fix. **One line**: bumps the `cosmos/evm` replace to the patched commit.

```
github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34
```

`51190f04` is the current tip of `zeta-chain/evm`'s `release/v35` — the fork line mainnet's v36 pins — after [zeta-chain/evm#36](https://github.com/zeta-chain/evm/pull/36) merged. It carries:

- `SubBalance` underflow guard + `ParseAmount` extended-denom handling
- `AddBalance` overflow guard
- `StateDB.Commit()` atomicity (cache-context staging)
- the module-account guard, gated on the chain's blocked-receive policy
- snapshot locked balance on the statedb account
- `x/ibc/callbacks` `onPacketTimeout`: `cachedCtx`, not the live `ctx`

- **Logic-only**: no module-set change, no store migration, **no upgrade handler** → ships as an ordinary `v36.x` patch (handlers key on major version).
- Vesting-module drop is intentionally **NOT** here — it changes the module version map and needs a coordinated upgrade; separate, non-urgent.

### Note on the pin

Pinned to the merged `release/v35` tip rather than to a commit on the PR branch. #36 was squash-merged, so the pre-merge commits are unreachable from any branch and a pseudo-version naming one of them would break as soon as the PR branch is deleted.

The `v0.0.0-` prefix matches the existing convention in this `replace` block. Note that `go mod tidy` would canonicalise it to `v1.0.0-rc2.0.20260903155132-51190f042d34` (the repo has a reachable `v1.0.0-rc2` tag); both resolve to the same commit but hash differently in `go.sum`, so don't mix the two forms.

### Verification

`go build ./cmd/zetacored` is green and produces a working binary. No `GOPRIVATE` needed — the evm dependency is public.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus-critical EVM/state and IBC callback behavior via a dependency swap; incorrect pinning or missed rollout could leave nodes on vulnerable logic despite no local code diff.
> 
> **Overview**
> **Security patch for mainnet `release/v36`**: bumps only the `replace` pin for `github.com/cosmos/evm` to `github.com/zeta-chain/evm` at commit `51190f042d34` (tip of the fork’s `release/v35` line after [zeta-chain/evm#36](https://github.com/zeta-chain/evm/pull/36)), with matching `go.sum` entries.
> 
> No node application code, module set, store migrations, or upgrade handlers change—this ships as a normal **v36.x** patch binary that pulls in upstream EVM fixes (balance underflow/overflow guards, `StateDB.Commit` atomicity, module-account receive policy, snapshot locked balance, IBC callback timeout context isolation, and related hardening).
> 
> The pin uses the existing `v0.0.0-…` pseudo-version convention rather than `go mod tidy`’s `v1.0.0-rc2.0.…` form so `go.sum` stays consistent with prior pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de9c7180325b2db39938798332338ecbc7ebbf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR advances the `github.com/cosmos/evm` replacement to the patched ZetaChain EVM commit for the mainnet v36 release line.
- Updates the replacement pseudo-version in `go.mod`.
- Adds the corresponding module and `go.mod` checksums to `go.sum`.
- Leaves the dependency manifest and transitive version graph otherwise unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the dependency pin and checksums aligned and no changed-code defect identified.

The replacement advances only the EVM source revision, preserves the module dependency graph, and includes matching checksums; the stated node build verification further confirms that the pin resolves and compiles.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| go.mod | Updates the Cosmos EVM replacement to the intended patched fork commit without changing other dependency versions. |
| go.sum | Adds checksums corresponding to the new EVM pseudo-version; its module-manifest checksum matches the previous pin. |

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump cosmos/evm to GHSA A..."](https://github.com/zeta-chain/node/commit/5de9c7180325b2db39938798332338ecbc7ebbf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60015670)</sub>

<!-- /greptile_comment -->