### PR TITLE
fix(security): pin evm to the deployed commit, not the merged tip (mainnet/v36)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -415,7 +415,7 @@ replace (
 	// which is a fork of https://github.com/threshold-network/tss-lib
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 
-	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34
+	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260825060942-3e5f8e5337fa
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4
 )

--- a/go.sum
+++ b/go.sum
@@ -1961,6 +1961,8 @@ github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtC
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zeta-chain/evm v0.0.0-20250821154530-f0addce1e5ac h1:OQYitaQxJqWzyGvXq5EGJksQSXK+0XEdjgCc91BsYTM=
 github.com/zeta-chain/evm v0.0.0-20250821154530-f0addce1e5ac/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
+github.com/zeta-chain/evm v0.0.0-20260825060942-3e5f8e5337fa h1:frp1Fm3MID6hpg8ldFDI7looMqAwo00+P4fa1hGgMnw=
+github.com/zeta-chain/evm v0.0.0-20260825060942-3e5f8e5337fa/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34 h1:rBuDVBifvIJn0CDHkBpre1+/4pc6P8KuVrTjo1I0tE4=
 github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=


### PR DESCRIPTION
Repins `cosmos/evm` to the commit live **v36.0.6** was built from.

```
- github.com/zeta-chain/evm v0.0.0-20260903155132-51190f042d34   (#4637, merged release/v35 tip)
+ github.com/zeta-chain/evm v0.0.0-20260825060942-3e5f8e5337fa   (what v36.0.6 ships)
```

### Why

#4637 pinned the squash-merged `release/v35` tip. That tip includes the follow-up commit re-gating the module-account guard on the chain's blocked-receive policy:

```go
// 51190f04 — what #4637 pinned
if delta.Sign() != 0 && k.bankWrapper.BlockedAddr(cosmosAddr) {

// 3e5f8e53 — what live v36.0.6 runs
if delta.Sign() != 0 {
    if acct := k.accountKeeper.GetAccount(ctx, cosmosAddr); acct != nil {
        if _, isModule := acct.(sdk.ModuleAccountI); isModule {
```

ZetaChain's blocked-receive set is a **strict subset** of its module accounts — `x/fungible`, `x/crosschain` and emissions are deliberately not blocked. So for an unblocked module account with a non-zero delta the two forms take different branches: reject vs. mint/burn. Same input, different state transition — consensus-breaking, and it cannot ship as a `v36.0.x` patch.

The private node PR pinned `3e5f8e53` deliberately for this reason; the blocked-receive guard was always meant to ship separately as a coordinated upgrade. Repinning to the merged tip collapsed that separation, because the squash merge made the pre-gating commit unselectable from `release/v35`.

The guard change is still wanted — it fixes real breakage around sends to emissions — just not in a patch release.

### Note

`3e5f8e53` is reachable via the `sec/mainnet-v36-complete` branch on `zeta-chain/evm`. **Do not delete that branch** while this pin is live, or tag the commit to make it permanent.

### Verification

`go build ./cmd/zetacored` green. Guard confirmed as the `isModule` form in the downloaded module, not just by SHA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wrong EVM fork semantics directly affect consensus state transitions for module-account balance updates; correct pinning is security-critical for patch releases.
> 
> **Overview**
> **Repins** the `github.com/cosmos/evm` replace from `zeta-chain/evm` commit `51190f042d34` back to `3e5f8e5337fa`, matching what **v36.0.6** on mainnet actually runs. `go.sum` is updated for the new pseudo-version.
> 
> This reverses a pin that tracked the squash-merged `release/v35` tip, which pulled in **blocked-receive** gating on balance deltas for module accounts. On ZetaChain, blocked-receive is a strict subset of module accounts, so that newer logic can **reject** transfers the live binary would **mint/burn**—a consensus-breaking divergence unsuitable for a `v36.0.x` patch. The guard change remains intended for a later coordinated upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f3dae0e664ef8c028bb1646510bfd4517d16ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Repins the Cosmos EVM replacement to the commit used by deployed v36.0.6, preserving patch-release consensus behavior.
- Changes the `github.com/cosmos/evm` replacement from `51190f042d34` to `3e5f8e5337fa`.
- Adds the corresponding module and module-file checksums.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it restores the deployed EVM revision without changing the module dependency graph.

The replacement version and checksums are internally consistent, and no reachable build, runtime, consensus, or security regression caused by the repin was established.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| go.mod | Repins the EVM fork to the checksum-recorded revision used by the deployed release; no actionable defect was established. |
| go.sum | Adds matching checksums for the selected EVM revision while retaining prior version entries. |

<sub>Reviews (1): Last reviewed commit: ["fix(security): pin evm to the deployed c..."](https://github.com/zeta-chain/node/commit/55f3dae0e664ef8c028bb1646510bfd4517d16ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60039514)</sub>

<!-- /greptile_comment -->