### PR TITLE
fix(security): bump evm to GHSA Aug-2026 patched commit (testnet/v37)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ replace (
 	// which is a fork of https://github.com/threshold-network/tss-lib
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 
-	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348
+	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/gagliardetto/solana-go => github.com/zeta-chain/solana-go v0.0.0-20250919220552-6800a0427762
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4

--- a/go.sum
+++ b/go.sum
@@ -1955,6 +1955,8 @@ github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtC
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348 h1:Ta+tRdJ608We92ybjAUrOZ8SwnMP7YJM3v4K7HqT/co=
 github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
+github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214 h1:ZhDgxFGo8+VC4874CEyj7ZaFan0nfGB7dsuDquzmyNY=
+github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4/go.mod h1:TBv5NY/CqWYIfUstXO1fDWrt4bDoqgCw79yihqBspg8=
 github.com/zeta-chain/go-tss v0.6.3 h1:c/zSEvI0h7MJ+xxu42M58uBdEWrlzfD3NI1kP/FlWBE=


### PR DESCRIPTION
Testnet (node `release/zetacore/v37`) node-side. One line: bumps `cosmos/evm` to the patched v37 commit.

```
github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214
```

`a69d910e` is the current tip of `zeta-chain/evm`'s `release/v37` — the fork line testnet's v37 pins — after [zeta-chain/evm#37](https://github.com/zeta-chain/evm/pull/37) merged. Same guard set as mainnet.

Validate on **testnet first**, then promote mainnet.

### Note on the pin

Pinned to the merged `release/v37` tip, not a PR-branch commit: #37 was squash-merged, so the pre-merge commits are unreachable and such a pin would break once the branch is deleted.

The `v0.0.0-` prefix matches the existing convention in this `replace` block; `go mod tidy` would canonicalise it to `v1.0.0-rc2.0.20260903155126-a69d910e9214`. Both name the same commit but hash differently in `go.sum`.

### Verification

`go build ./cmd/zetacored` is green and produces a working binary. No `GOPRIVATE` needed — the evm dependency is public.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the forked EVM stack used for ante, VM, and feemarket paths; security-critical but scoped to a known patched commit with no local logic changes.
> 
> **Overview**
> Updates the **`github.com/cosmos/evm` → `github.com/zeta-chain/evm`** `replace` pin in `go.mod` from commit `515bbca4d348` to **`a69d910e9214`** (current `release/v37` tip after the security backport), with matching **`go.sum`** entries.
> 
> This is a **dependency-only** change for the testnet **`release/zetacore/v37`** line: node code is unchanged, but builds now pull the **GHSA Aug-2026–patched** EVM fork instead of the previous pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eefd380357fd233a92d93f798125aeae4c31e42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the testnet v37 `github.com/cosmos/evm` replacement to the patched `zeta-chain/evm` release commit.
- Updates the EVM fork pseudo-version in `go.mod`.
- Adds the corresponding module and module-metadata checksums to `go.sum`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the replacement version and integrity hashes updated consistently and no actionable defect identified.

The change is limited to an EVM fork revision and its matching checksums; available repository evidence does not establish a build, runtime, dependency-resolution, or newly introduced security failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| go.mod | Updates the Cosmos EVM replacement to the patched release/v37 fork commit; no concrete compatibility or dependency-graph defect was identified. |
| go.sum | Adds checksums corresponding to the new EVM fork revision while retaining harmless historical checksum entries. |

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump cosmos/evm to GHSA A..."](https://github.com/zeta-chain/node/commit/6eefd380357fd233a92d93f798125aeae4c31e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60015687)</sub>

<!-- /greptile_comment -->