### PR TITLE
fix(security): pin evm to the deployed commit, not the merged tip (testnet/v37)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -413,7 +413,7 @@ replace (
 	// which is a fork of https://github.com/threshold-network/tss-lib
 	github.com/bnb-chain/tss-lib => github.com/zeta-chain/tss-lib v0.0.0-20240916163010-2e6b438bd901
 
-	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214
+	github.com/cosmos/evm => github.com/zeta-chain/evm v0.0.0-20260825061144-198da04bfbd3
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/gagliardetto/solana-go => github.com/zeta-chain/solana-go v0.0.0-20250919220552-6800a0427762
 	github.com/libp2p/go-libp2p => github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4

--- a/go.sum
+++ b/go.sum
@@ -1955,6 +1955,8 @@ github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtC
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348 h1:Ta+tRdJ608We92ybjAUrOZ8SwnMP7YJM3v4K7HqT/co=
 github.com/zeta-chain/evm v0.0.0-20250917210719-515bbca4d348/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
+github.com/zeta-chain/evm v0.0.0-20260825061144-198da04bfbd3 h1:MNV4nHexIwFZWqvPUnmpRdwW/sKNjlJY7ItRuLeTFbU=
+github.com/zeta-chain/evm v0.0.0-20260825061144-198da04bfbd3/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214 h1:ZhDgxFGo8+VC4874CEyj7ZaFan0nfGB7dsuDquzmyNY=
 github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214/go.mod h1:WfvV0raMAIEEa5MX6kp8VyELvkwBTNw8JNVlAXtKAXA=
 github.com/zeta-chain/go-libp2p v0.0.0-20240710192637-567fbaacc2b4 h1:FmO3HfVdZ7LzxBUfg6sVzV7ilKElQU2DZm8PxJ7KcYI=


### PR DESCRIPTION
Repins `cosmos/evm` to the commit live **v37.0.3** was built from.

```
- github.com/zeta-chain/evm v0.0.0-20260903155126-a69d910e9214   (#4638, merged release/v37 tip)
+ github.com/zeta-chain/evm v0.0.0-20260825060942-198da04bfbd3   (what v37.0.3 ships)
```

### Why

#4638 pinned the squash-merged `release/v37` tip. That tip includes the follow-up commit re-gating the module-account guard on the chain's blocked-receive policy:

```go
// 51190f04 — what #4638 pinned
if delta.Sign() != 0 && k.bankWrapper.BlockedAddr(cosmosAddr) {

// 198da04b — what live v37.0.3 runs
if delta.Sign() != 0 {
    if acct := k.accountKeeper.GetAccount(ctx, cosmosAddr); acct != nil {
        if _, isModule := acct.(sdk.ModuleAccountI); isModule {
```

ZetaChain's blocked-receive set is a **strict subset** of its module accounts — `x/fungible`, `x/crosschain` and emissions are deliberately not blocked. So for an unblocked module account with a non-zero delta the two forms take different branches: reject vs. mint/burn. Same input, different state transition — consensus-breaking, and it cannot ship as a `v37.0.x` patch.

The private node PR pinned `198da04b` deliberately for this reason; the blocked-receive guard was always meant to ship separately as a coordinated upgrade. Repinning to the merged tip collapsed that separation, because the squash merge made the pre-gating commit unselectable from `release/v37`.

The guard change is still wanted — it fixes real breakage around sends to emissions — just not in a patch release.

### Note

`198da04b` is reachable via the `sec/testnet-v37-complete` branch on `zeta-chain/evm`. **Do not delete that branch** while this pin is live, or tag the commit to make it permanent.

### Verification

`go build ./cmd/zetacored` green. Guard confirmed as the `isModule` form in the downloaded module, not just by SHA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes which forked EVM bank/module-account logic is compiled into `zetacored`, directly affecting consensus state transitions for module balance updates.
> 
> **Overview**
> **Repins the `github.com/cosmos/evm` replace** from the squash-merged `release/v37` tip (`a69d910e9214`) to the older fork commit (`198da04bfbd3`) that **live v37.0.3** was built against. `go.sum` is updated for the new pseudo-version.
> 
> The newer tip reintroduced a **blocked-receive** guard on non-zero balance deltas for module accounts. On ZetaChain, several module accounts (e.g. fungible, crosschain, emissions) are **not** on the blocked-receive list, so that guard can **reject** transfers where the deployed code still **mints/burns**—a consensus-breaking divergence that is inappropriate for a `v37.0.x` patch. This change restores dependency parity with what testnet/mainnet v37.0.3 already runs; the guard is intended for a later coordinated upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd94ab2f9f69ee0c9598047ab8fbec94b52e052f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the main module’s `github.com/cosmos/evm` replacement to the commit used by the deployed v37.0.3 binary, avoiding an unintended consensus-behavior change in a patch release.
- Repins `github.com/zeta-chain/evm` from `a69d910e9214` to `198da04bfbd3`.
- Adds the corresponding module and `go.mod` checksums.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the dependency replacement and checksums consistently selecting the intended deployed EVM commit.

No concrete changed-code failure remains; the manifest and checksum changes agree, while the reported transitive dependency advisories were already present on the base revision.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| go.mod | Repins the EVM fork to the deployed v37.0.3 commit; no concrete defect was established in the replacement directive. |
| go.sum | Adds checksums matching the newly selected EVM pseudo-version; retained checksums for prior versions are harmless. |

<sub>Reviews (1): Last reviewed commit: ["fix(security): pin evm to the deployed c..."](https://github.com/zeta-chain/node/commit/dd94ab2f9f69ee0c9598047ab8fbec94b52e052f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60039541)</sub>

<!-- /greptile_comment -->